### PR TITLE
fixed errors in log due to accidently calling various init methods in…

### DIFF
--- a/runtime-impl/src/main/java/ai/labs/runtime/bootstrap/RuntimeModule.java
+++ b/runtime-impl/src/main/java/ai/labs/runtime/bootstrap/RuntimeModule.java
@@ -102,7 +102,9 @@ public class RuntimeModule extends AbstractBaseModule {
         public void afterInjection(Object injectee) {
             try {
                 Class<?> clazz = injectee.getClass();
-                clazz.getMethod("init").invoke(injectee);
+                if (clazz.equals(BaseRuntime.class)) {
+                    clazz.getMethod("init").invoke(injectee);
+                }
             } catch (Exception e) {
                 System.out.println(Arrays.toString(e.getStackTrace()));
             }


### PR DESCRIPTION
… the DI bootstrapping rather then only calling init() of BaseRuntime, which was originally intended!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/labsai/eddi/62)
<!-- Reviewable:end -->
