### PR TITLE
Facebook Quick Replies + Callbackmodule fixed

### DIFF
--- a/conversationcallback-definition/src/main/java/ai/labs/callback/model/ConversationDataResponseHolder.java
+++ b/conversationcallback-definition/src/main/java/ai/labs/callback/model/ConversationDataResponseHolder.java
@@ -1,0 +1,16 @@
+package ai.labs.callback.model;
+
+import ai.labs.memory.model.ConversationMemorySnapshot;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Created by rpi on 31.08.2017.
+ */
+@Getter
+@Setter
+
+public class ConversationDataResponseHolder {
+    private ConversationMemorySnapshot conversationMemorySnapshot;
+}
+

--- a/conversationcallback-impl/src/main/java/ai/labs/callback/http/ConversationCallback.java
+++ b/conversationcallback-impl/src/main/java/ai/labs/callback/http/ConversationCallback.java
@@ -48,9 +48,11 @@ public class ConversationCallback implements IConversationCallback {
 
             dataResponse.setHttpCode(httpResponse.getHttpCode());
             dataResponse.setHeader(httpResponse.getHttpHeader());
+            log.info("content as string: " + httpResponse.getContentAsString());
             dataResponse.setConversationMemorySnapshot(
                     jsonSerialization.deserialize(httpResponse.getContentAsString(),
                             ConversationMemorySnapshot.class));
+
 
         } catch (IRequest.HttpRequestException | IOException e) {
             log.error(e.getLocalizedMessage(), e);

--- a/conversationcallback-impl/src/main/java/ai/labs/callback/http/ConversationCallback.java
+++ b/conversationcallback-impl/src/main/java/ai/labs/callback/http/ConversationCallback.java
@@ -3,6 +3,7 @@ package ai.labs.callback.http;
 import ai.labs.callback.IConversationCallback;
 import ai.labs.callback.model.ConversationDataRequest;
 import ai.labs.callback.model.ConversationDataResponse;
+import ai.labs.callback.model.ConversationDataResponseHolder;
 import ai.labs.httpclient.IHttpClient;
 import ai.labs.httpclient.IRequest;
 import ai.labs.httpclient.IResponse;
@@ -49,9 +50,8 @@ public class ConversationCallback implements IConversationCallback {
             dataResponse.setHttpCode(httpResponse.getHttpCode());
             dataResponse.setHeader(httpResponse.getHttpHeader());
             log.info("content as string: " + httpResponse.getContentAsString());
-            dataResponse.setConversationMemorySnapshot(
-                    jsonSerialization.deserialize(httpResponse.getContentAsString(),
-                            ConversationMemorySnapshot.class));
+            ConversationDataResponseHolder responseHolder = jsonSerialization.deserialize(httpResponse.getContentAsString(), ConversationDataResponseHolder.class);
+            dataResponse.setConversationMemorySnapshot(responseHolder.getConversationMemorySnapshot());
 
 
         } catch (IRequest.HttpRequestException | IOException e) {

--- a/conversationcallback-impl/src/main/java/ai/labs/callback/http/ConversationCallback.java
+++ b/conversationcallback-impl/src/main/java/ai/labs/callback/http/ConversationCallback.java
@@ -49,7 +49,6 @@ public class ConversationCallback implements IConversationCallback {
 
             dataResponse.setHttpCode(httpResponse.getHttpCode());
             dataResponse.setHeader(httpResponse.getHttpHeader());
-            log.info("content as string: " + httpResponse.getContentAsString());
             ConversationDataResponseHolder responseHolder = jsonSerialization.deserialize(httpResponse.getContentAsString(), ConversationDataResponseHolder.class);
             dataResponse.setConversationMemorySnapshot(responseHolder.getConversationMemorySnapshot());
 

--- a/conversationcallback-impl/src/main/java/ai/labs/callback/impl/ConversationCallbackTask.java
+++ b/conversationcallback-impl/src/main/java/ai/labs/callback/impl/ConversationCallbackTask.java
@@ -66,6 +66,13 @@ public class ConversationCallbackTask implements ILifecycleTask {
                     conversationCallback.doExternalCall(callback, request, timeoutInMillis);
 
             if (String.valueOf(response.getHttpCode()).startsWith("2")) { //check for success, http code 2xx
+                for (ConversationMemorySnapshot.ConversationStepSnapshot snapshot : response.getConversationMemorySnapshot().getConversationSteps()) {
+                    for (ConversationMemorySnapshot.PackageRunSnapshot runSnapshot : snapshot.getPackages()) {
+                        for (ConversationMemorySnapshot.ResultSnapshot resultSnapshot : runSnapshot.getLifecycleTasks()) {
+                            log.info("key: " + resultSnapshot.getKey() + " value: " + resultSnapshot.getResult().toString());
+                        }
+                    }
+                }
                 mergeConversationMemory(memory, response.getConversationMemorySnapshot());
             } else {
                 String msg = "ConversationCallback was (%s) but should have been 2xx. Return value as been ignored";

--- a/conversationcallback-impl/src/main/java/ai/labs/callback/impl/ConversationCallbackTask.java
+++ b/conversationcallback-impl/src/main/java/ai/labs/callback/impl/ConversationCallbackTask.java
@@ -66,13 +66,6 @@ public class ConversationCallbackTask implements ILifecycleTask {
                     conversationCallback.doExternalCall(callback, request, timeoutInMillis);
 
             if (String.valueOf(response.getHttpCode()).startsWith("2")) { //check for success, http code 2xx
-                for (ConversationMemorySnapshot.ConversationStepSnapshot snapshot : response.getConversationMemorySnapshot().getConversationSteps()) {
-                    for (ConversationMemorySnapshot.PackageRunSnapshot runSnapshot : snapshot.getPackages()) {
-                        for (ConversationMemorySnapshot.ResultSnapshot resultSnapshot : runSnapshot.getLifecycleTasks()) {
-                            log.info("key: " + resultSnapshot.getKey() + " value: " + resultSnapshot.getResult().toString());
-                        }
-                    }
-                }
                 mergeConversationMemory(memory, response.getConversationMemorySnapshot());
             } else {
                 String msg = "ConversationCallback was (%s) but should have been 2xx. Return value as been ignored";

--- a/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
+++ b/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
@@ -189,8 +189,13 @@ public class FacebookEndpoint implements IFacebookEndpoint {
             }
 
             for (String outputText : output) {
-                messengerClientCache.get(botId).getSendClient().
-                        sendTextMessage(senderId, outputText, fbQuickReplies);
+                if (fbQuickReplies != null && !fbQuickReplies.isEmpty()) {
+                    messengerClientCache.get(botId).getSendClient().
+                            sendTextMessage(senderId, outputText, fbQuickReplies);
+                } else {
+                    messengerClientCache.get(botId).getSendClient().
+                            sendTextMessage(senderId, outputText);
+                }
             }
 
 

--- a/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
+++ b/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
@@ -171,7 +171,7 @@ public class FacebookEndpoint implements IFacebookEndpoint {
                     .send();
             log.debug("response: {}", httpResponse.getContentAsString());
             final List<String> output = getOutputText(httpResponse.getContentAsString());
-            final List<String> quickReplies = getQuickReplies(httpResponse.getContentAsString());
+            final List<Map<String, String>> quickReplies = getQuickReplies(httpResponse.getContentAsString());
 
             try {
                 messengerClientCache.get(botId).getSendClient().sendSenderAction(senderId, SenderAction.TYPING_OFF);
@@ -182,8 +182,8 @@ public class FacebookEndpoint implements IFacebookEndpoint {
             List<QuickReply> fbQuickReplies = new ArrayList<>();
             if (quickReplies != null && quickReplies.size() > 0) {
                 QuickReply.ListBuilder listBuilder = QuickReply.newListBuilder();
-                for (String quickReply : quickReplies) {
-                    listBuilder.addTextQuickReply(quickReply, quickReply).toList();
+                for (Map<String, String> quickReply : quickReplies) {
+                    listBuilder.addTextQuickReply(quickReply.get("value"), quickReply.get("expressions")).toList();
                 }
                fbQuickReplies = listBuilder.build();
             }
@@ -210,8 +210,8 @@ public class FacebookEndpoint implements IFacebookEndpoint {
 
     }
 
-    private List<String> getQuickReplies(String json) {
-        List<String> output = new ArrayList<>();
+    private List<Map<String,String>> getQuickReplies(String json) {
+        List<Map<String,String>> output = new ArrayList<>();
 
         ObjectMapper mapper = new ObjectMapper();
         try {
@@ -222,7 +222,10 @@ public class FacebookEndpoint implements IFacebookEndpoint {
                     if (conversationStepValues.get("key") != null && conversationStepValues.get("key").asText().startsWith("quickReplies")) {
                         if (conversationStepValues.get("value").isArray()) {
                             for (JsonNode node : conversationStepValues.get("value")) {
-                                output.add(node.asText());
+                                HashMap<String, String> map = new HashMap<>();
+                                map.put("value", node.get("value").asText());
+                                map.put("expressions", node.get("expressions").asText());
+                                output.add(map);
                             }
                         }
                     }


### PR DESCRIPTION
Because of the json serialization it was necessary to create a Holder Object in the Callbackmodule. This works now.
Also in this branch is the implementation of the quick replies for Facebook. Currently only text quickreplies are possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/labsai/eddi/78)
<!-- Reviewable:end -->
