### PR TITLE
Fix/not ignore bot version in messenger

### DIFF
--- a/facebookmessenger-definition/src/main/java/ai/labs/facebookmessenger/endpoint/IFacebookEndpoint.java
+++ b/facebookmessenger-definition/src/main/java/ai/labs/facebookmessenger/endpoint/IFacebookEndpoint.java
@@ -12,12 +12,15 @@ public interface IFacebookEndpoint {
     @POST
     @Path("{botId}")
     @Consumes(MediaType.APPLICATION_JSON)
-    Response webHook(@PathParam("botId") String botId, String callbackPayload,
+    Response webHook(@PathParam("botId") String botId,
+                     @QueryParam("version") @DefaultValue("-1") Integer version,
+                     String callbackPayload,
                      @HeaderParam("X-Hub-Signature") String sha1PayloadSignature);
 
     @GET
     @Path("{botId}")
     Response webHookSetup(@PathParam("botId") String botId,
+                          @QueryParam("version") @DefaultValue("-1") Integer version,
                           @QueryParam("hub.mode") String mode,
                           @QueryParam("hub.verify_token") String verificationToken,
                           @QueryParam("hub.challenge") String challenge);

--- a/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
+++ b/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
@@ -26,6 +26,7 @@ import com.github.messenger4j.send.MessengerSendClient;
 import com.github.messenger4j.send.QuickReply;
 import com.github.messenger4j.send.SenderAction;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +35,6 @@ import org.jboss.resteasy.plugins.guice.RequestScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -46,22 +46,24 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import static ai.labs.persistence.IResourceStore.ResourceNotFoundException;
+import static ai.labs.persistence.IResourceStore.ResourceStoreException;
 import static ai.labs.rest.restinterfaces.RestInterfaceFactory.RestInterfaceFactoryException;
 
 @RequestScoped
 @Slf4j
 public class FacebookEndpoint implements IFacebookEndpoint {
-    private static final String RESOURCE_URI_CHANNELCONNECTOR = "eddi://ai.labs.channel.facebook";
+    private static final String RESOURCE_URI_CHANNEL_CONNECTOR = "eddi://ai.labs.channel.facebook";
     private static final String AI_LABS_USER_AGENT = "Jetty 9.4/HTTP CLIENT - AI.LABS.EDDI";
     private static final String ENCODING = "UTF-8";
+    private static final int EDDI_TIMEOUT = 10000;
 
     private final IBotStore botStore;
     private final IHttpClient httpClient;
     private final IRestInterfaceFactory restInterfaceFactory;
     private final String apiServerURI;
-    private final ICache<String, BotConfiguration> botConfigCache;
     private final ICache<String, String> conversationIdCache;
-    private final ICache<String, MessengerClient> messengerClientCache;
+    private final ICache<BotResourceId, MessengerClient> messengerClientCache;
 
     @Inject
     public FacebookEndpoint(IBotStore botStore,
@@ -73,37 +75,35 @@ public class FacebookEndpoint implements IFacebookEndpoint {
         this.httpClient = httpClient;
         this.restInterfaceFactory = restInterfaceFactory;
         this.apiServerURI = apiServerURI;
-        this.botConfigCache = cacheFactory.getCache("facebook.botConfiguration");
         this.conversationIdCache = cacheFactory.getCache("facebook.conversationIds");
         this.messengerClientCache = cacheFactory.getCache("facebook.messengerReceiveClients");
     }
 
-    private MessengerClient getMessageClient(String botId) {
-        if (!messengerClientCache.containsKey(botId)) {
-            messengerClientCache.put(botId, createMessageClient(botId));
+    private MessengerClient getMessageClient(String botId, Integer botVersion)
+            throws ResourceNotFoundException, ResourceStoreException {
+
+        if (botVersion == -1) {
+            botVersion = botStore.getCurrentResourceId(botId).getVersion();
         }
 
-        return messengerClientCache.get(botId);
+        final BotResourceId botResourceId = new BotResourceId(botId, botVersion);
+        if (!messengerClientCache.containsKey(botResourceId)) {
+            messengerClientCache.put(botResourceId, createMessageClient(botId, botVersion));
+        }
+
+        return messengerClientCache.get(botResourceId);
     }
 
-    private MessengerClient createMessageClient(String botId) {
-        BotConfiguration botConfiguration;
-        try {
-            Integer botVersion = botStore.getCurrentResourceId(botId).getVersion();
-            String cacheKey = botId + ":" + botVersion;
-            if ((botConfiguration = botConfigCache.get(cacheKey)) == null) {
-                botConfiguration = botStore.read(botId, botVersion);
-                botConfigCache.put(cacheKey, botConfiguration);
-            }
-        } catch (Exception e) {
-            throw new WebApplicationException("Could not read bot configuration", e);
-        }
+    private MessengerClient createMessageClient(String botId, Integer botVersion)
+            throws ResourceNotFoundException, ResourceStoreException {
+
+        final BotConfiguration botConfiguration = botStore.read(botId, botVersion);
 
         String appSecret = null;
         String verificationToken = null;
         String pageAccessToken = null;
         for (BotConfiguration.ChannelConnector channelConnector : botConfiguration.getChannels()) {
-            if (channelConnector.getType().toString().equals(RESOURCE_URI_CHANNELCONNECTOR)) {
+            if (channelConnector.getType().toString().equals(RESOURCE_URI_CHANNEL_CONNECTOR)) {
                 Map<String, String> channelConnectorConfig = channelConnector.getConfig();
                 appSecret = channelConnectorConfig.get("appSecret");
                 verificationToken = channelConnectorConfig.get("verificationToken");
@@ -118,34 +118,34 @@ public class FacebookEndpoint implements IFacebookEndpoint {
 
         return new MessengerClient(MessengerPlatform.newSendClientBuilder(pageAccessToken).build(),
                 MessengerPlatform.newReceiveClientBuilder(appSecret, verificationToken)
-                        .onTextMessageEvent(getTextMessageEventHandler(botId, Deployment.Environment.unrestricted))
-                        .onQuickReplyMessageEvent(getQuickMessageEventHandler(botId, Deployment.Environment.unrestricted))
+                        .onTextMessageEvent(getTextMessageEventHandler(botId, botVersion, Deployment.Environment.unrestricted))
+                        .onQuickReplyMessageEvent(getQuickMessageEventHandler(botId, botVersion, Deployment.Environment.unrestricted))
                         .build());
     }
 
-    private TextMessageEventHandler getTextMessageEventHandler(String botId, Deployment.Environment environment) {
+    private TextMessageEventHandler getTextMessageEventHandler(String botId, Integer botVersion, Deployment.Environment environment) {
         return event -> {
             try {
                 String message = event.getText();
                 String senderId = event.getSender().getId();
                 final String conversationId = getConversationId(environment, botId, senderId);
-                say(environment, botId, conversationId, senderId, message);
+                say(environment, botId, botVersion, conversationId, senderId, message);
 
-            } catch (RestInterfaceFactoryException | IRequest.HttpRequestException e) {
+            } catch (Exception e) {
                 log.error(e.getLocalizedMessage(), e);
             }
         };
     }
 
-    private QuickReplyMessageEventHandler getQuickMessageEventHandler(String botId, Deployment.Environment environment) {
+    private QuickReplyMessageEventHandler getQuickMessageEventHandler(String botId, Integer botVersion, Deployment.Environment environment) {
         return event -> {
             try {
                 String message = event.getQuickReply().getPayload();
                 String senderId = event.getSender().getId();
                 final String conversationId = getConversationId(environment, botId, senderId);
-                say(environment, botId, conversationId, senderId, message);
+                say(environment, botId, botVersion, conversationId, senderId, message);
 
-            } catch (RestInterfaceFactoryException | IRequest.HttpRequestException e) {
+            } catch (Exception e) {
                 log.error(e.getLocalizedMessage(), e);
             }
         };
@@ -153,9 +153,11 @@ public class FacebookEndpoint implements IFacebookEndpoint {
 
     private void say(Deployment.Environment environment,
                      String botId,
+                     Integer botVersion,
                      String conversationId,
                      String senderId,
-                     String message) throws IRequest.HttpRequestException {
+                     String message)
+            throws IRequest.HttpRequestException, ResourceNotFoundException, ResourceStoreException {
 
         URI uri = RestUtilities.createURI(
                 apiServerURI, "/bots/",
@@ -163,8 +165,9 @@ public class FacebookEndpoint implements IFacebookEndpoint {
                 botId, "/",
                 conversationId);
 
+        final MessengerSendClient sendClient = getMessageClient(botId, botVersion).getSendClient();
         try {
-            messengerClientCache.get(botId).getSendClient().sendSenderAction(senderId, SenderAction.TYPING_ON);
+            sendClient.sendSenderAction(senderId, SenderAction.TYPING_ON);
         } catch (MessengerApiException | MessengerIOException e) {
             log.error(e.getLocalizedMessage(), e);
         }
@@ -173,7 +176,7 @@ public class FacebookEndpoint implements IFacebookEndpoint {
         try {
             IResponse httpResponse = httpClient.newRequest(uri, IHttpClient.Method.POST)
                     .setUserAgent(AI_LABS_USER_AGENT)
-                    .setTimeout(10000, TimeUnit.MILLISECONDS)
+                    .setTimeout(EDDI_TIMEOUT, TimeUnit.MILLISECONDS)
                     .setBodyEntity(jsonRequestBody, ENCODING, MediaType.APPLICATION_JSON)
                     .send();
             log.debug("response: {}", httpResponse.getContentAsString());
@@ -181,7 +184,7 @@ public class FacebookEndpoint implements IFacebookEndpoint {
             final List<Map<String, String>> quickReplies = getQuickReplies(httpResponse.getContentAsString());
 
             try {
-                messengerClientCache.get(botId).getSendClient().sendSenderAction(senderId, SenderAction.TYPING_OFF);
+                sendClient.sendSenderAction(senderId, SenderAction.TYPING_OFF);
             } catch (MessengerApiException | MessengerIOException e) {
                 log.error(e.getLocalizedMessage(), e);
             }
@@ -192,16 +195,14 @@ public class FacebookEndpoint implements IFacebookEndpoint {
                 for (Map<String, String> quickReply : quickReplies) {
                     listBuilder.addTextQuickReply(quickReply.get("value"), quickReply.get("expressions")).toList();
                 }
-               fbQuickReplies = listBuilder.build();
+                fbQuickReplies = listBuilder.build();
             }
 
             for (String outputText : output) {
                 if (!fbQuickReplies.isEmpty()) {
-                    messengerClientCache.get(botId).getSendClient().
-                            sendTextMessage(senderId, outputText, fbQuickReplies);
+                    sendClient.sendTextMessage(senderId, outputText, fbQuickReplies);
                 } else {
-                    messengerClientCache.get(botId).getSendClient().
-                            sendTextMessage(senderId, outputText);
+                    sendClient.sendTextMessage(senderId, outputText);
                 }
             }
 
@@ -214,8 +215,8 @@ public class FacebookEndpoint implements IFacebookEndpoint {
         }
     }
 
-    private List<Map<String,String>> getQuickReplies(String json) {
-        List<Map<String,String>> output = new ArrayList<>();
+    private List<Map<String, String>> getQuickReplies(String json) {
+        List<Map<String, String>> output = new ArrayList<>();
 
         ObjectMapper mapper = new ObjectMapper();
         try {
@@ -265,7 +266,6 @@ public class FacebookEndpoint implements IFacebookEndpoint {
     }
 
     private String getConversationState(String json) {
-
         String state = null;
 
         ObjectMapper mapper = new ObjectMapper();
@@ -317,11 +317,12 @@ public class FacebookEndpoint implements IFacebookEndpoint {
     }
 
     @Override
-    public Response webHook(final String botId, final String callbackPayload, final String sha1PayloadSignature) {
+    public Response webHook(final String botId, final Integer botVersion,
+                            final String callbackPayload, final String sha1PayloadSignature) {
         SystemRuntime.getRuntime().submitCallable((Callable<Void>) () -> {
             try {
-                log.info("webhook called");
-                getMessageClient(botId).getReceiveClient().
+                log.info("web hook called");
+                getMessageClient(botId, botVersion).getReceiveClient().
                         processCallbackPayload(callbackPayload, sha1PayloadSignature);
             } catch (MessengerVerificationException e) {
                 log.error(e.getLocalizedMessage(), e);
@@ -334,15 +335,21 @@ public class FacebookEndpoint implements IFacebookEndpoint {
     }
 
     @Override
-    public Response webHookSetup(final String botId, final String mode,
+    public Response webHookSetup(final String botId, final Integer botVersion, final String mode,
                                  final String verificationToken, final String challenge) {
         try {
-            log.info("webhook setup called");
-            return Response.ok(getMessageClient(botId).getReceiveClient().
-                    verifyWebhook(mode, verificationToken, challenge)).build();
+            log.info("web hook setup called");
+            return Response.ok(
+                    getMessageClient(botId, botVersion).
+                            getReceiveClient().
+                            verifyWebhook(mode, verificationToken, challenge)
+            ).build();
         } catch (MessengerVerificationException e) {
             log.error(e.getLocalizedMessage(), e);
             return Response.status(Response.Status.FORBIDDEN).build();
+        } catch (ResourceStoreException | ResourceNotFoundException e) {
+            log.error(e.getLocalizedMessage(), e);
+            return Response.serverError().build();
         }
     }
 
@@ -352,5 +359,13 @@ public class FacebookEndpoint implements IFacebookEndpoint {
     private static class MessengerClient {
         MessengerSendClient sendClient;
         MessengerReceiveClient receiveClient;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    private class BotResourceId {
+        private final String id;
+        private final Integer version;
     }
 }


### PR DESCRIPTION
* bot version query param will be used now as key
* if no bot version, then it takes latest that is deployed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/labsai/eddi/98)
<!-- Reviewable:end -->
