### PR TITLE
run PropertyInstruction and QuickRepliesBuildingInstruction depending on httpcode from response

### DIFF
--- a/basemodels/src/main/java/ai/labs/models/HttpCodeValidator.java
+++ b/basemodels/src/main/java/ai/labs/models/HttpCodeValidator.java
@@ -1,0 +1,14 @@
+package ai.labs.models;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@Setter
+public class HttpCodeValidator {
+    private List<Integer> runOnHttpCode = Arrays.asList(200);
+    private List<Integer> skipOnHttpCode = Arrays.asList(0, 400, 401, 402, 403, 404, 409, 410, 500, 501, 502);
+}

--- a/basemodels/src/main/java/ai/labs/models/PropertyInstruction.java
+++ b/basemodels/src/main/java/ai/labs/models/PropertyInstruction.java
@@ -12,4 +12,5 @@ import lombok.Setter;
 public class PropertyInstruction extends Property {
     private String fromObjectPath = "";
     private boolean override;
+    private HttpCodeValidator httpCodeValidator = new HttpCodeValidator();
 }

--- a/configurationrepository-definition/src/main/java/ai/labs/resources/rest/http/model/QuickRepliesBuildingInstruction.java
+++ b/configurationrepository-definition/src/main/java/ai/labs/resources/rest/http/model/QuickRepliesBuildingInstruction.java
@@ -1,5 +1,6 @@
 package ai.labs.resources.rest.http.model;
 
+import ai.labs.models.HttpCodeValidator;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,10 +9,12 @@ import lombok.Setter;
 public class QuickRepliesBuildingInstruction extends BuildingInstruction {
     private String quickReplyValue;
     private String quickReplyExpressions;
+    private HttpCodeValidator httpCodeValidator;
 
     public QuickRepliesBuildingInstruction() {
         super();
         quickReplyValue = "";
         quickReplyExpressions = "";
+        httpCodeValidator = new HttpCodeValidator();
     }
 }


### PR DESCRIPTION
We need to do proper error handling, in case an api returns an error such as 401 or 500. 

Chosen solution to that is to allow whitelisting && blacklisting of httpcodes from the response and use default httpcodes if none are defined by the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/labsai/eddi/124)
<!-- Reviewable:end -->
