### PR TITLE
Fix ERR_INVALID_SIGNED_EXCHANGE on chrome

### DIFF
--- a/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlApiResource.java
+++ b/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlApiResource.java
@@ -4,13 +4,14 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 /**
  * @author ginccc
  */
 
 @Path("/view")
-@Produces("text/html")
+@Produces(MediaType.TEXT_HTML)
 public interface IRestHtmlApiResource {
 
     @GET

--- a/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlApiResource.java
+++ b/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlApiResource.java
@@ -3,12 +3,14 @@ package ai.labs.staticresources.rest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 
 /**
  * @author ginccc
  */
 
 @Path("/view")
+@Produces("text/html")
 public interface IRestHtmlApiResource {
 
     @GET

--- a/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlChatResource.java
+++ b/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlChatResource.java
@@ -3,12 +3,14 @@ package ai.labs.staticresources.rest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 
 /**
  * @author ginccc
  */
 
 @Path("/chat")
+@Produces("text/html")
 public interface IRestHtmlChatResource {
 
     @GET

--- a/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlChatResource.java
+++ b/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlChatResource.java
@@ -4,13 +4,15 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.awt.*;
 
 /**
  * @author ginccc
  */
 
 @Path("/chat")
-@Produces("text/html")
+@Produces(MediaType.TEXT_HTML)
 public interface IRestHtmlChatResource {
 
     @GET

--- a/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlChatResource.java
+++ b/staticresourceprovider-definition/src/main/java/ai/labs/staticresources/rest/IRestHtmlChatResource.java
@@ -5,7 +5,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.awt.*;
 
 /**
  * @author ginccc


### PR DESCRIPTION
**The issue:** Chrome fails with ERR_INVALID_SIGNED_EXCHANGE while Firefox succeeds loading the page.
**More info:** https://issues.jboss.org/projects/RESTEASY/issues/RESTEASY-2198

After applying these changes, E.D.D.I web interface seems to work fine with the latest version of chrome (in my case 73.0.3683.86).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/labsai/eddi/131)
<!-- Reviewable:end -->
