### PR TITLE
Facebook channel bugfix

### DIFF
--- a/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
+++ b/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
@@ -204,10 +204,10 @@ public class FacebookEndpoint implements IFacebookEndpoint {
         final List<Map<String, String>> quickReplies = getQuickReplies(httpResponse.getContentAsString());
 
         final List<QuickReply> fbQuickReplies = new ArrayList<>();
-        if (quickReplies != null && quickReplies.size() > 0) {
+        if (!quickReplies.isEmpty()) {
             QuickReply.ListBuilder listBuilder = QuickReply.newListBuilder();
             for (Map<String, String> quickReply : quickReplies) {
-                listBuilder.addTextQuickReply(quickReply.get("value"), quickReply.get("expressions")).toList();
+                listBuilder.addTextQuickReply(quickReply.get("value"), quickReply.get("value")).toList();
             }
             fbQuickReplies.addAll(listBuilder.build());
         }

--- a/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
+++ b/facebookmessenger-impl/src/main/java/ai/labs/facebookmessenger/endpoint/FacebookEndpoint.java
@@ -145,6 +145,7 @@ public class FacebookEndpoint implements IFacebookEndpoint {
         return event -> {
             try {
                 String message = event.getText();
+                log.info("fb message text: {}", message);
                 String senderId = event.getSender().getId();
                 final String conversationId = getConversationId(environment, botId, senderId);
                 say(environment, botId, botVersion, conversationId, senderId, message);
@@ -161,6 +162,7 @@ public class FacebookEndpoint implements IFacebookEndpoint {
             try {
                 String message = event.getQuickReply().getPayload();
                 String senderId = event.getSender().getId();
+                log.info("fb quick message text: {}", message);
                 final String conversationId = getConversationId(environment, botId, senderId);
                 say(environment, botId, botVersion, conversationId, senderId, message);
 


### PR DESCRIPTION
just a tiny change in the facebook channel. The value that is written in the quick reply on facebook is now also the value that is sent back to eddi. This was done differently, but made more troubles than it was worth. This change does not warrant a new version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/labsai/eddi/136)
<!-- Reviewable:end -->
