### PR TITLE
Add ability to configure JVM additional options. Add some config for production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
 version: '3'
 services:
   eddi:
-    image: labsai/eddi:4.8.0-kkorsakov
+    image: labsai/eddi:latest
     ports:
       - "7070:7070"
       - "7443:7443"
-      - "9001:9001"
     links:
       - mongodb
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,23 @@
 version: '3'
 services:
   eddi:
-    image: labsai/eddi:latest
+    image: labsai/eddi:4.8.0-kkorsakov
     ports:
       - "7070:7070"
       - "7443:7443"
+      - "9001:9001"
     links:
       - mongodb
     depends_on:
       - mongodb
     environment:
       EDDI_VERSION: 4.8
-      EDDI_JVM_OPTIONS: "-verbose:class -Xlog:gc*=debug:stdout:time,uptime,level -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps/oom.bin"
+      EDDI_JVM_OPTIONS: "-verbose:class -Xlog:gc*=debug:stdout:time,uptime,level -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps/oom.bin -XX:+UseContainerSupport"
       EDDI_ENV: production
-      EDDI_MEMORY_MIN: 1G
-      EDDI_MEMORY_MAX: 1G
+      # configure memory as percentage (usefull for cgrouped envs like docker/k8s so you don't need to configure memory 2 times)
+      EDDI_MEMORY_PERCENTAGE_MIN: 50
+      # 70-80% as a good starting point
+      EDDI_MEMORY_PERCENTAGE_MAX: 80
       EDDI_JAVA_ENV_TUNE_BUFFER: "jdk.nio.MaxCachedBufferSize=1048576"
       #EDDI_JAVA_ENV_MONGODB_HOST: mongodb.hosts=mongodb
   mongodb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,11 @@ services:
       - mongodb
     environment:
       EDDI_VERSION: 4.8
+      EDDI_JVM_OPTIONS: "-verbose:class -Xlog:gc*=debug:stdout:time,uptime,level -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps/oom.bin"
       EDDI_ENV: production
       EDDI_MEMORY_MIN: 1G
       EDDI_MEMORY_MAX: 1G
+      EDDI_JAVA_ENV_TUNE_BUFFER: "jdk.nio.MaxCachedBufferSize=1048576"
       #EDDI_JAVA_ENV_MONGODB_HOST: mongodb.hosts=mongodb
   mongodb:
     image: mongo:3.6

--- a/start_eddi.sh
+++ b/start_eddi.sh
@@ -22,7 +22,18 @@ if ! [[ -z "${EDDI_MEMORY_MAX}" ]]; then
     memory_string="${memory_string} -Xmx${EDDI_MEMORY_MAX} -XX:NewSize=${EDDI_MEMORY_MAX}"
 fi
 
+if ! [[ -z "${EDDI_MEMORY_PERCENTAGE_MIN}" ]]; then
+    memory_string="${memory_string} -XX:MinRAMPercentage=${EDDI_MEMORY_PERCENTAGE_MIN}"
+fi
+
+if ! [[ -z "${EDDI_MEMORY_PERCENTAGE_MAX}" ]]; then
+    memory_string="${memory_string} -XX:MaxRAMPercentage=${EDDI_MEMORY_PERCENTAGE_MAX}"
+fi
+
+
 echo "memory params: ${memory_string}"
+
+
 
 # enable additional JVM options
 jvm_options=""

--- a/start_eddi.sh
+++ b/start_eddi.sh
@@ -24,7 +24,16 @@ fi
 
 echo "memory params: ${memory_string}"
 
+# enable additional JVM options
+jvm_options=""
+if ! [[ -z "${EDDI_JVM_OPTIONS}" ]]; then
+    jvm_options=${EDDI_JVM_OPTIONS}
+fi
+
+
+
 java -server ${memory_string} \
+${jvm_options} \
 -classpath '.:lib/*' \
 -DEDDI_ENV=$EDDI_ENV ${argument_string} \
 --add-opens java.base/java.lang=ALL-UNNAMED \


### PR DESCRIPTION
Options are written free-style so take care of syntax.

Configure some production-grade options for better diagnosis (GC logs, taking heap dump on OOM, etc). Configure jdk.nio.MaxCachedBufferSize to not to overrun non-heap memory on large number of concurrent http threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/labsai/eddi/152)
<!-- Reviewable:end -->
