### PR TITLE
Resolved mismatch stubbings in PropertySetterTaskTest.java

### DIFF
--- a/src/test/java/ai/labs/eddi/modules/properties/PropertySetterTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/properties/PropertySetterTaskTest.java
@@ -88,6 +88,7 @@ public class PropertySetterTaskTest {
         IData<List<Property>> expectedPropertyData = new Data<>("properties:extracted", propertyEntries);
 
         final String propertyExpression = "property(someMeaning(someValue))";
+        when(currentStep.getLatestData("actions")).thenReturn(null);
         when(currentStep.getLatestData(eq(KEY_EXPRESSIONS_PARSED))).thenAnswer(invocation ->
                 new Data<>(KEY_EXPRESSIONS_PARSED, propertyExpression));
         when(propertySetter.extractProperties(eq(expressions))).thenAnswer(invocation -> {


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `executeTask`: 
* the `getLatestData` method for the `currentStep` object:
i) during test execution the method is called with argument `"actions"`, but is not stubbed, resulting in a mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.