### PR TITLE
chore(ci): Added the OpenSSF Scorecard badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ permissions:
 env:
   DOCKER_IMAGE: labsai/eddi
   JAVA_VERSION: "25"
+  # Pin preflight version + hash — update both when upgrading
+  PREFLIGHT_VERSION: "1.17.1"
+  PREFLIGHT_SHA256: "15f58d0de7212ac948706515f824d0d2f42b94c11fa85cdb1bc08ad8993226ca"
 
 jobs:
   # ─── Job 0: Detect Changes ──────────────────────────────────────
@@ -430,10 +433,10 @@ jobs:
 
       - name: Install preflight
         run: |
-          PREFLIGHT_VERSION=$(curl -s https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/releases/latest | jq -r .tag_name)
           echo "Installing preflight ${PREFLIGHT_VERSION}..."
           curl -sL "https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/${PREFLIGHT_VERSION}/preflight-linux-amd64" \
             -o /usr/local/bin/preflight
+          echo "${PREFLIGHT_SHA256}  /usr/local/bin/preflight" | sha256sum -c -
           chmod +x /usr/local/bin/preflight
           preflight --version
 
@@ -513,10 +516,10 @@ jobs:
 
       - name: Install preflight
         run: |
-          PREFLIGHT_VERSION=$(curl -s https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/releases/latest | jq -r .tag_name)
           echo "Installing preflight ${PREFLIGHT_VERSION}..."
           curl -sL "https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/${PREFLIGHT_VERSION}/preflight-linux-amd64" \
             -o /usr/local/bin/preflight
+          echo "${PREFLIGHT_SHA256}  /usr/local/bin/preflight" | sha256sum -c -
           chmod +x /usr/local/bin/preflight
           preflight --version
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # E.D.D.I — Multi-Agent Orchestration Middleware for Conversational AI
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2c5d183d4bd24dbaa77427cfbf5d4074)](https://app.codacy.com/organizations/gh/labsai/dashboard?utm_source=github.com&utm_medium=referral&utm_content=labsai/EDDI&utm_campaign=Badge_Grade) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12355/badge)](https://www.bestpractices.dev/projects/12355) ![Tests](https://img.shields.io/badge/tests-2%2C400%2B-brightgreen)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2c5d183d4bd24dbaa77427cfbf5d4074)](https://app.codacy.com/organizations/gh/labsai/dashboard?utm_source=github.com&utm_medium=referral&utm_content=labsai/EDDI&utm_campaign=Badge_Grade) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12355/badge)](https://www.bestpractices.dev/projects/12355) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/labsai/EDDI/badge)](https://securityscorecards.dev/viewer/?uri=github.com/labsai/EDDI) ![Tests](https://img.shields.io/badge/tests-2%2C400%2B-brightgreen)
 
 [![CI](https://github.com/labsai/EDDI/actions/workflows/ci.yml/badge.svg)](https://github.com/labsai/EDDI/actions/workflows/ci.yml) [![CodeQL](https://github.com/labsai/EDDI/actions/workflows/codeql.yml/badge.svg)](https://github.com/labsai/EDDI/actions/workflows/codeql.yml)
 


### PR DESCRIPTION
This pull request introduces improvements to both the project's documentation and its CI workflow. The most significant change is the enhancement of the CI process for installing the `preflight` tool, which now uses a pinned version and verifies its integrity. Additionally, the project README has been updated to include a new OpenSSF Scorecard badge.

Enhancements to CI workflow:

* The `preflight` installation step in `.github/workflows/ci.yml` now uses pinned environment variables for the version (`PREFLIGHT_VERSION`) and SHA256 hash (`PREFLIGHT_SHA256`), ensuring reproducibility and security by verifying the binary's checksum before execution. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR432-R440) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR519-R527)

Documentation updates:

* Added the OpenSSF Scorecard badge to `README.md`, providing visibility into the project's security best practices and posture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD pipeline now uses pinned binary versions with checksum verification for enhanced security.
  * Added OpenSSF Scorecard badge to project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->