### PR TITLE
fix: add EDDI_SECURITY_ALLOW_UNAUTHENTICATED to non-auth compose file…

### DIFF
--- a/docker-compose.postgres-only.yml
+++ b/docker-compose.postgres-only.yml
@@ -14,6 +14,7 @@ services:
       QUARKUS_DATASOURCE_USERNAME: eddi
       QUARKUS_DATASOURCE_PASSWORD: eddi
       EDDI_DATASTORE_TYPE: "${EDDI_DATASTORE_TYPE:-postgres}"
+      EDDI_SECURITY_ALLOW_UNAUTHENTICATED: "true"
       EDDI_VAULT_MASTER_KEY: "${EDDI_VAULT_MASTER_KEY:-}"
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -10,6 +10,7 @@ services:
       QUARKUS_DATASOURCE_USERNAME: eddi
       QUARKUS_DATASOURCE_PASSWORD: eddi
       EDDI_DATASTORE_TYPE: postgres
+      EDDI_SECURITY_ALLOW_UNAUTHENTICATED: "true"
       EDDI_VAULT_MASTER_KEY: "${EDDI_VAULT_MASTER_KEY:-}"
     depends_on:
       postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     environment:
       - "EDDI_VAULT_MASTER_KEY=${EDDI_VAULT_MASTER_KEY:-}"
       - "EDDI_DATASTORE_TYPE=${EDDI_DATASTORE_TYPE:-mongodb}"
+      - "EDDI_SECURITY_ALLOW_UNAUTHENTICATED=true"
       - "QUARKUS_MONGODB_CONNECTION_STRING=mongodb://${MONGO_INITDB_ROOT_USERNAME:-eddi}:${MONGO_INITDB_ROOT_PASSWORD:-changeme}@mongodb:27017/eddi?authSource=admin"
 #      - "JAVA_OPTS_APPEND=-Dquarkus.http.cors.origins=http://localhost:3000"
     extra_hosts:


### PR DESCRIPTION
This pull request updates the Docker Compose configuration files to allow unauthenticated access to the EDDI service by default in all environments. The main change is the addition of the `EDDI_SECURITY_ALLOW_UNAUTHENTICATED` environment variable set to `"true"` for all service configurations.

Security & configuration updates:

* Added `EDDI_SECURITY_ALLOW_UNAUTHENTICATED=true` to the `environment` section of the `eddi` service in `docker-compose.yml`, enabling unauthenticated access for the default (MongoDB) setup.
* Added `EDDI_SECURITY_ALLOW_UNAUTHENTICATED: "true"` to the `eddi` service in `docker-compose.postgres.yml` and `docker-compose.postgres-only.yml`, enabling unauthenticated access for the Postgres setups as well. [[1]](diffhunk://#diff-7e6b1727f564dc3911e76a2cae79d5fa10d6d27e1c91751d54343944a5cf00c2R13) [[2]](diffhunk://#diff-91a226dda25e0eea0881b0f3665a4b10a3816168c54ddddfa8c4f872f3fa6d86R17)