### PR TITLE
fix(ci): Slack notification and Docker job bypass detect-changes on t…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,8 +923,8 @@ jobs:
             exit 0
           fi
 
-          # Skip notification for docs-only changes (all jobs skipped)
-          if [ "${{ needs.detect-changes.outputs.code }}" = "false" ]; then
+          # Skip notification for docs-only changes (all jobs skipped) — but always notify on tags
+          if [ "${{ needs.detect-changes.outputs.code }}" = "false" ] && [[ "$GITHUB_REF" != refs/tags/* ]]; then
             echo "### ⏭️ Docs-only change — no build notification sent" >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
@@ -956,6 +956,13 @@ jobs:
               *)        echo "❓" ;;
             esac
           }
+
+          # On tag pushes, build-and-test may be skipped (detect-changes bypass) — that's OK
+          # because Docker builds from source independently
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            [ "$BUILD" = "skipped" ] && BUILD="success"
+            [ "$IT" = "skipped" ] && IT="success"
+          fi
 
           # Overall status
           if [ "$BUILD" = "success" ] && [ "$IT" != "failure" ] && [ "$DOCKER" != "failure" ] && [ "$SMOKE" != "failure" ] && [ "$GITLEAKS" != "failure" ] && [ "$TRIVY" != "failure" ]; then

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,26 @@ Each entry follows this format:
 - **Decision** — Key design decisions and their reasoning
 - **Files** — Links to modified files
 
+## 🐛 Compose AuthStartupGuard Fix & CI Tag Bypass (2026-04-23)
+
+**Repo:** EDDI (`fix/compose-auth-guard`)
+
+**What changed:** Fixed container startup crash in non-auth Docker Compose configurations and fixed CI pipeline skipping Docker builds on tag pushes.
+
+### Root Cause
+
+The `AuthStartupGuard` (added in 6.0.2) blocks startup if OIDC is not configured and the escape hatch `EDDI_SECURITY_ALLOW_UNAUTHENTICATED=true` is not set. The non-auth compose files were missing this env var, causing immediate crash on `docker compose up`.
+
+### Changes
+
+- **`docker-compose.yml`** — Added `EDDI_SECURITY_ALLOW_UNAUTHENTICATED=true` to environment
+- **`docker-compose.postgres-only.yml`** — Same fix
+- **`docker-compose.postgres.yml`** — Same fix
+- **`docker-compose.auth.yml`** — No change needed (has `QUARKUS_OIDC_TENANT_ENABLED=true`)
+- **`.github/workflows/ci.yml`** — Docker job now uses `always()` with `needs: [detect-changes, build-and-test]` so tag pushes bypass the detect-changes gate. Branch pushes still require `build-and-test.result == 'success'`.
+
+---
+
 ## CI Coverage Gate Consolidation & Broken Pipe Fix (2026-04-22)
 
 **Repo:** EDDI (`chore/test-coverage-hardening`)


### PR DESCRIPTION
This pull request addresses two main issues: it fixes a startup crash in Docker Compose configurations that do not use authentication, and it ensures that the CI pipeline does not skip Docker builds when a tag is pushed. The most important changes are as follows:

**CI/CD Pipeline Improvements:**

* Modified `.github/workflows/ci.yml` so that Docker jobs always run on tag pushes, bypassing the docs-only change detection. This ensures Docker builds are not skipped when tags are pushed, while still requiring successful tests for branch pushes. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL926-R927) [[2]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R16-R35)

**Documentation:**

* Updated `docs/changelog.md` to document the Compose `AuthStartupGuard` fix and the CI tag bypass, including the root cause and specific files affected.