### PR TITLE
docs(redhat): rewrite RHEL/OpenShift certification documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Features: Dev Services (auto-starts EDDI in dev mode), fluent API, SSE streaming
 | **[Audit Ledger](docs/audit-ledger.md)**                     | EU AI Act-compliant audit trail                    |
 | **[Kubernetes](docs/kubernetes.md)**                         | Deploy with Kustomize or Helm                      |
 | **[Monitoring & Tracing](docs/monitoring/monitoring-guide.md)** | Prometheus, Grafana, OpenTelemetry, alerting     |
-| **[Red Hat OpenShift](docs/redhat-openshift.md)**            | Certified container, automated release             |
+| **[Red Hat & OpenShift](docs/redhat-openshift.md)**          | RHEL support, certified container, automated release |
 | **[Agent Father Deep Dive](docs/agent-father-deep-dive.md)** | How the meta-agent works                           |
 | **[Full Documentation](https://docs.labs.ai/)**              | Complete documentation site                        |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,7 +84,7 @@ Build agent behavior by composing these extensions:
 | ----------------------- | -------------------------------------------------- |
 | 🐳 Docker               | [→ Guide](docker.md)                               |
 | ☸️ Kubernetes & Helm    | [→ Guide](kubernetes.md)                           |
-| 🔴 Red Hat OpenShift    | [→ Guide](redhat-openshift.md)                     |
+| 🔴 Red Hat & OpenShift  | [→ Guide](redhat-openshift.md)                     |
 | ☁️ AWS + MongoDB Atlas  | [→ Guide](setup-eddi-on-aws-with-mongodb-atlas.md) |
 | 📊 Metrics & Monitoring | [→ Guide](metrics.md)                              |
 | 📋 Log Administration   | [→ Guide](log-administration.md)                   |

--- a/docs/redhat-openshift.md
+++ b/docs/redhat-openshift.md
@@ -1,33 +1,74 @@
-# RedHat OpenShift
+# Red Hat Enterprise Linux & OpenShift Support
 
-E.D.D.I is enterprise certified to run on RedHat OpenShift and is offered with support on the Red Hat Marketplace: [https://marketplace.redhat.com/en-us/products/labsai](https://marketplace.redhat.com/en-us/products/labsai)
+## Platform Support
+
+EDDI is built on and fully supports **Red Hat Enterprise Linux (RHEL)**. The production container image is based exclusively on Red Hat content:
+
+- **Base OS**: [Red Hat Universal Base Image 9 (UBI 9)](https://catalog.redhat.com/software/base-images) — a freely redistributable subset of RHEL 9, binary-compatible with RHEL 9 and supported by Red Hat when run on RHEL or OpenShift.
+- **Runtime**: OpenJDK 25 from the official Red Hat UBI 9 OpenJDK runtime image (`ubi9/openjdk-25-runtime`).
+- **Architecture**: `linux/amd64` (x86_64).
+- **Non-root execution**: Runs as UID `185` (the default `jboss` user from the UBI base image) — containers never run as root.
+
+EDDI is delivered as an OCI-compliant Docker container image and runs on any platform that supports OCI containers, including:
+
+| Platform | Support Level |
+|---|---|
+| **Red Hat Enterprise Linux 9** | ✅ Primary — UBI 9 base image, Red Hat-certified |
+| **Red Hat OpenShift 4.12+** | ✅ Certified — listed in the [Red Hat Ecosystem Catalog](https://catalog.redhat.com/) |
+| **Docker** (any Linux, macOS, Windows) | ✅ Full support — standard OCI container |
+| **Kubernetes** (any distribution) | ✅ Full support — standard OCI container |
+| **Podman** | ✅ Full support — OCI-compliant runtime |
+
+> **Note**: Because EDDI ships as a standard OCI container image built on Red Hat UBI 9, it is inherently compatible with RHEL 9 and any RHEL-based platform. No host-level OS dependencies are required beyond a container runtime.
+
+All EDDI releases are continuously validated against Red Hat certification requirements via automated [preflight checks](https://github.com/redhat-openshift-ecosystem/openshift-preflight) in CI/CD.
+
+---
+
+## Red Hat Ecosystem Catalog
+
+EDDI is listed in the [Red Hat Ecosystem Catalog](https://catalog.redhat.com/) as a certified container image, and is available on [Docker Hub](https://hub.docker.com/r/labsai/eddi):
+
+🔗 **[hub.docker.com/r/labsai/eddi](https://hub.docker.com/r/labsai/eddi)**
+
+---
 
 ## Container Certification
 
-The EDDI container image is certified by Red Hat / IBM for use on OpenShift. Certification is automated via the `redhat-certify.yml` GitHub Actions workflow.
+The EDDI container image is certified by Red Hat / IBM for use on OpenShift. Certification is automated via the [`redhat-certify.yml`](../.github/workflows/redhat-certify.yml) GitHub Actions workflow.
 
-### What's Certified
+### Certification Compliance
 
-- **Base image**: `registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24` (Red Hat UBI 9)
-- **Non-root execution**: Runs as user `185` (not root)
-- **Licenses**: Auto-generated `/licenses` directory containing `THIRD-PARTY.txt` and downloaded license texts for all runtime dependencies
-- **Required labels**: `name`, `vendor`, `version`, `release`, `summary`, `description` plus OpenShift labels (`io.k8s.display-name`, `io.openshift.tags`)
+| Requirement | Implementation |
+|---|---|
+| **Base image** | `registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24` (pinned by SHA256 digest) |
+| **Non-root execution** | Runs as UID `185` — the default `jboss` user |
+| **Licenses** | Auto-generated `/licenses` directory containing `THIRD-PARTY.txt` and downloaded license texts |
+| **Required labels** | `name`, `vendor`, `version`, `release`, `summary`, `description` |
+| **OpenShift labels** | `io.k8s.display-name`, `io.k8s.description`, `io.openshift.tags` |
+| **Health check** | Docker-native `HEALTHCHECK` on `/q/health/ready` |
+| **Security scanning** | Trivy image scan in CI blocks push on OS-level CVEs |
 
 ### Automated Certification Workflow
 
 The certification release process is fully automated:
 
-1. **Build** — `mvnw clean package` builds the app and auto-generates license files via the `license-maven-plugin`
+1. **Build** — `mvnw clean package -Plicense-gen` builds the application and auto-generates license files via the [MojoHaus license-maven-plugin](https://www.mojohaus.org/license-maven-plugin/)
 2. **Docker build** — Builds the image with Red Hat certification labels (parameterized via `--build-arg`)
 3. **Push** — Pushes to Docker Hub (or Quay.io when configured)
 4. **Preflight** — Runs the [Red Hat preflight tool](https://github.com/redhat-openshift-ecosystem/openshift-preflight) to validate certification requirements
 5. **Submit** — Optionally submits results to Red Hat Partner Connect for review
 
 To trigger a certification release, go to **Actions → Red Hat Certification Release → Run workflow** and provide:
-- `version` — EDDI version (e.g., `6.0.0`)
+
+- `version` — EDDI version (e.g., `6.0.2`)
 - `release` — Incremental release number (e.g., `1`, `2`, `3`)
 - `submit` — Whether to submit results to Red Hat (`true`/`false`)
 - `registry` — Target registry (`docker.io` or `quay.io`)
+
+### Preflight Quality Gate
+
+Every push to `main` or release tag that produces a Docker image is validated by a **preflight check** in CI. Pull requests also run a preflight dry-run. This catches certification regressions before they reach production (e.g., missing labels, license issues, prohibited packages).
 
 ### Required GitHub Secrets
 
@@ -40,9 +81,11 @@ To trigger a certification release, go to **Actions → Red Hat Certification Re
 | `QUAY_USERNAME` | Quay.io robot account (optional, for Quay.io publishing) |
 | `QUAY_PASSWORD` | Quay.io password (optional) |
 
-### License Automation
+---
 
-Licenses are generated on-demand using the [MojoHaus license-maven-plugin](https://www.mojohaus.org/license-maven-plugin/) via the `license-gen` Maven profile:
+## License Automation
+
+Third-party licenses are generated on-demand using the `license-gen` Maven profile:
 
 ```bash
 ./mvnw package -Plicense-gen -DskipTests
@@ -50,41 +93,37 @@ Licenses are generated on-demand using the [MojoHaus license-maven-plugin](https
 
 This generates:
 
-- `licenses/THIRD-PARTY.txt` — Lists all runtime dependencies with their license names
-- `licenses/third-party/` — Downloaded license text files for each dependency
-- `licenses/licenses.xml` — Machine-readable license index
+| File | Contents |
+|---|---|
+| `licenses/THIRD-PARTY.txt` | All runtime dependencies with their license names |
+| `licenses/third-party/` | Downloaded license text files for each dependency |
+| `licenses/licenses.xml` | Machine-readable license index |
 
-The profile is **not activated during normal dev builds** to keep them fast. CI workflows (`redhat-certify.yml`, `ci.yml` preflight, `docker-publish.yml`) activate it automatically.
+The profile is **not activated during normal dev builds** to keep them fast. CI workflows (`redhat-certify.yml`, `ci.yml`) activate it automatically.
 
-These files are **not committed to git** — they're always fresh and accurate in the Docker image.
+These files are **not committed to git** — they're generated fresh and accurate in every Docker image build.
 
-### Preflight Quality Gate
+---
 
-Every pull request to `main` runs a **preflight dry-run** as part of CI. This catches certification regressions before they're merged (e.g., missing labels, license issues, prohibited packages).
-
-## EDDI Operator
+## EDDI Operator for OpenShift
 
 [![Docker Repository on Quay](https://quay.io/repository/labsai/eddi-operator/status)](https://quay.io/repository/labsai/eddi-operator)
 
-### Usage
+### Prerequisites
 
-#### OpenShift Setup
+- OpenShift 4.12+ deployment
+- Block storage (preferably with a storage class)
 
-**Prerequisites**
+### Installing from OperatorHub
 
-* OpenShift 4.3+ Deployment
-* Block Storage (preferably with storage class)
+1. Navigate to **Operators → OperatorHub** in the OpenShift Admin console
+2. Search for "EDDI" and select the operator
+3. Click **Install** — leave defaults (All Namespaces, Update Channel `alpha`, Approval Strategy `Automatic`)
+4. Click **Subscribe**
 
-**Installing the Operator from the RedHat Marketplace**
+### Creating an EDDI Instance
 
-1. Head to the Operator section in the Admin Overview and go to the OperatorHub
-2. Choose which version of the EDDI Operator to use (Marketplace or normal)
-3. Click install and leave the defaults (All Namespaces, Update Channel alpha and Approval Strategy Automatic)
-4. Click subscribe
-
-**Using the operator**
-
-After the installation of the operator, go to the installed Operators menu point and click on the first EDDI menu on top and create a new Instance. Below is a minimal CustomResource. The storageclass\_name has to be changed to the name of an existing StorageClass, the environment variable will be added as a label to the mongoDB deployment.
+After installation, go to **Installed Operators → EDDI** and create a new instance:
 
 ```yaml
 apiVersion: labs.ai/v1alpha1
@@ -99,6 +138,38 @@ spec:
     storage_size: 20G
 ```
 
-The operator will create a route automatically so you can access the EDDI admin panel. Per default the route will take the name of the CR. With the CR from above the route would look like this: `eddi-route-$NAMESPACE.apps.ocp.example.com` ($NAMESPACE will be the name of the project where the CR was created.)
+The operator creates a route automatically. With the CR above, the route would be:
+`eddi-route-$NAMESPACE.apps.ocp.example.com`
 
-> **Note:** The EDDI operator is being updated for v6 to support both MongoDB and PostgreSQL storage backends. Stay tuned for the updated operator release.
+> **Note**: The EDDI operator is being updated for v6 to support both MongoDB and PostgreSQL storage backends. Stay tuned for the updated operator release.
+
+---
+
+## Docker Image Details
+
+| Property | Value |
+|---|---|
+| **Image** | `docker.io/labsai/eddi` |
+| **Base** | `registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24` |
+| **Digest pinning** | SHA256 digest for supply-chain integrity (OpenSSF Silver) |
+| **User** | `185` (non-root) |
+| **Port** | `7070` |
+| **Health endpoint** | `GET /q/health/ready` |
+| **Java** | OpenJDK 25 (Red Hat build) |
+| **Framework** | Quarkus 3.34.x |
+
+### Quick Start
+
+```bash
+docker pull labsai/eddi:latest
+docker run -i --rm -p 7070:7070 labsai/eddi
+```
+
+For production deployments with MongoDB:
+
+```bash
+docker run -d \
+  -p 7070:7070 \
+  -e QUARKUS_MONGODB_CONNECTION_STRING=mongodb://mongo:27017 \
+  labsai/eddi:6.0.2
+```


### PR DESCRIPTION
- Add explicit Platform Support section with RHEL 9 compatibility statement
- Replace sunset Red Hat Marketplace links (shutdown April 2025) with Red Hat Ecosystem Catalog
- Remove old Red Hat catalog container URL that 404s
- Add certification compliance table matching actual Dockerfile labels
- Document automated preflight workflow (PR dry-run + push verification)
- Update doc references in README.md and docs/README.md
- Correct preflight quality gate wording to cover main + tags + PRs