### PR TITLE
fix(metrics): prevent bogus Slack deltas from stale/missing baselines

### DIFF
--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -2,15 +2,21 @@ name: Project Metrics Tracker
 
 on:
   schedule:
-    - cron: '*/15 * * * *' # every 15 min — collect metrics + push to analytics
-    - cron: '0 18 * * *'    # daily — 6pm UTC, digest (only if activity)
-    - cron: '0 9 * * 0'    # weekly — Sunday 9am UTC, Slack digest
+    # Offset to :05 to avoid overlapping with daily (18:00) and weekly (09:00)
+    - cron: '5,20,35,50 * * * *' # every 15 min — collect metrics + push to analytics
+    - cron: '0 18 * * *'          # daily — 6pm UTC, digest (only if activity)
+    - cron: '0 9 * * 0'           # weekly — Sunday 9am UTC, Slack digest
   workflow_dispatch:
     inputs:
       force_digest:
         description: 'Send weekly digest now'
         type: boolean
         default: false
+
+# Prevent overlapping runs from racing on the shared cache
+concurrency:
+  group: project-metrics
+  cancel-in-progress: false
 
 permissions:
   contents: read   # repo metadata + traffic API
@@ -46,8 +52,19 @@ jobs:
             echo "day_forks=$(jq -r '.day_forks // 0' metrics.json)" >> "$GITHUB_OUTPUT"
             echo "last_milestone=$(jq -r '.last_milestone // 0' metrics.json)" >> "$GITHUB_OUTPUT"
             echo "has_data=true" >> "$GITHUB_OUTPUT"
+
+            # Detect whether day/week baseline fields actually exist in the cached JSON.
+            # Legacy caches from before these fields were added will be missing them,
+            # and jq defaults them to 0 above — but 0 can also be a legitimate value.
+            # Field-presence is the only reliable way to distinguish "missing" from "zero".
+            DAY_PRESENT=$(jq 'has("day_docker") and has("day_stars") and has("day_forks")' metrics.json)
+            WEEK_PRESENT=$(jq 'has("week_docker") and has("week_stars") and has("week_forks")' metrics.json)
+            echo "day_fields_present=$DAY_PRESENT" >> "$GITHUB_OUTPUT"
+            echo "week_fields_present=$WEEK_PRESENT" >> "$GITHUB_OUTPUT"
           else
             echo "has_data=false" >> "$GITHUB_OUTPUT"
+            echo "day_fields_present=false" >> "$GITHUB_OUTPUT"
+            echo "week_fields_present=false" >> "$GITHUB_OUTPUT"
             for key in docker_pulls stars forks week_docker week_stars week_forks day_docker day_stars day_forks last_milestone; do
               echo "${key}=0" >> "$GITHUB_OUTPUT"
             done
@@ -103,6 +120,24 @@ jobs:
           echo "clones=$CLONES" >> "$GITHUB_OUTPUT"
           echo "Views: $VIEWS (uniques: $UNIQUES), Clones: $CLONES"
 
+      # ── Detect trigger type ──────────────────────────────────
+      - name: Detect schedule type
+        id: schedule
+        run: |
+          SCHEDULE="${{ github.event.schedule }}"
+          FORCE="${{ github.event.inputs.force_digest }}"
+
+          # Determine which schedule triggered this run
+          if [ "$SCHEDULE" = "0 18 * * *" ]; then
+            TYPE="daily"
+          elif [ "$SCHEDULE" = "0 9 * * 0" ] || [ "$FORCE" = "true" ]; then
+            TYPE="weekly"
+          else
+            TYPE="collect"
+          fi
+          echo "type=$TYPE" >> "$GITHUB_OUTPUT"
+          echo "Schedule: '$SCHEDULE' → type=$TYPE"
+
       # ── Compute deltas ──────────────────────────────────────
       - name: Compute deltas
         id: delta
@@ -129,6 +164,32 @@ jobs:
             echo "milestone=$CURRENT_MS" >> "$GITHUB_OUTPUT"
           else
             echo "milestone=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Validate baselines ──────────────────────────────────
+      # Use field-presence (not > 0) to distinguish "missing from legacy cache"
+      # from "legitimately zero". A repo with 0 forks should still get digests.
+      - name: Validate baselines
+        id: baselines
+        run: |
+          HAS_DATA="${{ steps.prev.outputs.has_data }}"
+          DAY_PRESENT="${{ steps.prev.outputs.day_fields_present }}"
+          WEEK_PRESENT="${{ steps.prev.outputs.week_fields_present }}"
+
+          # Day baselines are valid only if cache existed AND the fields were present
+          if [ "$HAS_DATA" = "true" ] && [ "$DAY_PRESENT" = "true" ]; then
+            echo "day_valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "day_valid=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️  Day baselines invalid (has_data=$HAS_DATA, day_fields_present=$DAY_PRESENT)"
+          fi
+
+          # Week baselines are valid only if cache existed AND the fields were present
+          if [ "$HAS_DATA" = "true" ] && [ "$WEEK_PRESENT" = "true" ]; then
+            echo "week_valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "week_valid=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️  Week baselines invalid (has_data=$HAS_DATA, week_fields_present=$WEEK_PRESENT)"
           fi
 
       # ── Push to analytics (always, if data changed) ─────────
@@ -212,12 +273,17 @@ jobs:
       # ── Weekly digest (Sunday or manual) ────────────────────
       - name: Weekly digest
         if: >-
-          (github.event.schedule == '0 9 * * 0' || github.event.inputs.force_digest == 'true')
-          && steps.prev.outputs.has_data == 'true'
+          steps.schedule.outputs.type == 'weekly'
+          && steps.baselines.outputs.week_valid == 'true'
         continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then
+            echo "No SLACK_WEBHOOK_URL configured, skipping"
+            exit 0
+          fi
+
           PULLS=${{ steps.docker.outputs.pulls }}
           STARS=${{ steps.github.outputs.stars }}
           FORKS=${{ steps.github.outputs.forks }}
@@ -266,8 +332,8 @@ jobs:
       # ── Daily digest (only if activity) ──────────────────────
       - name: Daily digest
         if: >-
-          github.event.schedule == '0 18 * * *'
-          && steps.prev.outputs.has_data == 'true'
+          steps.schedule.outputs.type == 'daily'
+          && steps.baselines.outputs.day_valid == 'true'
         continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -327,46 +393,60 @@ jobs:
       # ── Save updated metrics ────────────────────────────────
       - name: Build metrics snapshot
         run: |
-          IS_WEEKLY="${{ github.event.schedule == '0 9 * * 0' || github.event.inputs.force_digest == 'true' }}"
-          IS_DAILY="${{ github.event.schedule == '0 18 * * *' }}"
+          SCHED_TYPE="${{ steps.schedule.outputs.type }}"
 
-          # On weekly digest, reset the week baseline
-          if [ "$IS_WEEKLY" = "true" ]; then
-            WEEK_DOCKER=${{ steps.docker.outputs.pulls }}
-            WEEK_STARS=${{ steps.github.outputs.stars }}
-            WEEK_FORKS=${{ steps.github.outputs.forks }}
+          CUR_PULLS=${{ steps.docker.outputs.pulls }}
+          CUR_STARS=${{ steps.github.outputs.stars }}
+          CUR_FORKS=${{ steps.github.outputs.forks }}
+
+          WEEK_VALID="${{ steps.baselines.outputs.week_valid }}"
+          DAY_VALID="${{ steps.baselines.outputs.day_valid }}"
+
+          # ── Determine week baseline ──
+          # Uses the same field-presence check as the Validate step
+          if [ "$WEEK_VALID" != "true" ]; then
+            # No prior data or legacy cache missing week fields — seed from current
+            WEEK_DOCKER=$CUR_PULLS
+            WEEK_STARS=$CUR_STARS
+            WEEK_FORKS=$CUR_FORKS
+          elif [ "$SCHED_TYPE" = "weekly" ]; then
+            # Weekly digest just sent — reset baseline to now
+            WEEK_DOCKER=$CUR_PULLS
+            WEEK_STARS=$CUR_STARS
+            WEEK_FORKS=$CUR_FORKS
           else
+            # Preserve existing baseline
             WEEK_DOCKER=${{ steps.prev.outputs.week_docker }}
             WEEK_STARS=${{ steps.prev.outputs.week_stars }}
             WEEK_FORKS=${{ steps.prev.outputs.week_forks }}
           fi
 
-          # On daily digest (or weekly), reset the day baseline
-          if [ "$IS_DAILY" = "true" ] || [ "$IS_WEEKLY" = "true" ]; then
-            DAY_DOCKER=${{ steps.docker.outputs.pulls }}
-            DAY_STARS=${{ steps.github.outputs.stars }}
-            DAY_FORKS=${{ steps.github.outputs.forks }}
+          # ── Determine day baseline ──
+          # Uses the same field-presence check as the Validate step
+          if [ "$DAY_VALID" != "true" ]; then
+            # No prior data or legacy cache missing day fields — seed from current
+            DAY_DOCKER=$CUR_PULLS
+            DAY_STARS=$CUR_STARS
+            DAY_FORKS=$CUR_FORKS
+          elif [ "$SCHED_TYPE" = "daily" ] || [ "$SCHED_TYPE" = "weekly" ]; then
+            # Daily/weekly digest just sent — reset baseline to now
+            DAY_DOCKER=$CUR_PULLS
+            DAY_STARS=$CUR_STARS
+            DAY_FORKS=$CUR_FORKS
           else
+            # Preserve existing baseline
             DAY_DOCKER=${{ steps.prev.outputs.day_docker }}
             DAY_STARS=${{ steps.prev.outputs.day_stars }}
             DAY_FORKS=${{ steps.prev.outputs.day_forks }}
           fi
 
-          # First run: initialize baselines
-          [ "$WEEK_DOCKER" = "0" ] && WEEK_DOCKER=${{ steps.docker.outputs.pulls }}
-          [ "$WEEK_STARS" = "0" ] && WEEK_STARS=${{ steps.github.outputs.stars }}
-          [ "$WEEK_FORKS" = "0" ] && WEEK_FORKS=${{ steps.github.outputs.forks }}
-          [ "$DAY_DOCKER" = "0" ] && DAY_DOCKER=${{ steps.docker.outputs.pulls }}
-          [ "$DAY_STARS" = "0" ] && DAY_STARS=${{ steps.github.outputs.stars }}
-          [ "$DAY_FORKS" = "0" ] && DAY_FORKS=${{ steps.github.outputs.forks }}
-
           # Current milestone marker
-          CURRENT_MS=$(( ${{ steps.docker.outputs.pulls }} / 10000 * 10000 ))
+          CURRENT_MS=$(( CUR_PULLS / 10000 * 10000 ))
 
           jq -n \
-            --argjson docker_pulls "${{ steps.docker.outputs.pulls }}" \
-            --argjson stars "${{ steps.github.outputs.stars }}" \
-            --argjson forks "${{ steps.github.outputs.forks }}" \
+            --argjson docker_pulls "$CUR_PULLS" \
+            --argjson stars "$CUR_STARS" \
+            --argjson forks "$CUR_FORKS" \
             --argjson week_docker "$WEEK_DOCKER" \
             --argjson week_stars "$WEEK_STARS" \
             --argjson week_forks "$WEEK_FORKS" \


### PR DESCRIPTION
Three root causes fixed:
- Schema evolution: day_* fields missing from legacy cache caused jq to return 0, making deltas equal to full cumulative totals
- Schedule collision: */15 cron fired at :00 same minute as daily/weekly, causing concurrent runs to race on cache and overwrite reset baselines
- No concurrency control: parallel runs could corrupt shared cache state

Changes:
- Offset collection cron to :05,:20,:35,:50 to avoid overlap
- Add concurrency group (queue, not cancel) to prevent cache races
- Add dedicated baseline validation step (day_valid/week_valid) that gates digest sending on has_data=true AND all baselines > 0
- Add schedule type detection step as single source of truth
- Seed baselines from current values on cache miss or uninitialized fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted scheduled job timing to reduce notification overlaps and spread dispatches more evenly.
  * Serialized workflow runs to prevent concurrent execution conflicts and improve reliability.
  * Improved metrics baseline validation to preserve correct day/week counts and reduce incorrect resets.
  * Added runtime safeguards to skip notifications when delivery configuration is not set, avoiding erroneous alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->