### PR TITLE
fix(cli): refresh compose files on eddi update

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -584,6 +584,7 @@ function Get-ComposeFiles {
 COMPOSE_FILES=$($ComposeFiles -join " ")
 EDDI_PORT=$EddiPort
 EDDI_HTTPS_PORT=$EddiHttpsPort
+EDDI_BRANCH=$EddiBranch
 "@ | Set-Content -Path $configPath
 
     # Write .env file for docker compose variable substitution
@@ -829,11 +830,17 @@ rem Safe config parsing — only extract known keys to prevent variable injectio
 set "COMPOSE_FILES="
 set "EDDI_PORT="
 set "EDDI_HTTPS_PORT="
+set "CFG_BRANCH="
 for /f "usebackq tokens=1,* delims==" %%A in ("%CONFIG_FILE%") do (
     if "%%A"=="COMPOSE_FILES" set "COMPOSE_FILES=%%B"
     if "%%A"=="EDDI_PORT" set "EDDI_PORT=%%B"
     if "%%A"=="EDDI_HTTPS_PORT" set "EDDI_HTTPS_PORT=%%B"
+    if "%%A"=="EDDI_BRANCH" set "CFG_BRANCH=%%B"
 )
+if not defined EDDI_BRANCH (
+    if defined CFG_BRANCH (set "EDDI_BRANCH=!CFG_BRANCH!") else (set "EDDI_BRANCH=main")
+)
+set "COMPOSE_BASE_URL=https://raw.githubusercontent.com/labsai/EDDI/!EDDI_BRANCH!"
 
 rem Build compose flags with delayed expansion for proper quoting
 set "FLAGS=--env-file "%ENV_FILE%""
@@ -882,6 +889,17 @@ docker compose %FLAGS% logs %1 %2 %3 %4 %5 %6 %7 %8 %9
 goto :eof
 
 :cmd_update
+echo Refreshing compose files from GitHub...
+for %%F in (%COMPOSE_FILES%) do (
+    for %%N in (%%~nxF) do (
+        echo   Updating %%N...
+        curl -fsSL "%COMPOSE_BASE_URL%/%%N" -o "%%F.tmp" 2>nul && move /y "%%F.tmp" "%%F" >nul 2>nul || (
+            del "%%F.tmp" 2>nul
+            echo   Warning: could not update %%N, keeping existing file
+        )
+    )
+)
+echo.
 echo Pulling latest images...
 docker compose %FLAGS% pull
 docker compose %FLAGS% up -d
@@ -918,7 +936,7 @@ echo   stop        Stop EDDI containers
 echo   restart     Restart EDDI containers
 echo   status      Show health and agent count
 echo   logs [-f]   View container logs
-echo   update      Pull latest images and restart
+echo   update      Refresh configs, pull latest images, restart
 echo   uninstall   Remove EDDI and all data
 goto :eof
 "@

--- a/install.sh
+++ b/install.sh
@@ -642,6 +642,7 @@ resolve_compose_files() {
   echo "COMPOSE_FILES=${COMPOSE_FILES[*]}" > "$EDDI_DIR/.eddi-config"
   echo "EDDI_PORT=$EDDI_PORT" >> "$EDDI_DIR/.eddi-config"
   echo "EDDI_HTTPS_PORT=$EDDI_HTTPS_PORT" >> "$EDDI_DIR/.eddi-config"
+  echo "EDDI_BRANCH=$EDDI_BRANCH" >> "$EDDI_DIR/.eddi-config"
 
   # Write .env file for docker compose variable substitution
   # Escape double quotes in vault key to prevent .env corruption
@@ -866,6 +867,13 @@ fi
 _cfg() { grep "^$1=" "$CONFIG_FILE" 2>/dev/null | head -1 | cut -d= -f2- | sed 's/^"//;s/"$//'; }
 EDDI_PORT=$(_cfg EDDI_PORT)
 EDDI_HTTPS_PORT=$(_cfg EDDI_HTTPS_PORT)
+EDDI_BRANCH="${EDDI_BRANCH:-$(_cfg EDDI_BRANCH)}"
+EDDI_BRANCH="${EDDI_BRANCH:-main}"
+if [[ ! "$EDDI_BRANCH" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+  echo "Invalid EDDI_BRANCH: $EDDI_BRANCH" >&2
+  exit 1
+fi
+COMPOSE_BASE_URL="https://raw.githubusercontent.com/labsai/EDDI/${EDDI_BRANCH}"
 
 # Parse compose files into array (handles paths with spaces)
 read -ra COMPOSE_FILE_LIST <<< "$(_cfg COMPOSE_FILES)"
@@ -907,6 +915,21 @@ case "${1:-help}" in
     docker compose "${compose_args[@]}" logs "${@}"
     ;;
   update)
+    echo "Refreshing compose files from GitHub..."
+    for f in "${COMPOSE_FILE_LIST[@]}"; do
+      local_name=$(basename "$f")
+      download_url="${COMPOSE_BASE_URL}/${local_name}"
+      tmp_file="${f}.tmp"
+      echo -n "  Updating ${local_name}... "
+      if curl -fsSL "${download_url}" -o "$tmp_file" 2>/dev/null && [[ -s "$tmp_file" ]]; then
+        mv -f "$tmp_file" "$f"
+        echo "✅"
+      else
+        rm -f "$tmp_file"
+        echo "⚠️  (keeping existing file)"
+      fi
+    done
+    echo ""
     echo "Pulling latest images..."
     docker compose "${compose_args[@]}" pull
     docker compose "${compose_args[@]}" up -d
@@ -937,7 +960,7 @@ case "${1:-help}" in
     echo "  restart     Restart EDDI containers"
     echo "  status      Show health and agent count"
     echo "  logs [-f]   View container logs"
-    echo "  update      Pull latest images and restart"
+    echo "  update      Refresh configs, pull latest images, restart"
     echo "  uninstall   Remove EDDI and all data"
     ;;
 esac


### PR DESCRIPTION
The 'eddi update' command only pulled new Docker images but never refreshed the compose files in ~/.eddi/. Users upgrading from 6.0.1 to 6.0.2 kept the old compose file missing the new EDDI_SECURITY_ALLOW_UNAUTHENTICATED env var, causing EDDI to fail on startup.

Now 'eddi update' re-downloads all compose files from GitHub before pulling images, ensuring new env vars and config changes are picked up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `eddi update` command now refreshes local compose/config files from the repository before pulling images and restarting services; failed downloads keep existing files to preserve stability.
* **Documentation**
  * Updated `update` help text to describe the new "refresh configs + pull latest images + restart" behavior and installer now persists the selected branch choice (defaults to main).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->