### PR TITLE
fix(utils): guard Boolean branch in MatchingUtilities behind existence check

### DIFF
--- a/.clusterfuzzlite/MatchingUtilities.java
+++ b/.clusterfuzzlite/MatchingUtilities.java
@@ -8,30 +8,35 @@ import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
 public class MatchingUtilities {
     public static boolean executeValuePath(Map<String, Object> conversationValues, String valuePath, String equals, String contains) {
 
-        boolean success = false;
-
         Object value = null;
         try {
             value = PathNavigator.getValue(valuePath, conversationValues);
         } catch (Exception _) {
             // no value was found, which is an expected case, so silent exception here
         }
-        if (value != null) {
-            if (!isNullOrEmpty(equals) && equals.equals(value.toString())) {
-                success = true;
-            } else if (!isNullOrEmpty(contains)) {
-                if (value instanceof String s && s.contains(contains)) {
-                    success = true;
-                } else if (value instanceof List<?> l && l.contains(contains)) {
-                    success = true;
-                }
-            } else if (value instanceof Boolean b) {
-                success = b;
-            } else if (isNullOrEmpty(equals) && isNullOrEmpty(contains)) {
-                success = true;
-            }
+
+        if (value == null) {
+            return false;
         }
 
-        return success;
+        if (!isNullOrEmpty(equals) && equals.equals(value.toString())) {
+            return true;
+        } else if (!isNullOrEmpty(contains)) {
+            if (value instanceof String s && s.contains(contains)) {
+                return true;
+            } else if (value instanceof List<?> l && l.contains(contains)) {
+                return true;
+            }
+        } else if (isNullOrEmpty(equals) && isNullOrEmpty(contains)) {
+            // Pure existence check — no comparison operators specified.
+            // For Booleans, return the value itself (false = condition fails).
+            // For any other non-null value, existence alone means success.
+            if (value instanceof Boolean b) {
+                return b;
+            }
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/ai/labs/eddi/utils/MatchingUtilities.java
+++ b/src/main/java/ai/labs/eddi/utils/MatchingUtilities.java
@@ -8,30 +8,35 @@ import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
 public class MatchingUtilities {
     public static boolean executeValuePath(Map<String, Object> conversationValues, String valuePath, String equals, String contains) {
 
-        boolean success = false;
-
         Object value = null;
         try {
             value = PathNavigator.getValue(valuePath, conversationValues);
         } catch (Exception _) {
             // no value was found, which is an expected case, so silent exception here
         }
-        if (value != null) {
-            if (!isNullOrEmpty(equals) && equals.equals(value.toString())) {
-                success = true;
-            } else if (!isNullOrEmpty(contains)) {
-                if (value instanceof String s && s.contains(contains)) {
-                    success = true;
-                } else if (value instanceof List<?> l && l.contains(contains)) {
-                    success = true;
-                }
-            } else if (value instanceof Boolean b) {
-                success = b;
-            } else if (isNullOrEmpty(equals) && isNullOrEmpty(contains)) {
-                success = true;
-            }
+
+        if (value == null) {
+            return false;
         }
 
-        return success;
+        if (!isNullOrEmpty(equals) && equals.equals(value.toString())) {
+            return true;
+        } else if (!isNullOrEmpty(contains)) {
+            if (value instanceof String s && s.contains(contains)) {
+                return true;
+            } else if (value instanceof List<?> l && l.contains(contains)) {
+                return true;
+            }
+        } else if (isNullOrEmpty(equals) && isNullOrEmpty(contains)) {
+            // Pure existence check — no comparison operators specified.
+            // For Booleans, return the value itself (false = condition fails).
+            // For any other non-null value, existence alone means success.
+            if (value instanceof Boolean b) {
+                return b;
+            }
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/test/java/ai/labs/eddi/utils/MatchingUtilitiesTest.java
+++ b/src/test/java/ai/labs/eddi/utils/MatchingUtilitiesTest.java
@@ -1,5 +1,6 @@
 package ai.labs.eddi.utils;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -10,62 +11,288 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class MatchingUtilitiesTest {
 
-    @Test
-    void executeValuePath_equalsMatch_returnsTrue() {
-        Map<String, Object> values = Map.of("name", "John");
-        assertTrue(MatchingUtilities.executeValuePath(values, "name", "John", null));
+    // ── Null / missing value paths ─────────────────────────────────
+
+    @Nested
+    class NullAndMissingValues {
+
+        @Test
+        void nullValue_returnsFalse() {
+            Map<String, Object> values = new HashMap<>();
+            values.put("key", null);
+            assertFalse(MatchingUtilities.executeValuePath(values, "key", null, null));
+        }
+
+        @Test
+        void emptyMap_returnsFalse() {
+            assertFalse(MatchingUtilities.executeValuePath(
+                    new HashMap<>(), "key", "val", null));
+        }
+
+        @Test
+        void nullValuePath_returnsFalse() {
+            assertFalse(MatchingUtilities.executeValuePath(
+                    Map.of("key", "value"), null, null, null));
+        }
+
+        @Test
+        void emptyValuePath_returnsFalse() {
+            assertFalse(MatchingUtilities.executeValuePath(
+                    Map.of("key", "value"), "", null, null));
+        }
+
+        @Test
+        void invalidPath_returnsFalse() {
+            // Unresolvable nested paths return null, so executeValuePath should return
+            // false
+            assertFalse(MatchingUtilities.executeValuePath(
+                    Map.of("a", "b"), "a.b.c.d.e", "something", null));
+        }
     }
 
-    @Test
-    void executeValuePath_equalsMismatch_returnsFalse() {
-        Map<String, Object> values = Map.of("name", "John");
-        assertFalse(MatchingUtilities.executeValuePath(values, "name", "Jane", null));
+    // ── Equals checks ──────────────────────────────────────────────
+
+    @Nested
+    class EqualsChecks {
+
+        @Test
+        void equalsMatch_returnsTrue() {
+            Map<String, Object> values = Map.of("name", "John");
+            assertTrue(MatchingUtilities.executeValuePath(values, "name", "John", null));
+        }
+
+        @Test
+        void equalsMismatch_returnsFalse() {
+            Map<String, Object> values = Map.of("name", "John");
+            assertFalse(MatchingUtilities.executeValuePath(values, "name", "Jane", null));
+        }
+
+        @Test
+        void equalsWithEmptyString_equalsIsEmpty_treatedAsNoEquals() {
+            // isNullOrEmpty("") returns true, so empty equals = existence check
+            Map<String, Object> values = Map.of("name", "John");
+            assertTrue(MatchingUtilities.executeValuePath(values, "name", "", null));
+        }
+
+        @Test
+        void equalsOnIntegerValue_usesToString() {
+            Map<String, Object> values = Map.of("count", 42);
+            assertTrue(MatchingUtilities.executeValuePath(values, "count", "42", null));
+        }
+
+        @Test
+        void equalsOnIntegerValue_mismatch_returnsFalse() {
+            Map<String, Object> values = Map.of("count", 42);
+            assertFalse(MatchingUtilities.executeValuePath(values, "count", "99", null));
+        }
+
+        @Test
+        void equalsOnDoubleValue_usesToString() {
+            Map<String, Object> values = Map.of("price", 19.99);
+            assertTrue(MatchingUtilities.executeValuePath(values, "price", "19.99", null));
+        }
     }
 
-    @Test
-    void executeValuePath_containsInString_returnsTrue() {
-        Map<String, Object> values = Map.of("greeting", "hello world");
-        assertTrue(MatchingUtilities.executeValuePath(values, "greeting", null, "world"));
+    // ── Contains checks ────────────────────────────────────────────
+
+    @Nested
+    class ContainsChecks {
+
+        @Test
+        void containsInString_returnsTrue() {
+            Map<String, Object> values = Map.of("greeting", "hello world");
+            assertTrue(MatchingUtilities.executeValuePath(values, "greeting", null, "world"));
+        }
+
+        @Test
+        void containsNotInString_returnsFalse() {
+            Map<String, Object> values = Map.of("greeting", "hello world");
+            assertFalse(MatchingUtilities.executeValuePath(values, "greeting", null, "xyz"));
+        }
+
+        @Test
+        void containsInList_returnsTrue() {
+            Map<String, Object> values = Map.of("tags", List.of("red", "blue", "green"));
+            assertTrue(MatchingUtilities.executeValuePath(values, "tags", null, "blue"));
+        }
+
+        @Test
+        void containsNotInList_returnsFalse() {
+            Map<String, Object> values = Map.of("tags", List.of("red", "blue"));
+            assertFalse(MatchingUtilities.executeValuePath(values, "tags", null, "yellow"));
+        }
+
+        @Test
+        void containsOnNonStringNonList_returnsFalse() {
+            // Integer is neither String nor List — contains can't match
+            Map<String, Object> values = Map.of("count", 42);
+            assertFalse(MatchingUtilities.executeValuePath(values, "count", null, "42"));
+        }
+
+        @Test
+        void containsOnBoolean_returnsFalse() {
+            // Boolean is neither String nor List — contains can't match
+            Map<String, Object> values = Map.of("active", true);
+            assertFalse(MatchingUtilities.executeValuePath(values, "active", null, "true"));
+        }
+
+        @Test
+        void containsWithEmptyString_treatedAsNoContains() {
+            // isNullOrEmpty("") returns true, so empty contains = existence check
+            Map<String, Object> values = Map.of("key", "anyValue");
+            assertTrue(MatchingUtilities.executeValuePath(values, "key", null, ""));
+        }
     }
 
-    @Test
-    void executeValuePath_containsInList_returnsTrue() {
-        Map<String, Object> values = Map.of("tags", List.of("red", "blue", "green"));
-        assertTrue(MatchingUtilities.executeValuePath(values, "tags", null, "blue"));
+    // ── Boolean value handling ──────────────────────────────────────
+
+    @Nested
+    class BooleanValues {
+
+        @Test
+        void booleanTrue_existenceCheck_returnsTrue() {
+            Map<String, Object> values = Map.of("active", true);
+            assertTrue(MatchingUtilities.executeValuePath(values, "active", null, null));
+        }
+
+        @Test
+        void booleanFalse_existenceCheck_returnsFalse() {
+            Map<String, Object> values = Map.of("active", false);
+            assertFalse(MatchingUtilities.executeValuePath(values, "active", null, null));
+        }
+
+        @Test
+        void booleanTrue_equalsTrue_returnsTrue() {
+            // Normal type-conversion path via toString()
+            Map<String, Object> values = Map.of("active", true);
+            assertTrue(MatchingUtilities.executeValuePath(values, "active", "true", null));
+        }
+
+        @Test
+        void booleanFalse_equalsFalse_returnsTrue() {
+            // Normal type-conversion path via toString()
+            Map<String, Object> values = Map.of("active", false);
+            assertTrue(MatchingUtilities.executeValuePath(values, "active", "false", null));
+        }
+
+        @Test
+        void booleanTrue_equalsFalse_returnsFalse() {
+            // THE BUG FIX: equals says "false" but value is true — should fail
+            Map<String, Object> values = Map.of("active", true);
+            assertFalse(MatchingUtilities.executeValuePath(values, "active", "false", null));
+        }
+
+        @Test
+        void booleanFalse_equalsTrue_returnsFalse() {
+            // equals says "true" but value is false — should fail
+            Map<String, Object> values = Map.of("active", false);
+            assertFalse(MatchingUtilities.executeValuePath(values, "active", "true", null));
+        }
+
+        @Test
+        void booleanTrue_equalsArbitraryString_returnsFalse() {
+            // THE BUG FIX: equals says "yes" but value is Boolean(true)
+            // Previously returned true (Boolean branch override), now correctly returns
+            // false
+            Map<String, Object> values = Map.of("active", true);
+            assertFalse(MatchingUtilities.executeValuePath(values, "active", "yes", null));
+        }
+
+        @Test
+        void booleanFalse_equalsArbitraryString_returnsFalse() {
+            Map<String, Object> values = Map.of("active", false);
+            assertFalse(MatchingUtilities.executeValuePath(values, "active", "no", null));
+        }
     }
 
-    @Test
-    void executeValuePath_containsNotInList_returnsFalse() {
-        Map<String, Object> values = Map.of("tags", List.of("red", "blue"));
-        assertFalse(MatchingUtilities.executeValuePath(values, "tags", null, "yellow"));
+    // ── Existence checks (no equals, no contains) ──────────────────
+
+    @Nested
+    class ExistenceChecks {
+
+        @Test
+        void existsCheck_stringValue_returnsTrue() {
+            Map<String, Object> values = Map.of("key", "anyValue");
+            assertTrue(MatchingUtilities.executeValuePath(values, "key", null, null));
+        }
+
+        @Test
+        void existsCheck_integerValue_returnsTrue() {
+            Map<String, Object> values = Map.of("count", 42);
+            assertTrue(MatchingUtilities.executeValuePath(values, "count", null, null));
+        }
+
+        @Test
+        void existsCheck_listValue_returnsTrue() {
+            Map<String, Object> values = Map.of("items", List.of("a", "b"));
+            assertTrue(MatchingUtilities.executeValuePath(values, "items", null, null));
+        }
+
+        @Test
+        void existsCheck_mapValue_returnsTrue() {
+            Map<String, Object> values = Map.of("nested", Map.of("a", 1));
+            assertTrue(MatchingUtilities.executeValuePath(values, "nested", null, null));
+        }
+
+        @Test
+        void existsCheck_missingKey_returnsFalse() {
+            Map<String, Object> values = Map.of("other", "value");
+            assertFalse(MatchingUtilities.executeValuePath(values, "missing", null, null));
+        }
     }
 
-    @Test
-    void executeValuePath_booleanTrue_returnsTrue() {
-        Map<String, Object> values = Map.of("active", true);
-        assertTrue(MatchingUtilities.executeValuePath(values, "active", null, null));
+    // ── Equals + Contains combined ─────────────────────────────────
+
+    @Nested
+    class EqualsAndContainsCombined {
+
+        @Test
+        void equalsMatchesTakesPriority_containsIgnored() {
+            // When equals matches, contains is not evaluated
+            Map<String, Object> values = Map.of("name", "John");
+            assertTrue(MatchingUtilities.executeValuePath(values, "name", "John", "xyz"));
+        }
+
+        @Test
+        void equalsMismatch_containsFallbackMatches_returnsTrue() {
+            // equals doesn't match but contains does — OR semantics
+            Map<String, Object> values = Map.of("name", "John");
+            assertTrue(MatchingUtilities.executeValuePath(values, "name", "Jane", "Joh"));
+        }
+
+        @Test
+        void equalsMismatch_containsFallbackAlsoFails_returnsFalse() {
+            Map<String, Object> values = Map.of("name", "John");
+            assertFalse(MatchingUtilities.executeValuePath(values, "name", "Jane", "xyz"));
+        }
     }
 
-    @Test
-    void executeValuePath_booleanFalse_returnsFalse() {
-        Map<String, Object> values = Map.of("active", false);
-        assertFalse(MatchingUtilities.executeValuePath(values, "active", null, null));
-    }
+    // ── Nested path navigation ─────────────────────────────────────
 
-    @Test
-    void executeValuePath_existsCheck_noEqualsOrContains_returnsTrue() {
-        Map<String, Object> values = Map.of("key", "anyValue");
-        assertTrue(MatchingUtilities.executeValuePath(values, "key", null, null));
-    }
+    @Nested
+    class NestedPaths {
 
-    @Test
-    void executeValuePath_missingKey_returnsFalse() {
-        Map<String, Object> values = Map.of("other", "value");
-        assertFalse(MatchingUtilities.executeValuePath(values, "missing", "something", null));
-    }
+        @Test
+        void nestedMapPath_equalsMatch() {
+            Map<String, Object> values = Map.of(
+                    "memory", Map.of("current", Map.of("input", "hello")));
+            assertTrue(MatchingUtilities.executeValuePath(
+                    values, "memory.current.input", "hello", null));
+        }
 
-    @Test
-    void executeValuePath_emptyMap_returnsFalse() {
-        assertFalse(MatchingUtilities.executeValuePath(new HashMap<>(), "key", "val", null));
+        @Test
+        void arrayIndexPath_equalsMatch() {
+            Map<String, Object> values = Map.of(
+                    "items", List.of(Map.of("city", "Vienna"), Map.of("city", "Berlin")));
+            assertTrue(MatchingUtilities.executeValuePath(
+                    values, "items[0].city", "Vienna", null));
+        }
+
+        @Test
+        void deepNestedMissing_returnsFalse() {
+            Map<String, Object> values = Map.of("a", Map.of("b", "c"));
+            assertFalse(MatchingUtilities.executeValuePath(
+                    values, "a.b.c.d", null, null));
+        }
     }
 }


### PR DESCRIPTION
The Boolean branch in executeValuePath fired even when an explicit equals check had failed, silently overriding the mismatch with the raw Boolean value. For example, equals='false' with value=Boolean(true) would return true instead of false.

Root cause: the 'else if (value instanceof Boolean b)' branch was a peer of the equals/contains branches in the if-else chain, so it would fire whenever equals didn't match AND contains was empty, regardless of whether equals was intentionally specified.

Fix: move the Boolean check inside the existence-check guard (isNullOrEmpty(equals) && isNullOrEmpty(contains)) so it only applies when no comparison operators were specified.

Also applies the early-return refactoring requested in PR#444 review by @rolandpickl — invert the null check to return early, eliminating the boolean accumulator and flattening the nesting.

Test coverage expanded from 10 to 30 tests covering all branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved value matching logic with clearer handling of equals, contains, and existence checks.

* **Tests**
  * Expanded test coverage with reorganized test structure, including null handling, numeric comparisons, boolean logic, nested path navigation, and combined matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->