### PR TITLE
fix(compose): use authenticated MongoDB healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     volumes:
       - mongodb-db:/data/db
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      test: ["CMD", "mongosh", "-u", "${MONGO_INITDB_ROOT_USERNAME:-eddi}", "-p", "${MONGO_INITDB_ROOT_PASSWORD:-changeme}", "--authenticationDatabase", "admin", "--eval", "db.adminCommand('ping')"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
The MongoDB healthcheck used an unauthenticated ping, which reported 'healthy' even when auth credentials were misconfigured (e.g. existing volumes upgraded from a pre-auth setup that lack the expected user). This caused EDDI to start against a MongoDB it couldn't authenticate to.

Now the healthcheck authenticates with the same credentials EDDI uses, so depends_on: service_healthy catches auth mismatches before EDDI attempts to connect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB container healthcheck to require authentication, improving security for self-hosted deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->