### PR TITLE
Fix/ps1 docker info check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "EDDI_VAULT_MASTER_KEY=${EDDI_VAULT_MASTER_KEY:-}"
       - "EDDI_DATASTORE_TYPE=${EDDI_DATASTORE_TYPE:-mongodb}"
       - "EDDI_SECURITY_ALLOW_UNAUTHENTICATED=true"
-      - "QUARKUS_MONGODB_CONNECTION_STRING=mongodb://${MONGO_INITDB_ROOT_USERNAME:-eddi}:${MONGO_INITDB_ROOT_PASSWORD:-changeme}@mongodb:27017/eddi?authSource=admin"
+      - "MONGODB_CONNECTIONSTRING=mongodb://${MONGO_INITDB_ROOT_USERNAME:-eddi}:${MONGO_INITDB_ROOT_PASSWORD:-changeme}@mongodb:27017/eddi?authSource=admin&retryWrites=true&w=majority&connectTimeoutMS=10000&socketTimeoutMS=30000"
 #      - "JAVA_OPTS_APPEND=-Dquarkus.http.cors.origins=http://localhost:3000"
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/install.ps1
+++ b/install.ps1
@@ -350,8 +350,14 @@ function Step-Database {
 
 function New-VaultKey {
     $bytes = New-Object byte[] 24
-    $rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::new()
-    try { $rng.GetBytes($bytes) } finally { $rng.Dispose() }
+    try {
+        # PS 7+ / .NET 6+
+        [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    } catch {
+        # PS 5.1 / .NET Framework 4.x fallback
+        $rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::new()
+        try { $rng.GetBytes($bytes) } finally { $rng.Dispose() }
+    }
     return [System.Convert]::ToBase64String($bytes)
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -275,12 +275,12 @@ function Test-Prerequisites {
         exit 1
     }
 
-    # Docker daemon
-    try {
-        docker info 2>$null | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw "not running" }
-    }
-    catch {
+    # Docker daemon -- use cmd /c to isolate stderr from PS error stream.
+    # docker info writes warnings to stderr (e.g. "WARNING: No blkio...").
+    # With ErrorActionPreference=Stop, PS 5.1 treats native stderr as
+    # terminating errors -- even 2>$null and 2>&1 don't prevent this.
+    cmd /c "docker info >nul 2>&1"
+    if ($LASTEXITCODE -ne 0) {
         Write-Fail "Docker is installed but not running.`n     Start Docker Desktop."
     }
 
@@ -350,7 +350,8 @@ function Step-Database {
 
 function New-VaultKey {
     $bytes = New-Object byte[] 24
-    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    $rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::new()
+    try { $rng.GetBytes($bytes) } finally { $rng.Dispose() }
     return [System.Convert]::ToBase64String($bytes)
 }
 


### PR DESCRIPTION
## Problem

The install wizard (`install.ps1`) crashes on **Windows PowerShell 5.1** (the default on Windows 10/11) due to two .NET compatibility issues, and MongoDB deployments fail silently because `docker-compose.yml` sets the wrong environment variable.

**Impact:** Every Windows user running the installer hits at least one of these. MongoDB users additionally get `Unauthorized` errors on startup. PostgreSQL users and `install.sh` (Linux/Mac) are unaffected.

### 1. `docker info` falsely reports Docker not running

`docker info` writes warnings to stderr (e.g. `WARNING: No blkio throttle.read_bps_device support`). With `$ErrorActionPreference = "Stop"` (set at script init), PowerShell 5.1 treats **any** native command stderr output as a terminating error — the `catch` block fires before `$LASTEXITCODE` is ever checked.

Neither `2>$null` nor `2>&1` prevent this in PS 5.1.

### 2. `New-VaultKey` crashes with `MethodNotFound`

`[System.Security.Cryptography.RandomNumberGenerator]::Fill()` is a .NET Core 2.1+ API. PowerShell 5.1 runs on .NET Framework 4.x, which doesn't have it.

### 3. MongoDB `Unauthorized` on every deployment

`docker-compose.yml` set `QUARKUS_MONGODB_CONNECTION_STRING`, but EDDI's `PersistenceModule.java` reads the **custom** property `mongodb.connectionString` — not the standard Quarkus one. MicroProfile Config maps that to env var `MONGODB_CONNECTIONSTRING`. The Quarkus-prefixed variable was silently ignored, so credentials were never passed (`credential=null` in logs), causing `Command listCollections requires authentication` on startup.

## Fix

| File | Change |
|---|---|
| `install.ps1` | Wrap `docker info` in `cmd /c` to isolate stderr from PS error stream |
| `install.ps1` | Try modern `RandomNumberGenerator.Fill()` first (PS 7+), fall back to `RNGCryptoServiceProvider` (PS 5.1) — future-proof against eventual .NET deprecation removal |
| `docker-compose.yml` | Rename env var to `MONGODB_CONNECTIONSTRING` + add full connection params matching `application.properties` defaults |

## Testing

- ✅ `docker info` check passes with `$ErrorActionPreference = "Stop"` and Docker running
- ✅ Vault key generation works on both PS 5.1 (legacy fallback) and PS 7+ (modern API)
- ✅ MongoDB container starts with auth, EDDI connects with `credential=MongoCredential{userName='eddi'}`
- ✅ Script parses with 0 errors (both with BOM and ANSI-simulated without BOM)
- ✅ No new non-ASCII characters introduced
- ✅ `install.sh` verified unaffected (bash handles UTF-8 natively)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved MongoDB connection reliability with enhanced retry logic and timeout parameters
* Enhanced installation script compatibility and resilience across PowerShell and .NET versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->