### PR TITLE
fix(ci): align CodeQL category to java-kotlin to match scheduled scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
-          languages: java
+          languages: java-kotlin
           queries: security-extended
 
       - name: Set execute permission for mvnw
@@ -299,7 +299,7 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
-          category: "/language:java"
+          category: "/language:java-kotlin"
 
   # ─── Job 2c: Trivy Filesystem Scan ─────────────────────────────
   trivy-scan:


### PR DESCRIPTION
The scheduled codeql.yml uses language 'java-kotlin' (the canonical CodeQL identifier) while ci.yml used 'java'. This category mismatch caused GitHub Code Scanning to report '1 configuration not found' on every PR, because the java-kotlin configuration uploaded by the scheduled scan on main was absent from the PR ci.yml results.
