### PR TITLE
chore(docker): update base image digest

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -78,7 +78,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24@sha256:0b80559a680229acf2d61b2f7f23087f61d729627c768d5f31528d69fc58ae70
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24@sha256:2f3844123fede3fd04fbcc1fd4d5497ac2230cf80935a3111890202edff0390a
 
 ### Red Hat Container Certification — required labels
 ARG EDDI_VERSION=6.0.2


### PR DESCRIPTION
This pull request updates the base image used in the `src/main/docker/Dockerfile` to a newer version. This change ensures the application benefits from the latest security patches and improvements available in the updated image.

Dependency update:

* Updated the base image in `Dockerfile` from an older SHA to a newer SHA for `ubi9/openjdk-25-runtime:1.24`, ensuring the latest security and stability updates are included.