### PR TITLE
docs(agents): selective commits, changelog before commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,10 @@ EDDI is a **config-driven engine**, not a monolithic application. Agent behavior
    **Only stage files you actually worked on.** Never use `git add .` or `git add -A`. The working tree may contain changes from other people, other branches, or other tools — those are not yours to commit. Always:
    - Stage files individually: `git add path/to/file1 path/to/file2`
    - Run `git status` before committing — if any staged file is not part of your task, unstage it
-   - Run `git diff --stat HEAD` after committing to confirm the commit only contains your files
+   - Run `git log --stat -1` after committing to confirm the commit only contains your files
 6. **Each commit must build**: Run `./mvnw compile` (or `./mvnw test` for backend) before committing. Never commit broken code.
 7. **Verify factual claims against authoritative sources**: When writing documentation about the project's technology stack, dependencies, or CI configuration, **always verify against the canonical source** (`pom.xml` for dependencies, `ci.yml` for CI behavior, `Dockerfile` for container config). **Never infer from codebase grep results** — migration code, comments about "previous implementations," and backward-compatibility references describe what the project *used to* use, not what it currently uses. If a term appears 40 times in the codebase but zero times in `pom.xml`, the project does not use it.
-8. **Update the changelog BEFORE committing**: Edit [`docs/changelog.md`](docs/changelog.md) and include it in the same commit (or the final commit of a task). The changelog must land on the **same branch** as the work it documents — never on a different branch after the fact. Each entry should include:
+8. **Update the changelog immediately before committing**: Edit [`docs/changelog.md`](docs/changelog.md) and include it in the commit that contains the changes being documented. The changelog must land on the **same branch** as the work it documents — never on a different branch after the fact. Each entry should include:
    - Date and short title
    - Repo and branch
    - What changed (files + reasoning)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,21 +43,32 @@ EDDI is a **config-driven engine**, not a monolithic application. Agent behavior
 ### During Work
 
 3. **Branching**: Check `git branch --show-current` and `git log -5 --oneline` to understand the current branch context. **Do NOT commit directly to `main`.** If unsure which branch to use, ask the user.
+   - **Always branch from `origin/main`**, never from another feature branch. Run `git fetch origin main` then `git checkout -b my-branch origin/main` to guarantee a clean base.
 4. **Never force-push**: `git push --force` and `git push --force-with-lease` are **forbidden**. To avoid ever needing them, follow these sub-rules:
    - **Never `git commit --amend` after pushing.** Amend only works on unpushed commits. If you already pushed, make a new commit instead.
    - **Never `git rebase -i` on a pushed branch.** Interactive rebase rewrites history. If the branch is pushed, history is immutable.
    - **Never `git reset` on a pushed branch.** Use `git revert` to undo pushed commits (it creates a new forward commit).
    - **Always `git pull --rebase` before pushing** if the remote has new commits.
    - A `.githooks/pre-push` hook will block non-fast-forward pushes as a safety net.
-5. **Commit often**: Every working unit gets a commit. Use conventional commits:
+5. **Commit often and selectively**: Every working unit gets a commit. Use conventional commits:
    ```
    feat(scope): description
    fix(scope): description
    chore(scope): description
    refactor(scope): description
    ```
+   **Only stage files you actually worked on.** Never use `git add .` or `git add -A`. The working tree may contain changes from other people, other branches, or other tools — those are not yours to commit. Always:
+   - Stage files individually: `git add path/to/file1 path/to/file2`
+   - Run `git status` before committing — if any staged file is not part of your task, unstage it
+   - Run `git diff --stat HEAD` after committing to confirm the commit only contains your files
 6. **Each commit must build**: Run `./mvnw compile` (or `./mvnw test` for backend) before committing. Never commit broken code.
 7. **Verify factual claims against authoritative sources**: When writing documentation about the project's technology stack, dependencies, or CI configuration, **always verify against the canonical source** (`pom.xml` for dependencies, `ci.yml` for CI behavior, `Dockerfile` for container config). **Never infer from codebase grep results** — migration code, comments about "previous implementations," and backward-compatibility references describe what the project *used to* use, not what it currently uses. If a term appears 40 times in the codebase but zero times in `pom.xml`, the project does not use it.
+8. **Update the changelog BEFORE committing**: Edit [`docs/changelog.md`](docs/changelog.md) and include it in the same commit (or the final commit of a task). The changelog must land on the **same branch** as the work it documents — never on a different branch after the fact. Each entry should include:
+   - Date and short title
+   - Repo and branch
+   - What changed (files + reasoning)
+   - Design decisions made
+   - What's in progress / what's next (if interrupted mid-task)
 
 #### Git Recovery — What To Do Instead of Force-Push
 
@@ -71,12 +82,7 @@ EDDI is a **config-driven engine**, not a monolithic application. Agent behavior
 
 ### After Completing Work (or if interrupted/switching sessions)
 
-8. **Update the changelog**: Edit [`docs/changelog.md`](docs/changelog.md) and add an entry with:
-   - Date and short title
-   - Repo and branch
-   - What changed (files + reasoning)
-   - Design decisions made
-   - What's in progress / what's next (if interrupted mid-task)
+9. **Verify branch hygiene**: Before switching branches, run `git status` and `git stash` any uncommitted work. When returning to a branch, run `git stash pop` and verify the restored changes belong to that branch.
 
 ---
 


### PR DESCRIPTION
This pull request updates the contribution workflow documentation in `AGENTS.md` to clarify and strengthen best practices for branching, committing, and changelog management. The changes emphasize branch hygiene, selective staging, and integrating changelog updates into the development process.

**Git Workflow and Branching:**

* Added a rule to always branch from `origin/main`, never from another feature branch, ensuring a clean base for new work.
* Strengthened guidelines to never force-push, amend, rebase, or reset pushed branches, and to always pull with rebase before pushing.

**Committing Best Practices:**

* Updated commit guidance to stress selective staging—explicitly avoid `git add .` or `git add -A` and only stage files actually worked on. Added steps to verify staged and committed files.
* Clarified that each commit must build, and to run compilation/tests before committing.

**Changelog Management:**

* Moved changelog updates to occur before committing, ensuring the changelog is updated and included in the same commit as the work it documents.
* Updated after-work steps to focus on verifying branch hygiene rather than changelog updates, which are now handled earlier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation with refined guidance on branch creation, commit staging practices, and branch-switching verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->