### PR TITLE
fix(ci): enforce least-privilege token permissions for OpenSSF Scorecard

### DIFF
--- a/.github/workflows/base-image-check.yml
+++ b/.github/workflows/base-image-check.yml
@@ -17,9 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 env:
   DOCKERFILE: src/main/docker/Dockerfile
@@ -28,6 +26,10 @@ jobs:
   check-base-image:
     name: Check Base Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # git push for PR branch
+      pull-requests: write  # gh pr create/edit
+      issues: write         # gh issue create
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,9 +386,9 @@ jobs:
       is-release: ${{ steps.meta.outputs.is-release }}
 
     permissions:
-      contents: write  # Required for creating GitHub Releases on tag pushes
-      id-token: write  # Required for Sigstore cosign keyless signing (OIDC → Fulcio)
-      attestations: write  # Required for SLSA provenance attestation
+      contents: read       # checkout + build
+      id-token: write      # Sigstore cosign keyless signing (OIDC → Fulcio)
+      attestations: write  # SLSA provenance attestation
 
     steps:
       - name: Checkout
@@ -546,8 +546,17 @@ jobs:
           subject-digest: ${{ steps.docker-push.outputs.digest }}
           push-to-registry: true
 
+
+  # ─── Job 3b: GitHub Release (tag pushes only) ──────────────────
+  release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs: docker
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write  # Required for creating GitHub Releases
+    steps:
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
@@ -558,7 +567,7 @@ jobs:
             This release is distributed as a Docker image:
 
             ```bash
-            docker pull ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.primary-tag }}
+            docker pull ${{ env.DOCKER_IMAGE }}:${{ needs.docker.outputs.primary-tag }}
             ```
 
             ### Verify image signature
@@ -567,7 +576,7 @@ jobs:
             cosign verify \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               --certificate-identity-regexp '^https://github\.com/labsai/EDDI/\.github/workflows/ci\.yml@refs/(heads/main|tags/.+)$' \
-              ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.primary-tag }}
+              ${{ env.DOCKER_IMAGE }}:${{ needs.docker.outputs.primary-tag }}
             ```
 
             > **Note:** EDDI is distributed exclusively as a Docker image. There are no binary downloads.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,12 +6,14 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # checkout + dependency manifest
+      pull-requests: write  # comment-summary-in-pr
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       # ── Restore cached metrics ──────────────────────────────
-      # Uses date-based key rotation to avoid needing actions:write for cache delete.
+      # Uses run_id-based key rotation to avoid needing actions:write for cache delete.
       # Save always creates a new key; restore-keys finds the latest.
       - name: Restore metrics cache
         id: cache-restore

--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -25,16 +25,19 @@ jobs:
   track:
     runs-on: ubuntu-latest
     permissions:
-      actions: write   # cache delete (job-level for least privilege)
       contents: read
     steps:
       # ── Restore cached metrics ──────────────────────────────
+      # Uses date-based key rotation to avoid needing actions:write for cache delete.
+      # Save always creates a new key; restore-keys finds the latest.
       - name: Restore metrics cache
         id: cache-restore
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: metrics.json
-          key: project-metrics-data
+          key: project-metrics-${{ github.run_id }}
+          restore-keys: |
+            project-metrics-
 
       - name: Load previous metrics
         id: prev
@@ -462,13 +465,8 @@ jobs:
           echo "Saved metrics:"
           cat metrics.json
 
-      - name: Delete old cache
-        run: gh cache delete project-metrics-data || true
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       - name: Save metrics cache
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: metrics.json
-          key: project-metrics-data
+          key: project-metrics-${{ github.run_id }}


### PR DESCRIPTION
Remediate Token-Permissions check (0/10 → target 10/10) by applying the principle of least privilege across all workflow files.

Changes:
- base-image-check.yml: move contents/pull-requests/issues write from top-level to job-level (top-level write is the nr 1 score killer)
- ci.yml: split GitHub Release into dedicated job with narrow contents:write; Docker job drops to contents:read
- dependency-review.yml: move pull-requests:write from top-level to job-level with explicit contents:read
- docker-pull-notify.yml: eliminate actions:write entirely by switching from cache-delete to run_id-based key rotation with restore-keys

All 8 workflows now have read-only (or none) top-level permissions. Job-level writes are narrowly scoped to the specific jobs that need them, with explicit contents:read where checkout is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened workflow permission defaults to reduce write access across CI jobs for improved security.
  * Separated release creation into its own job so release tasks run only on tags, with scoped permissions.
  * Switched pipeline metrics caching to a run-specific key and restore-prefix strategy for more reliable caches.
  * Scoped dependency-review permissions to the job that posts summaries, limiting PR write rights elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->