### PR TITLE
Fix/slack notification deltas

### DIFF
--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -2,10 +2,10 @@ name: Project Metrics Tracker
 
 on:
   schedule:
-    # Offset to :05 to avoid overlapping with daily (18:00) and weekly (09:00)
+    # Offset to :05 to avoid overlapping with daily (07:00) and weekly (07:00)
     - cron: '5,20,35,50 * * * *' # every 15 min — collect metrics + push to analytics
-    - cron: '0 18 * * *'          # daily — 6pm UTC, digest (only if activity)
-    - cron: '0 9 * * 0'           # weekly — Sunday 9am UTC, Slack digest
+    - cron: '0 7 * * *'           # daily — 7am UTC (9am CEST), digest (only if activity)
+    - cron: '0 7 * * 1'           # weekly — Monday 7am UTC (9am CEST), Slack digest
   workflow_dispatch:
     inputs:
       force_digest:
@@ -131,9 +131,9 @@ jobs:
           FORCE="${{ github.event.inputs.force_digest }}"
 
           # Determine which schedule triggered this run
-          if [ "$SCHEDULE" = "0 18 * * *" ]; then
+          if [ "$SCHEDULE" = "0 7 * * *" ]; then
             TYPE="daily"
-          elif [ "$SCHEDULE" = "0 9 * * 0" ] || [ "$FORCE" = "true" ]; then
+          elif [ "$SCHEDULE" = "0 7 * * 1" ] || [ "$FORCE" = "true" ]; then
             TYPE="weekly"
           else
             TYPE="collect"

--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -50,9 +50,13 @@ jobs:
             echo "week_docker=$(jq -r '.week_docker // 0' metrics.json)" >> "$GITHUB_OUTPUT"
             echo "week_stars=$(jq -r '.week_stars // 0' metrics.json)" >> "$GITHUB_OUTPUT"
             echo "week_forks=$(jq -r '.week_forks // 0' metrics.json)" >> "$GITHUB_OUTPUT"
+            echo "week_views=$(jq -r '.week_views // 0' metrics.json)" >> "$GITHUB_OUTPUT"
+            echo "week_clones=$(jq -r '.week_clones // 0' metrics.json)" >> "$GITHUB_OUTPUT"
             echo "day_docker=$(jq -r '.day_docker // 0' metrics.json)" >> "$GITHUB_OUTPUT"
             echo "day_stars=$(jq -r '.day_stars // 0' metrics.json)" >> "$GITHUB_OUTPUT"
             echo "day_forks=$(jq -r '.day_forks // 0' metrics.json)" >> "$GITHUB_OUTPUT"
+            echo "day_views=$(jq -r '.day_views // 0' metrics.json)" >> "$GITHUB_OUTPUT"
+            echo "day_clones=$(jq -r '.day_clones // 0' metrics.json)" >> "$GITHUB_OUTPUT"
             echo "last_milestone=$(jq -r '.last_milestone // 0' metrics.json)" >> "$GITHUB_OUTPUT"
             echo "has_data=true" >> "$GITHUB_OUTPUT"
 
@@ -68,7 +72,7 @@ jobs:
             echo "has_data=false" >> "$GITHUB_OUTPUT"
             echo "day_fields_present=false" >> "$GITHUB_OUTPUT"
             echo "week_fields_present=false" >> "$GITHUB_OUTPUT"
-            for key in docker_pulls stars forks week_docker week_stars week_forks day_docker day_stars day_forks last_milestone; do
+            for key in docker_pulls stars forks week_docker week_stars week_forks week_views week_clones day_docker day_stars day_forks day_views day_clones last_milestone; do
               echo "${key}=0" >> "$GITHUB_OUTPUT"
             done
           fi
@@ -278,7 +282,7 @@ jobs:
               ]
             }"
 
-      # ── Weekly digest (Sunday or manual) ────────────────────
+      # ── Weekly digest (Monday or manual) ────────────────────
       - name: Weekly digest
         if: >-
           steps.schedule.outputs.type == 'weekly'
@@ -302,6 +306,8 @@ jobs:
           WEEK_PULL_DIFF=$(( PULLS - ${{ steps.prev.outputs.week_docker }} ))
           WEEK_STAR_DIFF=$(( STARS - ${{ steps.prev.outputs.week_stars }} ))
           WEEK_FORK_DIFF=$(( FORKS - ${{ steps.prev.outputs.week_forks }} ))
+          WEEK_VIEW_DIFF=$(( VIEWS - ${{ steps.prev.outputs.week_views }} ))
+          WEEK_CLONE_DIFF=$(( CLONES - ${{ steps.prev.outputs.week_clones }} ))
 
           # Sanity check: if delta equals current, baseline was 0 (cold-start artifact)
           if [ "$WEEK_PULL_DIFF" -eq "$PULLS" ] && [ "$PULLS" -gt 0 ]; then
@@ -311,10 +317,12 @@ jobs:
 
           PULLS_FMT=$(printf "%'d" "$PULLS")
 
-          # Build sign prefixes
+          # Build sign prefixes (pulls/stars/forks only increase; views/clones can decrease)
           pull_sign=""; [ "$WEEK_PULL_DIFF" -gt 0 ] && pull_sign="+"
           star_sign=""; [ "$WEEK_STAR_DIFF" -gt 0 ] && star_sign="+"
           fork_sign=""; [ "$WEEK_FORK_DIFF" -gt 0 ] && fork_sign="+"
+          view_sign=""; [ "$WEEK_VIEW_DIFF" -gt 0 ] && view_sign="+"
+          clone_sign=""; [ "$WEEK_CLONE_DIFF" -gt 0 ] && clone_sign="+"
 
           curl -sf -X POST "$SLACK_WEBHOOK" \
             -H 'Content-type: application/json' \
@@ -330,8 +338,8 @@ jobs:
                     { \"type\": \"mrkdwn\", \"text\": \"*🐳 Docker Pulls*\n${PULLS_FMT} (${pull_sign}${WEEK_PULL_DIFF})\" },
                     { \"type\": \"mrkdwn\", \"text\": \"*⭐ GitHub Stars*\n${STARS} (${star_sign}${WEEK_STAR_DIFF})\" },
                     { \"type\": \"mrkdwn\", \"text\": \"*🍴 Forks*\n${FORKS} (${fork_sign}${WEEK_FORK_DIFF})\" },
-                    { \"type\": \"mrkdwn\", \"text\": \"*👀 Repo Views (14d)*\n${VIEWS} (${UNIQUES} unique)\" },
-                    { \"type\": \"mrkdwn\", \"text\": \"*📥 Git Clones (14d)*\n${CLONES}\" }
+                    { \"type\": \"mrkdwn\", \"text\": \"*👀 Repo Views (14d)*\n${VIEWS} (${UNIQUES} unique, ${view_sign}${WEEK_VIEW_DIFF})\" },
+                    { \"type\": \"mrkdwn\", \"text\": \"*📥 Git Clones (14d)*\n${CLONES} (${clone_sign}${WEEK_CLONE_DIFF})\" }
                   ]
                 },
                 {
@@ -366,6 +374,8 @@ jobs:
           DAY_PULL_DIFF=$(( PULLS - ${{ steps.prev.outputs.day_docker }} ))
           DAY_STAR_DIFF=$(( STARS - ${{ steps.prev.outputs.day_stars }} ))
           DAY_FORK_DIFF=$(( FORKS - ${{ steps.prev.outputs.day_forks }} ))
+          DAY_VIEW_DIFF=$(( VIEWS - ${{ steps.prev.outputs.day_views }} ))
+          DAY_CLONE_DIFF=$(( CLONES - ${{ steps.prev.outputs.day_clones }} ))
 
           # Sanity check: if delta equals current, baseline was 0 (cold-start artifact)
           if [ "$DAY_PULL_DIFF" -eq "$PULLS" ] && [ "$PULLS" -gt 0 ]; then
@@ -379,10 +389,12 @@ jobs:
             exit 0
           fi
 
-          # Build sign prefixes
+          # Build sign prefixes (pulls/stars/forks only increase; views/clones can decrease)
           pull_sign=""; [ "$DAY_PULL_DIFF" -gt 0 ] && pull_sign="+"
           star_sign=""; [ "$DAY_STAR_DIFF" -gt 0 ] && star_sign="+"
           fork_sign=""; [ "$DAY_FORK_DIFF" -gt 0 ] && fork_sign="+"
+          view_sign=""; [ "$DAY_VIEW_DIFF" -gt 0 ] && view_sign="+"
+          clone_sign=""; [ "$DAY_CLONE_DIFF" -gt 0 ] && clone_sign="+"
 
           PULLS_FMT=$(printf "%'d" "$PULLS")
 
@@ -404,7 +416,7 @@ jobs:
                 {
                   \"type\": \"context\",
                   \"elements\": [
-                    { \"type\": \"mrkdwn\", \"text\": \"👀 Views: ${VIEWS} · 📥 Clones: ${CLONES} · <https://github.com/labsai/EDDI|GitHub>\" }
+                    { \"type\": \"mrkdwn\", \"text\": \"👀 Views: ${VIEWS} (${view_sign}${DAY_VIEW_DIFF}) · 📥 Clones: ${CLONES} (${clone_sign}${DAY_CLONE_DIFF}) · <https://github.com/labsai/EDDI|GitHub>\" }
                   ]
                 }
               ]
@@ -422,6 +434,9 @@ jobs:
           WEEK_VALID="${{ steps.baselines.outputs.week_valid }}"
           DAY_VALID="${{ steps.baselines.outputs.day_valid }}"
 
+          CUR_VIEWS=${{ steps.traffic.outputs.views }}
+          CUR_CLONES=${{ steps.traffic.outputs.clones }}
+
           # ── Determine week baseline ──
           # Uses the same field-presence check as the Validate step
           if [ "$WEEK_VALID" != "true" ]; then
@@ -429,16 +444,22 @@ jobs:
             WEEK_DOCKER=$CUR_PULLS
             WEEK_STARS=$CUR_STARS
             WEEK_FORKS=$CUR_FORKS
+            WEEK_VIEWS=$CUR_VIEWS
+            WEEK_CLONES=$CUR_CLONES
           elif [ "$SCHED_TYPE" = "weekly" ]; then
             # Weekly digest just sent — reset baseline to now
             WEEK_DOCKER=$CUR_PULLS
             WEEK_STARS=$CUR_STARS
             WEEK_FORKS=$CUR_FORKS
+            WEEK_VIEWS=$CUR_VIEWS
+            WEEK_CLONES=$CUR_CLONES
           else
             # Preserve existing baseline
             WEEK_DOCKER=${{ steps.prev.outputs.week_docker }}
             WEEK_STARS=${{ steps.prev.outputs.week_stars }}
             WEEK_FORKS=${{ steps.prev.outputs.week_forks }}
+            WEEK_VIEWS=${{ steps.prev.outputs.week_views }}
+            WEEK_CLONES=${{ steps.prev.outputs.week_clones }}
           fi
 
           # ── Determine day baseline ──
@@ -448,16 +469,22 @@ jobs:
             DAY_DOCKER=$CUR_PULLS
             DAY_STARS=$CUR_STARS
             DAY_FORKS=$CUR_FORKS
-          elif [ "$SCHED_TYPE" = "daily" ] || [ "$SCHED_TYPE" = "weekly" ]; then
-            # Daily/weekly digest just sent — reset baseline to now
+            DAY_VIEWS=$CUR_VIEWS
+            DAY_CLONES=$CUR_CLONES
+          elif [ "$SCHED_TYPE" = "daily" ]; then
+            # Daily digest just sent — reset baseline to now
             DAY_DOCKER=$CUR_PULLS
             DAY_STARS=$CUR_STARS
             DAY_FORKS=$CUR_FORKS
+            DAY_VIEWS=$CUR_VIEWS
+            DAY_CLONES=$CUR_CLONES
           else
             # Preserve existing baseline
             DAY_DOCKER=${{ steps.prev.outputs.day_docker }}
             DAY_STARS=${{ steps.prev.outputs.day_stars }}
             DAY_FORKS=${{ steps.prev.outputs.day_forks }}
+            DAY_VIEWS=${{ steps.prev.outputs.day_views }}
+            DAY_CLONES=${{ steps.prev.outputs.day_clones }}
           fi
 
           # Current milestone marker
@@ -470,13 +497,19 @@ jobs:
             --argjson week_docker "$WEEK_DOCKER" \
             --argjson week_stars "$WEEK_STARS" \
             --argjson week_forks "$WEEK_FORKS" \
+            --argjson week_views "$WEEK_VIEWS" \
+            --argjson week_clones "$WEEK_CLONES" \
             --argjson day_docker "$DAY_DOCKER" \
             --argjson day_stars "$DAY_STARS" \
             --argjson day_forks "$DAY_FORKS" \
+            --argjson day_views "$DAY_VIEWS" \
+            --argjson day_clones "$DAY_CLONES" \
             --argjson last_milestone "$CURRENT_MS" \
             '{docker_pulls: $docker_pulls, stars: $stars, forks: $forks,
               week_docker: $week_docker, week_stars: $week_stars, week_forks: $week_forks,
+              week_views: $week_views, week_clones: $week_clones,
               day_docker: $day_docker, day_stars: $day_stars, day_forks: $day_forks,
+              day_views: $day_views, day_clones: $day_clones,
               last_milestone: $last_milestone}' > metrics.json
 
           echo "Saved metrics:"

--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -321,8 +321,14 @@ jobs:
           pull_sign=""; [ "$WEEK_PULL_DIFF" -gt 0 ] && pull_sign="+"
           star_sign=""; [ "$WEEK_STAR_DIFF" -gt 0 ] && star_sign="+"
           fork_sign=""; [ "$WEEK_FORK_DIFF" -gt 0 ] && fork_sign="+"
-          view_sign=""; [ "$WEEK_VIEW_DIFF" -gt 0 ] && view_sign="+"
-          clone_sign=""; [ "$WEEK_CLONE_DIFF" -gt 0 ] && clone_sign="+"
+
+          # Views/clones: suppress delta when baseline was 0 (field missing from old cache)
+          view_delta=""; if [ "${{ steps.prev.outputs.week_views }}" -ne 0 ] || [ "$VIEWS" -eq 0 ]; then
+            vs=""; [ "$WEEK_VIEW_DIFF" -gt 0 ] && vs="+"; view_delta=", ${vs}${WEEK_VIEW_DIFF}"
+          fi
+          clone_delta=""; if [ "${{ steps.prev.outputs.week_clones }}" -ne 0 ] || [ "$CLONES" -eq 0 ]; then
+            cs=""; [ "$WEEK_CLONE_DIFF" -gt 0 ] && cs="+"; clone_delta=" (${cs}${WEEK_CLONE_DIFF})"
+          fi
 
           curl -sf -X POST "$SLACK_WEBHOOK" \
             -H 'Content-type: application/json' \
@@ -338,8 +344,8 @@ jobs:
                     { \"type\": \"mrkdwn\", \"text\": \"*🐳 Docker Pulls*\n${PULLS_FMT} (${pull_sign}${WEEK_PULL_DIFF})\" },
                     { \"type\": \"mrkdwn\", \"text\": \"*⭐ GitHub Stars*\n${STARS} (${star_sign}${WEEK_STAR_DIFF})\" },
                     { \"type\": \"mrkdwn\", \"text\": \"*🍴 Forks*\n${FORKS} (${fork_sign}${WEEK_FORK_DIFF})\" },
-                    { \"type\": \"mrkdwn\", \"text\": \"*👀 Repo Views (14d)*\n${VIEWS} (${UNIQUES} unique, ${view_sign}${WEEK_VIEW_DIFF})\" },
-                    { \"type\": \"mrkdwn\", \"text\": \"*📥 Git Clones (14d)*\n${CLONES} (${clone_sign}${WEEK_CLONE_DIFF})\" }
+                    { \"type\": \"mrkdwn\", \"text\": \"*👀 Repo Views (14d)*\n${VIEWS} (${UNIQUES} unique${view_delta})\" },
+                    { \"type\": \"mrkdwn\", \"text\": \"*📥 Git Clones (14d)*\n${CLONES}${clone_delta}\" }
                   ]
                 },
                 {
@@ -393,8 +399,14 @@ jobs:
           pull_sign=""; [ "$DAY_PULL_DIFF" -gt 0 ] && pull_sign="+"
           star_sign=""; [ "$DAY_STAR_DIFF" -gt 0 ] && star_sign="+"
           fork_sign=""; [ "$DAY_FORK_DIFF" -gt 0 ] && fork_sign="+"
-          view_sign=""; [ "$DAY_VIEW_DIFF" -gt 0 ] && view_sign="+"
-          clone_sign=""; [ "$DAY_CLONE_DIFF" -gt 0 ] && clone_sign="+"
+
+          # Views/clones: suppress delta when baseline was 0 (field missing from old cache)
+          view_delta=""; if [ "${{ steps.prev.outputs.day_views }}" -ne 0 ] || [ "$VIEWS" -eq 0 ]; then
+            vs=""; [ "$DAY_VIEW_DIFF" -gt 0 ] && vs="+"; view_delta=" (${vs}${DAY_VIEW_DIFF})"
+          fi
+          clone_delta=""; if [ "${{ steps.prev.outputs.day_clones }}" -ne 0 ] || [ "$CLONES" -eq 0 ]; then
+            cs=""; [ "$DAY_CLONE_DIFF" -gt 0 ] && cs="+"; clone_delta=" (${cs}${DAY_CLONE_DIFF})"
+          fi
 
           PULLS_FMT=$(printf "%'d" "$PULLS")
 
@@ -416,7 +428,7 @@ jobs:
                 {
                   \"type\": \"context\",
                   \"elements\": [
-                    { \"type\": \"mrkdwn\", \"text\": \"👀 Views: ${VIEWS} (${view_sign}${DAY_VIEW_DIFF}) · 📥 Clones: ${CLONES} (${clone_sign}${DAY_CLONE_DIFF}) · <https://github.com/labsai/EDDI|GitHub>\" }
+                    { \"type\": \"mrkdwn\", \"text\": \"👀 Views (14d): ${VIEWS}${view_delta} · 📥 Clones (14d): ${CLONES}${clone_delta} · <https://github.com/labsai/EDDI|GitHub>\" }
                   ]
                 }
               ]

--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -170,29 +170,34 @@ jobs:
           fi
 
       # ── Validate baselines ──────────────────────────────────
-      # Use field-presence (not > 0) to distinguish "missing from legacy cache"
-      # from "legitimately zero". A repo with 0 forks should still get digests.
+      # A baseline is valid when: (1) the cache existed, (2) the fields are present,
+      # AND (3) the Docker pulls baseline is non-zero. Docker pulls only ever increase,
+      # so a zero baseline is always a cold-start artifact (cache eviction/rebuild).
+      # Stars and forks CAN legitimately be 0 for new repos, but Docker pulls cannot
+      # be 0 for an established project with 300k+ pulls.
       - name: Validate baselines
         id: baselines
         run: |
           HAS_DATA="${{ steps.prev.outputs.has_data }}"
           DAY_PRESENT="${{ steps.prev.outputs.day_fields_present }}"
           WEEK_PRESENT="${{ steps.prev.outputs.week_fields_present }}"
+          DAY_DOCKER="${{ steps.prev.outputs.day_docker }}"
+          WEEK_DOCKER="${{ steps.prev.outputs.week_docker }}"
 
-          # Day baselines are valid only if cache existed AND the fields were present
-          if [ "$HAS_DATA" = "true" ] && [ "$DAY_PRESENT" = "true" ]; then
+          # Day baselines: fields must exist AND docker baseline must be non-zero
+          if [ "$HAS_DATA" = "true" ] && [ "$DAY_PRESENT" = "true" ] && [ "$DAY_DOCKER" -gt 0 ]; then
             echo "day_valid=true" >> "$GITHUB_OUTPUT"
           else
             echo "day_valid=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️  Day baselines invalid (has_data=$HAS_DATA, day_fields_present=$DAY_PRESENT)"
+            echo "⚠️  Day baselines invalid (has_data=$HAS_DATA, day_present=$DAY_PRESENT, day_docker=$DAY_DOCKER)"
           fi
 
-          # Week baselines are valid only if cache existed AND the fields were present
-          if [ "$HAS_DATA" = "true" ] && [ "$WEEK_PRESENT" = "true" ]; then
+          # Week baselines: fields must exist AND docker baseline must be non-zero
+          if [ "$HAS_DATA" = "true" ] && [ "$WEEK_PRESENT" = "true" ] && [ "$WEEK_DOCKER" -gt 0 ]; then
             echo "week_valid=true" >> "$GITHUB_OUTPUT"
           else
             echo "week_valid=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️  Week baselines invalid (has_data=$HAS_DATA, week_fields_present=$WEEK_PRESENT)"
+            echo "⚠️  Week baselines invalid (has_data=$HAS_DATA, week_present=$WEEK_PRESENT, week_docker=$WEEK_DOCKER)"
           fi
 
       # ── Push to analytics (always, if data changed) ─────────
@@ -298,6 +303,12 @@ jobs:
           WEEK_STAR_DIFF=$(( STARS - ${{ steps.prev.outputs.week_stars }} ))
           WEEK_FORK_DIFF=$(( FORKS - ${{ steps.prev.outputs.week_forks }} ))
 
+          # Sanity check: if delta equals current, baseline was 0 (cold-start artifact)
+          if [ "$WEEK_PULL_DIFF" -eq "$PULLS" ] && [ "$PULLS" -gt 0 ]; then
+            echo "⚠️  Weekly deltas are bogus (baseline was 0) — skipping digest"
+            exit 0
+          fi
+
           PULLS_FMT=$(printf "%'d" "$PULLS")
 
           # Build sign prefixes
@@ -355,6 +366,12 @@ jobs:
           DAY_PULL_DIFF=$(( PULLS - ${{ steps.prev.outputs.day_docker }} ))
           DAY_STAR_DIFF=$(( STARS - ${{ steps.prev.outputs.day_stars }} ))
           DAY_FORK_DIFF=$(( FORKS - ${{ steps.prev.outputs.day_forks }} ))
+
+          # Sanity check: if delta equals current, baseline was 0 (cold-start artifact)
+          if [ "$DAY_PULL_DIFF" -eq "$PULLS" ] && [ "$PULLS" -gt 0 ]; then
+            echo "⚠️  Daily deltas are bogus (baseline was 0) — skipping digest"
+            exit 0
+          fi
 
           # Only send if something actually changed today
           if [ "$DAY_PULL_DIFF" -eq 0 ] && [ "$DAY_STAR_DIFF" -eq 0 ] && [ "$DAY_FORK_DIFF" -eq 0 ]; then

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,25 @@ Each entry follows this format:
 - **Decision** — Key design decisions and their reasoning
 - **Files** — Links to modified files
 
+## 🔔 Slack Notification — Bogus Delta Fix (2026-05-01)
+
+**Repo:** EDDI (`fix/slack-notification-deltas`)
+
+**What changed:** Fixed Slack daily/weekly digests showing deltas equal to the total value (e.g., `+391490` pulls, `+320` stars, `+107` forks) instead of the actual daily/weekly change.
+
+### Root Cause
+
+The `Validate baselines` step only checked whether `day_docker`/`week_docker` fields **existed** in the cached `metrics.json`, not whether they contained sensible values. When the GitHub Actions cache was evicted or rebuilt, the baseline fields were present but set to `0` (from the initial seeding), making `day_valid=true`. The daily digest then computed `delta = current - 0 = current`, producing absurd deltas.
+
+### Fix (two-layer defense)
+
+1. **Strengthened baseline validation** — baselines are now rejected if the Docker pulls baseline is `0`. Docker pulls only increase, so a zero baseline is always a cold-start artifact for an established project. Stars and forks can legitimately be 0 for new repos, but Docker pulls cannot.
+2. **Added sanity guards in digest steps** — both daily and weekly digest steps now detect when `delta == current` (baseline was 0) and skip sending the digest. This catches any future edge case where validation passes but the baseline is still bogus.
+
+**Files:** `.github/workflows/docker-pull-notify.yml`
+
+---
+
 ## 🔒 OpenSSF Scorecard: Pinned-Dependencies Remediation (2026-04-28)
 
 **Repo:** EDDI (`chore/openssf-pinned-dependencies`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,22 +13,29 @@ Each entry follows this format:
 - **Decision** — Key design decisions and their reasoning
 - **Files** — Links to modified files
 
-## 🔔 Slack Notification — Bogus Delta Fix (2026-05-01)
+## 🔔 Slack Notification — Digest Improvements (2026-05-01)
 
 **Repo:** EDDI (`fix/slack-notification-deltas`)
 
-**What changed:** Fixed Slack daily/weekly digests showing deltas equal to the total value (e.g., `+391490` pulls, `+320` stars, `+107` forks) instead of the actual daily/weekly change.
+**What changed:** Fixed bogus Slack daily/weekly deltas, added views/clones delta tracking, rescheduled digests, and made daily/weekly baselines independent.
 
-### Root Cause
+### Root Cause (bogus deltas)
 
-The `Validate baselines` step only checked whether `day_docker`/`week_docker` fields **existed** in the cached `metrics.json`, not whether they contained sensible values. When the GitHub Actions cache was evicted or rebuilt, the baseline fields were present but set to `0` (from the initial seeding), making `day_valid=true`. The daily digest then computed `delta = current - 0 = current`, producing absurd deltas.
+The `Validate baselines` step only checked whether the required day/week baseline fields **existed** in the cached `metrics.json`, not whether they contained sensible values. When the GitHub Actions cache was evicted or rebuilt, those baseline fields were present, but the Docker baseline could still be set to `0` (from the initial seeding), making `day_valid=true`. The daily digest then computed `delta = current - 0 = current`, producing absurd deltas (e.g., `+391490` pulls).
 
-### Fix (two-layer defense)
+### Changes
 
-1. **Strengthened baseline validation** — baselines are now rejected if the Docker pulls baseline is `0`. Docker pulls only increase, so a zero baseline is always a cold-start artifact for an established project. Stars and forks can legitimately be 0 for new repos, but Docker pulls cannot.
-2. **Added sanity guards in digest steps** — both daily and weekly digest steps now detect when `delta == current` (baseline was 0) and skip sending the digest. This catches any future edge case where validation passes but the baseline is still bogus.
+1. **Strengthened baseline validation** — baselines are now rejected if the Docker pulls baseline is `0`. Docker pulls only increase, so a zero baseline is always a cold-start artifact for an established project.
+2. **Added sanity guards in digest steps** — both daily and weekly digest steps detect when `delta == current` (baseline was 0) and skip the notification.
+3. **Views/clones delta tracking** — added `day_views`, `day_clones`, `week_views`, `week_clones` baselines to the metrics cache. Digests now show deltas for all 5 stats. Deltas are conditionally suppressed when the baseline field is missing from an older cache (avoids one-time bogus delta on first deploy).
+4. **Rescheduled digests** — daily moved from 6pm UTC (8pm CEST) to 7am UTC (9am CEST); weekly moved from Sunday 9am UTC to Monday 7am UTC (9am CEST).
+5. **Independent day/week baselines** — weekly runs no longer reset daily baselines. On Mondays both digests fire independently: daily shows yesterday's change, weekly shows the full week.
 
-**Files:** `.github/workflows/docker-pull-notify.yml`
+### Decision
+
+- Views/clones baselines are NOT included in the field-presence check (`DAY_PRESENT`/`WEEK_PRESENT`). Adding them would skip the entire digest on first deploy (old cache lacks the new fields). Instead, view/clone deltas are conditionally hidden when the baseline is 0.
+
+**Files:** `.github/workflows/docker-pull-notify.yml`, `docs/changelog.md`
 
 ---
 


### PR DESCRIPTION
This pull request addresses an important bug in the Slack daily and weekly digest notifications, where metric deltas (like Docker pulls, stars, and forks) could be incorrectly reported as the total value instead of the actual change. The main cause was insufficient validation of cached baseline values, especially after cache eviction or rebuild. The fix strengthens baseline validation and adds runtime sanity checks to prevent bogus notifications. Additional metrics (views and clones) are now also tracked and reported.

**Bug Fixes and Validation Improvements:**

* Strengthened baseline validation in `.github/workflows/docker-pull-notify.yml` to ensure Docker pulls baselines are non-zero before accepting them as valid, preventing cold-start artifacts from producing bogus deltas.
* Added runtime sanity checks in both daily and weekly digest steps to skip sending digests if the calculated delta equals the current value, indicating an invalid baseline. [[1]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658R309-R325) [[2]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658R377-R397)

**Metrics and Notification Enhancements:**

* Added tracking and reporting of `views` and `clones` metrics for both daily and weekly periods, including their deltas and sign prefixes in Slack notifications. [[1]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658R53-R59) [[2]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658L322-R342) [[3]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658L390-R419) [[4]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658R437-R462) [[5]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658L434-R487) [[6]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658R500-R512)
* Updated the schedule for daily and weekly digests to run at 7am UTC (9am CEST), and clarified comments to match the new schedule. [[1]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658L5-R8) [[2]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658L134-R140) [[3]](diffhunk://#diff-a305017f335d1f258f562cf63ba599bbfe63104f747e9c594c84f7147e678658L276-R285)

**Documentation:**

* Added a detailed changelog entry describing the root cause, fix, and affected files for this bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed daily and weekly Slack digests to accurately calculate and display changes in views and clones.

* **New Features**
  * Digests now show view and clone change metrics with sign prefixes for better visibility.

* **Schedule Updates**
  * Adjusted timing: daily digests run at 07:00 UTC; weekly digests run at 07:00 UTC on Mondays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->