### PR TITLE
fix(install): replace iwr|iex with scriptblock pattern for PS 5.1 compat

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -935,7 +935,7 @@ Critical architectural fixes from thorough v6 feature review. 12 files modified,
 
 ### One-Command Install & Onboarding Wizard ✅
 
-New users can set up EDDI with `curl ... | bash` (Linux/macOS/WSL) or `iwr ... | iex` (Windows). Interactive 5-step wizard.
+New users can set up EDDI with `curl ... | bash` (Linux/macOS/WSL) or `& ([scriptblock]::Create((iwr ...).Content))` (Windows). Interactive 5-step wizard.
 
 | File                               | Description                                                                                                       |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ curl -fsSL https://raw.githubusercontent.com/labsai/EDDI/main/install.sh | bash
 **Windows (PowerShell):**
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1 | iex
+& ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1).Content))
 ```
 
-> **Note:** If your Antivirus blocks this command as "malicious content", securely download and run it instead:
+> **Note:** If your Antivirus blocks this command or you prefer to inspect the script first:
 >
 > ```powershell
 > Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,36 @@ Each entry follows this format:
 - **Decision** — Key design decisions and their reasoning
 - **Files** — Links to modified files
 
+## 🐛 Fix: `install.ps1` fails when invoked via `iwr | iex` (2026-05-06)
+
+**Repo:** EDDI (`fix/install-ps1-iwr-iex-compat`)
+
+**What changed:** Replaced the documented `iwr -useb ... | iex` one-liner with `& ([scriptblock]::Create((iwr -useb ...).Content))` across all docs.
+
+### Root Cause
+
+When PowerShell pipes content to `Invoke-Expression` (`iex`), it processes the text as a raw expression string — not as a script file. This means:
+- `<# ... #>` block comments containing `&` are parsed as code (the `&` call operator is reserved)
+- `[CmdletBinding()]` and `param()` blocks are only valid at the top of a script file, not inside an expression
+- The `[ValidateSet]` workaround from the previous fix (2026-04-01) addressed one symptom but the fundamental parsing issue remained
+
+The German error message confirms this: *"Das kaufmännische Und-Zeichen (&) ist nicht zulässig"* — the `&` in the ASCII art comment `One-Command Install & Onboarding Wizard` is being treated as a PowerShell operator.
+
+### Fix
+
+The `[scriptblock]::Create()` pattern downloads the entire script text via `.Content`, parses it as a complete script block (honoring block comments, `param()`, etc.), then executes it. This is the standard pattern used by major installers (Scoop, Chocolatey) for scripts with advanced PowerShell syntax.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `install.ps1` | Updated `.EXAMPLE` comment to use new pattern |
+| `README.md` | Updated Quick Start PowerShell command |
+| `docs/getting-started.md` | Updated Option 0 PowerShell command |
+| `HANDOFF.md` | Updated installer reference |
+
+---
+
 ## 🔧 PR #470 Review Remediation (2026-05-05)
 
 **Repo:** EDDI (`feat/global-variables`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,10 +35,10 @@ curl -fsSL https://raw.githubusercontent.com/labsai/EDDI/main/install.sh | bash
 **Windows (PowerShell):**
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1 | iex
+& ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1).Content))
 ```
 
-> **Note:** If your Antivirus blocks this command as "malicious content", securely download and run it instead:
+> **Note:** If your Antivirus blocks this command or you prefer to inspect the script first:
 >
 > ```powershell
 > Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     E.D.D.I -- One-Command Install & Onboarding Wizard
 
@@ -50,7 +50,7 @@
     Install with PostgreSQL and Keycloak authentication.
 
 .EXAMPLE
-    iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1 | iex
+    & ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1).Content))
     One-line remote install (uses defaults).
 
 .LINK
@@ -81,7 +81,7 @@ if ($Help) {
     exit 0
 }
 
-# Detect piped execution (iwr | iex) -- disable interactive prompts
+# Detect non-interactive execution (remote invoke or CI) -- disable prompts
 if (-not [Environment]::UserInteractive -or $Host.Name -eq 'Default Host') {
     $Defaults = $true
 }

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     E.D.D.I -- One-Command Install & Onboarding Wizard
 
@@ -51,7 +51,7 @@
 
 .EXAMPLE
     & ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1).Content))
-    One-line remote install (uses defaults).
+    One-line remote install (interactive wizard). Add -Defaults to skip prompts.
 
 .LINK
     https://eddi.labs.ai
@@ -81,7 +81,7 @@ if ($Help) {
     exit 0
 }
 
-# Detect non-interactive execution (remote invoke or CI) -- disable prompts
+# Detect non-interactive host (CI runners, scheduled tasks, services) -- disable prompts
 if (-not [Environment]::UserInteractive -or $Host.Name -eq 'Default Host') {
     $Defaults = $true
 }


### PR DESCRIPTION
The iwr|iex pipe pattern fails on scripts with block comments containing & characters, [CmdletBinding()], and param() blocks. PowerShell treats the piped text as a raw expression, not a script file.

Replace with & ([scriptblock]::Create((iwr -useb ...).Content)) which downloads the full script text, extracts the response body via .Content, and parses it as a complete script block honoring all PowerShell syntax including block comments and param declarations.

Key review finding: iwr returns a WebResponseObject, not a string. Without .Content, PS 5.1 would pass the type name to Create().

Updated: install.ps1 example, README.md, getting-started.md, HANDOFF.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Windows PowerShell installation instructions and added guidance on execution/antivirus considerations
  * Added extensive changelog entries covering recent fixes, features, and security updates

* **Chores**
  * Improved the one-line Windows installer invocation and refined non-interactive detection for CI/remote runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->