### PR TITLE
fix(install): use download-and-execute for Windows PowerShell install

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -935,7 +935,7 @@ Critical architectural fixes from thorough v6 feature review. 12 files modified,
 
 ### One-Command Install & Onboarding Wizard ✅
 
-New users can set up EDDI with `curl ... | bash` (Linux/macOS/WSL) or `& ([scriptblock]::Create((iwr ...).Content))` (Windows). Interactive 5-step wizard.
+New users can set up EDDI with `curl ... | bash` (Linux/macOS/WSL) or download-and-run `install.ps1` (Windows). Interactive 5-step wizard.
 
 | File                               | Description                                                                                                       |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -50,16 +50,10 @@ curl -fsSL https://raw.githubusercontent.com/labsai/EDDI/main/install.sh | bash
 **Windows (PowerShell):**
 
 ```powershell
-& ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1).Content))
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
+Unblock-File .\install.ps1
+.\install.ps1
 ```
-
-> **Note:** If your Antivirus blocks this command or you prefer to inspect the script first:
->
-> ```powershell
-> Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
-> Unblock-File .\install.ps1
-> .\install.ps1
-> ```
 
 Requires [Docker](https://docs.docker.com/get-docker/). The wizard auto-generates a unique vault encryption key for secret management.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ curl -fsSL https://raw.githubusercontent.com/labsai/EDDI/main/install.sh | bash
 **Windows (PowerShell):**
 
 ```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
+Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
 Unblock-File .\install.ps1
 .\install.ps1
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,9 +15,9 @@ Each entry follows this format:
 
 ## 🐛 Fix: Windows PowerShell install command (2026-05-06)
 
-**Repo:** EDDI (`fix/install-ps1-download-execute`)
+**Repo:** EDDI (`docs/windows-install-command`)
 
-**What changed:** Replaced the broken `scriptblock::Create` one-liner (and its predecessor `iwr | iex`) with a download-and-execute approach that works on all PowerShell versions and past AMSI.
+**What changed:** Replaced the broken `scriptblock::Create` one-liner (and its predecessor `iwr | iex`) with a download-and-execute approach that works on PowerShell 5.1+ and avoids expression-parser limitations.
 
 ### Root Cause
 
@@ -28,7 +28,7 @@ Each entry follows this format:
 Download-and-execute — the only pattern that uses the script-file parser:
 
 ```powershell
-Invoke-WebRequest -Uri "https://...install.ps1" -OutFile "install.ps1"
+Invoke-WebRequest -UseBasicParsing -Uri "https://...install.ps1" -OutFile "install.ps1"
 Unblock-File .\install.ps1
 .\install.ps1
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,30 @@ Each entry follows this format:
 - **Decision** — Key design decisions and their reasoning
 - **Files** — Links to modified files
 
+## 🐛 Fix: Windows PowerShell install command (2026-05-06)
+
+**Repo:** EDDI (`fix/install-ps1-download-execute`)
+
+**What changed:** Replaced the broken `scriptblock::Create` one-liner (and its predecessor `iwr | iex`) with a download-and-execute approach that works on all PowerShell versions and past AMSI.
+
+### Root Cause
+
+`install.ps1` uses `<# #>` block comments with `&`, `[CmdletBinding()]`, and `param()` — syntax only valid in the **script-file parser**. Both `iex` and `[scriptblock]::Create()` use the expression parser, which rejects these constructs. Behavior was also environment-dependent (passed on some PS 5.1 builds, failed on others).
+
+### Fix
+
+Download-and-execute — the only pattern that uses the script-file parser:
+
+```powershell
+Invoke-WebRequest -Uri "https://...install.ps1" -OutFile "install.ps1"
+Unblock-File .\install.ps1
+.\install.ps1
+```
+
+**Files:** `install.ps1` (`.EXAMPLE` comment), `README.md`, `docs/getting-started.md`, `HANDOFF.md`
+
+---
+
 ## 🐛 Improved Template Error Messages (2026-05-06)
 
 **Repo:** EDDI (`fix/template-error-message`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,16 +35,10 @@ curl -fsSL https://raw.githubusercontent.com/labsai/EDDI/main/install.sh | bash
 **Windows (PowerShell):**
 
 ```powershell
-& ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1).Content))
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
+Unblock-File .\install.ps1
+.\install.ps1
 ```
-
-> **Note:** If your Antivirus blocks this command or you prefer to inspect the script first:
->
-> ```powershell
-> Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
-> Unblock-File .\install.ps1
-> .\install.ps1
-> ```
 
 The wizard guides you through choosing a database (MongoDB or PostgreSQL), optional authentication (Keycloak), and monitoring (Grafana). After setup, Agent Father is deployed automatically to help you create your first AI agent.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ curl -fsSL https://raw.githubusercontent.com/labsai/EDDI/main/install.sh | bash
 **Windows (PowerShell):**
 
 ```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
+Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
 Unblock-File .\install.ps1
 .\install.ps1
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -50,8 +50,10 @@
     Install with PostgreSQL and Keycloak authentication.
 
 .EXAMPLE
-    & ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1).Content))
-    One-line remote install (interactive wizard). Add -Defaults to skip prompts.
+    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
+    Unblock-File .\install.ps1
+    .\install.ps1
+    Remote install: download, unblock, run.
 
 .LINK
     https://eddi.labs.ai

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     E.D.D.I -- One-Command Install & Onboarding Wizard
 
@@ -50,7 +50,7 @@
     Install with PostgreSQL and Keycloak authentication.
 
 .EXAMPLE
-    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
+    Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/labsai/EDDI/main/install.ps1" -OutFile "install.ps1"
     Unblock-File .\install.ps1
     .\install.ps1
     Remote install: download, unblock, run.


### PR DESCRIPTION
Both iwr|iex and [scriptblock]::Create() use the expression parser, which rejects block comments with &, [CmdletBinding()], and param(). Only executing an actual .ps1 file uses the script-file parser.

Replace with three-line download-and-execute approach:
  Invoke-WebRequest ... -OutFile install.ps1
  Unblock-File .\install.ps1
  .\install.ps1

This also avoids AMSI (antivirus) blocks that trigger on download-and-execute one-liners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Windows PowerShell installation instructions to use a more reliable three-step process (download, unblock, execute) for improved compatibility across all PowerShell versions.

* **Bug Fixes**
  * Resolved Windows PowerShell installation execution issues that occurred with previous inline command approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->