### PR TITLE
Fix/ExtensionEndpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,7 +487,7 @@ public class MyFeatureTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        ExtensionDescriptor descriptor = new ExtensionDescriptor(ID);
+        ExtensionDescriptor descriptor = new ExtensionDescriptor(getId());
         descriptor.setDisplayName("My Feature");
         ConfigValue uriConfig = new ConfigValue("Resource URI", FieldType.URI, false, null);
         descriptor.getConfigs().put("uri", uriConfig);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,7 +305,7 @@ A new `ILifecycleTask` requires ALL of:
 - [ ] `ExtensionDescriptor` (UI field definitions via `getExtensionDescriptor()`)
 - [ ] Unit test with Mockito
 
-All task implementations MUST implement: `getId()`, `getType()`, `execute()`, `configure()`, `getExtensionDescriptor()`.
+All task implementations MUST implement: `getId()` (returns `TaskId`), `getType()`, `execute()`, `configure()`, `getExtensionDescriptor()`.
 
 ### 4.4 Code Patterns
 
@@ -441,7 +441,7 @@ public class MyFeatureTask implements ILifecycleTask {
         this.dataFactory = dataFactory;
     }
 
-    @Override public String getId() { return ID; }
+    @Override public TaskId getId() { return new TaskId(ID); }
     @Override public String getType() { return KEY_MYFEATURE; }
 
     @Override

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,7 +144,7 @@ A typical agent lifecycle includes these task types:
 
 ```java
 public interface ILifecycleTask {
-    String getId();
+    TaskId getId();
     String getType();
     void execute(IConversationMemory memory, Object component)
         throws LifecycleException;

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -547,8 +547,8 @@ Create a custom lifecycle task:
 @ApplicationScoped
 public class MyCustomTask implements ILifecycleTask {
     @Override
-    public String getId() {
-        return "ai.labs.mycompany.customtask";
+    public TaskId getId() {
+        return new TaskId("ai.labs.mycompany.customtask");
     }
 
     @Override

--- a/mise.toml
+++ b/mise.toml
@@ -1,23 +1,49 @@
 [tools]
 java = "temurin-25.0.3+9.0.LTS"
 maven = "3.9.12"
+"npm:chromadb" = "3.4.3"
 
-[tasks]
-dev = { run = "mvn compile quarkus:dev", description = "Start dev mode with live reload (port 7070)" }
-compile = { run = "mvn compile", description = "Compile sources only (fast feedback)" }
+[tasks.dev]
+depends = ["clean"]
+run = "mvn compile quarkus:dev"
+description = "Start dev mode with live reload (port 7070)"
 
-clean-build = { run = "mvn clean compile", description = "Clean build — delete target/ and recompile from scratch" }
-test = { run = "mvn test", description = "Run unit tests (excludes *IT.java integration tests)" }
+[tasks.compile]
+depends = ["clean"]
+run = "mvn compile"
+description = "Compile sources only (fast feedback)"
 
-verify = { run = "mvn verify -DskipITs", description = "Compile + unit tests + package (no integration tests)" }
-full-build = { run = "mvn verify", description = "Full build — compile + unit tests + integration tests (requires Docker)" }
-validate = { run = "mvn validate", description = "Run Checkstyle code style checks" }
-format = { run = "mvn formatter:format", description = "Auto-format Java sources using the project Eclipse formatter" }
+[tasks.test]
+run = "mvn verify"
+description = "Compile + unit tests + integration tests (requires Docker)"
 
-docker-build = { run = "mvn clean package '-Dquarkus.container-image.build=true'", description = "Build the app + Docker image" }
-license-gen = { run = "mvn package -Plicense-gen -DskipTests", description = "Generate third-party licenses (Red Hat certification)" }
+[tasks.validate]
+run = "mvn validate"
+description = "Run Checkstyle code style checks"
 
-debug = { run = "mvn quarkus:dev -Dsuspend", description = "Start dev mode and wait for debugger on port 5005" }
-dev-no-debug = { run = "mvn quarkus:dev -Ddebug=false", description = "Start dev mode without the debug agent" }
-chroma = { run = "docker compose -f docker-compose.chroma.yml up", description = "Starts ChromaDB" }
+[tasks.format]
+run = "mvn formatter:format"
+description = "Auto-format Java sources using the project Eclipse formatter"
+
+[tasks.docker-build]
+run = "mvn clean package '-Dquarkus.container-image.build=true'"
+description = "Build the app + Docker image"
+
+
+[tasks.license-gen]
+run = "mvn package -Plicense-gen -DskipTests"
+description = "Generate third-party licenses (Red Hat certification)"
+
+[tasks.debug]
+run = "mvn quarkus:dev -Dsuspend"
+description = "Start dev mode and wait for debugger on port 5005"
+
+[tasks.clean]
+run = "mvn clean"
+description = "Clean build — delete target"
+
+
+[tasks.chroma]
+run = "docker compose -f docker-compose.chroma.yml up"
+description = "Starts ChromaDB"
 

--- a/planning/memory-architecture-plan.md
+++ b/planning/memory-architecture-plan.md
@@ -327,9 +327,9 @@ Changes required:
    } catch (Exception e) {
        // Failure → mark all NEW data written by this task as uncommitted
        markNewDataUncommitted(memory.getCurrentStep(), preTaskData);
-        auditLedger.logTaskFailure(task.getId().type(), e, conversationId);
+        auditLedger.logTaskFailure(task.getId().name(), e, conversationId);
         // Inject error action, NOT the exception, into the pipeline
-        memory.getCurrentStep().storeData(new Data<>("actions", List.of("task_failed_" + task.getId().type())));
+        memory.getCurrentStep().storeData(new Data<>("actions", List.of("task_failed_" + task.getId().name())));
    }
    ```
 

--- a/planning/memory-architecture-plan.md
+++ b/planning/memory-architecture-plan.md
@@ -327,9 +327,9 @@ Changes required:
    } catch (Exception e) {
        // Failure → mark all NEW data written by this task as uncommitted
        markNewDataUncommitted(memory.getCurrentStep(), preTaskData);
-       auditLedger.logTaskFailure(task.getId(), e, conversationId);
-       // Inject error action, NOT the exception, into the pipeline
-       memory.getCurrentStep().storeData(new Data<>("actions", List.of("task_failed_" + task.getId())));
+        auditLedger.logTaskFailure(task.getId().type(), e, conversationId);
+        // Inject error action, NOT the exception, into the pipeline
+        memory.getCurrentStep().storeData(new Data<>("actions", List.of("task_failed_" + task.getId().type())));
    }
    ```
 

--- a/planning/observability-and-pipeline-plan.md
+++ b/planning/observability-and-pipeline-plan.md
@@ -31,7 +31,7 @@
 The main execution path is in [`LifecycleManager.executeLifecycle()`](../../src/main/java/ai/labs/eddi/engine/lifecycle/LifecycleManager.java). Add span-per-task:
 
 ```java
-Span span = tracer.spanBuilder("eddi.task." + task.getId())
+Span span = tracer.spanBuilder("eddi.task." + task.getId().type())
     .setAttribute("conversationId", conversationId)
     .setAttribute("agentId", agentId)
     .startSpan();

--- a/planning/observability-and-pipeline-plan.md
+++ b/planning/observability-and-pipeline-plan.md
@@ -31,7 +31,7 @@
 The main execution path is in [`LifecycleManager.executeLifecycle()`](../../src/main/java/ai/labs/eddi/engine/lifecycle/LifecycleManager.java). Add span-per-task:
 
 ```java
-Span span = tracer.spanBuilder("eddi.task." + task.getId().type())
+Span span = tracer.spanBuilder("eddi.task." + task.getId().name())
     .setAttribute("conversationId", conversationId)
     .setAttribute("agentId", agentId)
     .startSpan();

--- a/src/main/java/ai/labs/eddi/configs/workflows/model/ExtensionDescriptor.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/model/ExtensionDescriptor.java
@@ -9,13 +9,16 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import ai.labs.eddi.engine.lifecycle.TaskId;
+
 public class ExtensionDescriptor {
-    private String type;
+    private TaskId type;
+
     private String displayName;
     private Map<String, ConfigValue> configs = new HashMap<>();
     private Map<String, List<ExtensionDescriptor>> extensions = new HashMap<>();
 
-    public ExtensionDescriptor(String type) {
+    public ExtensionDescriptor(TaskId type) {
         this.type = type;
     }
 
@@ -73,11 +76,11 @@ public class ExtensionDescriptor {
         extensions.computeIfAbsent(extensionName, k -> new LinkedList<>()).add(extensionDescriptor);
     }
 
-    public String getType() {
+    public TaskId getType() {
         return type;
     }
 
-    public void setType(String type) {
+    public void setType(TaskId type) {
         this.type = type;
     }
 

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStepStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStepStore.java
@@ -27,7 +27,7 @@ public class RestWorkflowStepStore implements IRestWorkflowStepStore {
     @Override
     public List<ExtensionDescriptor> getWorkflowSteps(String filter) {
         return lifecycleExtensionsProvider.keySet().stream()
-                .filter(type -> filter.isEmpty() || type.contains(filter))
+                .filter(type -> filter == null || filter.isEmpty() || type.contains(filter))
                 .map(type -> {
                     Provider<ILifecycleTask> taskProvider = lifecycleExtensionsProvider.get(type);
                     return taskProvider.get().getExtensionDescriptor();

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStepStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStepStore.java
@@ -14,21 +14,23 @@ import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import java.util.List;
 import java.util.Map;
+
 @ApplicationScoped
 public class RestWorkflowStepStore implements IRestWorkflowStepStore {
     private final Map<String, Provider<ILifecycleTask>> lifecycleExtensionsProvider;
 
     @Inject
     public RestWorkflowStepStore(@LifecycleExtensions Map<String, Provider<ILifecycleTask>> lifecycleExtensionsProvider) {
-
         this.lifecycleExtensionsProvider = lifecycleExtensionsProvider;
     }
 
     @Override
     public List<ExtensionDescriptor> getWorkflowSteps(String filter) {
-        return lifecycleExtensionsProvider.keySet().stream().filter(type -> filter.isEmpty() || type.contains(filter)).map(type -> {
-            Provider<ILifecycleTask> taskProvider = lifecycleExtensionsProvider.get(type);
-            return taskProvider.get().getExtensionDescriptor();
-        }).toList();
+        return lifecycleExtensionsProvider.keySet().stream()
+                .filter(type -> filter.isEmpty() || type.contains(filter))
+                .map(type -> {
+                    Provider<ILifecycleTask> taskProvider = lifecycleExtensionsProvider.get(type);
+                    return taskProvider.get().getExtensionDescriptor();
+                }).toList();
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/api/IConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IConversationService.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
 import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.model.Context;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.model.InputData;
@@ -105,9 +106,9 @@ public interface IConversationService {
      * Callback for streaming conversation responses via SSE.
      */
     interface StreamingResponseHandler {
-        void onTaskStart(String taskId, String taskType, int index);
+        void onTaskStart(TaskId taskId, String taskType, int index);
 
-        void onTaskComplete(String taskId, String taskType, long durationMs, Map<String, Object> summary);
+        void onTaskComplete(TaskId taskId, String taskType, long durationMs, Map<String, Object> summary);
 
         void onToken(String token);
 

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
@@ -19,6 +19,7 @@ import ai.labs.eddi.engine.caching.ICache;
 import ai.labs.eddi.engine.caching.ICacheFactory;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.IConversation;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import ai.labs.eddi.engine.memory.ConversationLogGenerator;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -420,12 +421,12 @@ public class ConversationService implements IConversationService {
             // Create event sink that delegates to the streaming handler
             var eventSink = new ConversationEventSink() {
                 @Override
-                public void onTaskStart(String taskId, String taskType, int index) {
+                public void onTaskStart(TaskId taskId, String taskType, int index) {
                     streamingHandler.onTaskStart(taskId, taskType, index);
                 }
 
                 @Override
-                public void onTaskComplete(String taskId, String taskType, long durationMs, Map<String, Object> summary) {
+                public void onTaskComplete(TaskId taskId, String taskType, long durationMs, Map<String, Object> summary) {
                     streamingHandler.onTaskComplete(taskId, taskType, durationMs, summary);
                 }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IRestAgentEngineStreaming;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.model.InputData;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -55,15 +56,16 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
             conversationService.sayStreaming(conversationId, returnDetailed, returnCurrentStepOnly, returningFields, inputData,
                     new IConversationService.StreamingResponseHandler() {
                         @Override
-                        public void onTaskStart(String taskId, String taskType, int index) {
+                        public void onTaskStart(TaskId taskId, String taskType, int index) {
                             sendEvent(eventSink, sse, "task_start",
-                                    String.format("{\"taskId\":\"%s\",\"taskType\":\"%s\",\"index\":%d}", taskId, taskType, index));
+                                    String.format("{\"taskId\":\"%s\",\"taskType\":\"%s\",\"index\":%d}", taskId.getIdentifier(), taskType, index));
                         }
 
                         @Override
-                        public void onTaskComplete(String taskId, String taskType, long durationMs, Map<String, Object> summary) {
+                        public void onTaskComplete(TaskId taskId, String taskType, long durationMs, Map<String, Object> summary) {
                             var sb = new StringBuilder();
-                            sb.append(String.format("{\"taskId\":\"%s\",\"taskType\":\"%s\",\"durationMs\":%d", taskId, taskType, durationMs));
+                            sb.append(String.format("{\"taskId\":\"%s\",\"taskType\":\"%s\",\"durationMs\":%d", taskId.getIdentifier(), taskType,
+                                    durationMs));
                             if (summary.containsKey("actions")) {
                                 sb.append(",\"actions\":").append(toJsonArray(summary.get("actions")));
                             }

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/ConversationEventSink.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/ConversationEventSink.java
@@ -33,7 +33,7 @@ public interface ConversationEventSink {
      * @param index
      *            0-based position in the workflow
      */
-    void onTaskStart(String taskId, String taskType, int index);
+    void onTaskStart(TaskId taskId, String taskType, int index);
 
     /**
      * Called after a lifecycle task completes execution.
@@ -48,7 +48,7 @@ public interface ConversationEventSink {
      *            optional task-specific summary data (e.g. emitted actions). May be
      *            empty, never null.
      */
-    void onTaskComplete(String taskId, String taskType, long durationMs, Map<String, Object> summary);
+    void onTaskComplete(TaskId taskId, String taskType, long durationMs, Map<String, Object> summary);
 
     /**
      * Called for each LLM token during streaming chat completion.

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/ILifecycleTask.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/ILifecycleTask.java
@@ -99,7 +99,7 @@ public interface ILifecycleTask {
      * @return unique identifier of this task (e.g., "ai.labs.parser",
      *         "ai.labs.behavior")
      */
-    String getId();
+    TaskId getId();
 
     /**
      * Returns the type identifier for this lifecycle task.

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/TaskId.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/TaskId.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.lifecycle;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Immutable identifier for lifecycle tasks in the EDDI conversation pipeline.
+ *
+ * <p>
+ * TaskId provides a type-safe wrapper around task identifiers with a canonical
+ * URI format ({@code eddi://ai.labs.taskname}). It ensures consistent
+ * identifier handling across the system and provides clean JSON serialization.
+ * </p>
+ *
+ * <p>
+ * <strong>Usage:</strong>
+ * </p>
+ *
+ * <pre>{@code
+ * TaskId parserTask = new TaskId("ai.labs.parser");
+ * String identifier = parserTask.getIdentifier(); // "eddi://ai.labs.parser"
+ * String name = parserTask.name(); // "ai.labs.parser"
+ * }</pre>
+ *
+ * <p>
+ * <strong>JSON Serialization:</strong>
+ * </p>
+ * <ul>
+ * <li><strong>Serialize:</strong> {@code "eddi://ai.labs.parser"} (via
+ * {@link #getIdentifier()})</li>
+ * <li><strong>Deserialize:</strong> Accepts both
+ * {@code "eddi://ai.labs.parser"} and {@code "ai.labs.parser"}</li>
+ * </ul>
+ *
+ * @param name
+ *            the task identifier (e.g., "ai.labs.parser", "ai.labs.behavior")
+ * @author EDDI Team
+ * @since 6.0
+ * @see ILifecycleTask#getId()
+ */
+public record TaskId(String name) {
+
+    /**
+     * URI scheme prefix for all task identifiers. Full identifiers have the format
+     * {@code eddi://<name>}.
+     */
+    private static final String SCHEME = "eddi://";
+
+    /**
+     * Returns the full URI identifier for this task.
+     *
+     * <p>
+     * This is the canonical string representation used for:
+     * <ul>
+     * <li>JSON serialization (via {@link JsonValue})</li>
+     * <li>Component cache lookups</li>
+     * <li>Logging and debugging</li>
+     * <li>OpenTelemetry span attributes</li>
+     * </ul>
+     * </p>
+     *
+     * @return the full URI identifier (e.g., "eddi://ai.labs.parser")
+     */
+    @JsonValue
+    public String getIdentifier() {
+        return SCHEME + name;
+    }
+
+    /**
+     * Returns the full URI identifier.
+     *
+     * <p>
+     * Delegates to {@link #getIdentifier()} for consistent string representation.
+     * </p>
+     *
+     * @return the full URI identifier
+     */
+    @Override
+    public String toString() {
+        return getIdentifier();
+    }
+
+    /**
+     * Factory method for deserializing TaskId from a string value.
+     *
+     * <p>
+     * Accepts both formats:
+     * <ul>
+     * <li>Full URI: {@code "eddi://ai.labs.parser"}</li>
+     * <li>Bare type: {@code "ai.labs.parser"}</li>
+     * </ul>
+     * </p>
+     *
+     * @param value
+     *            the string to deserialize (must not be null)
+     * @return a new TaskId instance
+     * @throws IllegalArgumentException
+     *             if value is null
+     */
+    @JsonCreator
+    public static TaskId fromValue(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("TaskId cannot be null");
+        }
+
+        if (value.startsWith(SCHEME)) {
+            return new TaskId(value.substring(SCHEME.length()));
+        }
+
+        return new TaskId(value);
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/TaskId.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/TaskId.java
@@ -44,6 +44,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 public record TaskId(String name) {
 
+    public TaskId {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("TaskId name cannot be null or blank");
+        }
+    }
+
     /**
      * URI scheme prefix for all task identifiers. Full identifiers have the format
      * {@code eddi://<name>}.
@@ -96,15 +102,15 @@ public record TaskId(String name) {
      * </p>
      *
      * @param value
-     *            the string to deserialize (must not be null)
+     *            the string to deserialize (must not be null or blank)
      * @return a new TaskId instance
      * @throws IllegalArgumentException
-     *             if value is null
+     *             if value is null or blank
      */
     @JsonCreator
     public static TaskId fromValue(String value) {
-        if (value == null) {
-            throw new IllegalArgumentException("TaskId cannot be null");
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("TaskId cannot be null or blank");
         }
 
         if (value.startsWith(SCHEME)) {

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManager.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManager.java
@@ -236,7 +236,7 @@ public class LifecycleManager implements ILifecycleManager {
 
             // === OpenTelemetry: create span per task ===
             Span taskSpan = getTracer().spanBuilder("eddi.pipeline.task")
-                    .setAttribute("eddi.task.id", Objects.requireNonNullElse(task.getId(), "unknown"))
+                    .setAttribute("eddi.task.id", Objects.requireNonNullElse(task.getId().name(), "unknown"))
                     .setAttribute("eddi.task.type", Objects.requireNonNullElse(task.getType(), "unknown"))
                     .setAttribute("eddi.task.index", (long) index)
                     .setAttribute("eddi.conversation.id",
@@ -251,7 +251,7 @@ public class LifecycleManager implements ILifecycleManager {
                 // Retrieve task's component from cache
                 // Component contains task-specific configuration loaded during agent
                 // initialization
-                var components = componentCache.getComponentMap(task.getId());
+                var components = componentCache.getComponentMap(task.getId().name());
                 var componentKey = createComponentKey(workflowId.getId(), workflowId.getVersion(), index);
                 var component = components.getOrDefault(componentKey, null);
 
@@ -286,7 +286,7 @@ public class LifecycleManager implements ILifecycleManager {
                 taskSpan.recordException(e);
 
                 // Record error counter for dashboards & alerting
-                String errTaskId = task.getId() != null ? task.getId() : "unknown";
+                String errTaskId = task.getId() != null ? task.getId().name() : "unknown";
                 String errTaskType = task.getType() != null ? task.getType() : "unknown";
                 String errMeterKey = errTaskId + "|" + errTaskType;
                 TASK_ERROR_COUNTERS.computeIfAbsent(errMeterKey, k -> Counter.builder("eddi.pipeline.task.errors")
@@ -315,7 +315,7 @@ public class LifecycleManager implements ILifecycleManager {
                 // duration histogram (failing tasks with long timeouts are especially
                 // important for latency monitoring during incidents).
                 long durationMs = (System.nanoTime() - taskStartTime) / 1_000_000;
-                String taskId = task.getId() != null ? task.getId() : "unknown";
+                String taskId = task.getId() != null ? task.getId().name() : "unknown";
                 String taskType = task.getType() != null ? task.getType() : "unknown";
                 String meterKey = taskId + "|" + taskType;
                 TASK_TIMERS.computeIfAbsent(meterKey, k -> Timer.builder("eddi.pipeline.task.duration")
@@ -342,7 +342,7 @@ public class LifecycleManager implements ILifecycleManager {
             summary.put("actions", actionData.getResult());
         }
         // Tool execution trace (for LLM tasks) — enables live tool call display in UI
-        IData<?> traceData = conversationMemory.getCurrentStep().getLatestData("langchain:trace:" + task.getId());
+        IData<?> traceData = conversationMemory.getCurrentStep().getLatestData("langchain:trace:" + task.getId().name());
         if (traceData != null && traceData.getResult() != null) {
             summary.put("toolTrace", traceData.getResult());
         }
@@ -397,9 +397,11 @@ public class LifecycleManager implements ILifecycleManager {
         @SuppressWarnings("unchecked")
         List<String> actions = summary.containsKey("actions") ? (List<String>) summary.get("actions") : null;
 
-        return new AuditEntry(UUID.randomUUID().toString(), memory.getConversationId(), memory.getAgentId(), memory.getAgentVersion(),
+        return new AuditEntry(UUID.randomUUID().toString(), memory.getConversationId(), memory.getAgentId(),
+                memory.getAgentVersion(),
                 memory.getUserId(), null, // environment is set by ConversationService
-                stepIndex, task.getId(), task.getType(), taskIndex, durationMs, input.isEmpty() ? null : input, output.isEmpty() ? null : output,
+                stepIndex, task.getId().name(), task.getType(), taskIndex, durationMs, input.isEmpty() ? null : input,
+                output.isEmpty() ? null : output,
                 llmDetail, null, // toolCalls — set by LlmTask in memory
                 actions, 0.0, // cost — set by ToolCostTracker integration
                 Instant.now(), null // HMAC computed by AuditLedgerService
@@ -583,7 +585,7 @@ public class LifecycleManager implements ILifecycleManager {
         // Store under separate "taskErrors" key — never mixed into "output"
         var errorOutput = new LinkedHashMap<String, Object>();
         errorOutput.put("type", "errorDigest");
-        errorOutput.put("taskId", task.getId());
+        errorOutput.put("taskId", task.getId().name());
         errorOutput.put("taskType", task.getType());
         errorOutput.put("text", digestText);
         step.addConversationOutputList("taskErrors", List.of(errorOutput));
@@ -605,7 +607,7 @@ public class LifecycleManager implements ILifecycleManager {
      */
     private void injectFailureAction(ConversationStep step, ILifecycleTask task,
                                      List<String> actionsBefore) {
-        String failureAction = "task_failed_" + task.getId();
+        String failureAction = "task_failed_" + task.getId().name();
 
         // Rebuild from pre-failure state + failure action
         List<String> actions = new ArrayList<>(actionsBefore);

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManager.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManager.java
@@ -214,6 +214,11 @@ public class LifecycleManager implements ILifecycleManager {
         for (int index = 0; index < lifecycleTasks.size(); index++) {
             ILifecycleTask task = lifecycleTasks.get(index);
 
+            // Fail-fast: every task must have a non-null TaskId
+            if (task.getId() == null) {
+                throw new LifecycleException("Lifecycle task returned null TaskId: " + task.getClass().getName());
+            }
+
             // Check if execution should be interrupted (graceful shutdown)
             if (Thread.currentThread().isInterrupted()) {
                 throw new LifecycleException.LifecycleInterruptedException("Execution was interrupted!");
@@ -236,7 +241,7 @@ public class LifecycleManager implements ILifecycleManager {
 
             // === OpenTelemetry: create span per task ===
             Span taskSpan = getTracer().spanBuilder("eddi.pipeline.task")
-                    .setAttribute("eddi.task.id", Objects.requireNonNullElse(task.getId().name(), "unknown"))
+                    .setAttribute("eddi.task.id", task.getId().name())
                     .setAttribute("eddi.task.type", Objects.requireNonNullElse(task.getType(), "unknown"))
                     .setAttribute("eddi.task.index", (long) index)
                     .setAttribute("eddi.conversation.id",
@@ -286,7 +291,7 @@ public class LifecycleManager implements ILifecycleManager {
                 taskSpan.recordException(e);
 
                 // Record error counter for dashboards & alerting
-                String errTaskId = task.getId() != null ? task.getId().name() : "unknown";
+                String errTaskId = task.getId().name();
                 String errTaskType = task.getType() != null ? task.getType() : "unknown";
                 String errMeterKey = errTaskId + "|" + errTaskType;
                 TASK_ERROR_COUNTERS.computeIfAbsent(errMeterKey, k -> Counter.builder("eddi.pipeline.task.errors")
@@ -315,7 +320,7 @@ public class LifecycleManager implements ILifecycleManager {
                 // duration histogram (failing tasks with long timeouts are especially
                 // important for latency monitoring during incidents).
                 long durationMs = (System.nanoTime() - taskStartTime) / 1_000_000;
-                String taskId = task.getId() != null ? task.getId().name() : "unknown";
+                String taskId = task.getId().name();
                 String taskType = task.getType() != null ? task.getType() : "unknown";
                 String meterKey = taskId + "|" + taskType;
                 TASK_TIMERS.computeIfAbsent(meterKey, k -> Timer.builder("eddi.pipeline.task.duration")

--- a/src/main/java/ai/labs/eddi/engine/runtime/client/workflows/WorkflowStoreClientLibrary.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/client/workflows/WorkflowStoreClientLibrary.java
@@ -84,7 +84,7 @@ public class WorkflowStoreClientLibrary implements IWorkflowStoreClientLibrary {
                     var component = lifecycleTask.configure(workflowStep.getConfig(), workflowStep.getExtensions());
 
                     if (component != null) {
-                        componentCache.put(lifecycleTask.getId(), componentKey, component);
+                        componentCache.put(lifecycleTask.getId().name(), componentKey, component);
                     }
                     lifecycleManager.addLifecycleTask(lifecycleTask);
                 }

--- a/src/main/java/ai/labs/eddi/engine/runtime/client/workflows/WorkflowStoreClientLibrary.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/client/workflows/WorkflowStoreClientLibrary.java
@@ -84,6 +84,10 @@ public class WorkflowStoreClientLibrary implements IWorkflowStoreClientLibrary {
                     var component = lifecycleTask.configure(workflowStep.getConfig(), workflowStep.getExtensions());
 
                     if (component != null) {
+                        if (lifecycleTask.getId() == null) {
+                            throw new WorkflowInitializationException(
+                                    "Lifecycle task returned null TaskId: " + lifecycleTask.getClass().getName(), null);
+                        }
                         componentCache.put(lifecycleTask.getId().name(), componentKey, component);
                     }
                     lifecycleManager.addLifecycleTask(lifecycleTask);

--- a/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTask.java
+++ b/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTask.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor.ConfigValue;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor.FieldType;
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -32,6 +33,8 @@ import static java.lang.String.format;
 @ApplicationScoped
 public class ApiCallsTask implements ILifecycleTask {
     public static final String ID = "ai.labs.httpcalls";
+    public static final TaskId TASK_ID = new TaskId(ID);
+
     private static final String KEY_HTTP_CALLS = "httpCalls";
     private final IResourceClientLibrary resourceClientLibrary;
     private final IMemoryItemConverter memoryItemConverter;
@@ -47,8 +50,8 @@ public class ApiCallsTask implements ILifecycleTask {
     }
 
     @Override
-    public String getId() {
-        return ID;
+    public TaskId getId() {
+        return TASK_ID;
     }
 
     @Override
@@ -118,7 +121,7 @@ public class ApiCallsTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(ID);
+        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(new TaskId(ID));
         extensionDescriptor.setDisplayName("Http Calls");
         ConfigValue configValue = new ConfigValue("Resource URI", FieldType.URI, false, null);
         extensionDescriptor.getConfigs().put("uri", configValue);

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
@@ -15,6 +15,7 @@ import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
 import ai.labs.eddi.engine.memory.*;
@@ -62,6 +63,7 @@ import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
 @ApplicationScoped
 public class LlmTask implements ILifecycleTask {
     public static final String ID = "ai.labs.llm";
+    public static final TaskId TASK_ID = new TaskId(ID);
 
     private static final String KEY_URI = "uri";
     private static final String KEY_LANGCHAIN = "langchain";
@@ -152,8 +154,8 @@ public class LlmTask implements ILifecycleTask {
     }
 
     @Override
-    public String getId() {
-        return ID;
+    public TaskId getId() {
+        return TASK_ID;
     }
 
     @Override
@@ -672,7 +674,7 @@ public class LlmTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(ID);
+        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(new TaskId(ID));
         extensionDescriptor.setDisplayName("Lang Chain");
 
         ConfigValue configValue = new ConfigValue("Resource URI", FieldType.URI, false, null);

--- a/src/main/java/ai/labs/eddi/modules/mcpcalls/impl/McpCallsTask.java
+++ b/src/main/java/ai/labs/eddi/modules/mcpcalls/impl/McpCallsTask.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -62,8 +63,9 @@ import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
  */
 @ApplicationScoped
 public class McpCallsTask implements ILifecycleTask {
-
     public static final String ID = "ai.labs.mcpcalls";
+    public static final TaskId TASK_ID = new TaskId(ID);
+
     private static final String KEY_ACTIONS = "actions";
     private static final String KEY_MCP_CALLS = "mcpCalls";
 
@@ -86,8 +88,8 @@ public class McpCallsTask implements ILifecycleTask {
     }
 
     @Override
-    public String getId() {
-        return ID;
+    public TaskId getId() {
+        return TASK_ID;
     }
 
     @Override
@@ -277,7 +279,7 @@ public class McpCallsTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        ExtensionDescriptor descriptor = new ExtensionDescriptor(ID);
+        ExtensionDescriptor descriptor = new ExtensionDescriptor(new TaskId(ID));
         descriptor.setDisplayName("MCP Calls");
         descriptor.getConfigs().put("uri", new ExtensionDescriptor.ConfigValue("Resource URI", ExtensionDescriptor.FieldType.URI, false, null));
         return descriptor;

--- a/src/main/java/ai/labs/eddi/modules/nlp/InputParserTask.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/InputParserTask.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.modules.nlp;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor.ConfigValue;
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.exceptions.IllegalExtensionConfigurationException;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
 import ai.labs.eddi.engine.lifecycle.exceptions.UnrecognizedExtensionException;
@@ -61,6 +62,8 @@ import static ai.labs.eddi.utils.StringUtilities.joinStrings;
 @ApplicationScoped
 public class InputParserTask implements ILifecycleTask {
     public static final String ID = "ai.labs.parser";
+    public static final TaskId TASK_ID = new TaskId(ID);
+
     private static final String CONFIG_APPEND_EXPRESSIONS = "appendExpressions";
     private static final String CONFIG_INCLUDE_UNUSED = "includeUnused";
     private static final String CONFIG_INCLUDE_UNKNOWN = "includeUnknown";
@@ -94,8 +97,8 @@ public class InputParserTask implements ILifecycleTask {
     }
 
     @Override
-    public String getId() {
-        return "ai.labs.parser";
+    public TaskId getId() {
+        return TASK_ID;
     }
 
     @Override
@@ -258,11 +261,11 @@ public class InputParserTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(ID);
+        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(new TaskId(ID));
         extensionDescriptor.setDisplayName("Input Parser");
 
         normalizerProviders.keySet().forEach(type -> {
-            ExtensionDescriptor normalizerDescriptor = new ExtensionDescriptor(type);
+            ExtensionDescriptor normalizerDescriptor = new ExtensionDescriptor(new TaskId(type));
             Provider<INormalizerProvider> normalizerProvider = normalizerProviders.get(type);
             INormalizerProvider provider = normalizerProvider.get();
             normalizerDescriptor.setDisplayName(provider.getDisplayName());
@@ -271,7 +274,7 @@ public class InputParserTask implements ILifecycleTask {
         });
 
         dictionaryProviders.keySet().forEach(type -> {
-            ExtensionDescriptor dictionaryDescriptor = new ExtensionDescriptor(type);
+            ExtensionDescriptor dictionaryDescriptor = new ExtensionDescriptor(new TaskId(type));
             Provider<IDictionaryProvider> dictionaryProvider = dictionaryProviders.get(type);
             IDictionaryProvider provider = dictionaryProvider.get();
             dictionaryDescriptor.setDisplayName(provider.getDisplayName());
@@ -280,7 +283,7 @@ public class InputParserTask implements ILifecycleTask {
         });
 
         correctionProviders.keySet().forEach(type -> {
-            ExtensionDescriptor correctionsDescriptor = new ExtensionDescriptor(type);
+            ExtensionDescriptor correctionsDescriptor = new ExtensionDescriptor(new TaskId(type));
             Provider<ICorrectionProvider> correctionProvider = correctionProviders.get(type);
             ICorrectionProvider provider = correctionProvider.get();
             correctionsDescriptor.setDisplayName(provider.getDisplayName());

--- a/src/main/java/ai/labs/eddi/modules/output/impl/OutputGenerationTask.java
+++ b/src/main/java/ai/labs/eddi/modules/output/impl/OutputGenerationTask.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor.ConfigValue;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor.FieldType;
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IConversationMemory.IConversationProperties;
@@ -47,6 +48,8 @@ import static ai.labs.eddi.engine.memory.MemoryKeys.ACTIONS;
 @ApplicationScoped
 public class OutputGenerationTask implements ILifecycleTask {
     public static final String ID = "ai.labs.output";
+    public static final TaskId TASK_ID = new TaskId(ID);
+
     private static final String MEMORY_OUTPUT_IDENTIFIER = "output";
     private static final String MEMORY_QUICK_REPLIES_IDENTIFIER = "quickReplies";
     private static final String CONTEXT_IDENTIFIER = "context";
@@ -70,8 +73,8 @@ public class OutputGenerationTask implements ILifecycleTask {
     }
 
     @Override
-    public String getId() {
-        return ID;
+    public TaskId getId() {
+        return TASK_ID;
     }
 
     @Override
@@ -301,7 +304,7 @@ public class OutputGenerationTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(ID);
+        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(new TaskId(ID));
         extensionDescriptor.setDisplayName("Output Generation");
 
         ConfigValue configValue = new ConfigValue("Resource URI", FieldType.URI, false, null);

--- a/src/main/java/ai/labs/eddi/modules/properties/impl/PropertySetterTask.java
+++ b/src/main/java/ai/labs/eddi/modules/properties/impl/PropertySetterTask.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.properties.model.PropertyInstruction;
 import ai.labs.eddi.configs.propertysetter.model.PropertySetterConfiguration;
 import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -50,6 +51,8 @@ import static java.lang.Boolean.parseBoolean;
 @ApplicationScoped
 public class PropertySetterTask implements ILifecycleTask {
     public static final String ID = "ai.labs.property";
+    public static final TaskId TASK_ID = new TaskId(ID);
+
     private static final Logger LOGGER = Logger.getLogger(PropertySetterTask.class);
     private static final String EXPRESSIONS_PARSED_IDENTIFIER = "expressions:parsed";
     private static final String ACTIONS_IDENTIFIER = "actions";
@@ -93,8 +96,8 @@ public class PropertySetterTask implements ILifecycleTask {
     }
 
     @Override
-    public String getId() {
-        return ID;
+    public TaskId getId() {
+        return TASK_ID;
     }
 
     @Override
@@ -270,7 +273,7 @@ public class PropertySetterTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(ID);
+        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(new TaskId(ID));
         extensionDescriptor.setDisplayName("Property Extraction");
         return extensionDescriptor;
     }

--- a/src/main/java/ai/labs/eddi/modules/rules/impl/RulesEvaluationTask.java
+++ b/src/main/java/ai/labs/eddi/modules/rules/impl/RulesEvaluationTask.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.datastore.serialization.DeserializationException;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -38,6 +39,8 @@ import static ai.labs.eddi.engine.memory.MemoryKeys.EXPRESSIONS_PARSED;
 @ApplicationScoped
 public class RulesEvaluationTask implements ILifecycleTask {
     public static final String ID = "ai.labs.behavior";
+    public static final TaskId TASK_ID = new TaskId(ID);
+
     public static final String BEHAVIOR_RULES_TYPE = "behavior_rules";
     private static final String KEY_BEHAVIOR_RULES_SUCCESS = BEHAVIOR_RULES_TYPE + ":success";
     private static final String KEY_BEHAVIOR_RULES_DROPPED_SUCCESS = BEHAVIOR_RULES_TYPE + ":droppedSuccess";
@@ -65,8 +68,8 @@ public class RulesEvaluationTask implements ILifecycleTask {
     }
 
     @Override
-    public String getId() {
-        return ID;
+    public TaskId getId() {
+        return TASK_ID;
     }
 
     @Override
@@ -192,7 +195,7 @@ public class RulesEvaluationTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        var extensionDescriptor = new ExtensionDescriptor(ID);
+        var extensionDescriptor = new ExtensionDescriptor(new TaskId(ID));
         extensionDescriptor.setDisplayName("Behavior Rules");
 
         var configValue = new ConfigValue("Resource URI", FieldType.URI, false, null);

--- a/src/main/java/ai/labs/eddi/modules/rules/impl/RulesEvaluationTask.java
+++ b/src/main/java/ai/labs/eddi/modules/rules/impl/RulesEvaluationTask.java
@@ -195,7 +195,7 @@ public class RulesEvaluationTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        var extensionDescriptor = new ExtensionDescriptor(new TaskId(ID));
+        var extensionDescriptor = new ExtensionDescriptor(TASK_ID);
         extensionDescriptor.setDisplayName("Behavior Rules");
 
         var configValue = new ConfigValue("Resource URI", FieldType.URI, false, null);

--- a/src/main/java/ai/labs/eddi/modules/templating/OutputTemplateTask.java
+++ b/src/main/java/ai/labs/eddi/modules/templating/OutputTemplateTask.java
@@ -204,7 +204,7 @@ public class OutputTemplateTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(new TaskId(ID));
+        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(TASK_ID);
         extensionDescriptor.setDisplayName("Templating");
         return extensionDescriptor;
     }

--- a/src/main/java/ai/labs/eddi/modules/templating/OutputTemplateTask.java
+++ b/src/main/java/ai/labs/eddi/modules/templating/OutputTemplateTask.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.modules.templating;
 
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IConversationMemory.IWritableConversationStep;
 import ai.labs.eddi.engine.memory.IData;
@@ -34,6 +35,8 @@ import static ai.labs.eddi.utils.StringUtilities.joinStrings;
 @ApplicationScoped
 public class OutputTemplateTask implements ILifecycleTask {
     public static final String ID = "ai.labs.templating";
+    public static final TaskId TASK_ID = new TaskId(ID);
+
     private static final String OUTPUT_HTML = "output:html";
     private static final String PRE_TEMPLATED = "preTemplated";
     private static final String POST_TEMPLATED = "postTemplated";
@@ -56,8 +59,8 @@ public class OutputTemplateTask implements ILifecycleTask {
     }
 
     @Override
-    public String getId() {
-        return "ai.labs.templating";
+    public TaskId getId() {
+        return TASK_ID;
     }
 
     @Override
@@ -201,7 +204,7 @@ public class OutputTemplateTask implements ILifecycleTask {
 
     @Override
     public ExtensionDescriptor getExtensionDescriptor() {
-        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(ID);
+        ExtensionDescriptor extensionDescriptor = new ExtensionDescriptor(new TaskId(ID));
         extensionDescriptor.setDisplayName("Templating");
         return extensionDescriptor;
     }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingExtendedTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.internal;
 
 import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
@@ -77,7 +78,7 @@ class RestAgentEngineStreamingExtendedTest {
             invokeSayStreaming();
             var handler = captureHandler();
 
-            handler.onTaskStart("task-1", "LlmTask", 0);
+            handler.onTaskStart(new TaskId("task-1"), "LlmTask", 0);
 
             verify(eventBuilder).name("task_start");
             verify(eventBuilder).data(eq(String.class), contains("task-1"));
@@ -90,7 +91,7 @@ class RestAgentEngineStreamingExtendedTest {
             invokeSayStreaming();
             var handler = captureHandler();
 
-            handler.onTaskComplete("task-1", "LlmTask", 150L, Map.of());
+            handler.onTaskComplete(new TaskId("task-1"), "LlmTask", 150L, Map.of());
 
             verify(eventBuilder).name("task_complete");
             verify(eventBuilder).data(eq(String.class), contains("task-1"));
@@ -102,7 +103,7 @@ class RestAgentEngineStreamingExtendedTest {
             invokeSayStreaming();
             var handler = captureHandler();
 
-            handler.onTaskComplete("task-1", "RulesEvaluation", 50L,
+            handler.onTaskComplete(new TaskId("task-1"), "RulesEvaluation", 50L,
                     Map.of("actions", List.of("greet", "respond")));
 
             var dataCaptor = ArgumentCaptor.forClass(String.class);
@@ -118,7 +119,7 @@ class RestAgentEngineStreamingExtendedTest {
             invokeSayStreaming();
             var handler = captureHandler();
 
-            handler.onTaskComplete("task-1", "LlmTask", 200L,
+            handler.onTaskComplete(new TaskId("task-1"), "LlmTask", 200L,
                     Map.of("toolTrace", List.of(Map.of("tool", "weather", "duration", 100))));
 
             var dataCaptor = ArgumentCaptor.forClass(String.class);
@@ -133,7 +134,7 @@ class RestAgentEngineStreamingExtendedTest {
             invokeSayStreaming();
             var handler = captureHandler();
 
-            handler.onTaskComplete("task-1", "LlmTask", 100L,
+            handler.onTaskComplete(new TaskId("task-1"), "LlmTask", 100L,
                     Map.of("confidence", 0.95));
 
             var dataCaptor = ArgumentCaptor.forClass(String.class);
@@ -262,7 +263,7 @@ class RestAgentEngineStreamingExtendedTest {
             };
 
             // Should not throw — handled gracefully
-            assertDoesNotThrow(() -> handler.onTaskComplete("t1", "LlmTask", 100L,
+            assertDoesNotThrow(() -> handler.onTaskComplete(new TaskId("ai.test.failure"), "LlmTask", 100L,
                     Map.of("toolTrace", circular)));
         }
     }

--- a/src/test/java/ai/labs/eddi/engine/lifecycle/LifecycleManagerTest.java
+++ b/src/test/java/ai/labs/eddi/engine/lifecycle/LifecycleManagerTest.java
@@ -40,6 +40,8 @@ public class LifecycleManagerTest {
     public void testExecuteLifecycle() throws Exception {
         // setup
         ILifecycleTask lifecycleTask = mock(ILifecycleTask.class);
+        when(lifecycleTask.getId()).thenReturn(new TaskId("test"));
+        when(lifecycleTask.getType()).thenReturn("test");
         lifecycleManager.addLifecycleTask(lifecycleTask);
 
         // test
@@ -71,11 +73,11 @@ public class LifecycleManagerTest {
         // Setup: tasks with types "behavior_rules" and "langchain"
         ILifecycleTask behaviorTask = mock(ILifecycleTask.class);
         when(behaviorTask.getType()).thenReturn("behavior_rules");
-        when(behaviorTask.getId()).thenReturn("behavior_rules");
+        when(behaviorTask.getId()).thenReturn(new TaskId("behavior_rules"));
 
         ILifecycleTask langchainTask = mock(ILifecycleTask.class);
         when(langchainTask.getType()).thenReturn("langchain");
-        when(langchainTask.getId()).thenReturn("langchain");
+        when(langchainTask.getId()).thenReturn(new TaskId("langchain"));
 
         lifecycleManager.addLifecycleTask(behaviorTask);
         lifecycleManager.addLifecycleTask(langchainTask);
@@ -93,11 +95,11 @@ public class LifecycleManagerTest {
         // Setup: task with type "behavior_rules"
         ILifecycleTask behaviorTask = mock(ILifecycleTask.class);
         when(behaviorTask.getType()).thenReturn("behavior_rules");
-        when(behaviorTask.getId()).thenReturn("behavior_rules");
+        when(behaviorTask.getId()).thenReturn(new TaskId("behavior_rules"));
 
         ILifecycleTask outputTask = mock(ILifecycleTask.class);
         when(outputTask.getType()).thenReturn("output");
-        when(outputTask.getId()).thenReturn("output");
+        when(outputTask.getId()).thenReturn(new TaskId("output"));
 
         lifecycleManager.addLifecycleTask(behaviorTask);
         lifecycleManager.addLifecycleTask(outputTask);
@@ -117,7 +119,7 @@ public class LifecycleManagerTest {
         // because "behavior_rules".startsWith("behavior_rules_extended") is false
         ILifecycleTask behaviorTask = mock(ILifecycleTask.class);
         when(behaviorTask.getType()).thenReturn("behavior_rules");
-        when(behaviorTask.getId()).thenReturn("behavior_rules");
+        when(behaviorTask.getId()).thenReturn(new TaskId("behavior_rules"));
 
         lifecycleManager.addLifecycleTask(behaviorTask);
 
@@ -132,11 +134,11 @@ public class LifecycleManagerTest {
     public void testExecuteLifecycle_NoFilter_ExecutesAll() throws Exception {
         ILifecycleTask task1 = mock(ILifecycleTask.class);
         when(task1.getType()).thenReturn("parser");
-        when(task1.getId()).thenReturn("parser");
+        when(task1.getId()).thenReturn(new TaskId("parser"));
 
         ILifecycleTask task2 = mock(ILifecycleTask.class);
         when(task2.getType()).thenReturn("output");
-        when(task2.getId()).thenReturn("output");
+        when(task2.getId()).thenReturn(new TaskId("output"));
 
         lifecycleManager.addLifecycleTask(task1);
         lifecycleManager.addLifecycleTask(task2);
@@ -152,7 +154,7 @@ public class LifecycleManagerTest {
     public void testExecuteLifecycle_EmptyFilter_ExecutesAll() throws Exception {
         ILifecycleTask task = mock(ILifecycleTask.class);
         when(task.getType()).thenReturn("parser");
-        when(task.getId()).thenReturn("parser");
+        when(task.getId()).thenReturn(new TaskId("parser"));
 
         lifecycleManager.addLifecycleTask(task);
 

--- a/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerStreamingTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.engine.lifecycle.internal;
 
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.IComponentCache;
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
@@ -52,11 +53,11 @@ class LifecycleManagerStreamingTest {
         eventSink = mock(ConversationEventSink.class);
 
         task1 = mock(ILifecycleTask.class);
-        when(task1.getId()).thenReturn("ai.labs.parser");
+        when(task1.getId()).thenReturn(new TaskId("ai.labs.parser"));
         when(task1.getType()).thenReturn("expressions");
 
         task2 = mock(ILifecycleTask.class);
-        when(task2.getId()).thenReturn("ai.labs.behavior");
+        when(task2.getId()).thenReturn(new TaskId("ai.labs.behavior"));
         when(task2.getType()).thenReturn("behavior_rules");
 
         lifecycleManager.addLifecycleTask(task1);
@@ -71,12 +72,12 @@ class LifecycleManagerStreamingTest {
         lifecycleManager.executeLifecycle(memory, null);
 
         // task_start for each task
-        verify(eventSink).onTaskStart("ai.labs.parser", "expressions", 0);
-        verify(eventSink).onTaskStart("ai.labs.behavior", "behavior_rules", 1);
+        verify(eventSink).onTaskStart(new TaskId("ai.labs.parser"), "expressions", 0);
+        verify(eventSink).onTaskStart(new TaskId("ai.labs.behavior"), "behavior_rules", 1);
 
         // task_complete for each task
-        verify(eventSink).onTaskComplete(eq("ai.labs.parser"), eq("expressions"), anyLong(), any());
-        verify(eventSink).onTaskComplete(eq("ai.labs.behavior"), eq("behavior_rules"), anyLong(), any());
+        verify(eventSink).onTaskComplete(eq(new TaskId("ai.labs.parser")), eq("expressions"), anyLong(), any());
+        verify(eventSink).onTaskComplete(eq(new TaskId("ai.labs.behavior")), eq("behavior_rules"), anyLong(), any());
 
         // Tasks are still executed
         verify(task1).execute(eq(memory), any());
@@ -108,14 +109,14 @@ class LifecycleManagerStreamingTest {
         lifecycleManager.executeLifecycle(memory, null);
 
         // Task 1: start → execute → complete
-        inOrder.verify(eventSink).onTaskStart("ai.labs.parser", "expressions", 0);
+        inOrder.verify(eventSink).onTaskStart(new TaskId("ai.labs.parser"), "expressions", 0);
         inOrder.verify(task1).execute(eq(memory), any());
-        inOrder.verify(eventSink).onTaskComplete(eq("ai.labs.parser"), eq("expressions"), anyLong(), any());
+        inOrder.verify(eventSink).onTaskComplete(eq(new TaskId("ai.labs.parser")), eq("expressions"), anyLong(), any());
 
         // Task 2: start → execute → complete
-        inOrder.verify(eventSink).onTaskStart("ai.labs.behavior", "behavior_rules", 1);
+        inOrder.verify(eventSink).onTaskStart(new TaskId("ai.labs.behavior"), "behavior_rules", 1);
         inOrder.verify(task2).execute(eq(memory), any());
-        inOrder.verify(eventSink).onTaskComplete(eq("ai.labs.behavior"), eq("behavior_rules"), anyLong(), any());
+        inOrder.verify(eventSink).onTaskComplete(eq(new TaskId("ai.labs.behavior")), eq("behavior_rules"), anyLong(), any());
     }
 
     @Test
@@ -125,7 +126,7 @@ class LifecycleManagerStreamingTest {
 
         lifecycleManager.executeLifecycle(memory, null);
 
-        verify(eventSink, times(2)).onTaskComplete(anyString(), anyString(), longThat(duration -> duration >= 0), any());
+        verify(eventSink, times(2)).onTaskComplete(any(TaskId.class), anyString(), longThat(duration -> duration >= 0), any());
     }
 
     @Test
@@ -137,8 +138,8 @@ class LifecycleManagerStreamingTest {
         assertThrows(LifecycleException.class, () -> lifecycleManager.executeLifecycle(memory, null));
 
         // task_start should have been emitted before the error
-        verify(eventSink).onTaskStart("ai.labs.parser", "expressions", 0);
+        verify(eventSink).onTaskStart(new TaskId("ai.labs.parser"), "expressions", 0);
         // task_complete should NOT have been emitted for the failed task
-        verify(eventSink, never()).onTaskComplete(eq("ai.labs.parser"), anyString(), anyLong(), any());
+        verify(eventSink, never()).onTaskComplete(eq(new TaskId("ai.labs.parser")), anyString(), anyLong(), any());
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerTest.java
+++ b/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerTest.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.lifecycle.IComponentCache;
 import ai.labs.eddi.engine.lifecycle.IConversation;
+import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.ILifecycleTask;
 import ai.labs.eddi.engine.lifecycle.exceptions.ConversationStopException;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
@@ -59,7 +60,7 @@ class LifecycleManagerTest {
         @DisplayName("valid task is accepted")
         void addValidTask() {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("task1");
+            when(task.getId()).thenReturn(new TaskId("task1"));
             assertDoesNotThrow(() -> lifecycleManager.addLifecycleTask(task));
         }
     }
@@ -86,7 +87,7 @@ class LifecycleManagerTest {
         @DisplayName("single task executes successfully")
         void singleTask() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("parser");
+            when(task.getId()).thenReturn(new TaskId("parser"));
             when(task.getType()).thenReturn("input");
 
             lifecycleManager.addLifecycleTask(task);
@@ -108,11 +109,11 @@ class LifecycleManagerTest {
         @DisplayName("multiple tasks execute in order")
         void multipleTasks() throws Exception {
             var task1 = mock(ILifecycleTask.class);
-            when(task1.getId()).thenReturn("parser");
+            when(task1.getId()).thenReturn(new TaskId("parser"));
             when(task1.getType()).thenReturn("input");
 
             var task2 = mock(ILifecycleTask.class);
-            when(task2.getId()).thenReturn("behavior");
+            when(task2.getId()).thenReturn(new TaskId("behavior"));
             when(task2.getType()).thenReturn("behavior_rules");
 
             lifecycleManager.addLifecycleTask(task1);
@@ -137,7 +138,7 @@ class LifecycleManagerTest {
         @DisplayName("STOP_CONVERSATION action throws ConversationStopException")
         void stopConversation() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("behavior");
+            when(task.getId()).thenReturn(new TaskId("behavior"));
             when(task.getType()).thenReturn("behavior_rules");
 
             lifecycleManager.addLifecycleTask(task);
@@ -163,7 +164,7 @@ class LifecycleManagerTest {
         @DisplayName("task failure propagates LifecycleException")
         void taskFailure() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("llm");
+            when(task.getId()).thenReturn(new TaskId("llm"));
             when(task.getType()).thenReturn("langchain");
 
             doThrow(new LifecycleException("LLM failed"))
@@ -187,7 +188,7 @@ class LifecycleManagerTest {
         @DisplayName("RuntimeException in task is wrapped in LifecycleException")
         void runtimeException() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("broken");
+            when(task.getId()).thenReturn(new TaskId("broken"));
             when(task.getType()).thenReturn("custom");
 
             doThrow(new RuntimeException("NPE"))
@@ -216,15 +217,15 @@ class LifecycleManagerTest {
         @DisplayName("filter by type — only matching and subsequent tasks execute")
         void filterByType() throws Exception {
             var parser = mock(ILifecycleTask.class);
-            when(parser.getId()).thenReturn("parser");
+            when(parser.getId()).thenReturn(new TaskId("parser"));
             when(parser.getType()).thenReturn("input");
 
             var behavior = mock(ILifecycleTask.class);
-            when(behavior.getId()).thenReturn("behavior");
+            when(behavior.getId()).thenReturn(new TaskId("behavior"));
             when(behavior.getType()).thenReturn("behavior_rules");
 
             var output = mock(ILifecycleTask.class);
-            when(output.getId()).thenReturn("output");
+            when(output.getId()).thenReturn(new TaskId("output"));
             when(output.getType()).thenReturn("output");
 
             lifecycleManager.addLifecycleTask(parser);
@@ -251,7 +252,7 @@ class LifecycleManagerTest {
         @DisplayName("filter with no match — no tasks execute")
         void filterNoMatch() throws Exception {
             var parser = mock(ILifecycleTask.class);
-            when(parser.getId()).thenReturn("parser");
+            when(parser.getId()).thenReturn(new TaskId("parser"));
             when(parser.getType()).thenReturn("input");
 
             lifecycleManager.addLifecycleTask(parser);
@@ -274,7 +275,7 @@ class LifecycleManagerTest {
         @DisplayName("task failure with strict write enabled — uncommits data and injects error digest")
         void taskFailureWithStrictWrite() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("llm_task");
+            when(task.getId()).thenReturn(new TaskId("llm_task"));
             when(task.getType()).thenReturn("langchain");
 
             doThrow(new LifecycleException("API timeout"))
@@ -316,7 +317,7 @@ class LifecycleManagerTest {
         @DisplayName("task failure with strict write exclude_all — no digest, but data uncommitted")
         void taskFailureExcludeAll() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("api_task");
+            when(task.getId()).thenReturn(new TaskId("api_task"));
             when(task.getType()).thenReturn("httpcalls");
 
             doThrow(new LifecycleException("API error"))
@@ -360,7 +361,7 @@ class LifecycleManagerTest {
         @DisplayName("event sink receives task_start and task_complete events")
         void eventSinkNotified() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("parser");
+            when(task.getId()).thenReturn(new TaskId("parser"));
             when(task.getType()).thenReturn("input");
 
             lifecycleManager.addLifecycleTask(task);
@@ -378,8 +379,8 @@ class LifecycleManagerTest {
 
             lifecycleManager.executeLifecycle(memory, null);
 
-            verify(eventSink).onTaskStart("parser", "input", 0);
-            verify(eventSink).onTaskComplete(eq("parser"), eq("input"), anyLong(), anyMap());
+            verify(eventSink).onTaskStart(new TaskId("parser"), "input", 0);
+            verify(eventSink).onTaskComplete(eq(new TaskId("parser")), eq("input"), anyLong(), anyMap());
         }
     }
 
@@ -391,7 +392,7 @@ class LifecycleManagerTest {
         @DisplayName("audit collector receives audit entry when set")
         void auditCollectorNotified() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("behavior");
+            when(task.getId()).thenReturn(new TaskId("behavior"));
             when(task.getType()).thenReturn("behavior_rules");
 
             lifecycleManager.addLifecycleTask(task);
@@ -423,7 +424,7 @@ class LifecycleManagerTest {
         @DisplayName("interrupted thread throws LifecycleInterruptedException")
         void interruptedThread() {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("parser");
+            when(task.getId()).thenReturn(new TaskId("parser"));
             when(task.getType()).thenReturn("input");
 
             lifecycleManager.addLifecycleTask(task);
@@ -453,7 +454,7 @@ class LifecycleManagerTest {
         @DisplayName("keep_all mode — isEffectivelyEnabled() returns false, no SWD applied")
         void keepAllMode() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("llm_task");
+            when(task.getId()).thenReturn(new TaskId("llm_task"));
             when(task.getType()).thenReturn("langchain");
 
             doThrow(new LifecycleException("LLM error"))
@@ -488,7 +489,7 @@ class LifecycleManagerTest {
         @DisplayName("null memoryPolicy — strict write discipline not applied")
         void nullMemoryPolicy() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("failing_task");
+            when(task.getId()).thenReturn(new TaskId("failing_task"));
             when(task.getType()).thenReturn("custom");
 
             doThrow(new LifecycleException("fail"))
@@ -516,7 +517,7 @@ class LifecycleManagerTest {
         @DisplayName("disabled strict write — no uncommit even on failure")
         void disabledStrictWrite() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("failing_task");
+            when(task.getId()).thenReturn(new TaskId("failing_task"));
             when(task.getType()).thenReturn("custom");
 
             doThrow(new LifecycleException("fail"))
@@ -549,11 +550,11 @@ class LifecycleManagerTest {
         @DisplayName("failure after first task — second task does NOT execute")
         void failureStopsPipeline() throws Exception {
             var task1 = mock(ILifecycleTask.class);
-            when(task1.getId()).thenReturn("parser");
+            when(task1.getId()).thenReturn(new TaskId("parser"));
             when(task1.getType()).thenReturn("input");
 
             var task2 = mock(ILifecycleTask.class);
-            when(task2.getId()).thenReturn("behavior");
+            when(task2.getId()).thenReturn(new TaskId("behavior"));
             when(task2.getType()).thenReturn("behavior_rules");
 
             doThrow(new LifecycleException("parse error"))
@@ -586,7 +587,7 @@ class LifecycleManagerTest {
         @DisplayName("empty lifecycleTaskTypes — all tasks execute (same as null)")
         void emptyListExecutesAll() throws Exception {
             var task = mock(ILifecycleTask.class);
-            when(task.getId()).thenReturn("parser");
+            when(task.getId()).thenReturn(new TaskId("parser"));
             when(task.getType()).thenReturn("input");
 
             lifecycleManager.addLifecycleTask(task);

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTaskTest.java
@@ -62,7 +62,7 @@ class ApiCallsTaskTest {
     @Test
     @DisplayName("returns correct ID")
     void getId() {
-        assertEquals("ai.labs.httpcalls", task.getId());
+        assertEquals("ai.labs.httpcalls", task.getId().name());
     }
 
     @Test
@@ -315,7 +315,7 @@ class ApiCallsTaskTest {
     @DisplayName("extension descriptor has correct ID and display name")
     void extensionDescriptor() {
         ExtensionDescriptor descriptor = task.getExtensionDescriptor();
-        assertEquals("ai.labs.httpcalls", descriptor.getType());
+        assertEquals("ai.labs.httpcalls", descriptor.getType().name());
         assertEquals("Http Calls", descriptor.getDisplayName());
         assertTrue(descriptor.getConfigs().containsKey("uri"));
     }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskTest.java
@@ -300,7 +300,7 @@ class LlmTaskTest {
         assertNotNull(descriptor, "The returned ExtensionDescriptor should not be null.");
 
         // Assuming ID and Display Name are known and static for the LangChainTask
-        assertEquals(LlmTask.ID, descriptor.getType(), "The ID should match the expected value.");
+        assertEquals(LlmTask.ID, descriptor.getType().name(), "The ID should match the expected value.");
         assertEquals("Lang Chain", descriptor.getDisplayName(), "The display name should match 'Lang Chain'.");
 
         assertFalse(descriptor.getConfigs().isEmpty(), "Expected configs to be defined.");
@@ -595,7 +595,7 @@ class LlmTaskTest {
         @Test
         @DisplayName("getId should return correct identifier")
         void testGetId() {
-            assertEquals("ai.labs.llm", langChainTask.getId());
+            assertEquals("ai.labs.llm", langChainTask.getId().name());
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/modules/mcpcalls/McpCallsTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/mcpcalls/McpCallsTaskTest.java
@@ -62,7 +62,7 @@ class McpCallsTaskTest {
     @Test
     @DisplayName("getId returns correct identifier")
     void testGetId() {
-        assertEquals("ai.labs.mcpcalls", task.getId());
+        assertEquals("ai.labs.mcpcalls", task.getId().name());
     }
 
     @Test
@@ -271,7 +271,7 @@ class McpCallsTaskTest {
         var descriptor = task.getExtensionDescriptor();
 
         assertNotNull(descriptor);
-        assertEquals("ai.labs.mcpcalls", descriptor.getType());
+        assertEquals("ai.labs.mcpcalls", descriptor.getType().name());
         assertEquals("MCP Calls", descriptor.getDisplayName());
         assertTrue(descriptor.getConfigs().containsKey("uri"));
     }

--- a/src/test/java/ai/labs/eddi/modules/nlp/InputParserTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/nlp/InputParserTaskTest.java
@@ -69,7 +69,7 @@ class InputParserTaskTest {
         @Test
         @DisplayName("getId returns correct identifier")
         void testGetId() {
-            assertEquals("ai.labs.parser", task.getId());
+            assertEquals("ai.labs.parser", task.getId().name());
         }
 
         @Test
@@ -348,7 +348,7 @@ class InputParserTaskTest {
             var descriptor = task.getExtensionDescriptor();
 
             assertNotNull(descriptor);
-            assertEquals("ai.labs.parser", descriptor.getType());
+            assertEquals("ai.labs.parser", descriptor.getType().name());
             assertEquals("Input Parser", descriptor.getDisplayName());
         }
 

--- a/src/test/java/ai/labs/eddi/modules/output/OutputGenerationTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/output/OutputGenerationTaskTest.java
@@ -64,7 +64,7 @@ class OutputGenerationTaskTest {
     @Test
     @DisplayName("getId returns correct identifier")
     void testGetId() {
-        assertEquals("ai.labs.output", task.getId());
+        assertEquals("ai.labs.output", task.getId().name());
     }
 
     @Test
@@ -201,7 +201,7 @@ class OutputGenerationTaskTest {
         var descriptor = task.getExtensionDescriptor();
 
         assertNotNull(descriptor);
-        assertEquals("ai.labs.output", descriptor.getType());
+        assertEquals("ai.labs.output", descriptor.getType().name());
         assertEquals("Output Generation", descriptor.getDisplayName());
         assertTrue(descriptor.getConfigs().containsKey("uri"));
     }

--- a/src/test/java/ai/labs/eddi/modules/properties/PropertySetterTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/properties/PropertySetterTaskTest.java
@@ -107,7 +107,7 @@ public class PropertySetterTaskTest {
         @Test
         @DisplayName("getId should return correct identifier")
         void testGetId() {
-            assertEquals("ai.labs.property", propertySetterTask.getId());
+            assertEquals("ai.labs.property", propertySetterTask.getId().name());
         }
 
         @Test
@@ -534,7 +534,7 @@ public class PropertySetterTaskTest {
             var descriptor = propertySetterTask.getExtensionDescriptor();
 
             assertNotNull(descriptor);
-            assertEquals("ai.labs.property", descriptor.getType());
+            assertEquals("ai.labs.property", descriptor.getType().name());
             assertEquals("Property Extraction", descriptor.getDisplayName());
         }
     }

--- a/src/test/java/ai/labs/eddi/modules/properties/impl/PropertySetterTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/properties/impl/PropertySetterTaskTest.java
@@ -58,7 +58,7 @@ class PropertySetterTaskTest {
     @Test
     @DisplayName("getId returns correct ID")
     void getId() {
-        assertEquals("ai.labs.property", task.getId());
+        assertEquals("ai.labs.property", task.getId().name());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/modules/rules/impl/RulesEvaluationTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/rules/impl/RulesEvaluationTaskTest.java
@@ -60,7 +60,7 @@ class RulesEvaluationTaskTest {
         @Test
         @DisplayName("getId should return correct identifier")
         void testGetId() {
-            assertEquals("ai.labs.behavior", task.getId());
+            assertEquals("ai.labs.behavior", task.getId().name());
         }
 
         @Test
@@ -247,7 +247,7 @@ class RulesEvaluationTaskTest {
             ExtensionDescriptor descriptor = task.getExtensionDescriptor();
 
             assertNotNull(descriptor);
-            assertEquals("ai.labs.behavior", descriptor.getType());
+            assertEquals("ai.labs.behavior", descriptor.getType().name());
             assertEquals("Behavior Rules", descriptor.getDisplayName());
 
             assertTrue(descriptor.getConfigs().containsKey("uri"));


### PR DESCRIPTION

## Summary

Frontend branch PR is https://github.com/labsai/EDDI-Manager/pull/85

Introduces a `TaskId` record to replace raw `String` identifiers for lifecycle tasks, making task identity type-safe and canonical. Also renames the record field from `type` → `name` to avoid confusion with `ILifecycleTask.getType()` which returns a different value.

The `/extensionstore/extensions` endpoint was returning bare strings like `"ai.labs.parser"` in its `type` field, but should always have returned the full `eddi://` URI format (e.g., `"eddi://ai.labs.parser"`) to comply with the MSW. This was an existing bug — the workflow step type is defined as a URI throughout the config model (`WorkflowStep.type` is `java.net.URI`), and the extension descriptor's `type` field should have been consistent with that. This PR fixes it by wrapping the value in `TaskId`, which serializes to the canonical URI format.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related Issue

Closes #

## Changes Made

- **New `TaskId` record** (`ai.labs.eddi.engine.lifecycle.TaskId`) — immutable wrapper with canonical URI format (`eddi://ai.labs.parser`). Serializes as full URI via `@JsonValue`, deserializes from both `"eddi://ai.labs.parser"` and bare `"ai.labs.parser"` via `@JsonCreator` for backward compatibility.
- **`ILifecycleTask.getId()`** return type changed from `String` → `TaskId`. All 8 task implementations updated with `static final TaskId TASK_ID` constant.
- **`ExtensionDescriptor.type`** changed from `String` → `TaskId`. Constructor, getter, and setter updated; all task `getExtensionDescriptor()` calls now pass `new TaskId(ID)`. This fixes the `/extensionstore/extensions` endpoint to return the canonical `eddi://` URI format as required by the MSW.
- **SSE streaming interfaces** (`ConversationEventSink`, `IConversationService.StreamingResponseHandler`) — `taskId` parameter type changed from `String` → `TaskId`. `RestAgentEngineStreaming` uses `taskId.getIdentifier()` for JSON output.
- **`LifecycleManager`** — 8 call sites updated to use `task.getId().name()` for bare identifier extraction (metrics, cache keys, audit entries, tracing).
- **`WorkflowStoreClientLibrary`** — component cache key uses `.name()`.
- **Field rename** `TaskId.type` → `TaskId.name` — eliminates naming clash with `ILifecycleTask.getType()` which returns a pipeline stage name (e.g., `"expressions"`), not the task identifier.

## How to Test

1. `./mvnw compile` — confirms all type changes compile
2. `./mvnw test -pl . -Dtest="InputParserTaskTest,RulesEvaluationTaskTest,ApiCallsTaskTest,PropertySetterTaskTest,OutputGenerationTaskTest,LlmTaskTest,McpCallsTaskTest"` — verifies all `getId()` and `getExtensionDescriptor()` assertions
3. `GET /extensionstore/extensions` — verify that `type` fields serialize as `"eddi://ai.labs.parser"` (not bare `"ai.labs.parser"`), matching the MSW URI convention
4. `POST /conversation/{id}/say` with SSE — verify `task_start` and `task_complete` events contain `"taskId": "eddi://ai.labs.parser"` format
5. Import an existing agent config ZIP — verify deserialization still accepts bare strings in `WorkflowStep.type` via `TaskId.fromValue()` backward compat

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [ ] I have updated documentation if needed
- [x] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [x] I have not committed any secrets, API keys, or tokens
- [x] This PR has a clear, focused scope (one concern per PR)

---

**Breaking change details for reviewers:**

| What changed | Before | After | Impact |
|---|---|---|---|
| `GET /extensionstore/extensions` `type` field | `"ai.labs.parser"` | `"eddi://ai.labs.parser"` | EDDI-Manager and any API clients parsing `type` — **bug fix** for MSW compliance |
| SSE `task_start`/`task_complete` `taskId` field | `"ai.labs.parser"` | `"eddi://ai.labs.parser"` | SSE event consumers |
| `ILifecycleTask.getId()` | returns `String` | returns `TaskId` | Binary incompatible for external task implementations (none exist outside this repo) |

**Backward compat:** `TaskId.fromValue(@JsonCreator)` accepts both `"eddi://ai.labs.parser"` and bare `"ai.labs.parser"` on deserialization, so existing agent configs and workflow step definitions continue to work without changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture, developer quickstart, agent, and planning docs and examples to reflect the new lifecycle task identifier format.

* **Refactor**
  * Standardized lifecycle task identifiers across the system.
  * Enhanced observability/span naming and updated streaming callbacks to use structured task identifiers.
  * Added runtime guards to validate task identifiers early.

* **Chores**
  * Added chromadb tool and reorganized build task configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/labsai/EDDI/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->