### PR TITLE
Fix: White Page at Root URL — Revert index.html to Redirect + Checkstyle Cleanup

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ Commit `0ec6cb47c` (Jun 2) replaced `index.html`'s simple redirect with a full c
 - **`deploy-to-local-eddi-repo.ps1`** — Removed `$IndexHtml` handling (no longer needed). Script only updates `manage.html`.
 
 ### Architecture Clarification
+
 | File | Served at | Purpose |
 |------|-----------|---------|
 | `index.html` | `/` (Quarkus static) | Redirect to `/manage` |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,29 @@
 
 ---
 
+## 🐛 Fix: White Page at Root — index.html Revert to Redirect (2026-06-03)
+
+**Repo:** EDDI (`fix/manager-deploy-and-index-html`) + EDDI-Manager (deploy script)
+**What changed:** Root URL (`/`) showed a white page because `index.html` referenced deleted asset hashes.
+
+### Root Cause
+Commit `0ec6cb47c` (Jun 2) replaced `index.html`'s simple redirect with a full copy of the Manager SPA, duplicating the hashed asset references from `manage.html`. When the deploy script (`deploy-to-local-eddi-repo.ps1`) ran a Manager rebuild in `d9e6361`, it updated `manage.html` and the asset files but had no knowledge of `index.html` — leaving it pointing at deleted files (`index-Bn-sgAam.js`, `index-BZNayFGO.css`). With `X-Content-Type-Options: nosniff`, the browser blocked the HTML fallback response.
+
+### Fix
+- **`index.html`** — Reverted to a simple `<meta http-equiv="refresh">` redirect to `/manage`. No asset references, no sync needed. Keycloak works because the SPA boots at `/manage` and sets `redirectUri` to its own URL; the Keycloak client's `redirectUris: ["http://localhost:*"]` matches any path.
+- **`deploy-to-local-eddi-repo.ps1`** — Removed `$IndexHtml` handling (no longer needed). Script only updates `manage.html`.
+
+### Architecture Clarification
+| File | Served at | Purpose |
+|------|-----------|---------|
+| `index.html` | `/` (Quarkus static) | Redirect to `/manage` |
+| `manage.html` | `/manage` + `/manage/{path}` (RestManagerResource) | Manager SPA entry + client-side route fallback |
+| `chat.html` | `/chat/...` | Chat widget (separate assets under `/scripts/`) |
+
+**Files:** `index.html`, `deploy-to-local-eddi-repo.ps1`
+
+---
+
 ## 🔍 PR Review Fixes — Code Quality & Correctness (2026-06-03)
 
 **Repo:** EDDI (`fix/mcp-endpoint-bugs`)

--- a/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
@@ -216,7 +216,10 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             // Window may be stale — try to reset and increment atomically
             try (PreparedStatement ps = conn.prepareStatement(
                     """
-                            INSERT INTO tenant_usage (tenant_id, conversations_today, day_start, api_calls_this_minute, minute_start, monthly_cost_usd, cost_month)
+                            INSERT INTO tenant_usage
+                                (tenant_id, conversations_today, day_start,
+                                 api_calls_this_minute, minute_start,
+                                 monthly_cost_usd, cost_month)
                             VALUES (?, 1, ?, 0, ?, 0.0, ?)
                             ON CONFLICT (tenant_id) DO UPDATE SET
                                 conversations_today = CASE WHEN tenant_usage.day_start < ? THEN 1 ELSE tenant_usage.conversations_today END,
@@ -274,7 +277,10 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             // Window may be stale — reset
             try (PreparedStatement ps = conn.prepareStatement(
                     """
-                            INSERT INTO tenant_usage (tenant_id, conversations_today, day_start, api_calls_this_minute, minute_start, monthly_cost_usd, cost_month)
+                            INSERT INTO tenant_usage
+                                (tenant_id, conversations_today, day_start,
+                                 api_calls_this_minute, minute_start,
+                                 monthly_cost_usd, cost_month)
                             VALUES (?, 0, ?, 1, ?, 0.0, ?)
                             ON CONFLICT (tenant_id) DO UPDATE SET
                                 api_calls_this_minute = CASE WHEN tenant_usage.minute_start < ? THEN 1 ELSE tenant_usage.api_calls_this_minute END,
@@ -311,7 +317,10 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
         try (Connection conn = dataSourceInstance.get().getConnection();
                 PreparedStatement ps = conn.prepareStatement(
                         """
-                                INSERT INTO tenant_usage (tenant_id, conversations_today, day_start, api_calls_this_minute, minute_start, monthly_cost_usd, cost_month)
+                                INSERT INTO tenant_usage
+                                    (tenant_id, conversations_today, day_start,
+                                     api_calls_this_minute, minute_start,
+                                     monthly_cost_usd, cost_month)
                                 VALUES (?, 0, ?, 0, ?, ?, ?)
                                 ON CONFLICT (tenant_id) DO UPDATE SET
                                     monthly_cost_usd = CASE WHEN tenant_usage.cost_month = ? THEN tenant_usage.monthly_cost_usd + ? ELSE ? END,

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackEventHandler.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackEventHandler.java
@@ -262,6 +262,7 @@ public class SlackEventHandler {
         switch (resolved.target().getType()) {
             case AGENT -> handleAgentConversation(resolved, channelId, userId, threadTs, text, botToken);
             case GROUP -> handleGroupDiscussion(resolved, channelId, userId, threadTs, text, botToken);
+            default -> LOGGER.warnf("Unsupported target type: %s", resolved.target().getType());
         }
     }
 

--- a/src/main/resources/META-INF/resources/index.html
+++ b/src/main/resources/META-INF/resources/index.html
@@ -1,16 +1,13 @@
-<!doctype html>
-<html lang="en" dir="ltr">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/eddi-icon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>EDDI — Redirecting to Manager</title>
     <meta name="description" content="EDDI Manager — Admin dashboard for the EDDI conversational AI platform" />
-    <title>EDDI Manager</title>
-    <script src="/manage/__auth_config__.js"></script>
-    <script type="module" crossorigin src="/assets/index-Bn-sgAam.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BZNayFGO.css">
-  </head>
-  <body class="min-h-screen bg-background text-foreground antialiased">
-    <div id="root"></div>
-  </body>
+    <meta http-equiv="refresh" content="0;url=/manage">
+    <link rel="icon" type="image/svg+xml" href="/eddi-icon.svg">
+</head>
+<body>
+    <p>Redirecting to <a href="/manage">EDDI Manager</a>…</p>
+</body>
 </html>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -185,7 +185,9 @@ quarkus.http.auth.permission.slack.paths=/integrations/slack/*
 quarkus.http.auth.permission.slack.policy=permit
 quarkus.http.auth.permission.slack.methods=POST
 # Catch-all — everything else requires authentication
-quarkus.http.auth.permission.authenticated.paths=/,/*
+# Note: / is intentionally absent here; it is covered by the static-assets permit
+# (exact match beats the /* wildcard) so the redirect page loads without auth.
+quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 quarkus.http.auth.permission.authenticated.methods=GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
 # Logging

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -168,7 +168,10 @@ authorization.enabled=${quarkus.oidc.tenant-enabled}
 eddi.security.allow-unauthenticated=false
 # Static assets + SPA entry points — GET/HEAD only (no mutation allowed)
 # Root-level icons/images must be listed explicitly because /* is caught by the authenticated policy
-quarkus.http.auth.permission.static-assets.paths=/manage,/manage/*,/chat,/chat/*,/scripts/*,/fonts/*,/css/*,/js/*,/img/*,/assets/*,/eddi-icon.svg,/eddi-icon.ico,/logo_eddi.png,/favicon.ico,/robots.txt,/mockServiceWorker.js
+quarkus.http.auth.permission.static-assets.paths=\
+  /,/manage,/manage/*,/chat,/chat/*,\
+  /scripts/*,/fonts/*,/css/*,/js/*,/img/*,/assets/*,\
+  /eddi-icon.svg,/eddi-icon.ico,/logo_eddi.png,/favicon.ico,/robots.txt,/mockServiceWorker.js
 quarkus.http.auth.permission.static-assets.policy=permit
 quarkus.http.auth.permission.static-assets.methods=GET,HEAD
 # Health endpoints — publicly readable (required for k8s probes)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -169,7 +169,7 @@ eddi.security.allow-unauthenticated=false
 # Static assets + SPA entry points — GET/HEAD only (no mutation allowed)
 # Root-level icons/images must be listed explicitly because /* is caught by the authenticated policy
 quarkus.http.auth.permission.static-assets.paths=\
-  /,/manage,/manage/*,/chat,/chat/*,\
+  /manage,/manage/*,/chat,/chat/*,\
   /scripts/*,/fonts/*,/css/*,/js/*,/img/*,/assets/*,\
   /eddi-icon.svg,/eddi-icon.ico,/logo_eddi.png,/favicon.ico,/robots.txt,/mockServiceWorker.js
 quarkus.http.auth.permission.static-assets.policy=permit
@@ -185,9 +185,7 @@ quarkus.http.auth.permission.slack.paths=/integrations/slack/*
 quarkus.http.auth.permission.slack.policy=permit
 quarkus.http.auth.permission.slack.methods=POST
 # Catch-all — everything else requires authentication
-# Note: / is intentionally absent here; it is covered by the static-assets permit
-# (exact match beats the /* wildcard) so the redirect page loads without auth.
-quarkus.http.auth.permission.authenticated.paths=/*
+quarkus.http.auth.permission.authenticated.paths=/,/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 quarkus.http.auth.permission.authenticated.methods=GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
 # Logging

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresGlobalVariableStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresGlobalVariableStoreTest.java
@@ -192,7 +192,7 @@ class PostgresGlobalVariableStoreTest {
         when(rs.getString("tenant_id")).thenReturn(DEFAULT, DEFAULT);
         when(rs.getString("key")).thenReturn("a", "b");
         when(rs.getString("value")).thenReturn("1", "2");
-        when(rs.getString("description")).thenReturn("desc-a", null);
+        when(rs.getString("description")).thenReturn("desc-a", (String) null);
         when(rs.getBoolean("exportable")).thenReturn(true, false);
 
         List<GlobalVariable> result = store.listAll(DEFAULT);


### PR DESCRIPTION
This PR fixes a critical bug where the root URL (/) served a broken white page due to stale hashed asset references in index.html. It also resolves all outstanding Checkstyle and compiler warnings.

Root Cause
Commit 0ec6cb47c replaced the original index.html redirect with a full copy of the Manager SPA, duplicating hashed asset references from manage.html. When the deploy script rebuilt the Manager, it updated manage.html and the asset files but had no knowledge of index.html — leaving it pointing at deleted files (index-Bn-sgAam.js, index-BZNayFGO.css). With X-Content-Type-Options: nosniff, the browser blocked the HTML fallback response, producing a white page.

Changes
Root URL & Deployment

index.html reverted to a minimal <meta http-equiv="refresh"> redirect to /manage — no asset references, no sync needed, no future breakage on Manager rebuilds. ([index.html](https://github.com/labsai/EDDI/pull/517/files#diff-2b1b7179c11e848f92d3e6716176ea6535974a1cd5c8884960b17317818355d5L1-R11))
deploy-to-local-eddi-repo.ps1 no longer handles index.html, focusing solely on manage.html. ([changelog](https://github.com/labsai/EDDI/pull/517/files#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R7-R29))
Changelog updated with root cause analysis and architecture clarification table.
Checkstyle & Compiler Warning Fixes (0 violations)

PostgresTenantQuotaStore.java — Multi-line formatting for 3× SQL INSERT INTO column lists that exceeded 150-char line length. ([1](https://github.com/labsai/EDDI/pull/517/files#diff-fb161ca1db6ad1e77cb4f24915875cbd3e06124c98c3d9c756f49c8f555fa01fL219-R222), [2](https://github.com/labsai/EDDI/pull/517/files#diff-fb161ca1db6ad1e77cb4f24915875cbd3e06124c98c3d9c756f49c8f555fa01fL277-R283), [3](https://github.com/labsai/EDDI/pull/517/files#diff-fb161ca1db6ad1e77cb4f24915875cbd3e06124c98c3d9c756f49c8f555fa01fL314-R323))
application.properties — Backslash line continuation for static-assets.paths that exceeded 150-char line length. Path values are unchanged. ([application.properties](https://github.com/labsai/EDDI/pull/517/files#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L171-R174))
SlackEventHandler.java — Added default branch with warning log to satisfy MissingSwitchDefault rule. ([SlackEventHandler.java](https://github.com/labsai/EDDI/pull/517/files#diff-debb55ebcfecdec372f7d6742d929209ceeb99aad79fd3c93906bb7b72f00967R265))
PostgresGlobalVariableStoreTest.java — Explicit (String) null cast to resolve varargs ambiguity compiler warning. ([PostgresGlobalVariableStoreTest.java](https://github.com/labsai/EDDI/pull/517/files#diff-f44aee2424004d5ede3489114d8c5316ab6b53781e330ed74dac521f2efb437bL195-R195))

What's NOT Changed
Auth permissions — authenticated.paths and static-assets.paths values are identical to main. The root path / being behind auth is pre-existing behavior (the old SPA index.html was equally inaccessible with Keycloak enabled at /; users navigate to /manage directly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blank page at repository root by implementing proper redirect to the manager interface.
  * Enhanced error handling for unsupported Slack event types with warning logging.

* **Refactor**
  * Reformatted SQL statements and configuration files for improved readability.

* **Tests**
  * Updated test code for better type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->