### PR TITLE
fix(security): relax CSP for Swagger UI via per-path quarkus.http.filter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,29 @@
 
 ---
 
+## 🐛 Fix: Swagger UI Broken by CSP — Per-Path Filter Override (2026-06-03)
+
+**Repo:** EDDI (`fix/swagger-ui-csp`)
+**What changed:** Swagger UI (`/q/swagger-ui/`) was blocked by the strict `Content-Security-Policy` header — inline scripts and `eval()` were rejected, rendering a blank page.
+
+### Root Cause
+The global `quarkus.http.header.Content-Security-Policy` applied `script-src 'self'` to all paths, including Swagger UI. Swagger UI requires `'unsafe-inline'` (inline `<script>` tags) and `'unsafe-eval'` (JSON schema rendering via `eval()`).
+
+### Fix
+Replaced the global `quarkus.http.header.Content-Security-Policy` with two `quarkus.http.filter` entries using Quarkus's native path-based filter mechanism:
+- **`csp-default`** (order=10, matches `/.*`): Strict CSP for the entire application — `script-src 'self'`
+- **`csp-swagger`** (order=20, matches `/q/swagger-ui/.*`): Relaxed CSP — adds `'unsafe-inline' 'unsafe-eval'` to `script-src`
+
+Higher `order` takes precedence, so the Swagger filter overrides the default for its path.
+
+### Why not a Java filter?
+An initial approach used `@Observes Router` to register a Vert.x handler, but this has an ordering race: Quarkus may apply `quarkus.http.header` headers via a `headersEndHandler` (fires just before wire flush), which would overwrite the Java handler's header. The `quarkus.http.filter` approach has no such ambiguity — Quarkus manages precedence internally via the `order` property.
+
+**Files:** `application.properties`
+
+---
+
+
 ## 🐛 Fix: White Page at Root — index.html Revert to Redirect (2026-06-03)
 
 **Repo:** EDDI (`fix/manager-deploy-and-index-html`) + EDDI-Manager (deploy script)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -149,7 +149,7 @@ quarkus.http.filter.csp-default.header."Content-Security-Policy"=default-src 'se
   font-src 'self'; frame-ancestors 'none';
 # Swagger UI: relaxed CSP (order=20, higher priority — overrides default)
 # Swagger UI requires 'unsafe-inline' + 'unsafe-eval' for inline scripts and JSON schema rendering.
-quarkus.http.filter.csp-swagger.matches=/q/swagger-ui/.*
+quarkus.http.filter.csp-swagger.matches=/q/swagger-ui(/.*)?
 quarkus.http.filter.csp-swagger.order=20
 quarkus.http.filter.csp-swagger.header."Content-Security-Policy"=default-src 'self'; \
   script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; \

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -135,12 +135,25 @@ quarkus.http.header.X-Frame-Options.value=DENY
 quarkus.http.header.Referrer-Policy.value=strict-origin-when-cross-origin
 quarkus.http.header.X-XSS-Protection.value=0
 quarkus.http.header.Permissions-Policy.value=camera=(), microphone=(), geolocation=()
-# CSP: Allow self + inline styles + connect to same-origin API and to Keycloak.
+# CSP: Two filters — strict default + relaxed override for Swagger UI.
+# Uses quarkus.http.filter (regex path matching + order-based precedence).
 # eddi.keycloak.public.url is set via EDDI_KEYCLOAK_PUBLIC_URL env var when auth is enabled.
 # When auth is disabled (no env var) the placeholder expands to empty string — harmless.
-quarkus.http.header.Content-Security-Policy.value=default-src 'self'; script-src 'self'; \
-  style-src 'self' 'unsafe-inline'; img-src 'self' data:; \
+#
+# Default: strict CSP for the entire application (order=10, lower priority)
+quarkus.http.filter.csp-default.matches=/.*
+quarkus.http.filter.csp-default.order=10
+quarkus.http.filter.csp-default.header."Content-Security-Policy"=default-src 'self'; \
+  script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; \
   connect-src 'self' ${eddi.keycloak.public.url:}; \
+  font-src 'self'; frame-ancestors 'none';
+# Swagger UI: relaxed CSP (order=20, higher priority — overrides default)
+# Swagger UI requires 'unsafe-inline' + 'unsafe-eval' for inline scripts and JSON schema rendering.
+quarkus.http.filter.csp-swagger.matches=/q/swagger-ui/.*
+quarkus.http.filter.csp-swagger.order=20
+quarkus.http.filter.csp-swagger.header."Content-Security-Policy"=default-src 'self'; \
+  script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; \
+  img-src 'self' data:; connect-src 'self' ${eddi.keycloak.public.url:}; \
   font-src 'self'; frame-ancestors 'none';
 # OIDC Configuration
 # quarkus.oidc.enabled is BUILD-TIME — extension must be active for token validation


### PR DESCRIPTION
This pull request addresses a bug where the Swagger UI was broken due to an overly strict Content Security Policy (CSP) applied globally. The solution introduces path-based CSP overrides using Quarkus's native filter mechanism, ensuring strong security for the rest of the application while allowing Swagger UI to function properly. The change also documents the root cause and rationale for the chosen approach.

Security header configuration:

* Replaced the global `quarkus.http.header.Content-Security-Policy` with two path-based `quarkus.http.filter` entries in `application.properties`: a strict default CSP for all paths and a relaxed CSP for `/q/swagger-ui/.*` that adds `'unsafe-inline'` and `'unsafe-eval'` to `script-src` for Swagger UI compatibility.
* Documented the filter override approach and rationale (including why a Java filter was not used) in the changelog, providing clear guidance for future maintenance and audits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Swagger UI rendering (previously blank) by adjusting content security rules so the UI can load while preserving strict defaults for the rest of the app.
* **Documentation**
  * Added a changelog entry documenting the security configuration adjustment and its effect on Swagger UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->