### PR TITLE
add script to reset demo systems via cron or manually

### DIFF
--- a/gcp/eddi-demo-reset.sh
+++ b/gcp/eddi-demo-reset.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+#  eddi-demo-reset.sh — Wipes EDDI session data every 48 hours
+#
+#  Clears (session / runtime data):
+#    conversationmemories    all chat history
+#    usermemories            long-term user properties
+#    userconversations       user ↔ conversation index
+#    conversation_checkpoints  forked-conversation snapshots
+#    agenttriggers           runtime trigger records
+#    audit_ledger            audit log entries
+#    logs                    internal DB logs
+#    tenant_usage            per-tenant usage counters
+#
+#  Preserves (configuration / secrets):
+#    agent configs, workflows, behaviors, outputs, llms, apicalls, ...
+#    secretvault_*           encrypted API keys — NEVER cleared
+#    eddi_schedules          scheduled job definitions
+#    globalvariables         deployment-wide config
+#    migrationlog            schema migration state
+#
+#  After clearing, EDDI is restarted and the Agent Father is re-imported.
+#
+#  ── Install on the VM ────────────────────────────────────────────────────────
+#
+#  From your local machine:
+#    ./gcp/provision-vm.sh install-reset eddi-demo
+#
+#  Or manually on the VM:
+#    sudo cp eddi-demo-reset.sh /root/.eddi/eddi-demo-reset.sh
+#    sudo chmod +x /root/.eddi/eddi-demo-reset.sh
+#    echo "0 3 */2 * * root /root/.eddi/eddi-demo-reset.sh >> /var/log/eddi-reset.log 2>&1" \
+#      | sudo tee /etc/cron.d/eddi-demo-reset
+#
+#  ── Manual run ───────────────────────────────────────────────────────────────
+#
+#    sudo /root/.eddi/eddi-demo-reset.sh
+#
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+EDDI_DIR="${EDDI_DIR:-/root/.eddi}"
+EDDI_PORT="${EDDI_PORT:-7070}"
+LOGFILE="/var/log/eddi-reset.log"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+log()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOGFILE"; }
+fail() { log "ERROR: $*"; exit 1; }
+
+log "=== EDDI demo reset starting ==="
+
+# ── Load install config ───────────────────────────────────────────────────────
+
+CONFIG_FILE="$EDDI_DIR/.eddi-config"
+ENV_FILE="$EDDI_DIR/.env"
+
+[[ -f "$CONFIG_FILE" ]] || fail "$CONFIG_FILE not found — is EDDI installed?"
+[[ -f "$ENV_FILE" ]]    || fail "$ENV_FILE not found — is EDDI installed?"
+
+# Safe config parsing (no eval)
+_cfg() { grep "^$1=" "$CONFIG_FILE" 2>/dev/null | head -1 | cut -d= -f2- | sed 's/^"//;s/"$//'; }
+_env() { grep "^$1=" "$ENV_FILE"    2>/dev/null | head -1 | cut -d= -f2- | sed 's/^"//;s/"$//'; }
+
+COMPOSE_FILES_STR=$(_cfg COMPOSE_FILES)
+read -ra CF_ARRAY <<< "$COMPOSE_FILES_STR"
+
+COMPOSE_ARGS=(--env-file "$ENV_FILE")
+for f in "${CF_ARRAY[@]}"; do
+  [[ -n "$f" ]] && COMPOSE_ARGS+=(-f "$f")
+done
+
+# MongoDB credentials (fall back to EDDI docker-compose defaults)
+MONGO_USER=$(_env MONGO_INITDB_ROOT_USERNAME); MONGO_USER="${MONGO_USER:-eddi}"
+MONGO_PASS=$(_env MONGO_INITDB_ROOT_PASSWORD); MONGO_PASS="${MONGO_PASS:-changeme}"
+
+log "Compose files: ${CF_ARRAY[*]}"
+
+# ── Verify MongoDB is running ─────────────────────────────────────────────────
+
+if ! docker compose "${COMPOSE_ARGS[@]}" ps --status running mongodb \
+    2>/dev/null | grep -q "running"; then
+  fail "MongoDB container is not running. Aborting reset."
+fi
+
+# ── Clear session collections ─────────────────────────────────────────────────
+
+log "Clearing session collections..."
+MONGOSH_OUTPUT=$(docker compose "${COMPOSE_ARGS[@]}" exec -T mongodb mongosh \
+  --username  "$MONGO_USER" \
+  --password  "$MONGO_PASS" \
+  --authenticationDatabase admin \
+  --quiet \
+  --eval '
+    var d = db.getSiblingDB("eddi");
+    var cols = [
+      "conversationmemories",
+      "usermemories",
+      "userconversations",
+      "conversation_checkpoints",
+      "agenttriggers",
+      "audit_ledger",
+      "logs",
+      "tenant_usage"
+    ];
+    var totals = {};
+    cols.forEach(function(c) {
+      var r = d.getCollection(c).deleteMany({});
+      totals[c] = r.deletedCount;
+    });
+    var summary = Object.keys(totals).map(function(k) {
+      return k + ": " + totals[k];
+    }).join(", ");
+    print("Deleted — " + summary);
+  ' 2>&1) || fail "mongosh failed: $MONGOSH_OUTPUT"
+
+log "$MONGOSH_OUTPUT"
+
+# ── Restart EDDI (MongoDB stays up) ──────────────────────────────────────────
+
+log "Restarting EDDI container..."
+docker compose "${COMPOSE_ARGS[@]}" restart eddi
+log "EDDI container restarted."
+
+# ── Wait for health ───────────────────────────────────────────────────────────
+
+log "Waiting for EDDI to become healthy..."
+HEALTH_URL="http://localhost:$EDDI_PORT/q/health/ready"
+HEALTHY=false
+for i in $(seq 1 36); do
+  if curl -sf --connect-timeout 5 "$HEALTH_URL" &>/dev/null; then
+    log "EDDI healthy after $((i * 5))s."
+    HEALTHY=true
+    break
+  fi
+  sleep 5
+done
+
+if [[ "$HEALTHY" != "true" ]]; then
+  fail "EDDI did not become healthy within 180s. Check: docker compose logs eddi"
+fi
+
+# ── Re-import initial agents ──────────────────────────────────────────────────
+
+log "Re-importing initial agents (Agent Father + samples)..."
+STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+  -X POST "http://localhost:$EDDI_PORT/backup/import/initialAgents" 2>/dev/null) \
+  || STATUS="000"
+
+case "$STATUS" in
+  200) log "Initial agents imported successfully." ;;
+  409) log "Initial agents already present — skipping import." ;;
+  *)   log "WARN: /backup/import/initialAgents returned HTTP $STATUS (non-fatal)." ;;
+esac
+
+log "=== EDDI demo reset complete ==="

--- a/gcp/eddi-demo-reset.sh
+++ b/gcp/eddi-demo-reset.sh
@@ -23,14 +23,13 @@
 #
 #  ── Install on the VM ────────────────────────────────────────────────────────
 #
-#  From your local machine:
+#  From your local machine (recommended):
 #    ./gcp/provision-vm.sh install-reset eddi-demo
 #
 #  Or manually on the VM:
-#    sudo cp eddi-demo-reset.sh /root/.eddi/eddi-demo-reset.sh
-#    sudo chmod +x /root/.eddi/eddi-demo-reset.sh
-#    echo "0 3 */2 * * root /root/.eddi/eddi-demo-reset.sh >> /var/log/eddi-reset.log 2>&1" \
-#      | sudo tee /etc/cron.d/eddi-demo-reset
+#    sudo install -m 0755 eddi-demo-reset.sh /root/.eddi/eddi-demo-reset.sh
+#    # then create /etc/systemd/system/eddi-reset.{service,timer} — see
+#    # cmd_install_reset() in provision-vm.sh for the exact unit file content.
 #
 #  ── Manual run ───────────────────────────────────────────────────────────────
 #

--- a/gcp/provision-vm.sh
+++ b/gcp/provision-vm.sh
@@ -86,7 +86,7 @@ ${BOLD}Usage:${RESET}
 ${BOLD}Commands:${RESET}
   create          Provision a new GCP VM and install EDDI
   update          Update EDDI image tag on an existing VM
-  install-reset   Install the 48-hour demo-reset cron on a VM
+  install-reset   Install the 48-hour demo-reset timer on a VM
   delete          Delete a VM (pass VM_NAME as first positional arg)
   list            List all EDDI VMs in the project
   ssh             SSH into a VM (pass VM_NAME as first positional arg)
@@ -153,7 +153,7 @@ ${BOLD}Examples:${RESET}
   # Roll back to latest
   $(basename "$0") update eddi-demo --eddi-version=latest
 
-  # Install 48-hour demo reset cron
+  # Install 48-hour demo-reset timer
   $(basename "$0") install-reset eddi-demo
 
   # Delete
@@ -999,15 +999,15 @@ REMOTE_SCRIPT
 
 # ── Command: install-reset ────────────────────────────────────────────────────
 #
-# Copies eddi-demo-reset.sh to the VM and installs a cron job that runs it
-# every 48 hours at 03:00 UTC.  Idempotent — safe to re-run.
+# Copies eddi-demo-reset.sh to the VM and installs a systemd timer that fires
+# strictly every 48 hours.  Idempotent — safe to re-run.
 
 cmd_install_reset() {
   local name="${1:-$VM_NAME}"
   check_prerequisites
   resolve_project
 
-  step "Installing demo-reset cron on: ${name}"
+  step "Installing demo-reset timer on: ${name}"
 
   local vm_status
   vm_status=$(gcloud compute instances describe "$name" \
@@ -1028,37 +1028,63 @@ cmd_install_reset() {
   gcloud compute scp "$reset_script" "${name}:/tmp/eddi-demo-reset.sh" \
     --zone="$ZONE" --project="$GCP_PROJECT" >/dev/null
 
-  info "Installing script and cron job on VM..."
+  info "Installing script and systemd timer on VM..."
   gcloud compute ssh "$name" \
     --zone="$ZONE" --project="$GCP_PROJECT" \
     -- "sudo bash -s" << 'REMOTE_SCRIPT'
 set -euo pipefail
 EDDI_DIR=/root/.eddi
 DEST="${EDDI_DIR}/eddi-demo-reset.sh"
-CRON_FILE="/etc/cron.d/eddi-demo-reset"
 
 install -m 0755 /tmp/eddi-demo-reset.sh "$DEST"
 rm -f /tmp/eddi-demo-reset.sh
 
-# Runs at 03:00 on every even-numbered day  (≈ every 48 h)
-echo "0 3 */2 * * root ${DEST} >> /var/log/eddi-reset.log 2>&1" > "$CRON_FILE"
-chmod 644 "$CRON_FILE"
+# Remove any legacy cron file from a previous install
+rm -f /etc/cron.d/eddi-demo-reset
 
-echo "Installed: $DEST"
-echo "Cron:      $CRON_FILE  (03:00 UTC every 48 h)"
+# systemd service unit — runs the reset script, appends to log
+cat > /etc/systemd/system/eddi-reset.service << UNIT
+[Unit]
+Description=EDDI demo reset — clear conversation data
+After=docker.service
 
-if systemctl is-active --quiet cron 2>/dev/null || \
-   systemctl is-active --quiet crond 2>/dev/null; then
-  echo "Cron daemon is running — job active."
-else
-  echo "WARN: cron daemon not detected. File is in place but may not run."
-fi
+[Service]
+Type=oneshot
+ExecStart=${DEST}
+StandardOutput=append:/var/log/eddi-reset.log
+StandardError=append:/var/log/eddi-reset.log
+UNIT
+
+# systemd timer unit — fires strictly every 48 h after the last run
+# OnBootSec delays the first run by 10 min after a fresh reboot so
+# EDDI has time to finish starting before the reset executes.
+cat > /etc/systemd/system/eddi-reset.timer << UNIT
+[Unit]
+Description=Run EDDI demo reset every 48 hours
+Requires=eddi-reset.service
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=48h
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now eddi-reset.timer
+
+echo "Installed:  ${DEST}"
+echo "Service:    /etc/systemd/system/eddi-reset.service"
+echo "Timer:      /etc/systemd/system/eddi-reset.timer  (every 48 h)"
+echo "Status:     $(systemctl is-active eddi-reset.timer)"
 REMOTE_SCRIPT
 
   echo ""
-  info "Demo-reset cron installed on ${CYAN}${name}${RESET}."
+  info "Demo-reset timer installed on ${CYAN}${name}${RESET}."
   echo ""
-  dim "Runs automatically: 03:00 UTC every 48 h"
+  dim "Runs automatically: every 48 h (systemd timer)"
+  dim "Check timer:        $(basename "$0") ssh ${name}  →  sudo systemctl status eddi-reset.timer"
   dim "Trigger manually:   $(basename "$0") ssh ${name}  →  sudo /root/.eddi/eddi-demo-reset.sh"
   dim "Watch log:          $(basename "$0") ssh ${name}  →  tail -f /var/log/eddi-reset.log"
   echo ""

--- a/gcp/provision-vm.sh
+++ b/gcp/provision-vm.sh
@@ -84,14 +84,15 @@ ${BOLD}Usage:${RESET}
   $(basename "$0") <command> [options]
 
 ${BOLD}Commands:${RESET}
-  create        Provision a new GCP VM and install EDDI
-  update        Update EDDI image tag on an existing VM
-  delete        Delete a VM (pass VM_NAME as first positional arg)
-  list          List all EDDI VMs in the project
-  ssh           SSH into a VM (pass VM_NAME as first positional arg)
-  status        Check VM state and EDDI health
-  logs          Stream startup/EDDI logs from the VM
-  ip            Print the external IP of a VM
+  create          Provision a new GCP VM and install EDDI
+  update          Update EDDI image tag on an existing VM
+  install-reset   Install the 48-hour demo-reset cron on a VM
+  delete          Delete a VM (pass VM_NAME as first positional arg)
+  list            List all EDDI VMs in the project
+  ssh             SSH into a VM (pass VM_NAME as first positional arg)
+  status          Check VM state and EDDI health
+  logs            Stream startup/EDDI logs from the VM
+  ip              Print the external IP of a VM
 
 ${BOLD}Create options:${RESET}
   --name=NAME               VM name                      [${DEFAULT_VM_NAME}]
@@ -151,6 +152,9 @@ ${BOLD}Examples:${RESET}
 
   # Roll back to latest
   $(basename "$0") update eddi-demo --eddi-version=latest
+
+  # Install 48-hour demo reset cron
+  $(basename "$0") install-reset eddi-demo
 
   # Delete
   $(basename "$0") delete eddi-demo
@@ -993,6 +997,73 @@ REMOTE_SCRIPT
   echo "  Check logs: $(basename "$0") logs ${name}"
 }
 
+# ── Command: install-reset ────────────────────────────────────────────────────
+#
+# Copies eddi-demo-reset.sh to the VM and installs a cron job that runs it
+# every 48 hours at 03:00 UTC.  Idempotent — safe to re-run.
+
+cmd_install_reset() {
+  local name="${1:-$VM_NAME}"
+  check_prerequisites
+  resolve_project
+
+  step "Installing demo-reset cron on: ${name}"
+
+  local vm_status
+  vm_status=$(gcloud compute instances describe "$name" \
+    --zone="$ZONE" --project="$GCP_PROJECT" \
+    --format='value(status)' 2>/dev/null) || {
+    fail "VM '${name}' not found in zone '${ZONE}'."
+  }
+  if [[ "$vm_status" != "RUNNING" ]]; then
+    fail "VM '${name}' is not running (status: ${vm_status})."
+  fi
+
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local reset_script="${script_dir}/eddi-demo-reset.sh"
+  [[ -f "$reset_script" ]] || fail "eddi-demo-reset.sh not found at: ${reset_script}"
+
+  info "Uploading eddi-demo-reset.sh..."
+  gcloud compute scp "$reset_script" "${name}:/tmp/eddi-demo-reset.sh" \
+    --zone="$ZONE" --project="$GCP_PROJECT" >/dev/null
+
+  info "Installing script and cron job on VM..."
+  gcloud compute ssh "$name" \
+    --zone="$ZONE" --project="$GCP_PROJECT" \
+    -- "sudo bash -s" << 'REMOTE_SCRIPT'
+set -euo pipefail
+EDDI_DIR=/root/.eddi
+DEST="${EDDI_DIR}/eddi-demo-reset.sh"
+CRON_FILE="/etc/cron.d/eddi-demo-reset"
+
+install -m 0755 /tmp/eddi-demo-reset.sh "$DEST"
+rm -f /tmp/eddi-demo-reset.sh
+
+# Runs at 03:00 on every even-numbered day  (≈ every 48 h)
+echo "0 3 */2 * * root ${DEST} >> /var/log/eddi-reset.log 2>&1" > "$CRON_FILE"
+chmod 644 "$CRON_FILE"
+
+echo "Installed: $DEST"
+echo "Cron:      $CRON_FILE  (03:00 UTC every 48 h)"
+
+if systemctl is-active --quiet cron 2>/dev/null || \
+   systemctl is-active --quiet crond 2>/dev/null; then
+  echo "Cron daemon is running — job active."
+else
+  echo "WARN: cron daemon not detected. File is in place but may not run."
+fi
+REMOTE_SCRIPT
+
+  echo ""
+  info "Demo-reset cron installed on ${CYAN}${name}${RESET}."
+  echo ""
+  dim "Runs automatically: 03:00 UTC every 48 h"
+  dim "Trigger manually:   $(basename "$0") ssh ${name}  →  sudo /root/.eddi/eddi-demo-reset.sh"
+  dim "Watch log:          $(basename "$0") ssh ${name}  →  tail -f /var/log/eddi-reset.log"
+  echo ""
+}
+
 # ── Command: list ─────────────────────────────────────────────────────────────
 
 cmd_list() {
@@ -1175,14 +1246,15 @@ done
 # ── Dispatch ──────────────────────────────────────────────────────────────────
 
 case "$COMMAND" in
-  create)         cmd_create ;;
-  update)         cmd_update "${POSITIONAL[0]:-}" ;;
-  delete|destroy|rm) cmd_delete "${POSITIONAL[0]:-}" ;;
-  list|ls)        cmd_list ;;
-  ssh|connect)    cmd_ssh "${POSITIONAL[0]:-}" ;;
-  status|health)  cmd_status "${POSITIONAL[0]:-}" ;;
-  logs|log)       cmd_logs "${POSITIONAL[0]:-}" ;;
-  ip)             cmd_ip "${POSITIONAL[0]:-}" ;;
+  create)              cmd_create ;;
+  update)              cmd_update "${POSITIONAL[0]:-}" ;;
+  install-reset)       cmd_install_reset "${POSITIONAL[0]:-}" ;;
+  delete|destroy|rm)   cmd_delete "${POSITIONAL[0]:-}" ;;
+  list|ls)             cmd_list ;;
+  ssh|connect)         cmd_ssh "${POSITIONAL[0]:-}" ;;
+  status|health)       cmd_status "${POSITIONAL[0]:-}" ;;
+  logs|log)            cmd_logs "${POSITIONAL[0]:-}" ;;
+  ip)                  cmd_ip "${POSITIONAL[0]:-}" ;;
   help|--help|-h) usage ;;
   *)
     echo -e "${RED}Unknown command: ${COMMAND}${RESET}" >&2


### PR DESCRIPTION
## Summary

add a script to reset the contents of the demo system in order to be able to make the demo system public available. 

## Type of Change

<!-- Check the one that applies -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, CI changes, etc.)

## Related Issue

<!-- Link the issue this PR addresses -->
Closes #

## Changes Made

<!-- List the key changes in this PR -->

- added a new script
-
-

## How to Test

<!-- Describe how reviewers can test your changes -->

1. check if the eddi demo system is deleted every 48 hours.
2.
3.

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added tests that prove my fix/feature works
- [x] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [x] I have updated documentation if needed
- [x] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [x] I have not committed any secrets, API keys, or tokens
- [x] This PR has a clear, focused scope (one concern per PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated periodic demo reset: clears session/runtime data, restarts the service, waits for readiness, and reimports initial agents to restore demo state.
  * VM install command: adds an install-and-schedule option to deploy the reset mechanism on a VM with a systemd timer (runs every 48h) and guidance for manual triggering and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->