### PR TITLE
docs: fix outdated task type names in documentation and Javadoc

### DIFF
--- a/docs/agent-father-deep-dive.md
+++ b/docs/agent-father-deep-dive.md
@@ -471,7 +471,7 @@ public class BehaviorRulesTask implements ILifecycleTask {
 ### HTTP Calls Task (executes API calls)
 
 ```java
-public class HttpCallsTask implements ILifecycleTask {
+public class ApiCallsTask implements ILifecycleTask {
     @Override
     public void execute(IConversationMemory memory, Object component) {
         HttpCallsConfiguration config = (HttpCallsConfiguration) component;

--- a/docs/conversation-memory.md
+++ b/docs/conversation-memory.md
@@ -563,7 +563,7 @@ LifecycleManager.executeLifecycle(memory)
   ├─→ Input Parser
   ├─→ Behavior Rules → emit actions
   ├─→ PropertySetterTask → set properties based on actions
-  ├─→ HttpCallsTask → execute API calls based on actions
+  ├─→ ApiCallsTask → execute API calls based on actions
   ├─→ LlmTask → call LLM based on actions
   └─→ OutputGenerationTask → format response
 ```

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/ILifecycleTask.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/ILifecycleTask.java
@@ -54,8 +54,8 @@ import java.util.Map;
  * actions</li>
  * <li><strong>Property Extraction</strong>: Extract and store data in
  * conversation memory</li>
- * <li><strong>HTTP Calls</strong>: Call external REST APIs</li>
- * <li><strong>LangChain</strong>: Invoke LLM services (OpenAI, Claude, Gemini,
+ * <li><strong>API Calls</strong>: Call external REST APIs</li>
+ * <li><strong>LLM</strong>: Invoke LLM services (OpenAI, Claude, Gemini,
  * etc.)</li>
  * <li><strong>Output Generation</strong>: Format responses using templates</li>
  * </ul>


### PR DESCRIPTION
## Summary

Updates four documentation/Javadoc references that still used the pre-v6 task names. `HttpCallsTask` is now `ApiCallsTask` and `LangchainTask` is now `LlmTask`, so the comments and docs should match the current names.

## Type of Change

- [x] 📝 Documentation update

## Related Issue

Closes #549

## Changes Made

- `ILifecycleTask.java`: `HTTP Calls` → `API Calls` and `LangChain` → `LLM` in the "Standard Task Types" Javadoc list
- `docs/agent-father-deep-dive.md`: example class renamed `HttpCallsTask` → `ApiCallsTask`
- `docs/conversation-memory.md`: lifecycle diagram entry `HttpCallsTask` → `ApiCallsTask`

## How to Test

1. `grep -rn "HttpCallsTask" docs/ | grep -v changelog.md` returns nothing
2. The Javadoc list in `ILifecycleTask.java` now reads "API Calls" and "LLM"
3. Change is comment/markdown only, so `./mvnw compile` is unaffected

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [ ] I have added tests that prove my fix/feature works
- [ ] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [x] I have updated documentation if needed
- [x] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [x] I have not committed any secrets, API keys, or tokens
- [x] This PR has a clear, focused scope (one concern per PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Terminology updates across documentation and code references for improved clarity and consistency
  * Task type previously labeled 'HTTP Calls' is now called 'API Calls' to better reflect its functionality
  * Legacy references to 'LangChain' have been standardized to 'LLM' terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->