### PR TITLE
docs: update lifecycle task type names

### DIFF
--- a/docs/agent-father-deep-dive.md
+++ b/docs/agent-father-deep-dive.md
@@ -471,7 +471,7 @@ public class BehaviorRulesTask implements ILifecycleTask {
 ### HTTP Calls Task (executes API calls)
 
 ```java
-public class HttpCallsTask implements ILifecycleTask {
+public class ApiCallsTask implements ILifecycleTask {
     @Override
     public void execute(IConversationMemory memory, Object component) {
         HttpCallsConfiguration config = (HttpCallsConfiguration) component;

--- a/docs/conversation-memory.md
+++ b/docs/conversation-memory.md
@@ -563,7 +563,7 @@ LifecycleManager.executeLifecycle(memory)
   ├─→ Input Parser
   ├─→ Behavior Rules → emit actions
   ├─→ PropertySetterTask → set properties based on actions
-  ├─→ HttpCallsTask → execute API calls based on actions
+  ├─→ ApiCallsTask → execute API calls based on actions
   ├─→ LlmTask → call LLM based on actions
   └─→ OutputGenerationTask → format response
 ```

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/ILifecycleTask.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/ILifecycleTask.java
@@ -54,8 +54,8 @@ import java.util.Map;
  * actions</li>
  * <li><strong>Property Extraction</strong>: Extract and store data in
  * conversation memory</li>
- * <li><strong>HTTP Calls</strong>: Call external REST APIs</li>
- * <li><strong>LangChain</strong>: Invoke LLM services (OpenAI, Claude, Gemini,
+ * <li><strong>API Calls</strong>: Call external REST APIs</li>
+ * <li><strong>LLM</strong>: Invoke LLM services (OpenAI, Claude, Gemini,
  * etc.)</li>
  * <li><strong>Output Generation</strong>: Format responses using templates</li>
  * </ul>


### PR DESCRIPTION
## Summary

- Update `ILifecycleTask` Javadoc task names from `HTTP Calls` to `API Calls` and `LangChain` to `LLM`.
- Update docs examples from `HttpCallsTask` to `ApiCallsTask`.
- Leave `docs/changelog.md` unchanged because the issue notes those historical references are correct as-is.

Closes #549.

## Verification

- `./mvnw.cmd -DskipTests compile`

Ran successfully locally with Temurin JDK 25.0.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API lifecycle documentation to reflect task type naming changes.
  * Refined terminology in lifecycle diagrams and interface documentation.
  * Updated task type references across multiple documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->