### PR TITLE
docs: add user memory API responses

### DIFF
--- a/src/main/java/ai/labs/eddi/configs/properties/IRestUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/IRestUserMemoryStore.java
@@ -51,6 +51,8 @@ public interface IRestUserMemoryStore {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Search user memories", description = "Filter memories by key or value content.")
     @APIResponse(responseCode = "200", description = "Memory entries matching the search query.")
+    @APIResponse(responseCode = "403", description = "Caller is not allowed to access the requested user's memories.")
+    @APIResponse(responseCode = "500", description = "Memory search failed due to an internal storage error.")
     List<UserMemoryEntry> searchMemories(@PathParam("userId") String userId, @QueryParam("q") String query);
 
     @GET
@@ -58,6 +60,8 @@ public interface IRestUserMemoryStore {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get memories by category", description = "Returns memories filtered by category (preference, fact, context).")
     @APIResponse(responseCode = "200", description = "Memory entries in the requested category.")
+    @APIResponse(responseCode = "403", description = "Caller is not allowed to access the requested user's memories.")
+    @APIResponse(responseCode = "500", description = "Category lookup failed due to an internal storage error.")
     List<UserMemoryEntry> getMemoriesByCategory(@PathParam("userId") String userId, @PathParam("category") String category);
 
     @GET

--- a/src/main/java/ai/labs/eddi/configs/properties/IRestUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/IRestUserMemoryStore.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.configs.properties;
 import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
 import jakarta.annotation.security.RolesAllowed;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import jakarta.ws.rs.*;
@@ -30,6 +31,7 @@ public interface IRestUserMemoryStore {
     @Path("/{userId}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get all memories for a user", description = "Returns all structured memory entries for the given user.")
+    @APIResponse(responseCode = "200", description = "Memory entries for the user.")
     List<UserMemoryEntry> getAllMemories(@PathParam("userId") String userId);
 
     @GET
@@ -37,6 +39,7 @@ public interface IRestUserMemoryStore {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get visible memories for an agent", description = "Returns memories visible to a specific agent, "
             + "considering self/group/global visibility.")
+    @APIResponse(responseCode = "200", description = "Memory entries visible to the requested agent.")
     List<UserMemoryEntry> getVisibleMemories(@PathParam("userId") String userId, @QueryParam("agentId") String agentId,
                                              @QueryParam("groupId") List<String> groupIds, @QueryParam("order")
                                              @DefaultValue("most_recent") String recallOrder,
@@ -47,40 +50,50 @@ public interface IRestUserMemoryStore {
     @Path("/{userId}/search")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Search user memories", description = "Filter memories by key or value content.")
+    @APIResponse(responseCode = "200", description = "Memory entries matching the search query.")
     List<UserMemoryEntry> searchMemories(@PathParam("userId") String userId, @QueryParam("q") String query);
 
     @GET
     @Path("/{userId}/category/{category}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get memories by category", description = "Returns memories filtered by category (preference, fact, context).")
+    @APIResponse(responseCode = "200", description = "Memory entries in the requested category.")
     List<UserMemoryEntry> getMemoriesByCategory(@PathParam("userId") String userId, @PathParam("category") String category);
 
     @GET
     @Path("/{userId}/key/{key}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get a specific memory by key", description = "Returns a single memory entry by its key name.")
+    @APIResponse(responseCode = "200", description = "The requested memory entry.")
+    @APIResponse(responseCode = "404", description = "No memory exists for the requested key.")
     Response getMemoryByKey(@PathParam("userId") String userId, @PathParam("key") String key);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Upsert a memory entry", description = "Insert or update a memory entry. Upsert key depends on visibility.")
+    @APIResponse(responseCode = "200", description = "Memory entry created or updated successfully.")
+    @APIResponse(responseCode = "400", description = "Request body or required memory fields are invalid.")
     Response upsertMemory(UserMemoryEntry entry);
 
     @DELETE
     @Path("/entry/{entryId}")
     @Operation(summary = "Delete a specific memory entry")
+    @APIResponse(responseCode = "204", description = "Memory entry deleted successfully.")
+    @APIResponse(responseCode = "404", description = "Memory entry not found.")
     Response deleteMemory(@PathParam("entryId") String entryId);
 
     @DELETE
     @Path("/{userId}")
     @Operation(summary = "Delete all memories for a user (GDPR)", description = "Permanently removes all memory entries for a user. "
             + "Intended for GDPR right-to-erasure requests.")
+    @APIResponse(responseCode = "204", description = "All memories for the user were deleted.")
     Response deleteAllForUser(@PathParam("userId") String userId);
 
     @GET
     @Path("/{userId}/count")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Count memory entries for a user")
+    @APIResponse(responseCode = "200", description = "Memory count for the user.")
     Response countMemories(@PathParam("userId") String userId);
 }


### PR DESCRIPTION
## Summary

Adds missing OpenAPI `@APIResponse` annotations to the user memory REST interface so generated API docs include expected status codes.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, CI changes, etc.)

## Related Issue

Closes #548

## Changes Made

- Imported `APIResponse` in `IRestUserMemoryStore`.
- Added success response annotations for all user memory endpoints.
- Added documented 400/404 responses where the implementation returns those statuses.

## How to Test

1. Review `IRestUserMemoryStore` OpenAPI annotations.
2. Generate or inspect Swagger/OpenAPI output for the user memory endpoints.
3. Run `./mvnw compile`.

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [ ] I have added tests that prove my fix/feature works
- [ ] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [x] I have updated documentation if needed
- [x] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [x] I have not committed any secrets, API keys, or tokens
- [x] This PR has a clear, focused scope (one concern per PR)

Note: I attempted `./mvnw compile`, but the first run was still resolving a large dependency tree after several minutes, so I stopped it before completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OpenAPI response metadata annotations across memory management REST endpoints, clarifying expected HTTP status codes (e.g., 200, 204, 400, 404) and improving overall API specification clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->