### PR TITLE
docs(openapi): add missing APIResponse annotations to REST interfaces

### DIFF
--- a/src/main/java/ai/labs/eddi/configs/IRestVersionInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/IRestVersionInfo.java
@@ -10,6 +10,8 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
 import java.net.URI;
 
 import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
@@ -23,6 +25,8 @@ public interface IRestVersionInfo {
     @POST
     @Path("/{id}/currentversion")
     @Operation(description = "Redirect to latest version.")
+    @APIResponse(responseCode = "303", description = "Redirect to latest version")
+    @APIResponse(responseCode = "404", description = "Resource not found")
     default Response redirectToLatestVersion(@PathParam("id") String id) {
         try {
             IResourceStore.IResourceId currentResourceId = getCurrentResourceId(id);
@@ -37,6 +41,8 @@ public interface IRestVersionInfo {
     @Path("/{id}/currentversion")
     @Produces(MediaType.TEXT_PLAIN)
     @Operation(description = "Get current version of this resource.")
+    @APIResponse(responseCode = "200", description = "Current version")
+    @APIResponse(responseCode = "404", description = "Resource not found")
     default Integer getCurrentVersion(@PathParam("id") String id) {
         try {
             IResourceStore.IResourceId currentResourceId = getCurrentResourceId(id);

--- a/src/main/java/ai/labs/eddi/configs/agents/IRestCapabilityRegistry.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/IRestCapabilityRegistry.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.agents.CapabilityRegistryService.CapabilityMatch;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
@@ -27,6 +28,7 @@ public interface IRestCapabilityRegistry {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "searchCapabilities", description = "Find agents matching a skill")
+    @APIResponse(responseCode = "200", description = "Matching agent capabilities")
     List<CapabilityMatch> searchBySkill(
                                         @QueryParam("skill") String skill,
                                         @QueryParam("strategy")
@@ -36,5 +38,6 @@ public interface IRestCapabilityRegistry {
     @Path("/skills")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "listAllSkills", description = "List all registered skills")
+    @APIResponse(responseCode = "200", description = "List of registered skills")
     Set<String> listSkills();
 }

--- a/src/main/java/ai/labs/eddi/configs/channels/IRestChannelIntegrationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/channels/IRestChannelIntegrationStore.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
@@ -36,6 +37,7 @@ public interface IRestChannelIntegrationStore extends IRestVersionInfo {
     @Path("/descriptors")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Read list of channel integration descriptors.")
+    @APIResponse(responseCode = "200", description = "List of channel integration descriptors")
     List<DocumentDescriptor> readChannelDescriptors(
                                                     @QueryParam("filter")
                                                     @DefaultValue("") String filter,
@@ -48,6 +50,8 @@ public interface IRestChannelIntegrationStore extends IRestVersionInfo {
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Read channel integration configuration.")
+    @APIResponse(responseCode = "200", description = "Channel integration configuration")
+    @APIResponse(responseCode = "404", description = "Channel integration configuration not found")
     ChannelIntegrationConfiguration readChannel(
                                                 @PathParam("id") String id,
                                                 @Parameter(name = "version", required = true, example = "1")
@@ -57,6 +61,9 @@ public interface IRestChannelIntegrationStore extends IRestVersionInfo {
     @Path("/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(description = "Update channel integration configuration.")
+    @APIResponse(responseCode = "200", description = "Channel integration configuration updated")
+    @APIResponse(responseCode = "400", description = "Invalid channel integration configuration")
+    @APIResponse(responseCode = "404", description = "Channel integration configuration not found")
     Response updateChannel(
                            @PathParam("id") String id,
                            @Parameter(name = "version", required = true, example = "1")
@@ -66,17 +73,23 @@ public interface IRestChannelIntegrationStore extends IRestVersionInfo {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(description = "Create channel integration configuration.")
+    @APIResponse(responseCode = "201", description = "Channel integration configuration created")
+    @APIResponse(responseCode = "400", description = "Invalid channel integration configuration")
     Response createChannel(ChannelIntegrationConfiguration channelConfiguration);
 
     @POST
     @Path("/{id}")
     @Operation(description = "Duplicate this channel integration configuration.")
+    @APIResponse(responseCode = "201", description = "Channel integration configuration duplicated")
+    @APIResponse(responseCode = "404", description = "Channel integration configuration not found")
     Response duplicateChannel(@PathParam("id") String id,
                               @QueryParam("version") Integer version);
 
     @DELETE
     @Path("/{id}")
     @Operation(description = "Delete channel integration configuration.")
+    @APIResponse(responseCode = "200", description = "Channel integration configuration deleted")
+    @APIResponse(responseCode = "404", description = "Channel integration configuration not found")
     Response deleteChannel(
                            @PathParam("id") String id,
                            @Parameter(name = "version", required = true, example = "1")

--- a/src/main/java/ai/labs/eddi/configs/channels/IRestChannelIntegrationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/channels/IRestChannelIntegrationStore.java
@@ -81,6 +81,7 @@ public interface IRestChannelIntegrationStore extends IRestVersionInfo {
     @Path("/{id}")
     @Operation(description = "Duplicate this channel integration configuration.")
     @APIResponse(responseCode = "201", description = "Channel integration configuration duplicated")
+    @APIResponse(responseCode = "400", description = "Invalid channel integration configuration")
     @APIResponse(responseCode = "404", description = "Channel integration configuration not found")
     Response duplicateChannel(@PathParam("id") String id,
                               @QueryParam("version") Integer version);

--- a/src/main/java/ai/labs/eddi/configs/deployment/IRestDeploymentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/deployment/IRestDeploymentStore.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.configs.deployment;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import jakarta.annotation.security.RolesAllowed;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import jakarta.ws.rs.GET;
@@ -25,5 +26,6 @@ public interface IRestDeploymentStore {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Read deployment infos.")
+    @APIResponse(responseCode = "200", description = "Deployment information list")
     List<DeploymentInfo> readDeploymentInfos();
 }

--- a/src/main/java/ai/labs/eddi/configs/descriptors/IRestDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/IRestDocumentDescriptorStore.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.descriptors.model.SimpleDocumentDescriptor;
 import jakarta.annotation.security.RolesAllowed;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import jakarta.ws.rs.*;
@@ -29,6 +30,7 @@ public interface IRestDocumentDescriptorStore {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Read list of descriptors.")
+    @APIResponse(responseCode = "200", description = "List of descriptors")
     List<DocumentDescriptor> readDescriptors(@QueryParam("type")
     @DefaultValue("") String type, @QueryParam("filter")
     @DefaultValue("") String filter,
@@ -41,6 +43,8 @@ public interface IRestDocumentDescriptorStore {
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Read descriptor.")
+    @APIResponse(responseCode = "200", description = "Descriptor")
+    @APIResponse(responseCode = "404", description = "Descriptor not found")
     DocumentDescriptor readDescriptor(@PathParam("id") String id,
                                       @Parameter(name = "version", required = true, example = "1")
                                       @QueryParam("version") Integer version);
@@ -49,6 +53,8 @@ public interface IRestDocumentDescriptorStore {
     @Path("/{id}/simple")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Read simple descriptor.")
+    @APIResponse(responseCode = "200", description = "Simple descriptor")
+    @APIResponse(responseCode = "404", description = "Descriptor not found")
     SimpleDocumentDescriptor readSimpleDescriptor(@PathParam("id") String id,
                                                   @Parameter(name = "version", required = true, example = "1")
                                                   @QueryParam("version") Integer version);
@@ -57,6 +63,9 @@ public interface IRestDocumentDescriptorStore {
     @Path("/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(description = "Partial update descriptor.")
+    @APIResponse(responseCode = "200", description = "Descriptor updated")
+    @APIResponse(responseCode = "404", description = "Descriptor not found")
+    @APIResponse(responseCode = "500", description = "Internal server error")
     void patchDescriptor(@PathParam("id") String id,
                          @Parameter(name = "version", required = true, example = "1")
                          @QueryParam("version") Integer version,

--- a/src/main/java/ai/labs/eddi/configs/descriptors/IRestDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/IRestDocumentDescriptorStore.java
@@ -63,7 +63,7 @@ public interface IRestDocumentDescriptorStore {
     @Path("/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(description = "Partial update descriptor.")
-    @APIResponse(responseCode = "200", description = "Descriptor updated")
+    @APIResponse(responseCode = "204", description = "Descriptor updated")
     @APIResponse(responseCode = "404", description = "Descriptor not found")
     @APIResponse(responseCode = "500", description = "Internal server error")
     void patchDescriptor(@PathParam("id") String id,

--- a/src/main/java/ai/labs/eddi/configs/properties/IRestPropertiesStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/IRestPropertiesStore.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.properties;
 
 import ai.labs.eddi.configs.properties.model.Properties;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import jakarta.ws.rs.*;
@@ -21,16 +22,22 @@ public interface IRestPropertiesStore {
     @Path("/{userId}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Read properties.")
+    @APIResponse(responseCode = "200", description = "Properties")
+    @APIResponse(responseCode = "404", description = "Properties not found")
     Properties readProperties(@PathParam("userId") String userId);
 
     @POST
     @Path("/{userId}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Merge properties.")
+    @APIResponse(responseCode = "200", description = "Properties merged")
+    @APIResponse(responseCode = "400", description = "Invalid properties")
     Response mergeProperties(@PathParam("userId") String userId, Properties properties);
 
     @DELETE
     @Path("/{userId}")
     @Operation(description = "Delete properties.")
+    @APIResponse(responseCode = "200", description = "Properties deleted")
+    @APIResponse(responseCode = "404", description = "Properties not found")
     Response deleteProperties(@PathParam("userId") String userId);
 }

--- a/src/main/java/ai/labs/eddi/configs/properties/IRestPropertiesStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/IRestPropertiesStore.java
@@ -23,7 +23,7 @@ public interface IRestPropertiesStore {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Read properties.")
     @APIResponse(responseCode = "200", description = "Properties")
-    @APIResponse(responseCode = "404", description = "Properties not found")
+    @APIResponse(responseCode = "204", description = "No properties found")
     Properties readProperties(@PathParam("userId") String userId);
 
     @POST
@@ -31,13 +31,13 @@ public interface IRestPropertiesStore {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Merge properties.")
     @APIResponse(responseCode = "200", description = "Properties merged")
-    @APIResponse(responseCode = "400", description = "Invalid properties")
+    @APIResponse(responseCode = "400", description = "Invalid request body")
+    @APIResponse(responseCode = "500", description = "Internal server error")
     Response mergeProperties(@PathParam("userId") String userId, Properties properties);
 
     @DELETE
     @Path("/{userId}")
     @Operation(description = "Delete properties.")
     @APIResponse(responseCode = "200", description = "Properties deleted")
-    @APIResponse(responseCode = "404", description = "Properties not found")
     Response deleteProperties(@PathParam("userId") String userId);
 }


### PR DESCRIPTION
## Summary

Add missing `@APIResponse` annotations to REST interfaces to improve generated OpenAPI specifications and Swagger UI documentation. Response codes were documented based on the actual endpoint behavior and existing implementation patterns.

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] 📝 Documentation update
* [ ] ♻️ Refactoring (no functional changes)
* [ ] 🔧 Chore (dependency updates, CI changes, etc.)

## Related Issue

Closes #550

## Changes Made

* Added missing `@APIResponse` annotations to REST interfaces with existing `@Operation` annotations.
* Documented success and error HTTP response codes for GET, POST, PUT, PATCH, and DELETE endpoints.
* Updated the following interfaces:

  * `IRestVersionInfo`
  * `IRestPropertiesStore`
  * `IRestDeploymentStore`
  * `IRestDocumentDescriptorStore`
  * `IRestChannelIntegrationStore`
  * `IRestCapabilityRegistry`

## How to Test

1. Run Maven compile/verification tasks.
2. Open the generated OpenAPI specification Swagger UI.
3. Verify that the updated endpoints display the expected response codes and descriptions.

## Checklist

* [x] My code follows the project's code style
* [ ] I have added tests that prove my fix/feature works
* [x] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
* [x] I have updated documentation if needed
* [x] My commit messages follow [[conventional commits](https://chatgpt.com/c/CONTRIBUTING.md#commit-convention)](CONTRIBUTING.md#commit-convention)
* [x] I have not committed any secrets, API keys, or tokens
* [x] This PR has a clear, focused scope (one concern per PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced OpenAPI/REST API documentation by adding explicit HTTP response code metadata to multiple endpoints (including success and error outcomes such as 200/201/204/303/400/404/500).
  * Updated endpoint documentation to more accurately reflect expected statuses, improving clarity for API consumers and integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->