### PR TITLE
chore: standardize logger field name to LOGGER

### DIFF
--- a/src/main/java/ai/labs/eddi/engine/exception/ResourceStoreExceptionMapper.java
+++ b/src/main/java/ai/labs/eddi/engine/exception/ResourceStoreExceptionMapper.java
@@ -13,11 +13,11 @@ import org.jboss.logging.Logger;
 
 @Provider
 public class ResourceStoreExceptionMapper implements ExceptionMapper<IResourceStore.ResourceStoreException> {
-    private static final Logger log = Logger.getLogger(ResourceStoreExceptionMapper.class);
+    private static final Logger LOGGER = Logger.getLogger(ResourceStoreExceptionMapper.class);
 
     @Override
     public Response toResponse(IResourceStore.ResourceStoreException exception) {
-        log.error(exception.getLocalizedMessage(), exception);
+        LOGGER.error(exception.getLocalizedMessage(), exception);
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).type(MediaType.TEXT_PLAIN).entity(exception.getLocalizedMessage()).build();
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/httpclient/impl/HttpClientWrapper.java
+++ b/src/main/java/ai/labs/eddi/engine/httpclient/impl/HttpClientWrapper.java
@@ -40,7 +40,7 @@ public class HttpClientWrapper implements IHttpClient {
     private static final int TEXT_LIMIT = 150;
     private final WebClientSession webClient;
     private final String userAgent;
-    private static final Logger log = Logger.getLogger(HttpClientWrapper.class);
+    private static final Logger LOGGER = Logger.getLogger(HttpClientWrapper.class);
 
     @Inject
     public HttpClientWrapper(VertxHttpClient httpClient, @ConfigProperty(name = "systemRuntime.projectDomain") String projectDomain,
@@ -109,7 +109,7 @@ public class HttpClientWrapper implements IHttpClient {
         @Override
         public IRequest setBasicAuthentication(String username, String password, String realm, boolean preemptive) {
             if (!preemptive) {
-                log.warn("Non-preemptive authentication is not supported with Vert.x WebClient; falling back to preemptive.");
+                LOGGER.warn("Non-preemptive authentication is not supported with Vert.x WebClient; falling back to preemptive.");
             }
             request.basicAuthentication(username, password);
             return this;
@@ -218,7 +218,7 @@ public class HttpClientWrapper implements IHttpClient {
                         long contentLength = Long.parseLong(contentLengthHeader);
                         if (contentLength > maxLength) {
                             String message = String.format("Response Content-Length %d exceeds maximum allowed length %d", contentLength, maxLength);
-                            log.warn(message);
+                            LOGGER.warn(message);
                             handler.handle(io.vertx.core.Future.failedFuture(new IResponse.HttpResponseException(message)));
                             return;
                         }
@@ -230,7 +230,7 @@ public class HttpClientWrapper implements IHttpClient {
                 Buffer body = response.body();
                 if (body != null && body.length() > maxLength) {
                     String message = String.format("Response body length %d exceeds maximum allowed length %d", body.length(), maxLength);
-                    log.warn(message);
+                    LOGGER.warn(message);
                     handler.handle(io.vertx.core.Future.failedFuture(new IResponse.HttpResponseException(message)));
                     return;
                 }
@@ -291,10 +291,10 @@ public class HttpClientWrapper implements IHttpClient {
                     try {
                         completeListener.onComplete(ar.result());
                     } catch (IResponse.HttpResponseException e) {
-                        log.error(e.getLocalizedMessage(), e);
+                        LOGGER.error(e.getLocalizedMessage(), e);
                     }
                 } else {
-                    log.error(ar.cause().getLocalizedMessage(), ar.cause());
+                    LOGGER.error(ar.cause().getLocalizedMessage(), ar.cause());
                     // Notify listener of failure via a synthetic 503 response.
                     ResponseWrapper errorResponse = new ResponseWrapper();
                     errorResponse.setHttpCode(503);
@@ -304,7 +304,7 @@ public class HttpClientWrapper implements IHttpClient {
                     try {
                         completeListener.onComplete(errorResponse);
                     } catch (IResponse.HttpResponseException e) {
-                        log.error("Error while calling onComplete with error response", e);
+                        LOGGER.error("Error while calling onComplete with error response", e);
                     }
                 }
             });

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
@@ -51,7 +51,7 @@ public class RestAgentAdministration implements IRestAgentAdministration {
     private final IScheduleStore scheduleStore;
     private final IRuntime runtime;
 
-    private static final Logger log = Logger.getLogger(RestAgentAdministration.class);
+    private static final Logger LOGGER = Logger.getLogger(RestAgentAdministration.class);
 
     @Inject
     public RestAgentAdministration(IRuntime runtime, IAgentFactory agentFactory, IDeploymentStore deploymentStore,
@@ -84,12 +84,13 @@ public class RestAgentAdministration implements IRestAgentAdministration {
                 try {
                     deployFuture.get(30, TimeUnit.SECONDS);
                 } catch (TimeoutException e) {
-                    log.warn("Deployment wait timed out for Agent " + agentId + " v" + version);
+                    LOGGER.warn("Deployment wait timed out for Agent " + agentId + " v" + version);
                     deployError = "Deployment timed out";
                 } catch (ExecutionException e) {
                     Throwable cause = e.getCause();
-                    // Log full details server-side, expose only safe message to client
-                    log.warn("Deployment failed for Agent " + agentId + " v" + version + ": " + (cause != null ? cause.getMessage() : e.getMessage()),
+                    // LOGGER full details server-side, expose only safe message to client
+                    LOGGER.warn(
+                            "Deployment failed for Agent " + agentId + " v" + version + ": " + (cause != null ? cause.getMessage() : e.getMessage()),
                             cause != null ? cause : e);
                     deployError = "Deployment failed. Check server logs for details.";
                 } catch (InterruptedException e) {
@@ -112,7 +113,7 @@ public class RestAgentAdministration implements IRestAgentAdministration {
 
             return Response.accepted().build();
         } catch (Exception e) {
-            log.error(e.getLocalizedMessage(), e);
+            LOGGER.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getLocalizedMessage(), e);
         }
     }
@@ -176,12 +177,13 @@ public class RestAgentAdministration implements IRestAgentAdministration {
                 }
 
                 undeploy(environment, agentId, version);
-                log.info(String.format("Successfully undeployed Agent (agentId=%s, agentVersion=%s, environment=%s)", agentId, version, environment));
+                LOGGER.info(
+                        String.format("Successfully undeployed Agent (agentId=%s, agentVersion=%s, environment=%s)", agentId, version, environment));
             } while (undeployThisAndAllPreviousAgentVersions && version-- > 1);
 
             return Response.accepted().build();
         } catch (Exception e) {
-            log.error(e.getLocalizedMessage(), e);
+            LOGGER.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getLocalizedMessage(), e);
         }
     }
@@ -214,7 +216,7 @@ public class RestAgentAdministration implements IRestAgentAdministration {
             } catch (IllegalAccessException e) {
                 return throwErrorForbidden(agentId, version, e);
             } catch (Exception e) {
-                log.error(e.getLocalizedMessage(), e);
+                LOGGER.error(e.getLocalizedMessage(), e);
                 throw new InternalServerErrorException(e.getLocalizedMessage(), e);
             }
 
@@ -273,14 +275,14 @@ public class RestAgentAdministration implements IRestAgentAdministration {
 
     private Status throwError(String agentId, Integer version, ServiceException e, String message) {
         message = String.format(message, agentId, version);
-        log.error(message, e);
+        LOGGER.error(message, e);
         throw sneakyThrow(e);
     }
 
     private Void throwErrorForbidden(String agentId, Integer version, IllegalAccessException e) {
         String message = "Agent deployment is currently in progress! (agentId=%s , version=%s)";
         message = String.format(message, agentId, version);
-        log.error(message, e);
+        LOGGER.error(message, e);
         throw new WebApplicationException(new Throwable(message), Response.Status.FORBIDDEN.getStatusCode());
     }
 
@@ -293,11 +295,11 @@ public class RestAgentAdministration implements IRestAgentAdministration {
                 if (!schedule.isEnabled()) {
                     var nextFire = schedule.getNextFire() != null ? schedule.getNextFire() : java.time.Instant.now();
                     scheduleStore.setScheduleEnabled(schedule.getId(), true, nextFire);
-                    log.infof("[SCHEDULE] Auto-enabled schedule '%s' (id=%s) on Agent %s deploy", schedule.getName(), schedule.getId(), agentId);
+                    LOGGER.infof("[SCHEDULE] Auto-enabled schedule '%s' (id=%s) on Agent %s deploy", schedule.getName(), schedule.getId(), agentId);
                 }
             }
         } catch (Exception e) {
-            log.warnf(e, "[SCHEDULE] Failed to auto-enable schedules for Agent %s (non-fatal)", agentId);
+            LOGGER.warnf(e, "[SCHEDULE] Failed to auto-enable schedules for Agent %s (non-fatal)", agentId);
         }
     }
 
@@ -307,11 +309,12 @@ public class RestAgentAdministration implements IRestAgentAdministration {
             for (var schedule : schedules) {
                 if (schedule.isEnabled()) {
                     scheduleStore.setScheduleEnabled(schedule.getId(), false, null);
-                    log.infof("[SCHEDULE] Auto-disabled schedule '%s' (id=%s) on Agent %s undeploy", schedule.getName(), schedule.getId(), agentId);
+                    LOGGER.infof("[SCHEDULE] Auto-disabled schedule '%s' (id=%s) on Agent %s undeploy", schedule.getName(), schedule.getId(),
+                            agentId);
                 }
             }
         } catch (Exception e) {
-            log.warnf(e, "[SCHEDULE] Failed to auto-disable schedules for Agent %s (non-fatal)", agentId);
+            LOGGER.warnf(e, "[SCHEDULE] Failed to auto-disable schedules for Agent %s (non-fatal)", agentId);
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentManagement.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentManagement.java
@@ -48,7 +48,7 @@ public class RestAgentManagement implements IRestAgentManagement {
     @Inject
     SecurityIdentity identity;
 
-    private static final Logger log = Logger.getLogger(RestAgentManagement.class);
+    private static final Logger LOGGER = Logger.getLogger(RestAgentManagement.class);
 
     @Inject
     public RestAgentManagement(IRestAgentEngine restAgentEngine, IUserConversationStore userConversationStore,
@@ -82,7 +82,7 @@ public class RestAgentManagement implements IRestAgentManagement {
                 asyncResponse.resume(memorySnapshot);
             }
         } catch (CannotCreateConversationException e) {
-            log.error(e.getLocalizedMessage(), e);
+            LOGGER.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getLocalizedMessage());
         }
     }
@@ -104,7 +104,7 @@ public class RestAgentManagement implements IRestAgentManagement {
                     response);
 
         } catch (Exception e) {
-            log.error(e.getLocalizedMessage(), e);
+            LOGGER.error(e.getLocalizedMessage(), e);
             Response.ResponseBuilder responseStatus;
             if (e instanceof WebApplicationException) {
                 Response exResponse = ((WebApplicationException) e).getResponse();

--- a/src/main/java/ai/labs/eddi/engine/internal/RestCoordinatorAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestCoordinatorAdmin.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @ApplicationScoped
 public class RestCoordinatorAdmin implements IRestCoordinatorAdmin {
 
-    private static final Logger log = Logger.getLogger(RestCoordinatorAdmin.class);
+    private static final Logger LOGGER = Logger.getLogger(RestCoordinatorAdmin.class);
 
     private final IConversationCoordinator coordinator;
 
@@ -76,7 +76,7 @@ public class RestCoordinatorAdmin implements IRestCoordinatorAdmin {
         if (!replayed) {
             throw new NotFoundException("Dead-letter entry not found: " + sanitize(entryId));
         }
-        log.infof("Dead-letter %s replayed via REST", sanitize(entryId));
+        LOGGER.infof("Dead-letter %s replayed via REST", sanitize(entryId));
     }
 
     @Override
@@ -85,13 +85,13 @@ public class RestCoordinatorAdmin implements IRestCoordinatorAdmin {
         if (!discarded) {
             throw new NotFoundException("Dead-letter entry not found: " + sanitize(entryId));
         }
-        log.infof("Dead-letter %s discarded via REST", sanitize(entryId));
+        LOGGER.infof("Dead-letter %s discarded via REST", sanitize(entryId));
     }
 
     @Override
     public int purgeDeadLetters() {
         int count = coordinator.purgeDeadLetters();
-        log.infof("Purged %d dead-letter entries via REST", count);
+        LOGGER.infof("Purged %d dead-letter entries via REST", count);
         return count;
     }
 
@@ -106,7 +106,7 @@ public class RestCoordinatorAdmin implements IRestCoordinatorAdmin {
             OutboundSseEvent event = sse.newEventBuilder().name("status").data(status).build();
             eventSink.send(event);
         } catch (Exception e) {
-            log.warnf(e, "Failed to send initial status to SSE client");
+            LOGGER.warnf(e, "Failed to send initial status to SSE client");
         }
     }
 
@@ -140,7 +140,7 @@ public class RestCoordinatorAdmin implements IRestCoordinatorAdmin {
                     }
                 }
             } catch (Exception e) {
-                log.debugf(e, "Error broadcasting SSE status");
+                LOGGER.debugf(e, "Error broadcasting SSE status");
             }
         }, 2, 2, TimeUnit.SECONDS);
     }

--- a/src/main/java/ai/labs/eddi/engine/internal/RestLogAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestLogAdmin.java
@@ -21,8 +21,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * REST implementation for log administration — provides real-time SSE streaming
- * from the in-memory ring buffer and historical queries from the database.
+ * REST implementation for LOGGER administration — provides real-time SSE
+ * streaming from the in-memory ring buffer and historical queries from the
+ * database.
  *
  * @author ginccc
  * @since 6.0.0
@@ -30,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 @ApplicationScoped
 public class RestLogAdmin implements IRestLogAdmin {
 
-    private static final Logger log = Logger.getLogger(RestLogAdmin.class);
+    private static final Logger LOGGER = Logger.getLogger(RestLogAdmin.class);
 
     private final BoundedLogStore boundedLogStore;
     private final IDatabaseLogs databaseLogs;
@@ -80,7 +81,7 @@ public class RestLogAdmin implements IRestLogAdmin {
         });
 
         // Clean up when client disconnects or after max lifetime
-        Thread.ofVirtual().name("sse-log-cleanup-" + listenerId).start(() -> {
+        Thread.ofVirtual().name("sse-LOGGER-cleanup-" + listenerId).start(() -> {
             long maxLifetimeMs = TimeUnit.HOURS.toMillis(24);
             long start = System.currentTimeMillis();
             try {
@@ -95,7 +96,7 @@ public class RestLogAdmin implements IRestLogAdmin {
                     if (!eventSink.isClosed()) {
                         eventSink.close();
                     }
-                    log.debugv("SSE log listener {0} removed (client disconnected or max lifetime reached)", listenerId);
+                    LOGGER.debugv("SSE LOGGER listener {0} removed (client disconnected or max lifetime reached)", listenerId);
                 } catch (Exception e) {
                     // CDI container may already be shut down (e.g. during test teardown) —
                     // swallow to avoid noisy "ArC container not initialized" stacktraces
@@ -103,7 +104,7 @@ public class RestLogAdmin implements IRestLogAdmin {
             }
         });
 
-        log.debugv("SSE log stream started (listenerId={0}, agentId={1}, level={2})", listenerId, agentId, level);
+        LOGGER.debugv("SSE LOGGER stream started (listenerId={0}, agentId={1}, level={2})", listenerId, agentId, level);
     }
 
     @Override
@@ -113,13 +114,13 @@ public class RestLogAdmin implements IRestLogAdmin {
 
     private void sendEvent(SseEventSink eventSink, Sse sse, LogEntry entry) {
         try {
-            OutboundSseEvent event = sse.newEventBuilder().name("log").data(entry).build();
+            OutboundSseEvent event = sse.newEventBuilder().name("LOGGER").data(entry).build();
             eventSink.send(event).exceptionally(t -> {
-                log.debugv("Failed to send SSE log event: {0}", t.getMessage());
+                LOGGER.debugv("Failed to send SSE LOGGER event: {0}", t.getMessage());
                 return null;
             });
         } catch (Exception e) {
-            log.debugv("Error sending SSE log event: {0}", e.getMessage());
+            LOGGER.debugv("Error sending SSE LOGGER event: {0}", e.getMessage());
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/internal/RestLogAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestLogAdmin.java
@@ -21,9 +21,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * REST implementation for LOGGER administration — provides real-time SSE
- * streaming from the in-memory ring buffer and historical queries from the
- * database.
+ * REST implementation for log administration — provides real-time SSE streaming
+ * from the in-memory ring buffer and historical queries from the database.
  *
  * @author ginccc
  * @since 6.0.0
@@ -81,7 +80,7 @@ public class RestLogAdmin implements IRestLogAdmin {
         });
 
         // Clean up when client disconnects or after max lifetime
-        Thread.ofVirtual().name("sse-LOGGER-cleanup-" + listenerId).start(() -> {
+        Thread.ofVirtual().name("sse-log-cleanup-" + listenerId).start(() -> {
             long maxLifetimeMs = TimeUnit.HOURS.toMillis(24);
             long start = System.currentTimeMillis();
             try {
@@ -96,7 +95,7 @@ public class RestLogAdmin implements IRestLogAdmin {
                     if (!eventSink.isClosed()) {
                         eventSink.close();
                     }
-                    LOGGER.debugv("SSE LOGGER listener {0} removed (client disconnected or max lifetime reached)", listenerId);
+                    LOGGER.debugv("SSE log listener {0} removed (client disconnected or max lifetime reached)", listenerId);
                 } catch (Exception e) {
                     // CDI container may already be shut down (e.g. during test teardown) —
                     // swallow to avoid noisy "ArC container not initialized" stacktraces
@@ -104,7 +103,7 @@ public class RestLogAdmin implements IRestLogAdmin {
             }
         });
 
-        LOGGER.debugv("SSE LOGGER stream started (listenerId={0}, agentId={1}, level={2})", listenerId, agentId, level);
+        LOGGER.debugv("SSE log stream started (listenerId={0}, agentId={1}, level={2})", listenerId, agentId, level);
     }
 
     @Override
@@ -114,13 +113,13 @@ public class RestLogAdmin implements IRestLogAdmin {
 
     private void sendEvent(SseEventSink eventSink, Sse sse, LogEntry entry) {
         try {
-            OutboundSseEvent event = sse.newEventBuilder().name("LOGGER").data(entry).build();
+            OutboundSseEvent event = sse.newEventBuilder().name("log").data(entry).build();
             eventSink.send(event).exceptionally(t -> {
-                LOGGER.debugv("Failed to send SSE LOGGER event: {0}", t.getMessage());
+                LOGGER.debugv("Failed to send SSE log event: {0}", t.getMessage());
                 return null;
             });
         } catch (Exception e) {
-            LOGGER.debugv("Error sending SSE LOGGER event: {0}", e.getMessage());
+            LOGGER.debugv("Error sending SSE log event: {0}", e.getMessage());
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/memory/rest/RestConversationStore.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/rest/RestConversationStore.java
@@ -57,7 +57,7 @@ public class RestConversationStore implements IRestConversationStore {
     private final Integer deleteMemoriesOlderThanDays;
     private final Instance<IAttachmentStorage> attachmentStorageInstance;
 
-    private static final Logger log = Logger.getLogger(RestConversationStore.class);
+    private static final Logger LOGGER = Logger.getLogger(RestConversationStore.class);
 
     @Inject
     // @formatter:off
@@ -114,7 +114,7 @@ public class RestConversationStore implements IRestConversationStore {
                         URI resourceUri = conversationDescriptor.getResource();
                         var conversationResourceId = extractResourceId(resourceUri);
                         if (conversationResourceId == null) {
-                            log.warn(format("conversationResourceId was null, this should never happen. (%s)", resourceUri));
+                            LOGGER.warn(format("conversationResourceId was null, this should never happen. (%s)", resourceUri));
                             continue;
                         }
 
@@ -149,7 +149,7 @@ public class RestConversationStore implements IRestConversationStore {
                         retConversationDescriptors.add(conversationDescriptor);
                     } catch (Exception e) {
                         // Skip individual corrupted/orphaned descriptors gracefully
-                        log.debug(format("Skipping descriptor due to error: %s", e.getMessage()));
+                        LOGGER.debug(format("Skipping descriptor due to error: %s", e.getMessage()));
                     }
                 }
 
@@ -180,7 +180,7 @@ public class RestConversationStore implements IRestConversationStore {
             var memorySnapshot = conversationMemoryStore.loadConversationMemorySnapshot(resourceId.getId());
 
             if (memorySnapshot == null) {
-                log.warn(format("Memory snapshot not found for conversation [%s, %s]. Descriptor is orphaned.",
+                LOGGER.warn(format("Memory snapshot not found for conversation [%s, %s]. Descriptor is orphaned.",
                         resourceId.getId(), resourceId.getVersion()));
                 return;
             }
@@ -201,7 +201,7 @@ public class RestConversationStore implements IRestConversationStore {
         } catch (IResourceStore.ResourceNotFoundException e) {
             String message = "Resource referenced in descriptor does not exist (anymore) [%s, %s]. ";
             message += "Ignoring this resource.";
-            log.warn(format(message, resourceId.getId(), resourceId.getVersion()));
+            LOGGER.warn(format(message, resourceId.getId(), resourceId.getVersion()));
         }
     }
 
@@ -240,7 +240,7 @@ public class RestConversationStore implements IRestConversationStore {
         if (deletePermanently) {
             deleteAttachmentsForConversation(conversationId);
             conversationMemoryStore.deleteConversationMemorySnapshot(conversationId);
-            log.info(format("Conversation has been permanently deleted (conversationId=%s)", conversationId));
+            LOGGER.info(format("Conversation has been permanently deleted (conversationId=%s)", conversationId));
         }
 
         // DocumentDescriptorInterceptor will mark the DocumentDescriptor of this
@@ -255,11 +255,11 @@ public class RestConversationStore implements IRestConversationStore {
                 var amountOfEndedConversations = permanentlyDeleteEndedConversationLogs(deleteEndedConversationsOnceOlderThanDays);
 
                 if (amountOfEndedConversations > 0) {
-                    log.info(format("Successfully deleted %s conversations, which were older than %s days", amountOfEndedConversations,
+                    LOGGER.info(format("Successfully deleted %s conversations, which were older than %s days", amountOfEndedConversations,
                             deleteEndedConversationsOnceOlderThanDays));
                 }
             } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
-                log.error(e.getLocalizedMessage(), e);
+                LOGGER.error(e.getLocalizedMessage(), e);
             }
             return null;
         }, ThreadContext.getResources());
@@ -275,11 +275,11 @@ public class RestConversationStore implements IRestConversationStore {
             try {
                 long deleted = userMemoryStore.deleteOlderThan(deleteMemoriesOlderThanDays);
                 if (deleted > 0) {
-                    log.infof("User memory retention: deleted %d entries older than %d days",
+                    LOGGER.infof("User memory retention: deleted %d entries older than %d days",
                             deleted, deleteMemoriesOlderThanDays);
                 }
             } catch (Exception e) {
-                log.error("User memory retention cleanup failed", e);
+                LOGGER.error("User memory retention cleanup failed", e);
             }
             return null;
         }, ThreadContext.getResources());
@@ -306,7 +306,7 @@ public class RestConversationStore implements IRestConversationStore {
                 } catch (IResourceStore.ResourceNotFoundException e) {
                     deleteAttachmentsForConversation(endedConversationId);
                     conversationMemoryStore.deleteConversationMemorySnapshot(endedConversationId);
-                    log.debug(format("Cleaned up orphaned conversation memory without descriptor (id=%s)", endedConversationId));
+                    LOGGER.debug(format("Cleaned up orphaned conversation memory without descriptor (id=%s)", endedConversationId));
                 }
             }
         }
@@ -350,7 +350,7 @@ public class RestConversationStore implements IRestConversationStore {
                 conversationDescriptor.setConversationState(ConversationState.ENDED);
                 conversationDescriptorStore.setDescriptor(conversationId, 0, conversationDescriptor);
 
-                log.info(format("conversation (%s) has been set to ENDED", conversationId));
+                LOGGER.info(format("conversation (%s) has been set to ENDED", conversationId));
             }
 
             return Response.ok().build();
@@ -368,10 +368,10 @@ public class RestConversationStore implements IRestConversationStore {
             try {
                 long deleted = attachmentStorageInstance.get().deleteByConversation(conversationId);
                 if (deleted > 0) {
-                    log.debug(format("Deleted %d attachments for conversation %s", deleted, conversationId));
+                    LOGGER.debug(format("Deleted %d attachments for conversation %s", deleted, conversationId));
                 }
             } catch (Exception e) {
-                log.warn(format("Failed to delete attachments for conversation %s: %s",
+                LOGGER.warn(format("Failed to delete attachments for conversation %s: %s",
                         conversationId, e.getMessage()));
             }
         }

--- a/src/main/java/ai/labs/eddi/engine/runtime/rest/interceptors/DocumentDescriptorFilter.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/rest/interceptors/DocumentDescriptorFilter.java
@@ -38,7 +38,7 @@ public class DocumentDescriptorFilter implements ContainerResponseFilter {
     private final IDocumentDescriptorStore documentDescriptorStore;
     private final IConversationDescriptorStore conversationDescriptorStore;
 
-    private static final Logger log = Logger.getLogger(DocumentDescriptorFilter.class);
+    private static final Logger LOGGER = Logger.getLogger(DocumentDescriptorFilter.class);
 
     @Inject
     UriInfo uriInfo;
@@ -109,10 +109,10 @@ public class DocumentDescriptorFilter implements ContainerResponseFilter {
                 }
             }
         } catch (IResourceStore.ResourceNotFoundException e) {
-            log.debug(e.getLocalizedMessage(), e);
+            LOGGER.debug(e.getLocalizedMessage(), e);
             throw new NotFoundException(e.getLocalizedMessage());
         } catch (IResourceStore.ResourceModifiedException e) {
-            log.debug(e.getLocalizedMessage(), e);
+            LOGGER.debug(e.getLocalizedMessage(), e);
             throw new BadRequestException(e.getLocalizedMessage());
         } catch (Exception e) {
             throw sneakyThrow(e);


### PR DESCRIPTION
## Summary

Standardizes the logger naming convention across 8 files in the engine package. Renamed log and LOG fields to LOGGER to ensure consistency with the project's established convention and improve grep-ability

## Type of Change

<!-- Check the one that applies -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ X] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, CI changes, etc.)

## Related Issue

<!-- Link the issue this PR addresses -->
Closes #

## Changes Made
- Renamed `private static final Logger log/LOG` to `private static final Logger LOGGER` in 8 files.
- Updated all associated logging method calls (e.g., `info`, `warn`, `error`) to reference the new `LOGGER` field.
- Affected classes:
    - `ResourceStoreExceptionMapper.java`
    - `HttpClientWrapper.java`
    - `RestAgentAdministration.java`
    - `RestAgentManagement.java`
    - `RestCoordinatorAdmin.java`
    - `RestLogAdmin.java`
    - `RestConversationStore.java`
    - `DocumentDescriptorFilter.java`

## How to Test

<!-- Describe how reviewers can test your changes -->

1. Run `./mvnw clean compile` to ensure the syntax is correct.
2. Run `./mvnw test -DskipITs` to verify that existing unit tests pass after the refactoring.

## Checklist

- [x ] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [ x] I have added tests that prove my fix/feature works
- [ x] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [ x] I have updated documentation if needed
- [ x] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [ x] I have not committed any secrets, API keys, or tokens
- [ x] This PR has a clear, focused scope (one concern per PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized internal logging naming by switching logger field usage to a consistent project-wide `LOGGER` convention across REST and HTTP components.
  * Updated log statements (warn/debug/info/error) to use the standardized logger while keeping REST, SSE, and response behavior the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->