### PR TITLE
chore: add OCI image.source label to Dockerfile

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -96,6 +96,7 @@ LABEL name="labsai/eddi" \
       Built on Quarkus for cloud-native, high-performance operation." \
       maintainer="LABS.AI GmbH <contact@labs.ai>" \
       url="https://eddi.labs.ai" \
+      org.opencontainers.image.source="https://github.com/labsai/EDDI" \
       io.k8s.display-name="EDDI AI Platform" \
       io.k8s.description="Multi-Agent AI Orchestration Middleware" \
       io.openshift.tags="ai,conversational-ai,llm,chatbot,multi-agent,quarkus"


### PR DESCRIPTION
## Summary

Adds the standard OCI `org.opencontainers.image.source` label to the existing Dockerfile label block so published images can link back to the GitHub repository.

## Type of Change

<!-- Check the one that applies -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🔧 Chore (dependency updates, CI changes, etc.)

## Related Issue

<!-- Link the issue this PR addresses -->
Closes #537

## Changes Made

<!-- List the key changes in this PR -->

- Added `org.opencontainers.image.source="https://github.com/labsai/EDDI"` to `src/main/docker/Dockerfile`
- Kept the label inside the existing multi-line `LABEL` instruction
- No runtime behavior changes

## How to Test

<!-- Describe how reviewers can test your changes -->

1. Confirm the OCI source label appears exactly once in the existing `LABEL` block.
2. Run static Dockerfile sanity checks for the label block.
3. Run `git diff --check`.

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [ ] I have added tests that prove my fix/feature works
- [ ] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [ ] I have updated documentation if needed
- [x] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [x] I have not committed any secrets, API keys, or tokens
- [x] This PR has a clear, focused scope (one concern per PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image metadata to include source information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->