### PR TITLE
refactor(backup): standardize logger field names

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,13 @@
 
 ---
 
+## Refactor: Standardize backup logger fields (2026-06-23)
+
+**Repo:** EDDI (`refactor/539-logger-name`)
+**What changed:** Renamed the private logger field from `log` to `LOGGER` in the seven backup implementation classes listed in #539. The change follows the existing project convention and does not alter runtime behavior.
+
+**Files:** `RemoteApiResourceSource.java`, `RestExportService.java`, `RestImportService.java`, `SourceUrlValidator.java`, `StructuralMatcher.java`, `UpgradeExecutor.java`, `ZipResourceSource.java`, `docs/changelog.md`
+
 ## 🐛 Fix: Swagger UI CSP Regression — Duplicate Header Causes Inline Script Block (2026-06-23)
 
 **Repo:** EDDI (`fix/swagger-csp-duplicate-header`)

--- a/src/main/java/ai/labs/eddi/backup/impl/RemoteApiResourceSource.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RemoteApiResourceSource.java
@@ -53,7 +53,7 @@ import java.util.*;
  */
 public class RemoteApiResourceSource implements IResourceSource {
 
-    private static final Logger log = Logger.getLogger(RemoteApiResourceSource.class);
+    private static final Logger LOGGER = Logger.getLogger(RemoteApiResourceSource.class);
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
@@ -159,7 +159,7 @@ public class RemoteApiResourceSource implements IResourceSource {
                     workflowDataList.add(wfData);
                 }
             } catch (Exception e) {
-                log.warnf("Failed to read workflow %d from remote %s: %s", i, baseUrl, e.getMessage());
+                LOGGER.warnf("Failed to read workflow %d from remote %s: %s", i, baseUrl, e.getMessage());
             }
         }
 
@@ -193,11 +193,11 @@ public class RemoteApiResourceSource implements IResourceSource {
                                 resId.getId(), snippet.getName(), snippet));
                     }
                 } catch (Exception e) {
-                    log.debugf("Could not read remote snippet %s: %s", desc.getName(), e.getMessage());
+                    LOGGER.debugf("Could not read remote snippet %s: %s", desc.getName(), e.getMessage());
                 }
             }
         } catch (Exception e) {
-            log.warnf("Failed to read snippets from remote %s: %s", baseUrl, e.getMessage());
+            LOGGER.warnf("Failed to read snippets from remote %s: %s", baseUrl, e.getMessage());
         }
 
         return snippetDataList;
@@ -303,7 +303,7 @@ public class RemoteApiResourceSource implements IResourceSource {
             String restPath = STEP_TYPE_TO_REST_PATH.get(stepTypeStr);
             String extLabel = STEP_TYPE_TO_EXT_LABEL.get(stepTypeStr);
             if (restPath == null || extLabel == null) {
-                log.debugf("Unknown step type: %s", stepTypeStr);
+                LOGGER.debugf("Unknown step type: %s", stepTypeStr);
                 continue;
             }
 
@@ -316,7 +316,7 @@ public class RemoteApiResourceSource implements IResourceSource {
                 extensions.put(stepTypeStr, new ExtensionSourceData(
                         extResId.getId(), name, extLabel, stepTypeStr, contentJson));
             } catch (Exception e) {
-                log.debugf("Could not read remote extension %s/%s: %s",
+                LOGGER.debugf("Could not read remote extension %s/%s: %s",
                         stepTypeStr, extResId.getId(), e.getMessage());
             }
         }
@@ -341,7 +341,7 @@ public class RemoteApiResourceSource implements IResourceSource {
                 }
             }
         } catch (Exception e) {
-            log.debugf("Could not resolve latest version for %s: %s", agentId, e.getMessage());
+            LOGGER.debugf("Could not resolve latest version for %s: %s", agentId, e.getMessage());
         }
         return 1; // fallback
     }
@@ -362,7 +362,7 @@ public class RemoteApiResourceSource implements IResourceSource {
                 }
             }
         } catch (Exception e) {
-            log.debugf("Could not read remote descriptor name for %s: %s", resourceId, e.getMessage());
+            LOGGER.debugf("Could not read remote descriptor name for %s: %s", resourceId, e.getMessage());
         }
         return null;
     }

--- a/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
@@ -78,7 +78,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
     private final IScheduleStore scheduleStore;
     private final Path tmpPath = Paths.get(FileUtilities.buildPath(System.getProperty("user.dir"), "tmp"));
 
-    private static final Logger log = Logger.getLogger(RestExportService.class);
+    private static final Logger LOGGER = Logger.getLogger(RestExportService.class);
     private static final String SCHEDULE_EXT = "schedule";
 
     /**
@@ -278,7 +278,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
             return new ExportPreview(agentId, agentName, agentVersion, resources);
 
         } catch (Exception e) {
-            log.error("Export preview failed: " + e.getMessage(), e);
+            LOGGER.error("Export preview failed: " + e.getMessage(), e);
             throw sneakyThrow(e);
         }
     }
@@ -312,7 +312,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                 resources.add(new ExportableResource(resId.getId(), resId.getVersion(), typeLabel, name, parentWorkflowId, -1, false));
             }
         } catch (Exception e) {
-            log.debugf("Could not extract %s resources from workflow: %s", typeLabel, e.getMessage());
+            LOGGER.debugf("Could not extract %s resources from workflow: %s", typeLabel, e.getMessage());
         }
     }
 
@@ -331,7 +331,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                 allConfigs.add(jsonSerialization.serialize(outputStore.read(resId.getId(), resId.getVersion())));
             }
         } catch (Exception e) {
-            log.debugf("Could not scan extension content for snippets: %s", e.getMessage());
+            LOGGER.debugf("Could not scan extension content for snippets: %s", e.getMessage());
         }
     }
 
@@ -345,7 +345,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
             try {
                 config = store.readIncludingDeleted(resourceIdUnused.getId(), versionToExport);
             } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
-                log.error(e.getLocalizedMessage(), e);
+                LOGGER.error(e.getLocalizedMessage(), e);
             }
             while (versionToExport < 10000) {
                 try {
@@ -391,7 +391,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                 // Scrub secrets before export (defense-in-depth)
                 return secretScrubber.scrubJson(json);
             } catch (IOException ex) {
-                log.error(ex.getLocalizedMessage(), ex);
+                LOGGER.error(ex.getLocalizedMessage(), ex);
                 return "";
             }
         }));
@@ -408,7 +408,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                     writeDocumentDescriptor(path, resourceId.getId(), resourceId.getVersion());
                 }
             } catch (IOException | IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
-                log.error(e.getLocalizedMessage(), e);
+                LOGGER.error(e.getLocalizedMessage(), e);
             }
         });
     }
@@ -470,7 +470,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                     writeDocumentDescriptor(path, resourceId.getId(), resourceId.getVersion());
                 }
             } catch (IOException | IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
-                log.error(e.getLocalizedMessage(), e);
+                LOGGER.error(e.getLocalizedMessage(), e);
             }
         });
     }
@@ -623,14 +623,14 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                     }
                     exportedCount++;
                 } catch (IResourceStore.ResourceNotFoundException e) {
-                    log.debugf("Snippet descriptor references missing resource: %s", descriptor.getResource());
+                    LOGGER.debugf("Snippet descriptor references missing resource: %s", descriptor.getResource());
                 }
             }
             if (exportedCount > 0) {
-                log.infof("Exported %d snippet(s) (referenced: %s)", exportedCount, referencedNames);
+                LOGGER.infof("Exported %d snippet(s) (referenced: %s)", exportedCount, referencedNames);
             }
         } catch (Exception e) {
-            log.warnf("Failed to export snippets: %s", e.getMessage());
+            LOGGER.warnf("Failed to export snippets: %s", e.getMessage());
         }
     }
 
@@ -652,9 +652,9 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                     writer.write(json);
                 }
             }
-            log.infof("Exported %d schedule(s) for Agent %s", schedules.size(), agentId);
+            LOGGER.infof("Exported %d schedule(s) for Agent %s", schedules.size(), agentId);
         } catch (Exception e) {
-            log.warnf("Failed to export schedules for Agent %s: %s", agentId, e.getMessage());
+            LOGGER.warnf("Failed to export schedules for Agent %s: %s", agentId, e.getMessage());
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
@@ -103,7 +103,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     private final StructuralMatcher structuralMatcher;
     private final UpgradeExecutor upgradeExecutor;
 
-    private static final Logger log = Logger.getLogger(RestImportService.class);
+    private static final Logger LOGGER = Logger.getLogger(RestImportService.class);
 
     @Inject
     public RestImportService(IZipArchive zipArchive, IJsonSerialization jsonSerialization,
@@ -146,7 +146,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             // Wait for all deployments to complete
             CompletableFuture.allOf(deploymentFutures.toArray(new CompletableFuture[0])).join();
 
-            log.info("Imported & Deployed Initial Agents");
+            LOGGER.info("Imported & Deployed Initial Agents");
             return restAgentAdministration.getDeploymentStatuses(production);
         } catch (IOException e) {
             throw sneakyThrow(e);
@@ -226,7 +226,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
             return new ImportPreview(null, null, null, null, List.of());
         } catch (Exception e) {
-            log.error(e.getLocalizedMessage(), e);
+            LOGGER.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException("Preview failed: " + e.getMessage(), e);
         }
     }
@@ -294,12 +294,12 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                                     null, null, null, -1));
                         }
                     } catch (Exception e) {
-                        log.debugf("Could not preview snippet %s: %s", snippetFilePath.getFileName(), e.getMessage());
+                        LOGGER.debugf("Could not preview snippet %s: %s", snippetFilePath.getFileName(), e.getMessage());
                     }
                 }
             }
         } catch (Exception e) {
-            log.debugf("Could not scan snippets for preview: %s", e.getMessage());
+            LOGGER.debugf("Could not scan snippets for preview: %s", e.getMessage());
         }
     }
 
@@ -315,7 +315,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 }
             }
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
-            log.debug("Could not look up origin ID " + originId + ": " + e.getMessage());
+            LOGGER.debug("Could not look up origin ID " + originId + ": " + e.getMessage());
         }
 
         // Fallback: try by resource ID directly (handles export→re-import round-trip
@@ -333,7 +333,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 }
             }
         } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
-            log.debugf("Fallback resource ID lookup for '%s' not found: %s", originId, e.getMessage());
+            LOGGER.debugf("Fallback resource ID lookup for '%s' not found: %s", originId, e.getMessage());
         }
 
         return new ResourceDiff(originId, resourceType, name, DiffAction.CREATE, null, null, null, null, null, -1);
@@ -375,7 +375,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
             return importAgentZipFile(zippedAgentConfigFiles, targetDir, isMerge, selectedSet);
         } catch (Exception e) {
-            log.error(e.getLocalizedMessage(), e);
+            LOGGER.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getMessage(), e);
         }
     }
@@ -430,12 +430,12 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
                     lastAgentUri = newAgentUri;
                 } catch (IOException | RestInterfaceFactory.RestInterfaceFactoryException e) {
-                    log.error(e.getLocalizedMessage(), e);
+                    LOGGER.error(e.getLocalizedMessage(), e);
                     throw new InternalServerErrorException(e.getLocalizedMessage(), e);
                 }
             }
         }
-        log.infof("Import complete: lastAgentUri=%s", lastAgentUri);
+        LOGGER.infof("Import complete: lastAgentUri=%s", lastAgentUri);
         if (lastAgentUri != null) {
             // Use manual .header("Location", ...) instead of Response.created(URI)
             // because Response.created() validates the URI scheme and may strip eddi://
@@ -568,7 +568,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                                 .collect(Collectors.toList()));
 
                     } catch (IOException | RestInterfaceFactory.RestInterfaceFactoryException | CallbackMatcher.CallbackMatcherException e) {
-                        log.error(e.getLocalizedMessage(), e);
+                        LOGGER.error(e.getLocalizedMessage(), e);
                         throw new InternalServerErrorException(e.getMessage(), e);
                     }
                 });
@@ -576,7 +576,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             }
 
         } catch (IOException e) {
-            log.error(e.getLocalizedMessage(), e);
+            LOGGER.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getMessage(), e);
         }
     }
@@ -659,7 +659,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 return existing.getFirst().getResource();
             }
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
-            log.debug("Could not look up origin ID " + originId + ": " + e.getMessage());
+            LOGGER.debug("Could not look up origin ID " + originId + ": " + e.getMessage());
         }
 
         // Fallback: try by resource ID directly (handles export→re-import round-trip
@@ -673,7 +673,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 }
             }
         } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
-            log.debugf("Fallback resource ID lookup for '%s' not found: %s", originId, e.getMessage());
+            LOGGER.debugf("Fallback resource ID lookup for '%s' not found: %s", originId, e.getMessage());
         }
         return null;
     }
@@ -734,7 +734,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 }
             }
         } catch (Exception e) {
-            log.warn("Could not set originId on descriptor for " + resourceUri + ": " + e.getMessage());
+            LOGGER.warn("Could not set originId on descriptor for " + resourceUri + ": " + e.getMessage());
         }
     }
 
@@ -934,17 +934,17 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                                 Response updateResp = restSnippetStore.updateSnippet(
                                         localResId.getId(), localResId.getVersion(), snippet);
                                 if (updateResp.getStatus() == 200) {
-                                    log.debugf("Updated existing snippet '%s' (id=%s, v=%d)",
+                                    LOGGER.debugf("Updated existing snippet '%s' (id=%s, v=%d)",
                                             snippetName, localResId.getId(), localResId.getVersion());
                                     importedCount++;
                                     continue;
                                 }
                                 // Update failed (e.g., version conflict) — fall through to create
-                                log.warnf("Update failed for snippet '%s' (status=%d), creating new",
+                                LOGGER.warnf("Update failed for snippet '%s' (status=%d), creating new",
                                         snippetName, updateResp.getStatus());
                             } else {
                                 // Create strategy: snippet already exists globally, skip to avoid duplicates
-                                log.debugf("Snippet '%s' already exists, skipping (create strategy)", snippetName);
+                                LOGGER.debugf("Snippet '%s' already exists, skipping (create strategy)", snippetName);
                                 skippedCount++;
                                 continue;
                             }
@@ -954,17 +954,17 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         Response createResp = restSnippetStore.createSnippet(snippet);
                         checkIfCreatedResponse(createResp);
                         importedCount++;
-                        log.debugf("Created new snippet '%s'", snippetName);
+                        LOGGER.debugf("Created new snippet '%s'", snippetName);
                     } catch (Exception e) {
-                        log.warnf("Failed to import snippet from %s: %s", snippetFilePath, e.getMessage());
+                        LOGGER.warnf("Failed to import snippet from %s: %s", snippetFilePath, e.getMessage());
                     }
                 }
                 if (importedCount > 0 || skippedCount > 0) {
-                    log.infof("Snippets: imported %d, skipped %d (already exist)", importedCount, skippedCount);
+                    LOGGER.infof("Snippets: imported %d, skipped %d (already exist)", importedCount, skippedCount);
                 }
             }
         } catch (Exception e) {
-            log.warnf("Failed to import snippets: %s", e.getMessage());
+            LOGGER.warnf("Failed to import snippets: %s", e.getMessage());
         }
     }
 
@@ -992,11 +992,11 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         nameMap.put(existing.getName(), resourceId);
                     }
                 } catch (Exception e) {
-                    log.debugf("Could not load snippet for dedup: %s", e.getMessage());
+                    LOGGER.debugf("Could not load snippet for dedup: %s", e.getMessage());
                 }
             }
         } catch (Exception e) {
-            log.warnf("Could not build snippet name map: %s", e.getMessage());
+            LOGGER.warnf("Could not build snippet name map: %s", e.getMessage());
         }
         return nameMap;
     }
@@ -1028,7 +1028,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 }
             }
         } catch (IOException e) {
-            log.debug("Error searching for snippets directory: " + e.getMessage());
+            LOGGER.debug("Error searching for snippets directory: " + e.getMessage());
         }
         return null;
     }
@@ -1098,7 +1098,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                     }
                 }
             } catch (IOException | IResourceStore.ResourceStoreException | IResourceStore.ResourceModifiedException e) {
-                log.error(e.getLocalizedMessage(), e);
+                LOGGER.error(e.getLocalizedMessage(), e);
             }
         });
     }
@@ -1176,11 +1176,11 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
                 return jsonSerialization.deserialize(resourceContent, clazz);
             } catch (Exception e) {
-                log.error(e.getLocalizedMessage());
-                log.error(String.format("uri is: %s", uri));
-                log.error(String.format("workflowPath is: %s", workflowPath));
-                log.error(String.format("resourcePath is: %s", resourcePath));
-                log.error(String.format("resourceContent is:\n%s", resourceContent));
+                LOGGER.error(e.getLocalizedMessage());
+                LOGGER.error(String.format("uri is: %s", uri));
+                LOGGER.error(String.format("workflowPath is: %s", workflowPath));
+                LOGGER.error(String.format("resourcePath is: %s", resourcePath));
+                LOGGER.error(String.format("resourceContent is:\n%s", resourceContent));
                 return null;
             }
         }).collect(Collectors.toList());
@@ -1206,7 +1206,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     private void checkIfCreatedResponse(Response response) {
         int status = response.getStatus();
         if (status != 201) {
-            log.error(String.format("Http Response Code was not 201 when attempting resource creation, but %s", status));
+            LOGGER.error(String.format("Http Response Code was not 201 when attempting resource creation, but %s", status));
         }
     }
 
@@ -1220,7 +1220,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             ZipResourceSource source = new ZipResourceSource(targetDir.toPath(), jsonSerialization);
             return structuralMatcher.buildPreview(source, targetAgentId, true);
         } catch (Exception e) {
-            log.error("Upgrade preview failed: " + e.getMessage(), e);
+            LOGGER.error("Upgrade preview failed: " + e.getMessage(), e);
             throw new InternalServerErrorException("Upgrade preview failed: " + e.getMessage(), e);
         }
     }
@@ -1239,7 +1239,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             return Response.status(Response.Status.CREATED)
                     .header("Location", resultUri.toString()).build();
         } catch (Exception e) {
-            log.error("Upgrade from ZIP failed: " + e.getMessage(), e);
+            LOGGER.error("Upgrade from ZIP failed: " + e.getMessage(), e);
             throw new InternalServerErrorException("Upgrade failed: " + e.getMessage(), e);
         }
     }
@@ -1273,7 +1273,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         try {
             return RemoteApiResourceSource.listRemoteAgentDescriptors(sourceUrl, sourceAuth, jsonSerialization);
         } catch (Exception e) {
-            log.errorf("Failed to list remote agents from %s: %s", sourceUrl, e.getMessage());
+            LOGGER.errorf("Failed to list remote agents from %s: %s", sourceUrl, e.getMessage());
             throw new InternalServerErrorException("Failed to connect to remote instance: " + e.getMessage(), e);
         }
     }
@@ -1285,7 +1285,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         try (var source = new RemoteApiResourceSource(sourceUrl, sourceAgentId, sourceVersion, sourceAuth, jsonSerialization)) {
             return structuralMatcher.buildPreview(source, targetAgentId, true);
         } catch (Exception e) {
-            log.errorf("Sync preview failed for agent %s from %s: %s", sourceAgentId, sourceUrl, e.getMessage());
+            LOGGER.errorf("Sync preview failed for agent %s from %s: %s", sourceAgentId, sourceUrl, e.getMessage());
             throw new InternalServerErrorException("Sync preview failed: " + e.getMessage(), e);
         }
     }
@@ -1305,7 +1305,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 ImportPreview preview = structuralMatcher.buildPreview(source, mapping.targetAgentId(), true);
                 previews.add(preview);
             } catch (Exception e) {
-                log.warnf("Batch preview failed for agent %s: %s", mapping.sourceAgentId(), e.getMessage());
+                LOGGER.warnf("Batch preview failed for agent %s: %s", mapping.sourceAgentId(), e.getMessage());
                 // Add a failed preview entry so the caller knows which agent failed
                 previews.add(new ImportPreview(
                         mapping.sourceAgentId(), "Error: " + e.getMessage(),
@@ -1331,7 +1331,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         .header("Location", resultUri.toString()).build();
             }
         } catch (Exception e) {
-            log.errorf("Sync execution failed for agent %s from %s: %s",
+            LOGGER.errorf("Sync execution failed for agent %s from %s: %s",
                     sourceAgentId, sourceUrl, e.getMessage());
             throw new InternalServerErrorException("Sync failed: " + e.getMessage(), e);
         }
@@ -1351,7 +1351,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                             request.selectedResources(), request.workflowOrder());
                     resultUris.add(resultUri);
                 } catch (Exception e) {
-                    log.warnf("Batch sync failed for agent %s→%s: %s",
+                    LOGGER.warnf("Batch sync failed for agent %s→%s: %s",
                             request.sourceAgentId(), request.targetAgentId(), e.getMessage());
                     // Continue with remaining agents — partial success is better than total failure
                 }
@@ -1359,7 +1359,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
             return Response.ok(resultUris).build();
         } catch (Exception e) {
-            log.errorf("Batch sync execution failed: %s", e.getMessage());
+            LOGGER.errorf("Batch sync execution failed: %s", e.getMessage());
             throw new InternalServerErrorException("Batch sync failed: " + e.getMessage(), e);
         }
     }

--- a/src/main/java/ai/labs/eddi/backup/impl/SourceUrlValidator.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/SourceUrlValidator.java
@@ -19,7 +19,7 @@ import java.net.UnknownHostException;
  */
 public final class SourceUrlValidator {
 
-    private static final Logger log = Logger.getLogger(SourceUrlValidator.class);
+    private static final Logger LOGGER = Logger.getLogger(SourceUrlValidator.class);
 
     private SourceUrlValidator() {
     }
@@ -75,7 +75,7 @@ public final class SourceUrlValidator {
             throw new IllegalArgumentException("Source URL must not point to a private IP address: " + sourceUrl);
         }
 
-        log.debugf("Source URL validated: %s", sourceUrl);
+        LOGGER.debugf("Source URL validated: %s", sourceUrl);
     }
 
     private static boolean isLoopback(String host) {
@@ -100,7 +100,7 @@ public final class SourceUrlValidator {
             return false;
         } catch (UnknownHostException e) {
             // DNS resolution failed — fail closed to prevent DNS rebinding attacks
-            log.debugf("Could not resolve host %s — rejecting source URL", host);
+            LOGGER.debugf("Could not resolve host %s — rejecting source URL", host);
             throw new IllegalArgumentException("Source URL host could not be resolved: " + host, e);
         }
     }

--- a/src/main/java/ai/labs/eddi/backup/impl/StructuralMatcher.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/StructuralMatcher.java
@@ -53,7 +53,7 @@ import java.util.*;
 @ApplicationScoped
 public class StructuralMatcher {
 
-    private static final Logger log = Logger.getLogger(StructuralMatcher.class);
+    private static final Logger LOGGER = Logger.getLogger(StructuralMatcher.class);
 
     private final IRestAgentStore agentStore;
     private final IDocumentDescriptorStore documentDescriptorStore;
@@ -105,7 +105,7 @@ public class StructuralMatcher {
                 targetConfig = readTargetAgent(targetAgentId);
                 targetAgentName = readDescriptorName(targetAgentId);
             } catch (Exception e) {
-                log.warnf("Could not load target agent %s: %s", targetAgentId, e.getMessage());
+                LOGGER.warnf("Could not load target agent %s: %s", targetAgentId, e.getMessage());
                 // Proceed without target — all resources will be CREATE
                 targetAgentId = null;
             }
@@ -297,7 +297,7 @@ public class StructuralMatcher {
             WorkflowConfiguration config = workflowStore.readWorkflow(workflowId, version);
             return serializeSafe(config);
         } catch (Exception e) {
-            log.debugf("Could not read target workflow %s v%d: %s", workflowId, version, e.getMessage());
+            LOGGER.debugf("Could not read target workflow %s v%d: %s", workflowId, version, e.getMessage());
             return null;
         }
     }
@@ -335,11 +335,11 @@ public class StructuralMatcher {
                     result.put(stepType.toString(), new TargetExtension(
                             extResId.getId(), extResId.getVersion(), json));
                 } catch (Exception e) {
-                    log.debugf("Could not read target extension %s: %s", extUri, e.getMessage());
+                    LOGGER.debugf("Could not read target extension %s: %s", extUri, e.getMessage());
                 }
             }
         } catch (Exception e) {
-            log.debugf("Could not read target workflow config %s v%d: %s", workflowId, version, e.getMessage());
+            LOGGER.debugf("Could not read target workflow config %s v%d: %s", workflowId, version, e.getMessage());
         }
 
         return result;
@@ -381,7 +381,7 @@ public class StructuralMatcher {
                     ai.labs.eddi.configs.rag.IRestRagStore.class)
                     .readRag(resId.getId(), resId.getVersion());
             default -> {
-                log.debugf("Unknown step type for typed read: %s", stepType);
+                LOGGER.debugf("Unknown step type for typed read: %s", stepType);
                 yield null;
             }
         };
@@ -392,7 +392,7 @@ public class StructuralMatcher {
             PromptSnippet snippet = snippetStore.readSnippet(snippetId, version);
             return serializeSafe(snippet);
         } catch (Exception e) {
-            log.debugf("Could not read target snippet %s v%d: %s", snippetId, version, e.getMessage());
+            LOGGER.debugf("Could not read target snippet %s v%d: %s", snippetId, version, e.getMessage());
             return null;
         }
     }
@@ -422,11 +422,11 @@ public class StructuralMatcher {
                         nameMap.put(name, resId);
                     }
                 } catch (Exception e) {
-                    log.debugf("Could not read snippet for name map: %s", e.getMessage());
+                    LOGGER.debugf("Could not read snippet for name map: %s", e.getMessage());
                 }
             }
         } catch (Exception e) {
-            log.debugf("Could not build snippet name map: %s", e.getMessage());
+            LOGGER.debugf("Could not build snippet name map: %s", e.getMessage());
         }
         return nameMap;
     }
@@ -466,7 +466,7 @@ public class StructuralMatcher {
         try {
             return jsonSerialization.serialize(obj);
         } catch (Exception e) {
-            log.debugf("Serialization failed: %s", e.getMessage());
+            LOGGER.debugf("Serialization failed: %s", e.getMessage());
             return null;
         }
     }

--- a/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
@@ -73,7 +73,7 @@ import static ai.labs.eddi.configs.descriptors.ResourceUtilities.createDocumentD
 @ApplicationScoped
 public class UpgradeExecutor {
 
-    private static final Logger log = Logger.getLogger(UpgradeExecutor.class);
+    private static final Logger LOGGER = Logger.getLogger(UpgradeExecutor.class);
 
     private final IRestAgentStore agentStore;
     private final IRestWorkflowStore workflowStore;
@@ -173,7 +173,7 @@ public class UpgradeExecutor {
                     newWorkflowUris, workflowOrder);
 
         } catch (Exception e) {
-            log.errorf("Upgrade failed for target agent %s: %s", targetAgentId, e.getMessage());
+            LOGGER.errorf("Upgrade failed for target agent %s: %s", targetAgentId, e.getMessage());
             throw new RuntimeException("Upgrade failed: " + e.getMessage(), e);
         }
     }
@@ -185,15 +185,15 @@ public class UpgradeExecutor {
             if (diff.action() == DiffAction.UPDATE && diff.targetId() != null) {
                 // Update existing snippet
                 snippetStore.updateSnippet(diff.targetId(), diff.targetVersion(), sourceSnippet.snippet());
-                log.infof("Updated snippet '%s' (target=%s, v%d→v%d)",
+                LOGGER.infof("Updated snippet '%s' (target=%s, v%d→v%d)",
                         sourceSnippet.name(), diff.targetId(), diff.targetVersion(), diff.targetVersion() + 1);
             } else if (diff.action() == DiffAction.CREATE) {
                 // Create new snippet
                 snippetStore.createSnippet(sourceSnippet.snippet());
-                log.infof("Created snippet '%s'", sourceSnippet.name());
+                LOGGER.infof("Created snippet '%s'", sourceSnippet.name());
             }
         } catch (Exception e) {
-            log.warnf("Failed to process snippet '%s': %s", sourceSnippet.name(), e.getMessage());
+            LOGGER.warnf("Failed to process snippet '%s': %s", sourceSnippet.name(), e.getMessage());
         }
     }
 
@@ -227,7 +227,7 @@ public class UpgradeExecutor {
                     URI updatedUri = updateExtension(sourceExt, extDiff.targetId(), extDiff.targetVersion());
                     if (updatedUri != null) {
                         updates.put(stepType, updatedUri);
-                        log.infof("Updated %s '%s' (target=%s, v%d→v%d)",
+                        LOGGER.infof("Updated %s '%s' (target=%s, v%d→v%d)",
                                 sourceExt.type(), sourceExt.name(),
                                 extDiff.targetId(), extDiff.targetVersion(), extDiff.targetVersion() + 1);
                     }
@@ -235,11 +235,11 @@ public class UpgradeExecutor {
                     URI newUri = createExtension(sourceExt);
                     if (newUri != null) {
                         updates.put(stepType, newUri);
-                        log.infof("Created %s '%s'", sourceExt.type(), sourceExt.name());
+                        LOGGER.infof("Created %s '%s'", sourceExt.type(), sourceExt.name());
                     }
                 }
             } catch (Exception e) {
-                log.warnf("Failed to process extension %s '%s': %s",
+                LOGGER.warnf("Failed to process extension %s '%s': %s",
                         sourceExt.type(), sourceExt.name(), e.getMessage());
             }
         }
@@ -333,7 +333,7 @@ public class UpgradeExecutor {
         try {
             ExtensionStoreOps<?> ops = resolveExtensionOps(source.type());
             if (ops == null) {
-                log.warnf("Unknown extension type: %s", source.type());
+                LOGGER.warnf("Unknown extension type: %s", source.type());
                 return null;
             }
             Response resp = dispatchUpdate(ops, source.contentJson(), targetId, targetVersion);
@@ -341,7 +341,7 @@ public class UpgradeExecutor {
                     ? URI.create(ops.resourceUri() + targetId + ops.versionQueryParam() + (targetVersion + 1))
                     : null;
         } catch (Exception e) {
-            log.warnf("Failed to update %s '%s' (target=%s): %s",
+            LOGGER.warnf("Failed to update %s '%s' (target=%s): %s",
                     source.type(), source.name(), targetId, e.getMessage());
             return null;
         }
@@ -355,12 +355,12 @@ public class UpgradeExecutor {
         try {
             ExtensionStoreOps<?> ops = resolveExtensionOps(source.type());
             if (ops == null) {
-                log.warnf("Unknown extension type for create: %s", source.type());
+                LOGGER.warnf("Unknown extension type for create: %s", source.type());
                 return null;
             }
             return dispatchCreateDirect(ops, source.contentJson());
         } catch (Exception e) {
-            log.warnf("Failed to create %s '%s': %s", source.type(), source.name(), e.getMessage());
+            LOGGER.warnf("Failed to create %s '%s': %s", source.type(), source.name(), e.getMessage());
             return null;
         }
     }
@@ -429,7 +429,7 @@ public class UpgradeExecutor {
 
             return createdUri;
         } catch (Exception e) {
-            log.warnf("Failed to create workflow '%s': %s", sourceWf.name(), e.getMessage());
+            LOGGER.warnf("Failed to create workflow '%s': %s", sourceWf.name(), e.getMessage());
             return null;
         }
     }
@@ -466,7 +466,7 @@ public class UpgradeExecutor {
 
             return null;
         } catch (Exception e) {
-            log.warnf("Failed to update workflow URIs %s: %s", workflowId, e.getMessage());
+            LOGGER.warnf("Failed to update workflow URIs %s: %s", workflowId, e.getMessage());
             return null;
         }
     }
@@ -512,13 +512,13 @@ public class UpgradeExecutor {
             Response resp = agentStore.updateAgent(agentId, currentVersion, agentConfig);
             if (resp.getStatus() == 200) {
                 URI updatedUri = URI.create(IRestAgentStore.resourceURI + agentId + "?version=" + (currentVersion + 1));
-                log.infof("Agent '%s' upgraded successfully (v%d→v%d)", agentId, currentVersion, currentVersion + 1);
+                LOGGER.infof("Agent '%s' upgraded successfully (v%d→v%d)", agentId, currentVersion, currentVersion + 1);
                 return updatedUri;
             }
 
             return null;
         } catch (Exception e) {
-            log.errorf("Failed to update agent config %s: %s", agentId, e.getMessage());
+            LOGGER.errorf("Failed to update agent config %s: %s", agentId, e.getMessage());
             throw new RuntimeException("Agent config update failed: " + e.getMessage(), e);
         }
     }
@@ -535,7 +535,7 @@ public class UpgradeExecutor {
                     return resId.getVersion();
             }
         } catch (Exception e) {
-            log.debugf("Could not find latest version for %s, using 1", resourceId);
+            LOGGER.debugf("Could not find latest version for %s, using 1", resourceId);
         }
         return 1;
     }

--- a/src/main/java/ai/labs/eddi/backup/impl/ZipResourceSource.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/ZipResourceSource.java
@@ -58,7 +58,7 @@ import static ai.labs.eddi.backup.impl.AbstractBackupService.*;
  */
 public class ZipResourceSource implements IResourceSource {
 
-    private static final Logger log = Logger.getLogger(ZipResourceSource.class);
+    private static final Logger LOGGER = Logger.getLogger(ZipResourceSource.class);
 
     /** Map from URI pattern authority to [file extension, step type label]. */
     private static final Map<Pattern, String[]> EXTENSION_TYPE_MAP = new LinkedHashMap<>();
@@ -130,7 +130,7 @@ public class ZipResourceSource implements IResourceSource {
                     workflowDataList.add(wfData);
                 }
             } catch (Exception e) {
-                log.warnf("Failed to read workflow %d from ZIP: %s", i, e.getMessage());
+                LOGGER.warnf("Failed to read workflow %d from ZIP: %s", i, e.getMessage());
             }
         }
 
@@ -161,12 +161,12 @@ public class ZipResourceSource implements IResourceSource {
                                 snippetId, snippet.getName(), snippet));
                     }
                 } catch (Exception e) {
-                    log.warnf("Failed to read snippet %s: %s",
+                    LOGGER.warnf("Failed to read snippet %s: %s",
                             snippetFile.getFileName(), e.getMessage());
                 }
             }
         } catch (IOException e) {
-            log.warnf("Failed to scan snippets directory: %s", e.getMessage());
+            LOGGER.warnf("Failed to scan snippets directory: %s", e.getMessage());
         }
 
         return snippetDataList;
@@ -178,10 +178,10 @@ public class ZipResourceSource implements IResourceSource {
         try {
             if (rootDir != null && Files.exists(rootDir)) {
                 deleteDirectoryRecursively(rootDir);
-                log.debugf("Cleaned up temp import directory: %s", rootDir);
+                LOGGER.debugf("Cleaned up temp import directory: %s", rootDir);
             }
         } catch (IOException e) {
-            log.warnf("Failed to clean up temp import directory %s: %s", rootDir, e.getMessage());
+            LOGGER.warnf("Failed to clean up temp import directory %s: %s", rootDir, e.getMessage());
         }
     }
 
@@ -252,7 +252,7 @@ public class ZipResourceSource implements IResourceSource {
                             resId.getId(), name, fileExtension, stepType, contentJson));
                 }
             } catch (Exception e) {
-                log.debugf("Failed to read %s extensions: %s", fileExtension, e.getMessage());
+                LOGGER.debugf("Failed to read %s extensions: %s", fileExtension, e.getMessage());
             }
         }
 
@@ -273,7 +273,7 @@ public class ZipResourceSource implements IResourceSource {
                 uris.add(URI.create(uri));
             }
         } catch (Exception e) {
-            log.debugf("URI extraction failed: %s", e.getMessage());
+            LOGGER.debugf("URI extraction failed: %s", e.getMessage());
         }
         return uris;
     }
@@ -335,7 +335,7 @@ public class ZipResourceSource implements IResourceSource {
             if (it.hasNext())
                 return it.next();
         } catch (IOException e) {
-            log.debugf("Could not scan for %s in %s: %s", suffix, dir, e.getMessage());
+            LOGGER.debugf("Could not scan for %s in %s: %s", suffix, dir, e.getMessage());
         }
         return null;
     }


### PR DESCRIPTION
Closes #539

Renames the private logger field from `log` to `LOGGER` in the seven backup implementation classes listed in the issue. The logger calls are otherwise unchanged.

I also added the required changelog entry.

Tested with:
- `./mvnw -DskipTests compile`
- `./mvnw validate`