### PR TITLE
chore(release): bump version to 6.1.2

### DIFF
--- a/.github/workflows/redhat-certify.yml
+++ b/.github/workflows/redhat-certify.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "EDDI version (e.g. 6.1.1)"
+        description: "EDDI version (e.g. 6.1.2)"
         required: true
         default: "6.1.2"
       release:

--- a/.github/workflows/redhat-certify.yml
+++ b/.github/workflows/redhat-certify.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "EDDI version (e.g. 6.1.1)"
         required: true
-        default: "6.2.0"
+        default: "6.1.2"
       release:
         description: "Release number (e.g. 1, 2, 3)"
         required: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # EDDI Architecture
 
-**Version: 6.2.0**
+**Version: 6.1.2**
 
 This document provides a comprehensive overview of EDDI's architecture, design principles, and internal workflow.
 

--- a/helm/eddi/Chart.yaml
+++ b/helm/eddi/Chart.yaml
@@ -6,7 +6,7 @@ description: >-
   and integrate with LLM providers via a unified REST API.
 type: application
 version: 1.0.0
-appVersion: "6.2.0"
+appVersion: "6.1.2"
 home: https://eddi.labs.ai
 sources:
   - https://github.com/labsai/EDDI

--- a/k8s/base/eddi-deployment.yaml
+++ b/k8s/base/eddi-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: eddi
   labels:
     app.kubernetes.io/name: eddi
-    app.kubernetes.io/version: "6.2.0"
+    app.kubernetes.io/version: "6.1.2"
     app.kubernetes.io/component: server
     app.kubernetes.io/part-of: eddi
 spec:
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: eddi
-        app.kubernetes.io/version: "6.2.0"
+        app.kubernetes.io/version: "6.1.2"
         app.kubernetes.io/component: server
         app.kubernetes.io/part-of: eddi
       annotations:

--- a/k8s/quickstart.yaml
+++ b/k8s/quickstart.yaml
@@ -169,7 +169,7 @@ metadata:
   namespace: eddi
   labels:
     app.kubernetes.io/name: eddi
-    app.kubernetes.io/version: "6.2.0"
+    app.kubernetes.io/version: "6.1.2"
     app.kubernetes.io/component: server
     app.kubernetes.io/part-of: eddi
 spec:
@@ -187,7 +187,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: eddi
-        app.kubernetes.io/version: "6.2.0"
+        app.kubernetes.io/version: "6.1.2"
         app.kubernetes.io/component: server
         app.kubernetes.io/part-of: eddi
       annotations:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ai.labs</groupId>
     <artifactId>eddi</artifactId>
-    <version>6.2.0</version>
+    <version>6.1.2</version>
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <maven.compiler.source>25</maven.compiler.source>
@@ -16,10 +16,10 @@
         <quarkus.microprofile.version>3.0.0.Final</quarkus.microprofile.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.36.3</quarkus.platform.version>
-        <langchain4j-beta.version>1.16.3-beta26</langchain4j-beta.version>
-        <langchain4j.version>1.16.3</langchain4j.version>
-        <langchain4j-libs.version>1.16.3</langchain4j-libs.version>
+        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <langchain4j-beta.version>1.17.0-beta27</langchain4j-beta.version>
+        <langchain4j.version>1.17.0</langchain4j.version>
+        <langchain4j-libs.version>1.17.0</langchain4j-libs.version>
         <jandex-maven-plugin.version>3.5.3</jandex-maven-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <surefire-plugin.version>3.5.5</surefire-plugin.version>
@@ -27,7 +27,7 @@
         <failsafe.useModulePath>false</failsafe.useModulePath>
         <war-plugin.version>3.4.0</war-plugin.version>
         <quarkus-mcp-server.version>1.13.0</quarkus-mcp-server.version>
-        <langchain4j-community.version>1.16.0-beta26</langchain4j-community.version>
+        <langchain4j-community.version>1.17.0-beta27</langchain4j-community.version>
         <skipITs>true</skipITs>
     </properties>
     <dependencyManagement>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -81,7 +81,7 @@
 FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24@sha256:2aed9f3a5fac4def355ac36d5c59c7a3067857da424adaa9c6929ff71310467e
 
 ### Red Hat Container Certification — required labels
-ARG EDDI_VERSION=6.1.1
+ARG EDDI_VERSION=6.1.2
 ARG EDDI_RELEASE=1
 
 LABEL name="labsai/eddi" \

--- a/src/main/java/ai/labs/eddi/configs/OpenApiConfig.java
+++ b/src/main/java/ai/labs/eddi/configs/OpenApiConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
  *
  * @since 6.0.0
  */
-@OpenAPIDefinition(info = @Info(title = "EDDI API", version = "6.2.0"), tags = {
+@OpenAPIDefinition(info = @Info(title = "EDDI API", version = "6.1.2"), tags = {
         // ── Agents ───────────────────────────────────────────────────────
         @Tag(name = "Agents", description = "Agent configuration CRUD"),
         @Tag(name = "Agents / Administration", description = "Deploy, undeploy, trigger, and monitor agents"),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -127,6 +127,11 @@ quarkus.http.cors.methods=OPTIONS,HEAD,GET,PUT,POST,DELETE,PATCH
 # Jackson JSON
 json.prettyPrint=false
 quarkus.jackson.write-dates-as-timestamps=true
+# Quarkus 3.37+ enables reflection-free Jackson serializers by default.
+# ConversationOutput extends LinkedHashMap — the generated serializer treats it
+# as a bean (missing getters) instead of a Map, so map entries serialize as null.
+# Disable until the domain model is refactored away from Map-extending classes.
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false
 # Qute Templating — strict in production (fail on missing template variables)
 %prod.quarkus.qute.strict-rendering=true
 # Security response headers — defense-in-depth for SPA and API responses

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ systemRuntime.projectName=eddi
 # Custom startup banner (replaces default Quarkus ASCII art)
 quarkus.banner.path=banner.txt
 systemRuntime.projectDomain=eddi.labs.ai
-systemRuntime.projectVersion=6.2.0
+systemRuntime.projectVersion=6.1.2
 systemRuntime.agentTimeoutInSeconds=60
 %dev.systemRuntime.agentTimeoutInSeconds=600
 %dev.eddi.conversations.maximumLifeTimeOfIdleConversationsInDays=10
@@ -221,7 +221,7 @@ quarkus.swagger-ui.theme=original
 quarkus.swagger-ui.tags-sorter=alpha
 quarkus.smallrye-openapi.info-title=EDDI API
 %dev.quarkus.smallrye-openapi.info-title=EDDI API (development)
-quarkus.smallrye-openapi.info-version=6.2.0
+quarkus.smallrye-openapi.info-version=6.1.2
 quarkus.smallrye-openapi.info-description=Enterprise-grade conversational AI platform. \
   Configure agents, orchestrate multi-agent group discussions, \
   and integrate with LLM providers via a unified REST API.
@@ -249,7 +249,7 @@ quarkus.swagger-ui.oauth2-redirect-url=http://localhost:7070/q/swagger-ui/oauth2
 quarkus.container-image.group=labsai
 quarkus.container-image.name=eddi
 quarkus.container-image.tag=latest
-quarkus.container-image.additional-tags=6.2.0
+quarkus.container-image.additional-tags=6.1.2
 
 # ╔══════════════════════════════════════════════════════════════════════════════╗
 # ║ SECURITY: MCP Server Authentication                                        ║

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceExtendedTest.java
@@ -184,16 +184,41 @@ class GroupConversationServiceExtendedTest {
                     new GroupMember("a1", "Alice", 1, null));
             cfg.setModeratorAgentId("mod");
             setupStore(cfg);
-            stubAgent("a1", "Opinion A");
+
+            // Gate the first agent response so the async thread blocks until we release it.
+            // This guarantees the state is still IN_PROGRESS when we assert.
+            var gate = new java.util.concurrent.CountDownLatch(1);
+
+            when(agentFactory.getLatestReadyAgent(any(Environment.class), eq("a1")))
+                    .thenReturn(mock(IAgent.class));
+            when(conversationService.startConversation(any(Environment.class),
+                    eq("a1"), anyString(), any()))
+                    .thenReturn(new IConversationService.ConversationResult("conv-a1", null));
+            doAnswer(inv -> {
+                gate.await(5, TimeUnit.SECONDS); // block until test releases
+                ConversationResponseHandler handler = inv.getArgument(8);
+                var snapshot = new SimpleConversationMemorySnapshot();
+                var output = new ConversationOutput();
+                output.put("output", List.of("Opinion A"));
+                snapshot.setConversationOutputs(new ArrayList<>(List.of(output)));
+                handler.onComplete(snapshot);
+                return null;
+            }).when(conversationService).say(any(Environment.class), eq("a1"),
+                    anyString(), any(), any(), any(), any(InputData.class),
+                    anyBoolean(), any(ConversationResponseHandler.class));
+
             stubAgent("mod", "Synthesis");
 
             var result = service.startAndDiscussAsync(GROUP_ID, QUESTION, USER_ID, null);
 
+            // Assert while the async thread is still blocked on the gate
             assertNotNull(result);
             assertEquals("gc-1", result.getId());
             assertEquals(GROUP_ID, result.getGroupId());
             assertEquals(GroupConversationState.IN_PROGRESS, result.getState());
-            // Give async thread time to complete
+
+            // Release the gate so the async thread can finish cleanly
+            gate.countDown();
             Thread.sleep(500);
         }
 


### PR DESCRIPTION
## Summary
**Release prep: set version 6.1.2, bump Quarkus 3.37.0 & langchain4j 1.17.0**

Sets the EDDI release version to `6.1.2` across the entire codebase and bumps core dependencies to their latest stable versions.

### Version Bump → 6.1.2

Updated the EDDI version to `6.1.2` in all build, deployment, and configuration files:

- `pom.xml` — Maven artifact version
- `application.properties` — runtime version, OpenAPI info, container image tag
- `Dockerfile` — Red Hat certification labels
- `OpenApiConfig.java` — `@OpenAPIDefinition` annotation
- `Chart.yaml` — Helm `appVersion`
- `k8s/base/eddi-deployment.yaml`, `k8s/quickstart.yaml` — Kubernetes version labels
- `.github/workflows/redhat-certify.yml` — default version input

### Dependency Updates

| Dependency | Previous | New |
|---|---|---|
| Quarkus Platform | 3.36.3 | **3.37.0** |
| langchain4j | 1.16.3 | **1.17.0** |
| langchain4j-libs | 1.16.3 | **1.17.0** |
| langchain4j-beta | 1.16.3-beta26 | **1.17.0-beta27** |
| langchain4j-community | 1.16.0-beta26 | **1.17.0-beta27** |

### Context

This release ships alongside the **group task orchestration** feature (merged via #572) and fixes the **broken Manager UI** caused by missing asset files in the 6.1.1 release. The correct Manager assets (`index-CHgQ1fX-.js` / `index-DwjjPW4w.css`) are now present and referenced in `manage.html`.


## Type of Change

<!-- Check the one that applies -->

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [X] 🔧 Chore (dependency updates, CI changes, etc.)

## Checklist

- [X] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [X] I have added tests that prove my fix/feature works
- [X] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [X] I have updated documentation if needed
- [X] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [X] I have not committed any secrets, API keys, or tokens
- [X] This PR has a clear, focused scope (one concern per PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application, build, and deployment version to **6.1.2** across workflow dispatch defaults, documentation, Helm chart metadata, Kubernetes labels, Docker image build defaults, and runtime/OpenAPI version reporting.
  * Refreshed Maven dependency version properties (including Quarkus and LangChain4j) to match the **6.1.x** line.
* **Tests**
  * Improved determinism of an async conversation test by adding a gating mechanism to reliably verify “in progress” behavior before completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->