### PR TITLE
refactor(channels): generalize signing-secret handling for multi-platform adapters

### DIFF
--- a/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
+++ b/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
@@ -34,14 +34,15 @@ import static ai.labs.eddi.utils.RestUtilities.extractResourceId;
  * (colon-required syntax: {@code keyword: message}).
  * <p>
  * Platform-agnostic: signing-secret aggregation and target resolution work for
- * any {@code channelType} registered in {@code REGISTERED_CHANNEL_TYPES}.
+ * any {@code channelType} accepted by the channel integration store validation
+ * (see {@code RestChannelIntegrationStore.REGISTERED_CHANNEL_TYPES}).
  * Platform-specific adapters (Slack, Teams, Discord, Telegram, WhatsApp)
  * provide their own webhook and event-handler classes.
  * <p>
  * <b>Fallback rule:</b> If any {@code ChannelIntegrationConfiguration} matches
- * a channelId, ALL legacy {@code ChannelConnector} entries for that channel are
- * ignored. Legacy entries only activate for channels with zero new-style
- * coverage.
+ * a channelType + channelId pair, ALL legacy {@code ChannelConnector} entries
+ * for that same type + channel are ignored. Legacy entries only activate for
+ * channels with zero new-style coverage of the same type.
  *
  * @since 6.1.0
  */
@@ -376,7 +377,7 @@ public class ChannelTargetRouter {
     private void refreshInternal() {
         var newIntegrationMap = new HashMap<String, ChannelIntegrationConfiguration>();
         var newSigningSecretsByType = new HashMap<String, Set<String>>();
-        var coveredChannelIds = new HashSet<String>();
+        var coveredChannelKeys = new HashSet<String>();
 
         // 1. Load new-style ChannelIntegrationConfigurations
         try {
@@ -398,7 +399,7 @@ public class ChannelTargetRouter {
                             resolvePlatformSecrets(copy);
                             String key = copy.getChannelType().toLowerCase(Locale.ROOT) + ":" + channelId;
                             newIntegrationMap.put(key, copy);
-                            coveredChannelIds.add(channelId);
+                            coveredChannelKeys.add(key); // type:channelId — scoped to prevent cross-type suppression
 
                             // Collect signing secrets per channel type
                             String ss = copy.getPlatformConfig().get("signingSecret");
@@ -440,8 +441,11 @@ public class ChannelTargetRouter {
 
                                 String chId = connector.getConfig().get("channelId");
 
-                                // Strict rule: new config wins, skip legacy
-                                if (chId != null && !coveredChannelIds.contains(chId)) {
+                                // Strict rule: new-style config wins, skip legacy
+                                // (scoped by type — only a new-style Slack config suppresses a legacy Slack
+                                // connector)
+                                String coveredKey = CHANNEL_TYPE_SLACK + ":" + chId;
+                                if (chId != null && !coveredChannelKeys.contains(coveredKey)) {
                                     String bt = resolveSecret(
                                             connector.getConfig().get("botToken"));
                                     String ss = resolveSecret(
@@ -468,7 +472,11 @@ public class ChannelTargetRouter {
             LOGGER.warn("Failed to scan legacy ChannelConnectors", e);
         }
 
-        // Atomic swap
+        // Swap cached references — each volatile write is individually atomic,
+        // but the three writes are NOT mutually atomic. A concurrent reader may
+        // briefly observe a mixed snapshot (e.g., new integrationMap with old
+        // signingSecretsByType). This is acceptable: the data converges within
+        // nanoseconds, and stale reads only affect a single request at worst.
         integrationMap = Map.copyOf(newIntegrationMap);
         legacyMap = Map.copyOf(newLegacyMap);
         // Freeze each per-type set, then freeze the outer map

--- a/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
+++ b/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
@@ -33,11 +33,12 @@ import static ai.labs.eddi.utils.RestUtilities.extractResourceId;
  * the correct {@link ChannelTarget} based on configured trigger keywords
  * (colon-required syntax: {@code keyword: message}).
  * <p>
- * Platform-agnostic: signing-secret aggregation and target resolution work for
- * any {@code channelType} accepted by the channel integration store validation
- * (see {@code RestChannelIntegrationStore.REGISTERED_CHANNEL_TYPES}).
- * Platform-specific adapters (Slack, Teams, Discord, Telegram, WhatsApp)
- * provide their own webhook and event-handler classes.
+ * Platform-agnostic: signing-secret aggregation and target resolution are keyed
+ * by {@code channelType} so multiple platform adapters can coexist. Currently,
+ * only {@code slack} is registered/validated (see
+ * {@code RestChannelIntegrationStore.REGISTERED_CHANNEL_TYPES}).
+ * Platform-specific adapters provide their own webhook and event-handler
+ * classes.
  * <p>
  * <b>Fallback rule:</b> If any {@code ChannelIntegrationConfiguration} matches
  * a channelType + channelId pair, ALL legacy {@code ChannelConnector} entries

--- a/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
+++ b/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
@@ -33,9 +33,10 @@ import static ai.labs.eddi.utils.RestUtilities.extractResourceId;
  * the correct {@link ChannelTarget} based on configured trigger keywords
  * (colon-required syntax: {@code keyword: message}).
  * <p>
- * Currently Slack-only with a platform-agnostic internal model; Teams/Discord
- * adapters will extend the platform-specific paths (signing secret aggregation,
- * legacy fallback) when added.
+ * Platform-agnostic: signing-secret aggregation and target resolution work for
+ * any {@code channelType} registered in {@code REGISTERED_CHANNEL_TYPES}.
+ * Platform-specific adapters (Slack, Teams, Discord, Telegram, WhatsApp)
+ * provide their own webhook and event-handler classes.
  * <p>
  * <b>Fallback rule:</b> If any {@code ChannelIntegrationConfiguration} matches
  * a channelId, ALL legacy {@code ChannelConnector} entries for that channel are
@@ -68,8 +69,8 @@ public class ChannelTargetRouter {
      */
     private volatile Map<String, ChannelIntegrationConfiguration> integrationMap = Map.of();
 
-    /** All unique signing secrets for Slack (from both new + legacy configs). */
-    private volatile Set<String> slackSigningSecrets = Set.of();
+    /** Signing secrets per channel type (from both new + legacy configs). */
+    private volatile Map<String, Set<String>> signingSecretsByType = Map.of();
 
     /** Legacy channelId → LegacyTarget for backward compat. */
     private volatile Map<String, LegacyTarget> legacyMap = Map.of();
@@ -229,10 +230,7 @@ public class ChannelTargetRouter {
     public Set<String> getSigningSecrets(String channelType) {
         refreshIfNeeded();
         String normalizedType = channelType != null ? channelType.toLowerCase(Locale.ROOT) : "";
-        if (CHANNEL_TYPE_SLACK.equals(normalizedType)) {
-            return slackSigningSecrets;
-        }
-        return Set.of();
+        return signingSecretsByType.getOrDefault(normalizedType, Set.of());
     }
 
     /**
@@ -377,7 +375,7 @@ public class ChannelTargetRouter {
 
     private void refreshInternal() {
         var newIntegrationMap = new HashMap<String, ChannelIntegrationConfiguration>();
-        var newSigningSecrets = new HashSet<String>();
+        var newSigningSecretsByType = new HashMap<String, Set<String>>();
         var coveredChannelIds = new HashSet<String>();
 
         // 1. Load new-style ChannelIntegrationConfigurations
@@ -402,13 +400,13 @@ public class ChannelTargetRouter {
                             newIntegrationMap.put(key, copy);
                             coveredChannelIds.add(channelId);
 
-                            // Collect signing secrets for Slack
-                            if (CHANNEL_TYPE_SLACK.equals(
-                                    config.getChannelType().toLowerCase(Locale.ROOT))) {
-                                String ss = copy.getPlatformConfig().get("signingSecret");
-                                if (ss != null && !ss.isBlank()) {
-                                    newSigningSecrets.add(ss);
-                                }
+                            // Collect signing secrets per channel type
+                            String ss = copy.getPlatformConfig().get("signingSecret");
+                            if (ss != null && !ss.isBlank()) {
+                                String type = copy.getChannelType().toLowerCase(Locale.ROOT);
+                                newSigningSecretsByType
+                                        .computeIfAbsent(type, k -> new HashSet<>())
+                                        .add(ss);
                             }
                         }
                     }
@@ -453,7 +451,9 @@ public class ChannelTargetRouter {
                                             new LegacyTarget(agentId, bt, ss,
                                                     gid != null && !gid.isBlank() ? gid : null));
                                     if (ss != null && !ss.isBlank()) {
-                                        newSigningSecrets.add(ss);
+                                        newSigningSecretsByType
+                                                .computeIfAbsent(CHANNEL_TYPE_SLACK, k -> new HashSet<>())
+                                                .add(ss);
                                     }
                                 }
                             }
@@ -471,10 +471,14 @@ public class ChannelTargetRouter {
         // Atomic swap
         integrationMap = Map.copyOf(newIntegrationMap);
         legacyMap = Map.copyOf(newLegacyMap);
-        slackSigningSecrets = Set.copyOf(newSigningSecrets);
+        // Freeze each per-type set, then freeze the outer map
+        var frozenSecrets = new HashMap<String, Set<String>>();
+        newSigningSecretsByType.forEach((type, secrets) -> frozenSecrets.put(type, Set.copyOf(secrets)));
+        signingSecretsByType = Map.copyOf(frozenSecrets);
 
-        LOGGER.debugf("Channel target router refreshed: %d integrations, %d legacy, %d signing secrets",
-                newIntegrationMap.size(), newLegacyMap.size(), newSigningSecrets.size());
+        int totalSecrets = frozenSecrets.values().stream().mapToInt(Set::size).sum();
+        LOGGER.debugf("Channel target router refreshed: %d integrations, %d legacy, %d signing secrets across %d channel types",
+                newIntegrationMap.size(), newLegacyMap.size(), totalSecrets, frozenSecrets.size());
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterBranchCoverageTest.java
@@ -242,14 +242,14 @@ class ChannelTargetRouterBranchCoverageTest {
     class GetSigningSecrets {
 
         @Test
-        @DisplayName("slack → returns slackSigningSecrets")
+        @DisplayName("slack → returns secrets from signingSecretsByType map")
         void slackSecrets() {
             var result = router.getSigningSecrets("slack");
             assertNotNull(result);
         }
 
         @Test
-        @DisplayName("other channel type → empty set")
+        @DisplayName("unregistered channel type → empty set")
         void otherType() {
             var result = router.getSigningSecrets("teams");
             assertTrue(result.isEmpty());

--- a/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterDeepBranchTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterDeepBranchTest.java
@@ -487,7 +487,7 @@ class ChannelTargetRouterDeepBranchTest {
         @Test
         @DisplayName("Slack signing secrets returned")
         void slackSecrets() throws Exception {
-            setField(router, "slackSigningSecrets", Set.of("sec1", "sec2"));
+            setField(router, "signingSecretsByType", Map.of("slack", Set.of("sec1", "sec2")));
             var secrets = router.getSigningSecrets("SLACK");
             assertEquals(2, secrets.size());
             assertTrue(secrets.contains("sec1"));

--- a/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterRefreshTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterRefreshTest.java
@@ -55,6 +55,9 @@ class ChannelTargetRouterRefreshTest {
     private SecretResolver secretResolver;
     private ChannelTargetRouter router;
 
+    /** Accumulated descriptors across multiple setupNewStyleConfigForType calls. */
+    private List<DocumentDescriptor> accumulatedDescriptors;
+
     @BeforeEach
     void setUp() throws Exception {
         channelStore = mock(IChannelIntegrationStore.class);
@@ -70,6 +73,8 @@ class ChannelTargetRouterRefreshTest {
         router = new ChannelTargetRouter(channelStore, descriptorStore, agentAdmin, agentStore,
                 secretResolver, cacheFactory);
 
+        accumulatedDescriptors = new ArrayList<>();
+
         // Default: no legacy agents
         when(agentAdmin.getDeploymentStatuses(any())).thenReturn(List.of());
     }
@@ -83,13 +88,31 @@ class ChannelTargetRouterRefreshTest {
                                                                 String botToken,
                                                                 String signingSecret)
             throws Exception {
+        return setupNewStyleConfigForType("slack", channelId, botToken, signingSecret,
+                CHANNEL_CONFIG_ID, "Test Slack Channel");
+    }
+
+    /**
+     * Set up the store mocks to return a channel integration config for any channel
+     * type. Each call uses a unique configId so multiple configs can coexist.
+     */
+    private ChannelIntegrationConfiguration setupNewStyleConfigForType(String channelType,
+                                                                       String channelId,
+                                                                       String botToken,
+                                                                       String signingSecret,
+                                                                       String configId,
+                                                                       String name)
+            throws Exception {
         var config = new ChannelIntegrationConfiguration();
-        config.setName("Test Slack Channel");
-        config.setChannelType("slack");
-        config.setPlatformConfig(new HashMap<>(Map.of(
-                "channelId", channelId,
-                "botToken", botToken,
-                "signingSecret", signingSecret)));
+        config.setName(name);
+        config.setChannelType(channelType);
+        var platformConfig = new HashMap<String, String>();
+        platformConfig.put("channelId", channelId);
+        platformConfig.put("botToken", botToken);
+        if (signingSecret != null) {
+            platformConfig.put("signingSecret", signingSecret);
+        }
+        config.setPlatformConfig(platformConfig);
         config.setDefaultTargetName("default-agent");
 
         var target = new ChannelTarget();
@@ -99,14 +122,20 @@ class ChannelTargetRouterRefreshTest {
         target.setTargetId(AGENT_ID);
         config.setTargets(List.of(target));
 
-        // Wire descriptor → config
+        // Wire descriptor → config (append to accumulated list)
         var descriptor = new DocumentDescriptor();
         URI resourceUri = URI.create("eddi://ai.labs.channel/channelstore/channels/"
-                + CHANNEL_CONFIG_ID + "?version=1");
+                + configId + "?version=1");
         descriptor.setResource(resourceUri);
+
+        // Track descriptors in a field — do NOT call the mock to read existing
+        // descriptors, as that would inflate invocation counts and break
+        // verify(times(N)) assertions in RefreshMechanism tests.
+        accumulatedDescriptors.add(descriptor);
+
         when(descriptorStore.readDescriptors(eq("ai.labs.channel"), anyString(), anyInt(), anyInt(), anyBoolean()))
-                .thenReturn(List.of(descriptor));
-        when(channelStore.read(eq(CHANNEL_CONFIG_ID), eq(1)))
+                .thenReturn(new ArrayList<>(accumulatedDescriptors));
+        when(channelStore.read(eq(configId), eq(1)))
                 .thenReturn(config);
 
         // Secret resolver: pass through (or resolve vault refs)
@@ -276,7 +305,7 @@ class ChannelTargetRouterRefreshTest {
     class SigningSecrets {
 
         @Test
-        @DisplayName("returns resolved signing secrets from new-style configs")
+        @DisplayName("returns resolved signing secrets from new-style Slack configs")
         void newStyleSigningSecrets() throws Exception {
             setupNewStyleConfig(CHANNEL_ID, "xoxb-token", "${eddivault:slack-signing}");
 
@@ -289,7 +318,7 @@ class ChannelTargetRouterRefreshTest {
         }
 
         @Test
-        @DisplayName("includes legacy signing secrets")
+        @DisplayName("includes legacy signing secrets under slack type")
         void legacySigningSecrets() throws Exception {
             when(descriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
                     .thenReturn(List.of());
@@ -303,13 +332,118 @@ class ChannelTargetRouterRefreshTest {
         }
 
         @Test
-        @DisplayName("returns empty for non-slack channel type")
-        void nonSlackReturnsEmpty() throws Exception {
+        @DisplayName("returns secrets only for the requested channel type — cross-type isolation")
+        void crossTypeIsolation() throws Exception {
+            // Set up a Slack config and a Telegram config with different secrets
+            setupNewStyleConfigForType("slack", CHANNEL_ID, "xoxb-token", "slack-secret",
+                    CHANNEL_CONFIG_ID, "Test Slack Channel");
+            setupNewStyleConfigForType("telegram", "tg-chat-123", "tg-bot-token", "telegram-secret",
+                    "aabbccddeeff001122aa", "Test Telegram Bot");
+
+            Set<String> slackSecrets = router.getSigningSecrets("slack");
+            Set<String> telegramSecrets = router.getSigningSecrets("telegram");
+
+            // Each type has exactly its own secret, not the other's
+            assertTrue(slackSecrets.contains("slack-secret"));
+            assertFalse(slackSecrets.contains("telegram-secret"),
+                    "Slack secrets must not contain Telegram's secret");
+
+            assertTrue(telegramSecrets.contains("telegram-secret"));
+            assertFalse(telegramSecrets.contains("slack-secret"),
+                    "Telegram secrets must not contain Slack's secret");
+        }
+
+        @Test
+        @DisplayName("collects secrets from multiple configs of the same channel type")
+        void multipleConfigsSameType() throws Exception {
+            setupNewStyleConfigForType("slack", CHANNEL_ID, "token-1", "secret-A",
+                    CHANNEL_CONFIG_ID, "Slack Channel 1");
+            setupNewStyleConfigForType("slack", "C99OTHERCHANNEL", "token-2", "secret-B",
+                    "ff00ff00ff00ff00ff00", "Slack Channel 2");
+
+            Set<String> secrets = router.getSigningSecrets("slack");
+
+            assertEquals(2, secrets.size());
+            assertTrue(secrets.containsAll(Set.of("secret-A", "secret-B")));
+        }
+
+        @Test
+        @DisplayName("getSigningSecrets is case-insensitive on channel type")
+        void caseInsensitiveLookup() throws Exception {
+            setupNewStyleConfigForType("discord", "guild-ch-1", "bot-token", "discord-secret",
+                    "1122334455667788aabb", "Test Discord Channel");
+
+            // All case variants should return the same secrets
+            Set<String> lower = router.getSigningSecrets("discord");
+            Set<String> upper = router.getSigningSecrets("DISCORD");
+            Set<String> mixed = router.getSigningSecrets("Discord");
+
+            assertEquals(lower, upper);
+            assertEquals(lower, mixed);
+            assertTrue(lower.contains("discord-secret"));
+        }
+
+        @Test
+        @DisplayName("returns empty set for channel type with no configs")
+        void unknownTypeReturnsEmpty() throws Exception {
             setupNewStyleConfig(CHANNEL_ID, "token", "secret");
 
             Set<String> secrets = router.getSigningSecrets("teams");
 
             assertTrue(secrets.isEmpty());
+        }
+
+        @Test
+        @DisplayName("returns empty set for null channel type")
+        void nullTypeReturnsEmpty() {
+            Set<String> secrets = router.getSigningSecrets(null);
+
+            assertTrue(secrets.isEmpty());
+        }
+
+        @Test
+        @DisplayName("config without signingSecret key does not contribute to secrets")
+        void configWithoutSigningSecretKey() throws Exception {
+            // Telegram might not use "signingSecret" as its key name
+            setupNewStyleConfigForType("telegram", "tg-chat-456", "tg-bot-token", null,
+                    "ccccddddeeeeffffaaaa", "Telegram No Secret");
+
+            Set<String> secrets = router.getSigningSecrets("telegram");
+
+            assertTrue(secrets.isEmpty(),
+                    "Config without signingSecret key should not appear in secrets map");
+        }
+
+        @Test
+        @DisplayName("config with blank signingSecret does not contribute to secrets")
+        void blankSigningSecretIgnored() throws Exception {
+            setupNewStyleConfigForType("slack", CHANNEL_ID, "token", "   ",
+                    CHANNEL_CONFIG_ID, "Slack with blank secret");
+
+            Set<String> secrets = router.getSigningSecrets("slack");
+
+            assertTrue(secrets.isEmpty(),
+                    "Blank signing secret should be excluded");
+        }
+
+        @Test
+        @DisplayName("legacy Slack secrets and new-style Slack secrets are combined")
+        void legacyAndNewStyleCombined() throws Exception {
+            // New-style config with one secret
+            setupNewStyleConfig(CHANNEL_ID, "xoxb-new", "new-style-secret");
+
+            // Legacy agent with a different secret on a different channel
+            setupLegacyAgent(AGENT_ID, "C99LEGACY", "xoxb-leg", "legacy-secret", null);
+            when(secretResolver.resolveValue("xoxb-leg")).thenReturn("xoxb-leg");
+            when(secretResolver.resolveValue("legacy-secret")).thenReturn("legacy-secret");
+
+            Set<String> secrets = router.getSigningSecrets("slack");
+
+            assertTrue(secrets.contains("new-style-secret"),
+                    "Should contain new-style secret");
+            assertTrue(secrets.contains("legacy-secret"),
+                    "Should contain legacy secret");
+            assertEquals(2, secrets.size());
         }
     }
 


### PR DESCRIPTION
## Summary

Replace Slack-only slackSigningSecrets field with per-channelType Map<String, Set<String>> signingSecretsByType. This unblocks all future channel adapters (Teams, Discord, Telegram, WhatsApp) from using the router's centralized secret management.

Changes:
- ChannelTargetRouter: Map<String, Set<String>> keyed by channelType
- getSigningSecrets() uses getOrDefault() instead of if/else
- refreshInternal() collects secrets per channelType
- Atomic swap freezes inner sets then outer map
- Legacy secrets still go into 'slack' bucket (correct: legacy is Slack-only)

Tests:
- 8 new tests: cross-type isolation, multi-config same type, case-insensitive lookup, null/blank/missing secret handling, legacy+new-style combined
- Updated reflection-based tests for new field name
- All 133 router tests pass

## Type of Change

<!-- Check the one that applies -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [X] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, CI changes, etc.)

## Checklist

- [X] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [X] I have added tests that prove my fix/feature works
- [X] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [x] I have updated documentation if needed
- [X] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [X] I have not committed any secrets, API keys, or tokens
- [X] This PR has a clear, focused scope (one concern per PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signing secrets are now grouped by channel type, supporting independent secret resolution across multiple channel integrations.
  * Secret lookup now works case-insensitively for channel types.

* **Bug Fixes**
  * Fixed secret isolation so non-Slack channel secrets no longer mix.
  * Legacy and new-style Slack secrets now aggregate correctly.
  * Improved handling for null, blank, unknown, and unregistered channel types; also tightened suppression behavior to consider channel type.

* **Tests**
  * Expanded refresh and `getSigningSecrets` test coverage across multiple configurations and channel types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->