### PR TITLE
docs: fix outdated task type names

### DIFF
--- a/docs/agent-father-deep-dive.md
+++ b/docs/agent-father-deep-dive.md
@@ -471,7 +471,7 @@ public class BehaviorRulesTask implements ILifecycleTask {
 ### HTTP Calls Task (executes API calls)
 
 ```java
-public class HttpCallsTask implements ILifecycleTask {
+public class ApiCallsTask implements ILifecycleTask {
     @Override
     public void execute(IConversationMemory memory, Object component) {
         HttpCallsConfiguration config = (HttpCallsConfiguration) component;

--- a/docs/agent-father-deep-dive.md
+++ b/docs/agent-father-deep-dive.md
@@ -468,38 +468,38 @@ public class BehaviorRulesTask implements ILifecycleTask {
 }
 ```
 
-### HTTP Calls Task (executes API calls)
+### API Calls Task (executes API calls)
 
 ```java
 public class ApiCallsTask implements ILifecycleTask {
     @Override
     public void execute(IConversationMemory memory, Object component) {
-        HttpCallsConfiguration config = (HttpCallsConfiguration) component;
+        ApiCallsConfiguration config = (ApiCallsConfiguration) component;
 
         // Get actions from previous task (behavior rules)
         List<String> actions = memory.getCurrentStep()
             .getLatestData("actions").getResult();
 
-        for (HttpCallDefinition httpCall : config.getHttpCalls()) {
-            if (actions.contains("httpcall(" + httpCall.getName() + ")")) {
+        for (ApiCall apiCall : config.getHttpCalls()) {
+            if (actions.contains("httpcall(" + apiCall.getName() + ")")) {
                 // Execute HTTP call
-                String url = config.getTargetServerUrl() + httpCall.getRequest().getPath();
-                String body = applyTemplate(httpCall.getRequest().getBody(), memory);
+                String url = config.getTargetServerUrl() + apiCall.getRequest().getPath();
+                String body = applyTemplate(apiCall.getRequest().getBody(), memory);
 
                 Response response = httpClient.post(url, body);
 
                 // Store response in memory
-                if (httpCall.isSaveResponse()) {
+                if (apiCall.isSaveResponse()) {
                     memory.getCurrentStep().storeData(
                         dataFactory.createData(
-                            "httpCalls." + httpCall.getResponseObjectName(),
+                            "httpCalls." + apiCall.getResponseObjectName(),
                             response.getBody()
                         )
                     );
                 }
 
                 // Extract properties from response
-                for (PropertyInstruction instruction : httpCall.getPostResponse().getPropertyInstructions()) {
+                for (PropertyInstruction instruction : apiCall.getPostResponse().getPropertyInstructions()) {
                     Object value = extractFromJsonPath(response.getBody(), instruction.getFromObjectPath());
                     memory.getConversationProperties().put(
                         "context." + instruction.getName(),

--- a/docs/conversation-memory.md
+++ b/docs/conversation-memory.md
@@ -563,7 +563,7 @@ LifecycleManager.executeLifecycle(memory)
   ├─→ Input Parser
   ├─→ Behavior Rules → emit actions
   ├─→ PropertySetterTask → set properties based on actions
-  ├─→ HttpCallsTask → execute API calls based on actions
+  ├─→ ApiCallsTask → execute API calls based on actions
   ├─→ LlmTask → call LLM based on actions
   └─→ OutputGenerationTask → format response
 ```

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/ILifecycleTask.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/ILifecycleTask.java
@@ -54,8 +54,8 @@ import java.util.Map;
  * actions</li>
  * <li><strong>Property Extraction</strong>: Extract and store data in
  * conversation memory</li>
- * <li><strong>HTTP Calls</strong>: Call external REST APIs</li>
- * <li><strong>LangChain</strong>: Invoke LLM services (OpenAI, Claude, Gemini,
+ * <li><strong>API Calls</strong>: Call external REST APIs</li>
+ * <li><strong>LLM</strong>: Invoke LLM services (OpenAI, Claude, Gemini,
  * etc.)</li>
  * <li><strong>Output Generation</strong>: Format responses using templates</li>
  * </ul>


### PR DESCRIPTION
## Summary

Update the outdated task type names called out in #549 across the Javadoc and the two affected docs pages.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, CI changes, etc.)

## Related Issue

Closes #549

## Changes Made

- renamed the ILifecycleTask Javadoc entries from `HTTP Calls` to `API Calls` and from `LangChain` to `LLM`
- updated the `HttpCallsTask` references in `docs/agent-father-deep-dive.md` and `docs/conversation-memory.md` to `ApiCallsTask`
- verified there are no other `HttpCallsTask` references left under `docs/` outside `docs/changelog.md`

## How to Test

1. Run `rg -n "HttpCallsTask|HTTP Calls|LangChain" src/main/java/ai/labs/eddi/engine/lifecycle/ILifecycleTask.java docs --glob '!docs/changelog.md'`
2. Confirm the three edited files use the updated task names
3. Run `./mvnw compile`

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [ ] I have added tests that prove my fix/feature works
- [ ] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [x] I have updated documentation if needed
- [x] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [x] I have not committed any secrets, API keys, or tokens
- [x] This PR has a clear, focused scope (one concern per PR)

`./mvnw compile` was attempted locally, but this host does not have a JDK with `--release 25` support, so Maven failed before project compilation could complete with: `error: release version 25 not supported`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated references from “HTTP Calls” to “API Calls” across the documentation, including the example task snippet and conversation flow diagram.
  * Refreshed the task name/label in the lifecycle guide for consistent terminology.
  * Adjusted the lifecycle task type list wording, including an update from “LangChain” to “LLM.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->