### PR TITLE
fix(datastore): escape PostgreSQL ?| operator in JDBC PreparedStatement

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,34 @@
 
 ---
 
+## 🐛 Fix: PostgreSQL group conversations broken — JDBC `?|` operator escape (2026-07-02)
+
+**Repo:** EDDI (`fix/postgres-group-conversation-jdbc-escape`)
+**Severity:** Critical — **all** group conversations fail on PostgreSQL; MongoDB unaffected.
+
+### Root cause
+
+`PostgresUserMemoryStore.getVisibleEntries()` builds a dynamic SQL query that uses PostgreSQL's `?|` (array overlap) operator for group-scoped visibility filtering. The JDBC driver interpreted the `?` in `?|` as a bind parameter placeholder, inflating the expected parameter count by one. This caused `PSQLException: No value specified for parameter 5` every time `groupIds` was non-empty.
+
+Group conversations always pass a `groupId` context when starting agent sub-conversations (`GroupConversationService.executeAgentTurn()` → `startConversation()` with `groupId` in context), so this bug was triggered on **every** group conversation turn — making group conversations completely non-functional on PostgreSQL.
+
+### Fix
+
+- **`PostgresUserMemoryStore.java`**: Changed `?|` to `??|` (JDBC escape syntax for a literal `?`). Single character fix.
+
+### Regression guard
+
+- **`PostgresUserMemoryStoreTest.java`**: Added two integration tests (Testcontainers PostgreSQL) that exercise `getVisibleEntries` with non-empty `groupIds`:
+  1. `groupIdsDoNotBreakQuery` — verifies the query doesn't throw with non-empty groupIds (would have caught this bug directly)
+  2. `groupScopedEntriesVisible` — verifies group-scoped entries are correctly returned when groupIds match, and excluded when they don't
+
+### Why existing tests missed it
+
+- The **unit test** (`PostgresUserMemoryStoreUnitTest.getVisibleEntries_withGroupIds_includesGroupClause`) tested with non-empty groupIds but mocked the JDBC PreparedStatement — never sent actual SQL to PostgreSQL, so the `?` parsing was invisible.
+- The **integration test** (`PostgresUserMemoryStoreTest.selfAndGlobalVisible`) ran against real PostgreSQL but only tested with `groupIds = null` — never exercised the group visibility branch.
+
+---
+
 ## 🔒 Security & Algorithm Hardening — SSRF/File-Read, Cron, DoS Guards (2026-06-29)
 
 **Repo:** EDDI (`fix/security-and-algo-hardening`)

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
@@ -275,7 +275,7 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
                 """);
 
         if (groupIds != null && !groupIds.isEmpty()) {
-            sql.append(" OR (visibility = 'group' AND group_ids ?| ARRAY[");
+            sql.append(" OR (visibility = 'group' AND group_ids ??| ARRAY[");
             for (int i = 0; i < groupIds.size(); i++) {
                 sql.append(i > 0 ? ",?" : "?");
             }

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreTest.java
@@ -217,6 +217,49 @@ class PostgresUserMemoryStoreTest extends PostgresTestBase {
                     null, "most_recent", 3);
             assertEquals(3, limited.size());
         }
+
+        @Test
+        @DisplayName("getVisibleEntries — non-empty groupIds does not cause JDBC parameter error")
+        void groupIdsDoNotBreakQuery() throws IResourceStore.ResourceStoreException {
+            // Regression test: PostgreSQL's ?| operator was misinterpreted by JDBC as a
+            // bind parameter, causing "No value specified for parameter 5" when groupIds
+            // was non-empty. This broke ALL group conversations on PostgreSQL.
+            store.upsert(createEntry("user1", "self_key", "v1", "fact", Visibility.self, "agentA"));
+            store.upsert(createEntry("user1", "global_key", "v2", "fact", Visibility.global, "agentA"));
+
+            // Must not throw — before the fix, this threw PSQLException
+            List<UserMemoryEntry> visible = store.getVisibleEntries("user1", "agentA",
+                    List.of("group-123"), "most_recent", 50);
+
+            assertTrue(visible.stream().anyMatch(e -> "self_key".equals(e.key())));
+            assertTrue(visible.stream().anyMatch(e -> "global_key".equals(e.key())));
+        }
+
+        @Test
+        @DisplayName("getVisibleEntries — group-scoped entries visible when groupIds match")
+        void groupScopedEntriesVisible() throws IResourceStore.ResourceStoreException {
+            var groupEntry = new UserMemoryEntry(null, "user1", "group_fact", "shared-value",
+                    "fact", Visibility.group, "agentA", List.of("group-abc", "group-xyz"),
+                    "conv1", false, 0, Instant.now(), Instant.now());
+            store.upsert(groupEntry);
+            store.upsert(createEntry("user1", "self_key", "v1", "fact", Visibility.self, "agentA"));
+
+            // Query with a matching groupId
+            List<UserMemoryEntry> visible = store.getVisibleEntries("user1", "agentA",
+                    List.of("group-abc"), "most_recent", 50);
+
+            assertTrue(visible.stream().anyMatch(e -> "group_fact".equals(e.key())),
+                    "Group-scoped entry should be visible when groupIds overlap");
+            assertTrue(visible.stream().anyMatch(e -> "self_key".equals(e.key())));
+
+            // Query with a non-matching groupId — group entry should NOT appear
+            List<UserMemoryEntry> noMatch = store.getVisibleEntries("user1", "agentA",
+                    List.of("group-other"), "most_recent", 50);
+
+            assertFalse(noMatch.stream().anyMatch(e -> "group_fact".equals(e.key())),
+                    "Group-scoped entry should NOT be visible when groupIds don't overlap");
+            assertTrue(noMatch.stream().anyMatch(e -> "self_key".equals(e.key())));
+        }
     }
 
     // ─── Filter and Category ────────────────────────────────────


### PR DESCRIPTION
## Summary

The ?| (array overlap) operator in getVisibleEntries() was interpreted by the JDBC driver as a bind parameter placeholder, causing 'No value specified for parameter 5' whenever groupIds was non-empty.

This broke ALL group conversations on PostgreSQL — every agent turn in a group starts a sub-conversation with groupId in context, which always triggers the group visibility SQL branch.

Fix: ?| → ??| (JDBC escape syntax for literal ?).

Added two Testcontainers integration tests that exercise getVisibleEntries with non-empty groupIds against real PostgreSQL to prevent regression.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, CI changes, etc.)

## Checklist

- [X] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [X] I have added tests that prove my fix/feature works
- [X] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [X] I have updated documentation if needed
- [X] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [X] I have not committed any secrets, API keys, or tokens
- [X] This PR has a clear, focused scope (one concern per PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could break PostgreSQL-backed group conversations when filtering visible entries.
  * Improved group visibility filtering so entries are returned only when the requested groups overlap with the entry’s allowed groups.
  * Prevented database parameter errors in this query path.

* **Tests**
  * Added regression coverage for PostgreSQL visibility behavior.
  * Added checks for both non-error query execution and correct self/global/group-scoped entry visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->