### PR TITLE
feat: add MongoDB driver handshake metadata

### DIFF
--- a/src/main/java/ai/labs/eddi/datastore/bootstrap/PersistenceModule.java
+++ b/src/main/java/ai/labs/eddi/datastore/bootstrap/PersistenceModule.java
@@ -51,7 +51,8 @@ public class PersistenceModule {
 
     private static MongoDriverInformation buildDriverInfo() {
         MongoDriverInformation.Builder builder = MongoDriverInformation.builder().driverName("EDDI");
-        String version = PersistenceModule.class.getPackage().getImplementationVersion();
+        Package pkg = PersistenceModule.class.getPackage();
+        String version = pkg != null ? pkg.getImplementationVersion() : null;
         if (version != null) {
             builder.driverVersion(version);
         }

--- a/src/main/java/ai/labs/eddi/datastore/bootstrap/PersistenceModule.java
+++ b/src/main/java/ai/labs/eddi/datastore/bootstrap/PersistenceModule.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.datastore.bootstrap;
 
+import ai.labs.eddi.datastore.mongo.MongoDriverInfoFactory;
 import ai.labs.eddi.datastore.mongo.codec.JacksonProvider;
 import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -47,17 +48,8 @@ import static org.bson.codecs.configuration.CodecRegistries.*;
 @DefaultBean
 public class PersistenceModule {
 
-    private static final MongoDriverInformation DRIVER_INFO = buildDriverInfo();
+    private static final MongoDriverInformation DRIVER_INFO = MongoDriverInfoFactory.build();
 
-    private static MongoDriverInformation buildDriverInfo() {
-        MongoDriverInformation.Builder builder = MongoDriverInformation.builder().driverName("EDDI");
-        Package pkg = PersistenceModule.class.getPackage();
-        String version = pkg != null ? pkg.getImplementationVersion() : null;
-        if (version != null) {
-            builder.driverVersion(version);
-        }
-        return builder.build();
-    }
     @Produces
     @ApplicationScoped
     @DefaultBean

--- a/src/main/java/ai/labs/eddi/datastore/bootstrap/PersistenceModule.java
+++ b/src/main/java/ai/labs/eddi/datastore/bootstrap/PersistenceModule.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoClient;
@@ -45,6 +46,17 @@ import static org.bson.codecs.configuration.CodecRegistries.*;
 @ApplicationScoped
 @DefaultBean
 public class PersistenceModule {
+
+    private static final MongoDriverInformation DRIVER_INFO = buildDriverInfo();
+
+    private static MongoDriverInformation buildDriverInfo() {
+        MongoDriverInformation.Builder builder = MongoDriverInformation.builder().driverName("EDDI");
+        String version = PersistenceModule.class.getPackage().getImplementationVersion();
+        if (version != null) {
+            builder.driverVersion(version);
+        }
+        return builder.build();
+    }
     @Produces
     @ApplicationScoped
     @DefaultBean
@@ -53,7 +65,7 @@ public class PersistenceModule {
         BsonFactory bsonFactory = new BsonFactory();
         bsonFactory.enable(BsonParser.Feature.HONOR_DOCUMENT_LENGTH);
 
-        MongoClient client = MongoClients.create(buildMongoClientOptions(ReadPreference.nearest(), connectionString, bsonFactory));
+        MongoClient client = MongoClients.create(buildMongoClientOptions(ReadPreference.nearest(), connectionString, bsonFactory), DRIVER_INFO);
         registerMongoClientShutdownHook(client);
 
         return client.getDatabase(database);

--- a/src/main/java/ai/labs/eddi/datastore/mongo/MongoDriverInfoFactory.java
+++ b/src/main/java/ai/labs/eddi/datastore/mongo/MongoDriverInfoFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.datastore.mongo;
+
+import com.mongodb.MongoDriverInformation;
+
+/**
+ * Builds the {@link MongoDriverInformation} used to identify EDDI in MongoDB
+ * server-side telemetry and handshake metadata.
+ */
+public final class MongoDriverInfoFactory {
+
+    static final String DRIVER_NAME = "EDDI";
+
+    private MongoDriverInfoFactory() {
+    }
+
+    /**
+     * Returns a {@link MongoDriverInformation} with {@code driverName = "EDDI"}
+     * and, when available, the implementation version from the JAR manifest.
+     */
+    public static MongoDriverInformation build() {
+        MongoDriverInformation.Builder builder = MongoDriverInformation.builder().driverName(DRIVER_NAME);
+        Package pkg = MongoDriverInfoFactory.class.getPackage();
+        String version = pkg != null ? pkg.getImplementationVersion() : null;
+        if (version != null) {
+            builder.driverVersion(version);
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/EmbeddingStoreFactory.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/EmbeddingStoreFactory.java
@@ -55,7 +55,8 @@ public class EmbeddingStoreFactory {
 
     private static MongoDriverInformation buildDriverInfo() {
         MongoDriverInformation.Builder builder = MongoDriverInformation.builder().driverName("EDDI");
-        String version = EmbeddingStoreFactory.class.getPackage().getImplementationVersion();
+        Package pkg = EmbeddingStoreFactory.class.getPackage();
+        String version = pkg != null ? pkg.getImplementationVersion() : null;
         if (version != null) {
             builder.driverVersion(version);
         }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/EmbeddingStoreFactory.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/EmbeddingStoreFactory.java
@@ -18,6 +18,9 @@ import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
 import dev.langchain4j.store.embedding.mongodb.MongoDbEmbeddingStore;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
 import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -48,6 +51,16 @@ import java.util.regex.Pattern;
 public class EmbeddingStoreFactory {
 
     private static final Logger LOGGER = Logger.getLogger(EmbeddingStoreFactory.class);
+    private static final MongoDriverInformation DRIVER_INFO = buildDriverInfo();
+
+    private static MongoDriverInformation buildDriverInfo() {
+        MongoDriverInformation.Builder builder = MongoDriverInformation.builder().driverName("EDDI");
+        String version = EmbeddingStoreFactory.class.getPackage().getImplementationVersion();
+        if (version != null) {
+            builder.driverVersion(version);
+        }
+        return builder.build();
+    }
     private static final int MAX_PG_IDENTIFIER_LENGTH = 63;
     private static final Pattern UNSAFE_IDENTIFIER_CHARS = Pattern.compile("[^a-z0-9_]");
     private static final Pattern TRAILING_UNDERSCORES = Pattern.compile("_+$");
@@ -162,7 +175,12 @@ public class EmbeddingStoreFactory {
         LOGGER.infof("Building MongoDB Atlas store: database=%s, collection=%s, index=%s", sanitize(databaseName), sanitize(collectionName),
                 sanitize(indexName));
 
-        MongoClient mongoClient = mongoClientCache.computeIfAbsent(connectionString, MongoClients::create);
+        MongoClient mongoClient = mongoClientCache.computeIfAbsent(connectionString, cs -> {
+            MongoClientSettings settings = MongoClientSettings.builder()
+                    .applyConnectionString(new ConnectionString(cs))
+                    .build();
+            return MongoClients.create(settings, DRIVER_INFO);
+        });
 
         return MongoDbEmbeddingStore.builder().fromClient(mongoClient).databaseName(databaseName).collectionName(collectionName).indexName(indexName)
                 .build();

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/EmbeddingStoreFactory.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/EmbeddingStoreFactory.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
+import ai.labs.eddi.datastore.mongo.MongoDriverInfoFactory;
 import ai.labs.eddi.secrets.SecretResolver;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -51,17 +52,8 @@ import java.util.regex.Pattern;
 public class EmbeddingStoreFactory {
 
     private static final Logger LOGGER = Logger.getLogger(EmbeddingStoreFactory.class);
-    private static final MongoDriverInformation DRIVER_INFO = buildDriverInfo();
+    private static final MongoDriverInformation DRIVER_INFO = MongoDriverInfoFactory.build();
 
-    private static MongoDriverInformation buildDriverInfo() {
-        MongoDriverInformation.Builder builder = MongoDriverInformation.builder().driverName("EDDI");
-        Package pkg = EmbeddingStoreFactory.class.getPackage();
-        String version = pkg != null ? pkg.getImplementationVersion() : null;
-        if (version != null) {
-            builder.driverVersion(version);
-        }
-        return builder.build();
-    }
     private static final int MAX_PG_IDENTIFIER_LENGTH = 63;
     private static final Pattern UNSAFE_IDENTIFIER_CHARS = Pattern.compile("[^a-z0-9_]");
     private static final Pattern TRAILING_UNDERSCORES = Pattern.compile("_+$");


### PR DESCRIPTION
Adds `MongoDriverInformation` to both MongoDB client construction sites so that the MongoDB server can identify EDDI traffic in server-side telemetry, Atlas dashboards, and `db.currentOp()`.

## What changes

**`PersistenceModule.java`** — the main datastore client is constructed via `MongoClients.create(settings, DRIVER_INFO)`. A `buildDriverInfo()` factory method builds a `MongoDriverInformation` with `driverName = "EDDI"` and the implementation version from the package manifest (omitted if null, which is normal in test environments where the JAR is not packaged).

**`EmbeddingStoreFactory.java`** — the MongoDB Atlas Vector Search client previously used a bare `MongoClients.create(connectionString)` call. This is converted to a settings-based construction via `MongoClientSettings.builder()` so that `MongoDriverInformation` can be passed as the second argument to `MongoClients.create()`. Same `buildDriverInfo()` pattern applied.

The handshake metadata will appear in `mongod` diagnostic logs as:

```json
{
  "driver": {
    "name": "mongodb-driver-sync|EDDI",
    "version": "<driver-version>|6.1.2"
  }
}
```

**Spec reference:**
https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md

## Testing

The existing `EmbeddingStoreFactoryTest` (20 tests) and related branch/extended test suites all pass. The `buildDriverInfo()` helper safely handles `null` from `getImplementationVersion()` (expected in unpackaged test runs) by omitting the version field rather than passing null.

```
./mvnw test -Dtest="EmbeddingStoreFactoryTest"
# Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MongoDB client identification by consistently supplying standardized driver information when connecting.
  * Updated embedding store MongoDB connections to use explicitly constructed client settings while keeping the existing connection caching behavior unchanged.
* **Chores**
  * Added a shared mechanism to build reusable MongoDB driver information for consistent handshake/telemetry identification across connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->