### PR TITLE
fix(datastore): make limit=0 mean unlimited in readDescriptors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,50 @@
 
 ---
 
+## 🐛 Fix: `readDescriptors(limit = 0)` silently returned only 20 descriptors (2026-07-21)
+
+**Repo:** EDDI (`fix/descriptor-store-limit-semantics`)
+
+### Summary
+
+`DescriptorStore.readDescriptors` resolved its limit with `(limit == null || limit < 1) ? 20 : limit`, so a caller passing `0` to mean "give me everything" silently received the first 20 rows. The same `limit < 1 ? 20` fallback was duplicated in `MongoResourceStorage.findResources`, `PostgresResourceStorage.findResources`, and `ResourceFilter.readResources` — four independent copies of a magic default, none of them documented.
+
+Three production call sites were affected in a user-visible way:
+
+- **`PromptSnippetService.loadAllSnippets`** — a deployment with more than 20 prompt snippets never got the rest into the `{snippets.*}` template namespace. Silent: templates just rendered empty.
+- **`RestExportService.exportSnippets`** — agent export dropped any referenced snippet outside the first 20, producing an incomplete ZIP that imports without error.
+- **`RestAgentStore.populateCapabilityRegistry`** — only the first 20 agents were scanned for capabilities at startup, so capability-based discovery/delegation silently missed agents.
+
+Three further call sites (`ChannelTargetRouter`, `ChannelConnectorMigration`, `RestChannelIntegrationStore`) passed a magic `1000` to dodge the cap; the channel-uniqueness check among them would have let a duplicate `channelId` through past that many configs.
+
+### Fix — explicit sentinel plus a hard ceiling
+
+Option (a) from the two candidates, because the storage layer supports a bounded unlimited query cleanly and paging every caller would have been six copies of `RestOrphanAdmin`'s batch loop:
+
+- **`IDescriptorStore.NO_LIMIT` (`0`)** and **`DEFAULT_LIMIT` (`20`)** define the contract in one place, with `resolveDescriptorLimit(Integer)`: `null` → default page, `<= 0` → unlimited, `> 0` → honoured.
+- **`IResourceStorage.MAX_RESULT_LIMIT` (`10_000`)** is the hard safety ceiling, applied through the shared static `IResourceStorage.resolveLimit(int)` that both backends now call — the two implementations can no longer drift apart.
+- **Truncation is no longer silent**: `DescriptorStore` logs a WARN naming the descriptor type when a result set hits the ceiling. The original defect was not the number 20, it was that nothing said anything.
+- All six "give me everything" call sites now pass `IDescriptorStore.NO_LIMIT` instead of `0` or `1000`, so intent is readable at the call site. `RestOrphanAdmin` keeps its explicit 200-row batch loop — it genuinely pages.
+
+### Key Design Decisions
+
+- **`null` and `0` deliberately mean different things.** `null` is "caller expressed no opinion" → default page; `0` is "no limit". Collapsing them would have made `?limit=` omission return everything.
+- **Redefining `0` is safe for the REST API** because every REST endpoint already declares `@QueryParam("limit") @DefaultValue("20")`. JAX-RS, not the store fallback, supplies the REST default, so no endpoint's behaviour changes when the parameter is omitted. Only internal callers and an explicit `?limit=0` are affected — and `?limit=0` now means what it reads like.
+- **Ceiling over true unbounded**: an unbounded query on a large `descriptors` collection is a memory risk, and `readDescriptors` issues one `read()` per descriptor. 10,000 is high enough that no realistic deployment hits it, and the WARN makes it loud if one does.
+- **Legacy `mongo/ResourceFilter` updated too**, so both descriptor-store implementations obey one contract rather than diverging.
+- **The ceiling warning sanitizes `type`.** Self-review caught that the new WARN logged `type` unsanitized — and `type` reaches `readDescriptors` straight from `@QueryParam("type")` on `IRestDocumentDescriptorStore`. That is the CWE-117 log-injection pattern that commit `d71de742` remediated across 13 files (the commit that also last touched this very method), so the new log line now uses the `LogSanitizer.sanitize` helper that commit introduced. Reachability is hard (10,000 matching descriptors), but CodeQL taint analysis is flow-based, not reachability-gated, and the repo's convention is to sanitize unconditionally.
+- **The warning states impact, not just cause.** Its reader is an operator who cannot "page" anything — the actionable fact for them is that the returned list is incomplete and dependent features are missing entries, so the message leads with that.
+
+### Verification
+
+- `./mvnw clean compile` — clean
+- 976 unit tests across the datastore package and every affected call site — 0 failures, 1 pre-existing skip
+- New tests pin the semantics: `null` → 20, `NO_LIMIT` → ceiling (with an explicit `assertNotEquals(DEFAULT_LIMIT)` regression guard), negative → ceiling, oversized → clamped, `skip == index * effectiveLimit`, results not post-truncated; plus helper-level tests and backend-level assertions (Mongo `iterable.limit(...)`, Postgres `LIMIT` in the generated SQL)
+- Two pre-existing tests asserted the old `limit=0 → 20` behaviour (`ResourceFilterTest`, `MongoResourceStorageBranchTest`) and were updated to the new contract — they were pinning the bug
+- `./mvnw formatter:format` + `./mvnw validate` clean
+
+---
+
 ## 🔎 Auto-approve workflow — Copilot pagination review comment is a false positive (2026-07-20)
 
 **Repo:** EDDI (`chore/auto-approve-copilot`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,12 @@ Option (a) from the two candidates, because the storage layer supports a bounded
 - **The ceiling warning sanitizes `type`.** Self-review caught that the new WARN logged `type` unsanitized — and `type` reaches `readDescriptors` straight from `@QueryParam("type")` on `IRestDocumentDescriptorStore`. That is the CWE-117 log-injection pattern that commit `d71de742` remediated across 13 files (the commit that also last touched this very method), so the new log line now uses the `LogSanitizer.sanitize` helper that commit introduced. Reachability is hard (10,000 matching descriptors), but CodeQL taint analysis is flow-based, not reachability-gated, and the repo's convention is to sanitize unconditionally.
 - **The warning states impact, not just cause.** Its reader is an operator who cannot "page" anything — the actionable fact for them is that the returned list is incomplete and dependent features are missing entries, so the message leads with that.
 
+### Review follow-ups (Copilot + CodeRabbit)
+
+- **`index` javadoc overstated the contract.** It claimed any `index > 0` with `NO_LIMIT` "yields an empty list". It does not: the effective limit is the ceiling, so `index=1` returns rows 10,000–20,000. The claim was only true for collections smaller than the ceiling — the common case mistaken for the contract. Reworded to say a non-zero index pages in ceiling-sized chunks.
+- **Integer overflow in the legacy `ResourceFilter` skip.** `index * limit` was int arithmetic; raising the effective limit from 20 to 10,000 dropped the overflow threshold from `index > ~107M` to `index > ~214,748`, where the skip goes negative. Now uses the same `long` cast + `Math.min` guard that `d71de742` added to `DescriptorStore.readDescriptors`, so both paths match. Reachability is low (this is the legacy store path), but the fix is three lines and removes a CodeQL-shaped pattern.
+- **Removed a duplicate test.** The added `nullLimitUsesDefaultPageSize` re-tested exactly what the pre-existing `defaultsLimitWhenNull` already covered. Deleted it and updated the pre-existing test to assert against `DEFAULT_LIMIT` instead of a literal `20`, keeping coverage and dropping the magic number.
+
 ### Verification
 
 - `./mvnw clean compile` — clean

--- a/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
@@ -28,6 +28,7 @@ import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.secrets.sanitize.SecretScrubber;
 import ai.labs.eddi.utils.FileUtilities;
@@ -582,7 +583,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
 
         try {
             List<DocumentDescriptor> descriptors = documentDescriptorStore.readDescriptors(
-                    "ai.labs.snippet", "", 0, 0, false);
+                    "ai.labs.snippet", "", 0, IDescriptorStore.NO_LIMIT, false);
             if (descriptors == null || descriptors.isEmpty()) {
                 return;
             }

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -16,6 +16,7 @@ import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.utils.RestUtilities;
 import org.jboss.logging.Logger;
@@ -67,7 +68,7 @@ public class RestAgentStore implements IRestAgentStore {
     @PostConstruct
     void populateCapabilityRegistry() {
         try {
-            var descriptors = documentDescriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false);
+            var descriptors = documentDescriptorStore.readDescriptors("ai.labs.agent", null, 0, IDescriptorStore.NO_LIMIT, false);
             int registered = 0;
             for (var descriptor : descriptors) {
                 try {

--- a/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
@@ -12,6 +12,7 @@ import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.rest.RestVersionInfo;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -259,7 +260,7 @@ public class RestChannelIntegrationStore implements IRestChannelIntegrationStore
 
         try {
             var descriptors = documentDescriptorStore.readDescriptors(
-                    "ai.labs.channel", "", 0, 1000, false);
+                    "ai.labs.channel", "", 0, IDescriptorStore.NO_LIMIT, false);
             for (var descriptor : descriptors) {
                 try {
                     var resId = RestUtilities.extractResourceId(descriptor.getResource());

--- a/src/main/java/ai/labs/eddi/configs/migration/ChannelConnectorMigration.java
+++ b/src/main/java/ai/labs/eddi/configs/migration/ChannelConnectorMigration.java
@@ -12,6 +12,7 @@ import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.configs.channels.model.ChannelTarget;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.configs.migration.model.MigrationLog;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -240,7 +241,7 @@ public class ChannelConnectorMigration {
         var keys = new HashSet<String>();
         try {
             var descriptors = descriptorStore.readDescriptors(
-                    "ai.labs.channel", "", 0, 1000, false);
+                    "ai.labs.channel", "", 0, IDescriptorStore.NO_LIMIT, false);
             for (var descriptor : descriptors) {
                 try {
                     var resId = extractResourceId(

--- a/src/main/java/ai/labs/eddi/datastore/DescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/DescriptorStore.java
@@ -7,9 +7,12 @@ package ai.labs.eddi.datastore;
 import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
 import ai.labs.eddi.utils.StringUtilities;
+import org.jboss.logging.Logger;
 
 import java.util.LinkedList;
 import java.util.List;
+
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
  * Database-agnostic descriptor store. Uses {@link IResourceStorageFactory} to
@@ -19,6 +22,8 @@ import java.util.List;
  * @author ginccc
  */
 public class DescriptorStore<T> implements IDescriptorStore<T> {
+    private static final Logger LOGGER = Logger.getLogger(DescriptorStore.class);
+
     private static final String FIELD_RESOURCE = "resource";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_AGENT_NAME = "agentName";
@@ -55,7 +60,7 @@ public class DescriptorStore<T> implements IDescriptorStore<T> {
             queryFiltersOptional.add(new IResourceFilter.QueryFilter(FIELD_RESOURCE, filter));
         }
 
-        int effectiveLimit = (limit == null || limit < 1) ? 20 : limit;
+        int effectiveLimit = IDescriptorStore.resolveDescriptorLimit(limit);
         int skip;
         if (index != null && index > 0) {
             long skipLong = (long) index * effectiveLimit;
@@ -75,6 +80,16 @@ public class DescriptorStore<T> implements IDescriptorStore<T> {
 
         // Use the storage-level findResources for database-agnostic querying
         List<IResourceStore.IResourceId> matchingIds = resourceStorage.findResources(allFilters, FIELD_LAST_MODIFIED, skip, effectiveLimit);
+
+        if (matchingIds.size() >= IResourceStorage.MAX_RESULT_LIMIT) {
+            // Never truncate silently — a short list that looks complete is
+            // exactly the bug the explicit NO_LIMIT contract exists to prevent.
+            // `type` reaches this method from a @QueryParam, so it is sanitized
+            // before it is logged (CWE-117).
+            LOGGER.warnv("Descriptor query for type ''{0}'' hit the internal {1}-result ceiling — the returned list is "
+                    + "INCOMPLETE and features reading this type will silently miss entries. This query needs to page.",
+                    sanitize(type), IResourceStorage.MAX_RESULT_LIMIT);
+        }
 
         // Read each matching resource
         List<T> ret = new LinkedList<>();

--- a/src/main/java/ai/labs/eddi/datastore/IResourceStorage.java
+++ b/src/main/java/ai/labs/eddi/datastore/IResourceStorage.java
@@ -12,6 +12,35 @@ import java.util.List;
  * @author ginccc
  */
 public interface IResourceStorage<T> {
+
+    /**
+     * Hard safety ceiling for any single {@link #findResources} query. Applies even
+     * when the caller asks for "no limit" — an unbounded query against a large
+     * collection is a memory risk, so the storage layer never returns more than
+     * this many ids in one call.
+     * <p>
+     * Callers that must be exhaustive on collections this large have to page (see
+     * {@code RestOrphanAdmin} for the pattern).
+     */
+    int MAX_RESULT_LIMIT = 10_000;
+
+    /**
+     * Resolve a caller-supplied limit into the concrete number of rows a backend
+     * should fetch.
+     * <p>
+     * {@code limit <= 0} is the explicit "no caller-imposed limit" sentinel and
+     * resolves to {@link #MAX_RESULT_LIMIT}; a positive limit is honoured but still
+     * clamped to the ceiling. Shared by every backend so the two implementations
+     * cannot drift apart.
+     *
+     * @param limit
+     *            the caller-supplied limit ({@code <= 0} means unlimited)
+     * @return a positive row count, never above {@link #MAX_RESULT_LIMIT}
+     */
+    static int resolveLimit(int limit) {
+        return limit < 1 ? MAX_RESULT_LIMIT : Math.min(limit, MAX_RESULT_LIMIT);
+    }
+
     IResource<T> newResource(T content) throws IOException;
 
     IResource<T> newResource(String id, Integer version, T content) throws IOException;
@@ -124,7 +153,10 @@ public interface IResourceStorage<T> {
      * @param skip
      *            number of results to skip
      * @param limit
-     *            maximum number of results
+     *            maximum number of results; {@code <= 0} means "no caller-imposed
+     *            limit" and returns up to {@link #MAX_RESULT_LIMIT}.
+     *            Implementations must resolve this through
+     *            {@link #resolveLimit(int)}.
      * @return list of matching resource IDs
      */
     default List<IResourceStore.IResourceId> findResources(IResourceFilter.QueryFilters[] filters, String sortField, int skip, int limit) {

--- a/src/main/java/ai/labs/eddi/datastore/mongo/MongoResourceStorage.java
+++ b/src/main/java/ai/labs/eddi/datastore/mongo/MongoResourceStorage.java
@@ -306,7 +306,7 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
 
         Bson query = Filters.and(connectedFilters);
         Document sort = sortField != null ? new Document(sortField, -1) : new Document();
-        int effectiveLimit = limit < 1 ? 20 : limit;
+        int effectiveLimit = IResourceStorage.resolveLimit(limit);
 
         var iterable = currentCollection.find(query.toBsonDocument()).sort(sort).limit(effectiveLimit).skip(skip > 0 ? skip : 0);
 

--- a/src/main/java/ai/labs/eddi/datastore/mongo/ResourceFilter.java
+++ b/src/main/java/ai/labs/eddi/datastore/mongo/ResourceFilter.java
@@ -43,11 +43,15 @@ public class ResourceFilter<T> implements IResourceFilter<T> {
         var iterable = collection.find(query).sort(sort);
         // Same limit contract as IDescriptorStore.readDescriptors: null means
         // "no opinion" (default page), <= 0 means "no limit" (up to the ceiling).
-        limit = IDescriptorStore.resolveDescriptorLimit(limit);
-        iterable.limit(limit);
+        int effectiveLimit = IDescriptorStore.resolveDescriptorLimit(limit);
+        iterable.limit(effectiveLimit);
 
         if (index != null) {
-            iterable.skip(index > 0 ? (index * limit) : 0);
+            // long arithmetic: with the ceiling as the effective limit, an int
+            // multiply here overflows to a negative skip at a far lower index
+            // than it used to. Same guard as DescriptorStore.readDescriptors.
+            long skipLong = index > 0 ? (long) index * effectiveLimit : 0L;
+            iterable.skip((int) Math.min(skipLong, Integer.MAX_VALUE));
         }
 
         for (Document result : iterable) {

--- a/src/main/java/ai/labs/eddi/datastore/mongo/ResourceFilter.java
+++ b/src/main/java/ai/labs/eddi/datastore/mongo/ResourceFilter.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.datastore.mongo;
 
 import ai.labs.eddi.datastore.IResourceFilter;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import org.bson.BsonDocument;
@@ -40,9 +41,9 @@ public class ResourceFilter<T> implements IResourceFilter<T> {
         BsonDocument query = createQuery(queryFilters);
         Document sort = createSortQuery(sortTypes);
         var iterable = collection.find(query).sort(sort);
-        if (limit == null || limit < 1) {
-            limit = 20;
-        }
+        // Same limit contract as IDescriptorStore.readDescriptors: null means
+        // "no opinion" (default page), <= 0 means "no limit" (up to the ceiling).
+        limit = IDescriptorStore.resolveDescriptorLimit(limit);
         iterable.limit(limit);
 
         if (index != null) {

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorage.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorage.java
@@ -389,7 +389,7 @@ public class PostgresResourceStorage<T> implements IResourceStorage<T> {
             sql.append(" ORDER BY data->>'" + sanitizeJsonPath(sortField) + "' DESC");
         }
 
-        int effectiveLimit = limit < 1 ? 20 : limit;
+        int effectiveLimit = IResourceStorage.resolveLimit(limit);
         sql.append(" LIMIT ").append(effectiveLimit);
         if (skip > 0) {
             sql.append(" OFFSET ").append(skip);

--- a/src/main/java/ai/labs/eddi/datastore/serialization/IDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/serialization/IDescriptorStore.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.datastore.serialization;
 
+import ai.labs.eddi.datastore.IResourceStorage;
 import ai.labs.eddi.datastore.IResourceStore;
 
 import java.util.List;
@@ -12,8 +13,60 @@ import java.util.List;
  * @author ginccc
  */
 public interface IDescriptorStore<T> {
+
+    /**
+     * Explicit "give me everything" sentinel for the {@code limit} argument of
+     * {@link #readDescriptors}. Prefer this over a bare {@code 0} or an arbitrarily
+     * large magic number so the intent is readable at the call site.
+     */
+    int NO_LIMIT = 0;
+
+    /**
+     * Page size used when {@code limit} is {@code null}, i.e. when the caller
+     * expressed no opinion at all. Matches the {@code @DefaultValue("20")} the REST
+     * layer declares on its {@code limit} query parameter.
+     */
+    int DEFAULT_LIMIT = 20;
+
+    /**
+     * Read descriptors of a given type, optionally filtered and paginated.
+     * <p>
+     * Limit semantics — a {@code 0} here means <em>unlimited</em>, not "use the
+     * default page size":
+     * <ul>
+     * <li>{@code null} — caller expressed no opinion; {@link #DEFAULT_LIMIT}
+     * descriptors are returned.</li>
+     * <li>{@code <= 0} ({@link #NO_LIMIT}) — no caller-imposed limit; returns up to
+     * {@link ai.labs.eddi.datastore.IResourceStorage#MAX_RESULT_LIMIT}.</li>
+     * <li>{@code > 0} — at most that many, clamped to
+     * {@link ai.labs.eddi.datastore.IResourceStorage#MAX_RESULT_LIMIT}.</li>
+     * </ul>
+     * Implementations must log a warning when a result set is truncated by the
+     * ceiling, so a silently short list can never be mistaken for a complete one.
+     *
+     * @param index
+     *            zero-based page index; the skip offset is
+     *            {@code index * effectiveLimit}, so any {@code index > 0} combined
+     *            with {@link #NO_LIMIT} is past the (single) unlimited page and
+     *            yields an empty list
+     * @param limit
+     *            see above
+     */
     List<T> readDescriptors(String type, String filter, Integer index, Integer limit, boolean includeDeleted)
             throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException;
+
+    /**
+     * Resolve the {@code limit} argument of {@link #readDescriptors} into a
+     * concrete positive row count, per the semantics documented there.
+     *
+     * @param limit
+     *            the caller-supplied limit, may be {@code null}
+     * @return a positive row count, never above
+     *         {@link ai.labs.eddi.datastore.IResourceStorage#MAX_RESULT_LIMIT}
+     */
+    static int resolveDescriptorLimit(Integer limit) {
+        return limit == null ? DEFAULT_LIMIT : IResourceStorage.resolveLimit(limit);
+    }
 
     T readDescriptor(String resourceId, Integer version) throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException;
 

--- a/src/main/java/ai/labs/eddi/datastore/serialization/IDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/serialization/IDescriptorStore.java
@@ -46,9 +46,12 @@ public interface IDescriptorStore<T> {
      *
      * @param index
      *            zero-based page index; the skip offset is
-     *            {@code index * effectiveLimit}, so any {@code index > 0} combined
-     *            with {@link #NO_LIMIT} is past the (single) unlimited page and
-     *            yields an empty list
+     *            {@code index * effectiveLimit}. With {@link #NO_LIMIT} the
+     *            effective limit is
+     *            {@link ai.labs.eddi.datastore.IResourceStorage#MAX_RESULT_LIMIT},
+     *            so a non-zero index pages in ceiling-sized chunks — it is not
+     *            rejected, and it only yields an empty list once the skip offset
+     *            exceeds the number of matching descriptors
      * @param limit
      *            see above
      */

--- a/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
+++ b/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
@@ -11,6 +11,7 @@ import ai.labs.eddi.configs.channels.IChannelIntegrationStore;
 import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.configs.channels.model.ChannelTarget;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.engine.api.IRestAgentAdministration;
 import ai.labs.eddi.engine.caching.ICache;
 import ai.labs.eddi.engine.caching.ICacheFactory;
@@ -446,7 +447,7 @@ public class ChannelTargetRouter {
         // 1. Load new-style ChannelIntegrationConfigurations
         try {
             var descriptors = descriptorStore.readDescriptors("ai.labs.channel",
-                    "", 0, 1000, false);
+                    "", 0, IDescriptorStore.NO_LIMIT, false);
             for (var descriptor : descriptors) {
                 try {
                     var resId = extractResourceId(descriptor.getResource());

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/PromptSnippetService.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/PromptSnippetService.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.snippets.IPromptSnippetStore;
 import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.micrometer.core.instrument.Counter;
@@ -119,7 +120,7 @@ public class PromptSnippetService {
         try {
             // Use descriptor store to enumerate all snippet resources
             List<DocumentDescriptor> descriptors = descriptorStore.readDescriptors(
-                    "ai.labs.snippet", "", 0, 0, false);
+                    "ai.labs.snippet", "", 0, IDescriptorStore.NO_LIMIT, false);
 
             if (descriptors == null || descriptors.isEmpty()) {
                 return Collections.emptyMap();

--- a/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreCrudTest.java
+++ b/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreCrudTest.java
@@ -11,6 +11,7 @@ import ai.labs.eddi.configs.channels.model.ObserveConfig;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -129,7 +130,7 @@ class RestChannelIntegrationStoreCrudTest {
             var config = validConfig();
             when(channelStore.create(any())).thenReturn(dummyResourceId(CHANNEL_ID, 1));
             // No existing channels for uniqueness check
-            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(1000), eq(false)))
+            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(IDescriptorStore.NO_LIMIT), eq(false)))
                     .thenReturn(List.of());
 
             Response response = sut.createChannel(config);
@@ -160,7 +161,7 @@ class RestChannelIntegrationStoreCrudTest {
             when(channelStore.update(eq(CHANNEL_ID), eq(1), any())).thenReturn(2);
             when(channelStore.getCurrentResourceId(CHANNEL_ID)).thenReturn(dummyResourceId(CHANNEL_ID, 2));
             when(documentDescriptorStore.readDescriptor(CHANNEL_ID, 2)).thenReturn(new DocumentDescriptor());
-            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(1000), eq(false)))
+            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(IDescriptorStore.NO_LIMIT), eq(false)))
                     .thenReturn(List.of());
 
             Response response = sut.updateChannel(CHANNEL_ID, 1, config);
@@ -222,7 +223,7 @@ class RestChannelIntegrationStoreCrudTest {
             when(channelStore.read(CHANNEL_ID, 1)).thenReturn(config);
             when(channelStore.getCurrentResourceId(CHANNEL_ID)).thenReturn(dummyResourceId(CHANNEL_ID, 1));
             when(channelStore.create(any())).thenReturn(dummyResourceId("newId12345678901234", 1));
-            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(1000), eq(false)))
+            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(IDescriptorStore.NO_LIMIT), eq(false)))
                     .thenReturn(List.of());
 
             Response response = sut.duplicateChannel(CHANNEL_ID, 1);
@@ -240,7 +241,7 @@ class RestChannelIntegrationStoreCrudTest {
             when(channelStore.read(CHANNEL_ID, 1)).thenReturn(config);
             when(channelStore.getCurrentResourceId(CHANNEL_ID)).thenReturn(dummyResourceId(CHANNEL_ID, 1));
             when(channelStore.create(any())).thenReturn(dummyResourceId("newId12345678901234", 1));
-            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(1000), eq(false)))
+            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(IDescriptorStore.NO_LIMIT), eq(false)))
                     .thenReturn(List.of());
 
             assertDoesNotThrow(() -> sut.duplicateChannel(CHANNEL_ID, 1));
@@ -348,7 +349,7 @@ class RestChannelIntegrationStoreCrudTest {
             // Existing config with the same channelId
             var descriptor = new DocumentDescriptor();
             descriptor.setResource(URI.create("eddi://ai.labs.channel/channelstore/channels/aabbccddeeff112233445566?version=1"));
-            when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(1000), eq(false)))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(IDescriptorStore.NO_LIMIT), eq(false)))
                     .thenReturn(List.of(descriptor));
 
             var existing = validConfig();
@@ -368,7 +369,7 @@ class RestChannelIntegrationStoreCrudTest {
 
             var descriptor = new DocumentDescriptor();
             descriptor.setResource(URI.create("eddi://ai.labs.channel/channelstore/channels/" + CHANNEL_ID + "?version=1"));
-            when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(1000), eq(false)))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(IDescriptorStore.NO_LIMIT), eq(false)))
                     .thenReturn(List.of(descriptor));
 
             var existing = validConfig();
@@ -417,7 +418,7 @@ class RestChannelIntegrationStoreCrudTest {
             var config = validConfig();
             when(channelStore.create(any())).thenReturn(dummyResourceId(CHANNEL_ID, 1));
             when(channelStore.getCurrentResourceId(CHANNEL_ID)).thenThrow(new IResourceStore.ResourceNotFoundException("not found"));
-            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(1000), eq(false)))
+            lenient().when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq(""), eq(0), eq(IDescriptorStore.NO_LIMIT), eq(false)))
                     .thenReturn(List.of());
 
             // Should not throw — descriptor sync failure is logged, not rethrown

--- a/src/test/java/ai/labs/eddi/datastore/DescriptorStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/DescriptorStoreTest.java
@@ -4,10 +4,13 @@
  */
 package ai.labs.eddi.datastore;
 
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.util.List;
@@ -135,14 +138,122 @@ class DescriptorStoreTest {
         assertEquals(1, result.size());
     }
 
-    @Test
-    @DisplayName("readDescriptors — uses default limit when null")
-    void readDescriptorsDefaultLimit() throws Exception {
+    // ==================== limit semantics ====================
+
+    /**
+     * The paging arguments {@code readDescriptors} actually hands to the storage
+     * layer. These are what the contract in {@link IDescriptorStore} is about — a
+     * caller asking for "everything" must not have its request quietly rewritten
+     * into a 20-row page.
+     */
+    private record Paging(int skip, int limit) {
+    }
+
+    private Paging capturePaging(Integer index, Integer limit) throws Exception {
         when(resourceStorage.findResources(any(IResourceFilter.QueryFilters[].class), anyString(), anyInt(), anyInt()))
                 .thenReturn(List.of());
 
-        List<String> result = store.readDescriptors("agents", null, null, null, false);
-        assertTrue(result.isEmpty());
+        store.readDescriptors("agents", null, index, limit, false);
+
+        ArgumentCaptor<Integer> skipCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(resourceStorage).findResources(any(IResourceFilter.QueryFilters[].class), anyString(), skipCaptor.capture(),
+                limitCaptor.capture());
+        return new Paging(skipCaptor.getValue(), limitCaptor.getValue());
+    }
+
+    @Nested
+    @DisplayName("readDescriptors — limit semantics")
+    class LimitSemantics {
+
+        @Test
+        @DisplayName("null limit — caller has no opinion, gets the default page")
+        void nullLimitUsesDefault() throws Exception {
+            assertEquals(IDescriptorStore.DEFAULT_LIMIT, capturePaging(0, null).limit());
+        }
+
+        @Test
+        @DisplayName("NO_LIMIT — means unlimited, NOT the default page size")
+        void noLimitMeansUnlimited() throws Exception {
+            Paging paging = capturePaging(0, IDescriptorStore.NO_LIMIT);
+
+            assertEquals(IResourceStorage.MAX_RESULT_LIMIT, paging.limit());
+            assertEquals(0, paging.skip());
+            // Regression guard: this used to silently resolve to 20, truncating
+            // every caller that passed 0 meaning "give me everything".
+            assertNotEquals(IDescriptorStore.DEFAULT_LIMIT, paging.limit());
+        }
+
+        @Test
+        @DisplayName("negative limit — treated as unlimited, like NO_LIMIT")
+        void negativeLimitMeansUnlimited() throws Exception {
+            assertEquals(IResourceStorage.MAX_RESULT_LIMIT, capturePaging(0, -5).limit());
+        }
+
+        @Test
+        @DisplayName("positive limit — honoured verbatim")
+        void positiveLimitIsHonoured() throws Exception {
+            assertEquals(50, capturePaging(0, 50).limit());
+        }
+
+        @Test
+        @DisplayName("oversized limit — clamped to the safety ceiling")
+        void oversizedLimitIsClamped() throws Exception {
+            assertEquals(IResourceStorage.MAX_RESULT_LIMIT, capturePaging(0, IResourceStorage.MAX_RESULT_LIMIT + 1).limit());
+        }
+
+        @Test
+        @DisplayName("index — skip is index * effective limit")
+        void skipIsIndexTimesEffectiveLimit() throws Exception {
+            assertEquals(100, capturePaging(2, 50).skip());
+        }
+
+        @Test
+        @DisplayName("results are not post-truncated to the default page size")
+        void returnsMoreThanDefaultPageSize() throws Exception {
+            int count = IDescriptorStore.DEFAULT_LIMIT + 5;
+            List<IResourceStore.IResourceId> ids = new java.util.ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                IResourceStore.IResourceId id = mock(IResourceStore.IResourceId.class);
+                when(id.getId()).thenReturn("res-" + i);
+                when(id.getVersion()).thenReturn(1);
+                ids.add(id);
+
+                IResourceStorage.IResource<String> resource = mock(IResourceStorage.IResource.class);
+                when(resource.getData()).thenReturn("data-" + i);
+                when(resourceStorage.read("res-" + i, 1)).thenReturn(resource);
+                when(resourceStorage.getCurrentVersion("res-" + i)).thenReturn(1);
+            }
+            when(resourceStorage.findResources(any(IResourceFilter.QueryFilters[].class), anyString(), anyInt(), anyInt()))
+                    .thenReturn(ids);
+
+            List<String> result = store.readDescriptors("agents", null, 0, IDescriptorStore.NO_LIMIT, false);
+
+            assertEquals(count, result.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("limit resolution helpers")
+    class LimitResolution {
+
+        @Test
+        @DisplayName("resolveDescriptorLimit — null is the only value meaning 'default page'")
+        void resolveDescriptorLimitNull() {
+            assertEquals(IDescriptorStore.DEFAULT_LIMIT, IDescriptorStore.resolveDescriptorLimit(null));
+            assertEquals(IResourceStorage.MAX_RESULT_LIMIT, IDescriptorStore.resolveDescriptorLimit(IDescriptorStore.NO_LIMIT));
+            assertEquals(7, IDescriptorStore.resolveDescriptorLimit(7));
+        }
+
+        @Test
+        @DisplayName("resolveLimit — never returns a non-positive or above-ceiling value")
+        void resolveLimitIsAlwaysUsable() {
+            assertEquals(IResourceStorage.MAX_RESULT_LIMIT, IResourceStorage.resolveLimit(0));
+            assertEquals(IResourceStorage.MAX_RESULT_LIMIT, IResourceStorage.resolveLimit(-1));
+            assertEquals(IResourceStorage.MAX_RESULT_LIMIT, IResourceStorage.resolveLimit(Integer.MIN_VALUE));
+            assertEquals(IResourceStorage.MAX_RESULT_LIMIT, IResourceStorage.resolveLimit(Integer.MAX_VALUE));
+            assertEquals(1, IResourceStorage.resolveLimit(1));
+        }
     }
 
     // ==================== findByOriginId ====================

--- a/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageBranchTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageBranchTest.java
@@ -193,7 +193,7 @@ class MongoResourceStorageBranchTest {
         }
 
         @Test
-        @DisplayName("null sortField → empty sort document; limit < 1 → defaults to 20")
+        @DisplayName("null sortField → empty sort document; limit < 1 → unlimited up to the ceiling")
         void nullSortAndDefaultLimit() throws Exception {
             IResourceFilter.QueryFilter qf = mock(IResourceFilter.QueryFilter.class);
             when(qf.getField()).thenReturn("name");
@@ -210,11 +210,11 @@ class MongoResourceStorageBranchTest {
             when(iterable.skip(anyInt())).thenReturn(iterable);
             doNothing().when(iterable).forEach(any(java.util.function.Consumer.class));
 
-            // sortField=null, skip=0, limit=0 → effectiveLimit=20, skip=0
+            // sortField=null, skip=0, limit=0 → "no caller limit" → the ceiling
             List<IResourceStore.IResourceId> result = storage.findResources(
                     new IResourceFilter.QueryFilters[]{qfs}, null, 0, 0);
 
-            verify(iterable).limit(20);
+            verify(iterable).limit(IResourceStorage.MAX_RESULT_LIMIT);
             verify(iterable).skip(0);
         }
     }

--- a/src/test/java/ai/labs/eddi/datastore/mongo/ResourceFilterTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/ResourceFilterTest.java
@@ -6,7 +6,9 @@ package ai.labs.eddi.datastore.mongo;
 
 import ai.labs.eddi.datastore.IResourceFilter.QueryFilter;
 import ai.labs.eddi.datastore.IResourceFilter.QueryFilters;
+import ai.labs.eddi.datastore.IResourceStorage;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
@@ -149,8 +151,8 @@ class ResourceFilterTest {
 
         @SuppressWarnings("unchecked")
         @Test
-        @DisplayName("should default to limit=20 when limit is 0")
-        void defaultsLimitWhenZero() throws Exception {
+        @DisplayName("should treat limit=0 as unlimited, up to the safety ceiling")
+        void zeroLimitMeansUnlimited() throws Exception {
             var queryFilter = new QueryFilter("field", false);
             var queryFilters = new QueryFilters(List.of(queryFilter));
 
@@ -165,7 +167,28 @@ class ResourceFilterTest {
 
             filter.readResources(new QueryFilters[]{queryFilters}, null, 0);
 
-            verify(iterable).limit(20);
+            verify(iterable).limit(IResourceStorage.MAX_RESULT_LIMIT);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Test
+        @DisplayName("should use the default page size when limit is null")
+        void nullLimitUsesDefaultPageSize() throws Exception {
+            var queryFilter = new QueryFilter("field", false);
+            var queryFilters = new QueryFilters(List.of(queryFilter));
+
+            FindIterable<Document> iterable = mock(FindIterable.class);
+            when(collection.find(any(BsonDocument.class))).thenReturn(iterable);
+            when(iterable.sort(any(Document.class))).thenReturn(iterable);
+            when(iterable.limit(anyInt())).thenReturn(iterable);
+
+            MongoCursor<Document> cursor = mock(MongoCursor.class);
+            doReturn(cursor).when(iterable).iterator();
+            when(cursor.hasNext()).thenReturn(false);
+
+            filter.readResources(new QueryFilters[]{queryFilters}, null, null);
+
+            verify(iterable).limit(IDescriptorStore.DEFAULT_LIMIT);
         }
 
         @SuppressWarnings("unchecked")

--- a/src/test/java/ai/labs/eddi/datastore/mongo/ResourceFilterTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/ResourceFilterTest.java
@@ -130,7 +130,7 @@ class ResourceFilterTest {
 
         @SuppressWarnings("unchecked")
         @Test
-        @DisplayName("should default to limit=20 when limit is null")
+        @DisplayName("should use the default page size when limit is null")
         void defaultsLimitWhenNull() throws Exception {
             var queryFilter = new QueryFilter("field", false);
             var queryFilters = new QueryFilters(List.of(queryFilter));
@@ -146,7 +146,7 @@ class ResourceFilterTest {
 
             filter.readResources(new QueryFilters[]{queryFilters}, null, null);
 
-            verify(iterable).limit(20);
+            verify(iterable).limit(IDescriptorStore.DEFAULT_LIMIT);
         }
 
         @SuppressWarnings("unchecked")
@@ -168,27 +168,6 @@ class ResourceFilterTest {
             filter.readResources(new QueryFilters[]{queryFilters}, null, 0);
 
             verify(iterable).limit(IResourceStorage.MAX_RESULT_LIMIT);
-        }
-
-        @SuppressWarnings("unchecked")
-        @Test
-        @DisplayName("should use the default page size when limit is null")
-        void nullLimitUsesDefaultPageSize() throws Exception {
-            var queryFilter = new QueryFilter("field", false);
-            var queryFilters = new QueryFilters(List.of(queryFilter));
-
-            FindIterable<Document> iterable = mock(FindIterable.class);
-            when(collection.find(any(BsonDocument.class))).thenReturn(iterable);
-            when(iterable.sort(any(Document.class))).thenReturn(iterable);
-            when(iterable.limit(anyInt())).thenReturn(iterable);
-
-            MongoCursor<Document> cursor = mock(MongoCursor.class);
-            doReturn(cursor).when(iterable).iterator();
-            when(cursor.hasNext()).thenReturn(false);
-
-            filter.readResources(new QueryFilters[]{queryFilters}, null, null);
-
-            verify(iterable).limit(IDescriptorStore.DEFAULT_LIMIT);
         }
 
         @SuppressWarnings("unchecked")

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorageTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorageTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import javax.sql.DataSource;
 import java.sql.*;
@@ -421,6 +422,43 @@ class PostgresResourceStorageTest {
                 "name", 0, 10);
 
         assertEquals(1, results.size());
+    }
+
+    @Test
+    void findResources_zeroLimit_meansUnlimitedUpToCeiling() throws Exception {
+        when(resultSet.next()).thenReturn(false);
+
+        var filter = new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("name", "test.*");
+        var queryFilters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(
+                java.util.List.of(filter));
+
+        storage.findResources(
+                new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{queryFilters},
+                "name", 0, 0);
+
+        var sql = ArgumentCaptor.forClass(String.class);
+        verify(connection).prepareStatement(sql.capture());
+        // limit 0 is the "no caller limit" sentinel — it must not become LIMIT 20
+        assertTrue(sql.getValue().contains("LIMIT " + IResourceStorage.MAX_RESULT_LIMIT),
+                "expected the safety ceiling in: " + sql.getValue());
+    }
+
+    @Test
+    void findResources_oversizedLimit_clampedToCeiling() throws Exception {
+        when(resultSet.next()).thenReturn(false);
+
+        var filter = new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("name", "test.*");
+        var queryFilters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(
+                java.util.List.of(filter));
+
+        storage.findResources(
+                new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{queryFilters},
+                "name", 0, IResourceStorage.MAX_RESULT_LIMIT * 2);
+
+        var sql = ArgumentCaptor.forClass(String.class);
+        verify(connection).prepareStatement(sql.capture());
+        assertTrue(sql.getValue().contains("LIMIT " + IResourceStorage.MAX_RESULT_LIMIT),
+                "expected the safety ceiling in: " + sql.getValue());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/PromptSnippetServiceTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/PromptSnippetServiceTest.java
@@ -9,10 +9,12 @@ import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.snippets.IPromptSnippetStore;
 import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.net.URI;
 import java.util.Collections;
@@ -45,6 +47,20 @@ class PromptSnippetServiceTest {
 
     @Nested
     class SnippetLoading {
+
+        @Test
+        void shouldRequestAllSnippetsNotJustTheFirstPage() throws Exception {
+            when(descriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(Collections.emptyList());
+
+            service.getAll();
+
+            ArgumentCaptor<Integer> limit = ArgumentCaptor.forClass(Integer.class);
+            verify(descriptorStore).readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), limit.capture(), anyBoolean());
+            // Every snippet must reach the template namespace — a paged request
+            // would silently drop snippets past the default page size.
+            assertEquals(IDescriptorStore.NO_LIMIT, limit.getValue());
+        }
 
         @Test
         void shouldReturnEmptyMapWhenNoDescriptorsExist() throws Exception {


### PR DESCRIPTION
## Summary

DescriptorStore resolved its limit with `(limit == null || limit < 1) ? 20`, so a caller passing 0 to mean "give me everything" silently received the first 20 rows. The same `limit < 1 ? 20` fallback was duplicated in MongoResourceStorage, PostgresResourceStorage and the legacy mongo ResourceFilter -- four copies of an undocumented magic default.

Three call sites were affected in a user-visible way:

- PromptSnippetService: snippets past the first 20 never reached the {snippets.*} template namespace, so templates rendered them empty.
- RestExportService: agent export dropped referenced snippets beyond 20, producing an incomplete ZIP that imports without error.
- RestAgentStore: the startup capability registry scanned only the first 20 agents, so capability-based discovery silently missed agents.

Three more (ChannelTargetRouter, ChannelConnectorMigration, RestChannelIntegrationStore) passed a magic 1000 to dodge the cap; the channel-uniqueness check among them would let a duplicate channelId through past that many configs.

Introduces an explicit contract. IDescriptorStore.NO_LIMIT/DEFAULT_LIMIT with resolveDescriptorLimit define it in one place (null -> default page, <= 0 -> unlimited, > 0 -> honoured), bounded by the hard ceiling IResourceStorage.MAX_RESULT_LIMIT that both backends now apply through a single shared resolveLimit, so the implementations cannot drift. All six "give me everything" call sites pass NO_LIMIT instead of 0 or 1000; RestOrphanAdmin keeps its explicit batch loop because it genuinely pages.

Truncation is no longer silent: DescriptorStore logs a WARN naming the descriptor type when a result set hits the ceiling. The original defect was not the number 20, it was that nothing said anything. That value reaches the method from @QueryParam("type"), so it is passed through LogSanitizer.sanitize to avoid reintroducing the CWE-117 log injection that d71de742 remediated in this same method.

Safe for the REST API: every endpoint already declares @QueryParam("limit") @DefaultValue("20"), so JAX-RS supplies the REST default and no endpoint changes behaviour when the parameter is omitted. Only internal callers and an explicit ?limit=0 are affected.

Two pre-existing tests asserted the old limit=0 -> 20 behaviour (ResourceFilterTest, MongoResourceStorageBranchTest) and were updated -- they were pinning the bug.

## Type of Change

<!-- Check the one that applies -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [X] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, CI changes, etc.)

## Checklist

- [X] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [X] I have added tests that prove my fix/feature works
- [X] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [X] I have updated documentation if needed
- [X] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [X] I have not committed any secrets, API keys, or tokens
- [X] This PR has a clear, focused scope (one concern per PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed “no limit” descriptor/resource requests so `limit=0` truly means unlimited (using a shared NO_LIMIT constant) rather than returning only the first 20 items.
  * Updated snippet loading/export, capability scanning, channel uniqueness checks, and connector migrations to enumerate complete result sets.
  * Added a per-query safety ceiling (10,000) with WARN logging when truncation occurs, and standardized limit resolution across MongoDB, PostgreSQL, and filtering.

* **Tests**
  * Expanded unit/regression coverage for default, NO_LIMIT, negative, oversized, and skip/index pagination semantics, plus SQL/iterator LIMIT assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->