### PR TITLE
fix: remove toString() fallback in ConversationOutputExtractor

### DIFF
--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
@@ -20,13 +20,14 @@ import java.util.Map;
  * {@code ConverseWithAgentTool}.
  *
  * <p>
- * Handles three output formats:
+ * Handles two output formats:
  * <ol>
  * <li>Nested {@code output} array — items may be plain Strings,
  * {@link OutputItem} POJOs, or Maps with a {@code text} key</li>
  * <li>Flat keys like {@code output:text:*} — legacy format</li>
- * <li>Fallback: {@code toString()} on the entire output map</li>
  * </ol>
+ * Returns {@code null} when no recognizable text is found (e.g., the output
+ * map contains only pipeline metadata like actions, context, or expressions).
  *
  * @since 6.0.0
  */
@@ -106,19 +107,14 @@ public final class ConversationOutputExtractor {
             return String.join("\n", texts);
         }
 
-        // Check if the output contains any actual LLM-generated content.
-        // Output keys follow patterns like "output", "output:text:*", "reply".
-        // If none are present, the map only contains pipeline metadata
-        // (e.g. "actions", "input", "context") — return null to avoid
-        // serializing raw metadata as a group discussion response.
-        boolean hasAnyOutput = lastOutput.keySet().stream()
-                .anyMatch(k -> k instanceof String s &&
-                        (s.startsWith("output") || s.startsWith("reply")));
-        if (!hasAnyOutput) {
-            return null;
-        }
-
-        // Fallback: serialize the entire output map
-        return lastOutput.toString();
+        // No recognizable text found in any standard format.
+        // The output map may only contain pipeline metadata
+        // (e.g. "actions", "input", "context", or "output" with null items).
+        // Return null to avoid serializing raw metadata as a group
+        // discussion response — the toString() fallback produced
+        // unreadable Java map dumps in the UI.
+        LOGGER.debugf("No extractable text from conversation output keys: %s",
+                lastOutput.keySet());
+        return null;
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.memory;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.modules.output.model.OutputItem;
+import ai.labs.eddi.utils.RuntimeUtilities;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
@@ -28,8 +29,8 @@ import java.util.Map;
  * <li>Flat keys like {@code output:text:*} — legacy format</li>
  * <li>{@code reply} key — String or List of Strings</li>
  * </ol>
- * Returns {@code null} when no recognizable text is found (e.g., the output
- * map contains only pipeline metadata like actions, context, or expressions).
+ * Returns {@code null} when no recognizable text is found (e.g., the output map
+ * contains only pipeline metadata like actions, context, or expressions).
  *
  * @since 6.0.0
  */
@@ -51,13 +52,10 @@ public final class ConversationOutputExtractor {
      *         (e.g., pipeline metadata only)
      */
     public static String extractResponse(SimpleConversationMemorySnapshot snapshot) {
-        if (snapshot == null || snapshot.getConversationOutputs() == null) {
+        if (snapshot == null || RuntimeUtilities.isNullOrEmpty(snapshot.getConversationOutputs())) {
             return null;
         }
         List<ConversationOutput> outputs = snapshot.getConversationOutputs();
-        if (outputs.isEmpty()) {
-            return null;
-        }
         ConversationOutput lastOutput = outputs.get(outputs.size() - 1);
         if (lastOutput == null) {
             return null;
@@ -69,25 +67,23 @@ public final class ConversationOutputExtractor {
         Object outputValue = lastOutput.get("output");
         if (outputValue instanceof List<?> list) {
             for (var item : list) {
-                if (item instanceof String s) {
+                if (item instanceof String s && hasText(s)) {
                     texts.add(s);
-                } else if (item instanceof OutputItem oi && oi.toString() != null) {
-                    // TextOutputItem.toString() returns the text field
+                } else if (item instanceof OutputItem oi && hasText(oi.toString())) {
                     texts.add(oi.toString());
-                } else if (item instanceof Map<?, ?> map) {
-                    Object text = map.get("text");
-                    if (text instanceof String s) {
-                        texts.add(s);
-                    }
+                } else if (item instanceof Map<?, ?> map
+                        && map.get("text") instanceof String s && hasText(s)) {
+                    texts.add(s);
                 }
             }
             if (!texts.isEmpty()) {
                 return String.join("\n", texts);
             }
-        } else if (outputValue instanceof String s && !s.isBlank()) {
+        } else if (outputValue instanceof String s && hasText(s)) {
             // Plain string written via addConversationOutputString("output", ...)
             return s;
-        } else if (outputValue instanceof Map<?, ?> map && map.get("text") instanceof String s) {
+        } else if (outputValue instanceof Map<?, ?> map
+                && map.get("text") instanceof String s && hasText(s)) {
             return s;
         }
 
@@ -95,16 +91,18 @@ public final class ConversationOutputExtractor {
         for (var entry : lastOutput.entrySet()) {
             if (entry.getKey() instanceof String key && key.startsWith("output:text:")) {
                 Object val = entry.getValue();
-                if (val instanceof String s) {
+                if (val instanceof String s && hasText(s)) {
                     texts.add(s);
                 } else if (val instanceof List<?> list) {
                     for (var item : list) {
-                        if (item instanceof String s)
+                        if (item instanceof String s && hasText(s))
                             texts.add(s);
-                        else if (item instanceof Map<?, ?> map && map.get("text") instanceof String s)
+                        else if (item instanceof Map<?, ?> map
+                                && map.get("text") instanceof String s && hasText(s))
                             texts.add(s);
                     }
-                } else if (val instanceof Map<?, ?> map && map.get("text") instanceof String s) {
+                } else if (val instanceof Map<?, ?> map
+                        && map.get("text") instanceof String s && hasText(s)) {
                     texts.add(s);
                 }
             }
@@ -116,11 +114,12 @@ public final class ConversationOutputExtractor {
 
         // Format 3: "reply" key — used by some task extensions
         Object replyValue = lastOutput.get("reply");
-        if (replyValue instanceof String s && !s.isBlank()) {
+        if (replyValue instanceof String s && hasText(s)) {
             return s;
         } else if (replyValue instanceof List<?> list) {
             for (var item : list) {
-                if (item instanceof String s) texts.add(s);
+                if (item instanceof String s && hasText(s))
+                    texts.add(s);
             }
             if (!texts.isEmpty()) {
                 return String.join("\n", texts);
@@ -136,5 +135,15 @@ public final class ConversationOutputExtractor {
         LOGGER.debugf("No extractable text from conversation output keys: %s",
                 lastOutput.keySet());
         return null;
+    }
+
+    /**
+     * Returns {@code true} if the string is non-null, non-empty, and not
+     * purely whitespace. Combines {@link RuntimeUtilities#isNullOrEmpty}
+     * with an additional blank check to avoid treating whitespace-only
+     * content as meaningful agent output.
+     */
+    private static boolean hasText(String s) {
+        return !RuntimeUtilities.isNullOrEmpty(s) && !s.isBlank();
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
@@ -20,11 +20,13 @@ import java.util.Map;
  * {@code ConverseWithAgentTool}.
  *
  * <p>
- * Handles two output formats:
+ * Handles multiple output formats:
  * <ol>
  * <li>Nested {@code output} array — items may be plain Strings,
  * {@link OutputItem} POJOs, or Maps with a {@code text} key</li>
+ * <li>Plain {@code output} value — String or Map with {@code text} key</li>
  * <li>Flat keys like {@code output:text:*} — legacy format</li>
+ * <li>{@code reply} key — String or List of Strings</li>
  * </ol>
  * Returns {@code null} when no recognizable text is found (e.g., the output
  * map contains only pipeline metadata like actions, context, or expressions).
@@ -64,8 +66,8 @@ public final class ConversationOutputExtractor {
         var texts = new ArrayList<String>();
 
         // Format 1: Nested "output" array — may contain TextOutputItem POJOs or Maps
-        Object outputArray = lastOutput.get("output");
-        if (outputArray instanceof List<?> list) {
+        Object outputValue = lastOutput.get("output");
+        if (outputValue instanceof List<?> list) {
             for (var item : list) {
                 if (item instanceof String s) {
                     texts.add(s);
@@ -82,6 +84,11 @@ public final class ConversationOutputExtractor {
             if (!texts.isEmpty()) {
                 return String.join("\n", texts);
             }
+        } else if (outputValue instanceof String s && !s.isBlank()) {
+            // Plain string written via addConversationOutputString("output", ...)
+            return s;
+        } else if (outputValue instanceof Map<?, ?> map && map.get("text") instanceof String s) {
+            return s;
         }
 
         // Format 2: Flat keys like "output:text:*"
@@ -105,6 +112,19 @@ public final class ConversationOutputExtractor {
 
         if (!texts.isEmpty()) {
             return String.join("\n", texts);
+        }
+
+        // Format 3: "reply" key — used by some task extensions
+        Object replyValue = lastOutput.get("reply");
+        if (replyValue instanceof String s && !s.isBlank()) {
+            return s;
+        } else if (replyValue instanceof List<?> list) {
+            for (var item : list) {
+                if (item instanceof String s) texts.add(s);
+            }
+            if (!texts.isEmpty()) {
+                return String.join("\n", texts);
+            }
         }
 
         // No recognizable text found in any standard format.

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
@@ -6,7 +6,7 @@ package ai.labs.eddi.engine.memory;
 
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
-import ai.labs.eddi.modules.output.model.OutputItem;
+import ai.labs.eddi.modules.output.model.types.TextOutputItem;
 import ai.labs.eddi.utils.RuntimeUtilities;
 import org.jboss.logging.Logger;
 
@@ -24,7 +24,7 @@ import java.util.Map;
  * Handles multiple output formats:
  * <ol>
  * <li>Nested {@code output} array — items may be plain Strings,
- * {@link OutputItem} POJOs, or Maps with a {@code text} key</li>
+ * {@link TextOutputItem} POJOs, or Maps with a {@code text} key</li>
  * <li>Plain {@code output} value — String or Map with {@code text} key</li>
  * <li>Flat keys like {@code output:text:*} — legacy format</li>
  * <li>{@code reply} key — String or List of Strings</li>
@@ -69,8 +69,8 @@ public final class ConversationOutputExtractor {
             for (var item : list) {
                 if (item instanceof String s && hasText(s)) {
                     texts.add(s);
-                } else if (item instanceof OutputItem oi && hasText(oi.toString())) {
-                    texts.add(oi.toString());
+                } else if (item instanceof TextOutputItem toi && hasText(toi.getText())) {
+                    texts.add(toi.getText());
                 } else if (item instanceof Map<?, ?> map
                         && map.get("text") instanceof String s && hasText(s)) {
                     texts.add(s);

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceBranchCoverageTest.java
@@ -373,13 +373,23 @@ class GroupConversationServiceBranchCoverageTest {
             cfg.setModeratorAgentId("mod");
             setupStore(cfg);
 
+            // Exact production scenario: output list contains a null item
+            var nullList = new LinkedList<>(List.of((Object) "placeholder"));
+            nullList.set(0, null); // output=[null]
             Map<String, Object> outputMap = new LinkedHashMap<>();
-            outputMap.put("output", 42); // Not a list — extractor returns null
+            outputMap.put("output", nullList);
+            outputMap.put("actions", List.of("send_message", "unknown"));
             stubAgentWithOutputMap("a1", outputMap);
             stubAgent("mod", "Synthesis");
 
             var result = service.discuss(GROUP_ID, QUESTION, USER_ID, 0);
             assertEquals(GroupConversationState.COMPLETED, result.getState());
+            // The a1 transcript entry must have empty content, not raw metadata
+            result.getTranscript().stream()
+                    .filter(e -> "a1".equals(e.speakerAgentId()))
+                    .forEach(e -> assertTrue(
+                            e.content() == null || e.content().isEmpty(),
+                            "Transcript should not contain raw metadata dump, got: " + e.content()));
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceBranchCoverageTest.java
@@ -385,11 +385,13 @@ class GroupConversationServiceBranchCoverageTest {
             var result = service.discuss(GROUP_ID, QUESTION, USER_ID, 0);
             assertEquals(GroupConversationState.COMPLETED, result.getState());
             // The a1 transcript entry must have empty content, not raw metadata
-            result.getTranscript().stream()
+            var a1Entries = result.getTranscript().stream()
                     .filter(e -> "a1".equals(e.speakerAgentId()))
-                    .forEach(e -> assertTrue(
-                            e.content() == null || e.content().isEmpty(),
-                            "Transcript should not contain raw metadata dump, got: " + e.content()));
+                    .toList();
+            assertFalse(a1Entries.isEmpty(), "Expected a transcript entry for agent a1");
+            a1Entries.forEach(e -> assertTrue(
+                    e.content() == null || e.content().isEmpty(),
+                    "Transcript should not contain raw metadata dump, got: " + e.content()));
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceBranchCoverageTest.java
@@ -366,21 +366,17 @@ class GroupConversationServiceBranchCoverageTest {
         }
 
         @Test
-        @DisplayName("should handle serialize exception by falling back to toString")
-        void serializeException() throws Exception {
+        @DisplayName("should complete gracefully when output has no extractable text")
+        void noExtractableText() throws Exception {
             var cfg = config(DiscussionStyle.ROUND_TABLE, 1,
                     new GroupMember("a1", "Alice", 1, null));
             cfg.setModeratorAgentId("mod");
             setupStore(cfg);
 
             Map<String, Object> outputMap = new LinkedHashMap<>();
-            outputMap.put("output", 42); // Not a list, forces fallback
+            outputMap.put("output", 42); // Not a list — extractor returns null
             stubAgentWithOutputMap("a1", outputMap);
             stubAgent("mod", "Synthesis");
-
-            // serialize throws
-            when(jsonSerialization.serialize(any()))
-                    .thenThrow(new RuntimeException("serialize failed"));
 
             var result = service.discuss(GROUP_ID, QUESTION, USER_ID, 0);
             assertEquals(GroupConversationState.COMPLETED, result.getState());

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTest.java
@@ -807,22 +807,18 @@ class GroupConversationServiceTest {
         }
 
         @Test
-        void hasOutputKeyButNoTexts_fallsBackToToString() throws Exception {
+        void hasOutputKeyButNoTexts_returnsEmpty() throws Exception {
             var snapshot = new SimpleConversationMemorySnapshot();
             var output = new ConversationOutput();
-            // Has an "output" key prefix but doesn't yield any text via known formats
-            output.put("outputUnknown", "value"); // Doesn't match the patterns
-            // But we need a key starting with "output" to pass the hasAnyOutput check
+            // Has keys that don't match any extraction format
+            output.put("outputUnknown", "value");
             output.put("output-status", "done");
             snapshot.setConversationOutputs(new LinkedList<>(List.of(output)));
 
-            // ConversationOutputExtractor uses toString() fallback (no
-            // jsonSerialization dependency). Just verify non-null and
-            // contains output key content.
-            String result = invoke(snapshot);
-            assertNotNull(result, "Should fall back to toString()");
-            assertTrue(result.contains("output-status"), "Fallback should include output key");
-            assertTrue(result.contains("done"), "Fallback should include value");
+            // ConversationOutputExtractor returns null (no recognizable text),
+            // GCS wrapper converts null → "" for backward compat.
+            assertEquals("", invoke(snapshot),
+                    "Unrecognized output keys should produce empty string, not a toString() dump");
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationOutputExtractorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationOutputExtractorTest.java
@@ -142,6 +142,56 @@ class ConversationOutputExtractorTest {
                 "output=[null] should return null, not dump raw metadata");
     }
 
+    // --- Format 1b: Plain "output" value (String or Map) ---
+
+    @Test
+    void extractResponse_outputAsPlainString() {
+        var output = new ConversationOutput();
+        output.put("output", "Direct string response");
+        var snapshot = snapshotWith(output);
+
+        assertEquals("Direct string response", ConversationOutputExtractor.extractResponse(snapshot));
+    }
+
+    @Test
+    void extractResponse_outputAsMapWithTextKey() {
+        var output = new ConversationOutput();
+        output.put("output", Map.of("text", "From output map"));
+        var snapshot = snapshotWith(output);
+
+        assertEquals("From output map", ConversationOutputExtractor.extractResponse(snapshot));
+    }
+
+    @Test
+    void extractResponse_blankOutputString_returnsNull() {
+        var output = new ConversationOutput();
+        output.put("output", "   ");
+        var snapshot = snapshotWith(output);
+
+        assertNull(ConversationOutputExtractor.extractResponse(snapshot),
+                "Blank output string should not be treated as meaningful text");
+    }
+
+    // --- Format 3: "reply" key ---
+
+    @Test
+    void extractResponse_replyAsString() {
+        var output = new ConversationOutput();
+        output.put("reply", "Reply text");
+        var snapshot = snapshotWith(output);
+
+        assertEquals("Reply text", ConversationOutputExtractor.extractResponse(snapshot));
+    }
+
+    @Test
+    void extractResponse_replyAsList() {
+        var output = new ConversationOutput();
+        output.put("reply", List.of("Reply line 1", "Reply line 2"));
+        var snapshot = snapshotWith(output);
+
+        assertEquals("Reply line 1\nReply line 2", ConversationOutputExtractor.extractResponse(snapshot));
+    }
+
     // --- Multiple outputs: always uses the LAST one ---
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationOutputExtractorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationOutputExtractorTest.java
@@ -192,6 +192,46 @@ class ConversationOutputExtractorTest {
         assertEquals("Reply line 1\nReply line 2", ConversationOutputExtractor.extractResponse(snapshot));
     }
 
+    @Test
+    void extractResponse_blankReplyString_returnsNull() {
+        var output = new ConversationOutput();
+        output.put("reply", "   ");
+        var snapshot = snapshotWith(output);
+
+        assertNull(ConversationOutputExtractor.extractResponse(snapshot),
+                "Blank reply string should not be treated as meaningful text");
+    }
+
+    @Test
+    void extractResponse_replyListWithOnlyBlankItems_returnsNull() {
+        var output = new ConversationOutput();
+        output.put("reply", List.of("  ", "\t"));
+        var snapshot = snapshotWith(output);
+
+        assertNull(ConversationOutputExtractor.extractResponse(snapshot),
+                "Reply list containing only blank strings should return null");
+    }
+
+    @Test
+    void extractResponse_outputMapWithBlankText_returnsNull() {
+        var output = new ConversationOutput();
+        output.put("output", Map.of("text", "   "));
+        var snapshot = snapshotWith(output);
+
+        assertNull(ConversationOutputExtractor.extractResponse(snapshot),
+                "Map with blank text value should not be treated as meaningful text");
+    }
+
+    @Test
+    void extractResponse_outputListWithBlankMapText_returnsNull() {
+        var output = new ConversationOutput();
+        output.put("output", List.of(Map.of("text", "   ")));
+        var snapshot = snapshotWith(output);
+
+        assertNull(ConversationOutputExtractor.extractResponse(snapshot),
+                "List item Map with blank text should not produce output");
+    }
+
     // --- Multiple outputs: always uses the LAST one ---
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationOutputExtractorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationOutputExtractorTest.java
@@ -131,7 +131,7 @@ class ConversationOutputExtractorTest {
         // This is the exact scenario from production: the pipeline produces
         // output=[null] when the langchain step has no output extension to
         // copy the LLM response into conversationOutputs.
-        var nullList = new java.util.ArrayList<>();
+        var nullList = new LinkedList<>();
         nullList.add(null);
         var output = new ConversationOutput();
         output.put("output", nullList);

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationOutputExtractorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationOutputExtractorTest.java
@@ -113,18 +113,33 @@ class ConversationOutputExtractorTest {
         assertNull(ConversationOutputExtractor.extractResponse(snapshot));
     }
 
-    // --- Fallback: output key exists but not extractable as text ---
+    // --- No extractable text: output key exists but content is not text ---
 
     @Test
-    void extractResponse_fallbackToString() {
+    void extractResponse_nonListOutputKey_returnsNull() {
         var output = new ConversationOutput();
         output.put("output", 42); // Not a List → falls through format 1
         var snapshot = snapshotWith(output);
 
-        // Should hit fallback toString() because "output" key exists
-        String result = ConversationOutputExtractor.extractResponse(snapshot);
-        assertNotNull(result, "Should fall back to toString()");
-        assertTrue(result.contains("output"), "Fallback should include the output key");
+        // No recognizable text format → should return null, not toString()
+        assertNull(ConversationOutputExtractor.extractResponse(snapshot),
+                "Non-list output value should not produce a toString() dump");
+    }
+
+    @Test
+    void extractResponse_outputListWithNullItems_returnsNull() {
+        // This is the exact scenario from production: the pipeline produces
+        // output=[null] when the langchain step has no output extension to
+        // copy the LLM response into conversationOutputs.
+        var nullList = new java.util.ArrayList<>();
+        nullList.add(null);
+        var output = new ConversationOutput();
+        output.put("output", nullList);
+        output.put("actions", List.of("send_message", "unknown"));
+        var snapshot = snapshotWith(output);
+
+        assertNull(ConversationOutputExtractor.extractResponse(snapshot),
+                "output=[null] should return null, not dump raw metadata");
     }
 
     // --- Multiple outputs: always uses the LAST one ---


### PR DESCRIPTION
## Summary

When the agent pipeline produces output=[null] (no LLM text), the extractor fell through to lastOutput.toString() which dumped the entire ConversationOutput map (context, actions, parser expressions) as the group transcript content. Now returns null instead, so the group shows an empty entry rather than raw Java metadata.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, CI changes, etc.)

## Checklist

- [X] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [X] I have added tests that prove my fix/feature works
- [X] Existing tests pass locally (`./mvnw clean verify -DskipITs`)
- [X] I have updated documentation if needed
- [X] My commit messages follow [conventional commits](CONTRIBUTING.md#commit-convention)
- [X] I have not committed any secrets, API keys, or tokens
- [X] This PR has a clear, focused scope (one concern per PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded conversation response extraction to handle additional `output`/`reply` shapes, including nested `output` arrays and `text`-wrapped values.
* **Bug Fixes**
  * Removed the legacy fallback that could expose unsupported/unextractable output payloads as raw metadata.
  * Extraction now returns no content when `output` exists but contains non-text or only blank/whitespace values.
* **Tests**
  * Updated and extended coverage for string/map/list and blank-value scenarios, including revised group conversation fallback expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->