### PR TITLE
fix(llm): don't re-cache a model built while a secret rotation lands mid-build

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,27 @@
 
 ---
 
+## 🧵 Model registry: a rotation landing mid-build could re-cache a stale model (2026-07-23)
+
+**Repo:** EDDI (`fix/chatmodel-stale-rebuild-race`)
+
+CodeRabbit flagged this on the `fix/backlog-defect-remediation` PR (Major / "Heavy lift") and it was deliberately deferred from that branch. It is **separate** from the `C1` check-then-act race fixed there (commit `96eacacde`, which stopped a concurrent `clear()` turning a cache *hit* into a `null` return).
+
+**The defect.** `getOrCreate`/`getOrCreateStreaming` resolve global-variable and vault-secret values, build a model from them, and then `put` it into the cache — all unsynchronised. A secret rotation (`invalidateForSecret` → `clear()`/`evictMatching`) or a global-variable edit (the invalidation listener → `clear()`) can land **between the resolve and the `put`**. The `clear()` finds nothing (the entry does not exist yet), and the in-flight build then `put`s a model constructed from the **now-stale** secret. Because the entry is present and valid-looking, every later turn keeps reusing that pre-rotation model until some *unrelated* invalidation happens to evict it — i.e. a rotation could silently fail to take effect.
+
+**The fix — an invalidation generation.** A process-wide `AtomicLong invalidationGeneration` is bumped by every invalidation (`invalidateForSecret` for both the bulk-clear and targeted-`evictMatching` paths, and the global-variable listener). A build snapshots the generation *before* it resolves any value, and publishes through `publishIfCurrent`, which caches the model **only if the generation is unchanged**; otherwise it discards it (the racing caller still receives the instance for its own turn — a one-turn window inherent to lock-free building — but the next lookup misses and rebuilds from current values). The re-check and the `put` are held under a new `publishLock` that the invalidation paths also hold around their bump-and-clear, so "re-check then put" and "bump then clear" cannot interleave — without that lock the re-check would itself be a check-then-act with the same hole.
+
+**Design decisions:**
+
+- **Do-not-cache rather than rebuild-and-retry.** CodeRabbit suggested "discard and rebuild (or at least do not cache)". Not caching fully closes the reported bug (persistent staleness) with no unbounded-retry surface under an invalidation storm; the residual one-turn exposure of the racing caller is fundamental to building without holding a lock across the whole (potentially slow) provider build.
+- **The generation is a coarse, registry-wide signal.** An invalidation for an unrelated secret still bumps it, so a concurrent build may be rebuilt needlessly — wasteful but always correct, and far simpler than trying to match the in-flight build against the specific rotated reference. Invalidations are rare.
+- **`publishLock` scope is minimal.** Builds (the expensive part) stay fully concurrent; the lock covers only the cheap re-check+`put` and the clear/evict. Both resolvers fire their listeners outside any lock, so taking `publishLock` in the callbacks introduces no lock-ordering/deadlock risk, and no path holds `publishLock` while calling back into a resolver.
+- **The counter is registry state, not conversation state.** The class stays `@ApplicationScoped` and per-conversation-stateless; the generation and lock are process-global memoization-cache concerns, which is the correct home for them.
+
+**Tests:** `ChatModelRegistryTest` gains a nested `StaleRebuildDuringInvalidationTests` (C5) with a sync and a streaming case. Each installs a builder that fires `invalidateForSecret(null)` from inside `build()`/`buildStreaming()` — deterministically the interleaving "clear lands between build-start and publish" — then asserts the racing model is **not** served to the next caller (it rebuilds) and that caching resumes normally afterwards, with an exact build-count assertion. Mutation-checked twice: against the pre-fix code both tests fail with `expected: not same but was: <same instance>`, and reverting only the generation guard in `publishIfCurrent` (unconditional `put`) fails exactly those two tests and no others.
+
+---
+
 ## 🧪 De-vacuum three tests and fix a doc/fixture drift (2026-07-23)
 
 **Repo:** EDDI (`fix/backlog-defect-remediation`)

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ChatModelRegistry.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ChatModelRegistry.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Manages ChatModel creation, caching, and lookup by type and parameters.
@@ -52,6 +53,27 @@ public class ChatModelRegistry {
     private final Map<ModelCacheKey, ChatModel> modelCache = new ConcurrentHashMap<>(1);
     private final Map<ModelCacheKey, StreamingChatModel> streamingModelCache = new ConcurrentHashMap<>(1);
 
+    /**
+     * Bumped by every cache invalidation — secret rotation, targeted secret
+     * eviction, and global-variable edits. A build snapshots this before it
+     * resolves any global or vault value and re-checks it before publishing, so a
+     * model built from values that a concurrent invalidation has since made stale
+     * is never cached. This is process-wide registry state, not per-conversation
+     * state, so it is safe on this singleton.
+     */
+    private final AtomicLong invalidationGeneration = new AtomicLong();
+
+    /**
+     * Serializes a build's publish decision against a concurrent invalidation. The
+     * publish path holds it for "re-check the generation, then {@code put}"; every
+     * invalidation path holds it for "bump the generation, then
+     * {@code clear}/evict". Without it the re-check would itself be a
+     * check-then-act — an invalidation landing between the check and the
+     * {@code put} would leave a stale model cached — which is exactly the defect
+     * this guards against.
+     */
+    private final Object publishLock = new Object();
+
     @Inject
     ChatModelRegistry(Map<String, Provider<ILanguageModelBuilder>> languageModelApiConnectorBuilders,
             GlobalVariableResolver globalVariableResolver, SecretResolver secretResolver) {
@@ -70,11 +92,14 @@ public class ChatModelRegistry {
     void registerSecretInvalidation() {
         secretResolver.registerInvalidationListener(this::invalidateForSecret);
         globalVariableResolver.registerInvalidationListener(() -> {
-            int total = modelCache.size() + streamingModelCache.size();
-            modelCache.clear();
-            streamingModelCache.clear();
-            if (total > 0) {
-                LOGGER.infof("Invalidated all %d model(s) due to global variable change", total);
+            synchronized (publishLock) {
+                invalidationGeneration.incrementAndGet();
+                int total = modelCache.size() + streamingModelCache.size();
+                modelCache.clear();
+                streamingModelCache.clear();
+                if (total > 0) {
+                    LOGGER.infof("Invalidated all %d model(s) due to global variable change", total);
+                }
             }
         });
         LOGGER.info("ChatModelRegistry registered for secret and global variable invalidation events");
@@ -96,6 +121,9 @@ public class ChatModelRegistry {
      * global variable edits), and a clear landing between the two calls made this
      * method return {@code null} to callers that hand the result straight to
      * {@code chat(...)}. A miss simply falls through to construction.
+     * <p>
+     * A freshly built model is published to the cache only if no invalidation raced
+     * the build — see {@link #publishIfCurrent}.
      */
     ChatModel getOrCreate(String type, Map<String, String> processedParams) throws UnsupportedLlmTaskException {
 
@@ -117,13 +145,19 @@ public class ChatModelRegistry {
 
         warnAboutRejectedTimeout(type, processedParams.get(KEY_TIMEOUT), timeoutMs);
 
+        // Snapshot the invalidation generation BEFORE resolving values: it is the
+        // resolved global/secret values that a concurrent rotation or edit makes stale,
+        // so publishIfCurrent refuses to cache this model if the generation moves while
+        // it is being built.
+        long generationAtBuildStart = invalidationGeneration.get();
+
         // Resolve global variable references, then vault secrets (late-binding:
         // after Qute, before builder.build())
         var resolvedParams = globalVariableResolver.resolveAll(builderParams(filteredParams));
         resolvedParams = secretResolver.resolveSecrets(resolvedParams);
         var rawModel = languageModelApiConnectorBuilders.get(type).get().build(resolvedParams);
         var model = ObservableChatModel.wrapIfNeeded(rawModel, type, timeoutMs, logReq, logResp);
-        modelCache.put(cacheKey, model);
+        publishIfCurrent(modelCache, cacheKey, model, generationAtBuildStart);
 
         return model;
     }
@@ -163,17 +197,53 @@ public class ChatModelRegistry {
         warnAboutRejectedTimeout(type, processedParams.get(KEY_TIMEOUT), filteredParams.get(KEY_TIMEOUT));
 
         try {
+            // Snapshot the invalidation generation before resolving values a concurrent
+            // invalidation could make stale (see publishIfCurrent), as on the sync path.
+            long generationAtBuildStart = invalidationGeneration.get();
+
             // Resolve global variable references, then vault secrets (late-binding:
             // after Qute, before builder.build())
             var resolvedParams = globalVariableResolver.resolveAll(builderParams(filteredParams));
             resolvedParams = secretResolver.resolveSecrets(resolvedParams);
             var rawModel = languageModelApiConnectorBuilders.get(type).get().buildStreaming(resolvedParams);
             var model = ObservableStreamingChatModel.wrapIfNeeded(rawModel, type, logReq, logResp);
-            streamingModelCache.put(cacheKey, model);
+            publishIfCurrent(streamingModelCache, cacheKey, model, generationAtBuildStart);
             return model;
         } catch (UnsupportedOperationException e) {
             LOGGER.debugf("Streaming not supported for type '%s', falling back to sync", type);
             return null;
+        }
+    }
+
+    /**
+     * Publish a freshly built model to its cache only if no invalidation has
+     * occurred since the build started.
+     * <p>
+     * The model was constructed from global-variable and vault-secret values
+     * resolved after {@code generationAtBuildStart} was snapshotted. If the
+     * generation has moved since, a secret rotation or global-variable edit landed
+     * while the model was being built, so those resolved values — and therefore
+     * this model — may be stale: it must not enter the cache, where later turns
+     * would keep reusing it until the next unrelated invalidation. The current
+     * caller still receives this instance for its own turn (its build began before
+     * the rotation committed — an unavoidable, one-turn window); the next lookup
+     * misses and rebuilds from current values.
+     * <p>
+     * The re-check and the {@code put} run under {@link #publishLock}, which every
+     * invalidation path also holds around its generation bump and clear/evict, so
+     * the two cannot interleave — closing the check-then-act window that a bare
+     * re-check would leave open. The generation is a coarse, registry-wide signal:
+     * an unrelated invalidation may cause a model to be rebuilt needlessly, which
+     * is wasteful but always correct.
+     */
+    private <T> void publishIfCurrent(Map<ModelCacheKey, T> cache, ModelCacheKey cacheKey, T model,
+                                      long generationAtBuildStart) {
+        synchronized (publishLock) {
+            if (invalidationGeneration.get() == generationAtBuildStart) {
+                cache.put(cacheKey, model);
+            } else {
+                LOGGER.debugf("Model built while an invalidation landed — not caching it; the next use rebuilds");
+            }
         }
     }
 
@@ -280,43 +350,53 @@ public class ChatModelRegistry {
      * <p>
      * When {@code reference} is null (DEK/KEK rotation — all secrets affected),
      * clear everything.
+     * <p>
+     * The whole event runs under {@link #publishLock} and first bumps
+     * {@link #invalidationGeneration}, so a build whose secret resolution overlaps
+     * this rotation cannot publish its now-stale model afterwards (see
+     * {@link #publishIfCurrent}). One bump covers both the full-clear and the
+     * targeted {@link #evictMatching} paths.
      *
      * @param reference
      *            the changed secret, or null for full invalidation
      */
     void invalidateForSecret(SecretReference reference) {
-        if (reference == null) {
-            // Full invalidation (DEK/KEK rotation)
-            int total = modelCache.size() + streamingModelCache.size();
-            modelCache.clear();
-            streamingModelCache.clear();
-            if (total > 0) {
-                LOGGER.infof("Invalidated all %d model(s) due to bulk secret rotation", total);
+        synchronized (publishLock) {
+            invalidationGeneration.incrementAndGet();
+
+            if (reference == null) {
+                // Full invalidation (DEK/KEK rotation)
+                int total = modelCache.size() + streamingModelCache.size();
+                modelCache.clear();
+                streamingModelCache.clear();
+                if (total > 0) {
+                    LOGGER.infof("Invalidated all %d model(s) due to bulk secret rotation", total);
+                }
+                return;
             }
-            return;
-        }
 
-        // Build the vault reference forms to search for in cached parameters.
-        // New canonical form: ${vault:tenantId/keyName} — always valid
-        String fullRef = "${vault:" + reference.tenantId() + "/" + reference.keyName() + "}";
-        // Legacy form: ${eddivault:tenantId/keyName} — for backward compat
-        String legacyFullRef = "${eddivault:" + reference.tenantId() + "/" + reference.keyName() + "}";
-        // Short form: ${vault:keyName} — only valid for the default tenant.
-        // The short form always resolves to "default", so a non-default tenant's
-        // secret must NOT match short-form references (that would be a false positive).
-        String shortRef = SecretReference.DEFAULT_TENANT.equals(reference.tenantId())
-                ? "${vault:" + reference.keyName() + "}"
-                : null;
-        String legacyShortRef = SecretReference.DEFAULT_TENANT.equals(reference.tenantId())
-                ? "${eddivault:" + reference.keyName() + "}"
-                : null;
+            // Build the vault reference forms to search for in cached parameters.
+            // New canonical form: ${vault:tenantId/keyName} — always valid
+            String fullRef = "${vault:" + reference.tenantId() + "/" + reference.keyName() + "}";
+            // Legacy form: ${eddivault:tenantId/keyName} — for backward compat
+            String legacyFullRef = "${eddivault:" + reference.tenantId() + "/" + reference.keyName() + "}";
+            // Short form: ${vault:keyName} — only valid for the default tenant.
+            // The short form always resolves to "default", so a non-default tenant's
+            // secret must NOT match short-form references (that would be a false positive).
+            String shortRef = SecretReference.DEFAULT_TENANT.equals(reference.tenantId())
+                    ? "${vault:" + reference.keyName() + "}"
+                    : null;
+            String legacyShortRef = SecretReference.DEFAULT_TENANT.equals(reference.tenantId())
+                    ? "${eddivault:" + reference.keyName() + "}"
+                    : null;
 
-        int evicted = evictMatching(modelCache, fullRef, legacyFullRef, shortRef, legacyShortRef)
-                + evictMatching(streamingModelCache, fullRef, legacyFullRef, shortRef, legacyShortRef);
+            int evicted = evictMatching(modelCache, fullRef, legacyFullRef, shortRef, legacyShortRef)
+                    + evictMatching(streamingModelCache, fullRef, legacyFullRef, shortRef, legacyShortRef);
 
-        if (evicted > 0) {
-            LOGGER.infof("Evicted %d model(s) using secret '%s/%s'",
-                    evicted, sanitize(reference.tenantId()), sanitize(reference.keyName()));
+            if (evicted > 0) {
+                LOGGER.infof("Evicted %d model(s) using secret '%s/%s'",
+                        evicted, sanitize(reference.tenantId()), sanitize(reference.keyName()));
+            }
         }
     }
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/ChatModelRegistryTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/ChatModelRegistryTest.java
@@ -158,6 +158,20 @@ class ChatModelRegistryTest {
         }
     }
 
+    /**
+     * A registry wired with pass-through secret/global resolvers and
+     * caller-supplied builders. Used by tests that need a builder with custom
+     * behaviour — e.g. one that triggers an invalidation from inside
+     * {@code build()} to race the publish.
+     */
+    private static ChatModelRegistry passThroughRegistry(Map<String, Provider<ILanguageModelBuilder>> builders) {
+        SecretResolver secretResolver = mock(SecretResolver.class);
+        when(secretResolver.resolveSecrets(any())).thenAnswer(inv -> inv.getArgument(0));
+        GlobalVariableResolver globalVariableResolver = mock(GlobalVariableResolver.class);
+        when(globalVariableResolver.resolveAll(any())).thenAnswer(inv -> inv.getArgument(0));
+        return new ChatModelRegistry(builders, globalVariableResolver, secretResolver);
+    }
+
     @Nested
     @DisplayName("Sync model tests")
     class SyncTests {
@@ -858,6 +872,134 @@ class ChatModelRegistryTest {
             StreamingChatModel streamRebuilt = invalidationRegistry.getOrCreateStreaming("openai", params);
             assertNotSame(syncOriginal, syncRebuilt, "Sync model should be evicted and rebuilt");
             assertNotSame(streamOriginal, streamRebuilt, "Streaming model should be evicted and rebuilt");
+        }
+    }
+
+    /**
+     * A defect distinct from the {@code C1} check-then-act race (which was about a
+     * concurrent {@code clear()} turning a cache <em>hit</em> into a {@code null}).
+     * <p>
+     * A secret rotation ({@link ChatModelRegistry#invalidateForSecret}) or a
+     * global-variable edit (the invalidation listener) can land <em>while a build
+     * is in flight</em> — after {@code getOrCreate}/{@code getOrCreateStreaming}
+     * has resolved the (now about-to-be-stale) global and vault values, but before
+     * it publishes the finished model. The old code then cached that model
+     * unconditionally, so every later turn kept reusing a model built from the
+     * pre-rotation secret until some unrelated invalidation happened to evict it —
+     * i.e. a rotation could silently fail to take effect.
+     * <p>
+     * The fix snapshots an invalidation generation before resolving values and
+     * refuses to publish the model if the generation moved while it was being
+     * built. These tests make the interleaving deterministic by triggering the
+     * invalidation from inside the builder — exactly between the generation
+     * snapshot and the publish. The racing caller still receives its freshly built
+     * instance; what must not happen is that instance being served to the
+     * <em>next</em> caller from the cache.
+     */
+    @Nested
+    @DisplayName("A model built while an invalidation lands is not cached as stale (C5)")
+    class StaleRebuildDuringInvalidationTests {
+
+        @Test
+        @DisplayName("sync: a rotation landing mid-build is discarded, not cached")
+        void getOrCreate_invalidationDuringBuild_isNotCached() throws Exception {
+            var buildCount = new AtomicInteger();
+            var registryRef = new AtomicReference<ChatModelRegistry>();
+
+            Map<String, Provider<ILanguageModelBuilder>> builders = new HashMap<>();
+            builders.put("openai", () -> new ILanguageModelBuilder() {
+                @Override
+                public ChatModel build(Map<String, String> parameters) {
+                    // Only the first build races an invalidation: a secret rotation lands
+                    // after the generation was snapshotted but before this model is published.
+                    if (buildCount.incrementAndGet() == 1) {
+                        registryRef.get().invalidateForSecret(null);
+                    }
+                    return new ChatModel() {
+                        @Override
+                        public ChatResponse chat(List<ChatMessage> messages) {
+                            return ChatResponse.builder().aiMessage(aiMessage("ok")).build();
+                        }
+                    };
+                }
+
+                @Override
+                public StreamingChatModel buildStreaming(Map<String, String> parameters) {
+                    return new StreamingChatModel() {
+                        @Override
+                        public void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                        }
+                    };
+                }
+            });
+
+            ChatModelRegistry reg = passThroughRegistry(builders);
+            registryRef.set(reg);
+            var params = Map.of("apiKey", "${vault:openai-key}");
+
+            ChatModel racing = reg.getOrCreate("openai", params);
+            assertNotNull(racing, "the racing caller still receives its freshly built model");
+
+            ChatModel afterRace = reg.getOrCreate("openai", params);
+            assertNotSame(racing, afterRace,
+                    "a model built from values a concurrent rotation made stale must NOT be cached — "
+                            + "the next lookup must miss and rebuild");
+
+            ChatModel stable = reg.getOrCreate("openai", params);
+            assertSame(afterRace, stable, "with no further invalidation, the rebuilt model caches normally");
+
+            assertEquals(2, buildCount.get(),
+                    "exactly two builds: the discarded stale one, then the cached one — the third call is a cache hit");
+        }
+
+        @Test
+        @DisplayName("streaming: a rotation landing mid-build is discarded, not cached")
+        void getOrCreateStreaming_invalidationDuringBuild_isNotCached() throws Exception {
+            var buildCount = new AtomicInteger();
+            var registryRef = new AtomicReference<ChatModelRegistry>();
+
+            Map<String, Provider<ILanguageModelBuilder>> builders = new HashMap<>();
+            builders.put("openai", () -> new ILanguageModelBuilder() {
+                @Override
+                public ChatModel build(Map<String, String> parameters) {
+                    return new ChatModel() {
+                        @Override
+                        public ChatResponse chat(List<ChatMessage> messages) {
+                            return ChatResponse.builder().aiMessage(aiMessage("ok")).build();
+                        }
+                    };
+                }
+
+                @Override
+                public StreamingChatModel buildStreaming(Map<String, String> parameters) {
+                    // Only the first build races an invalidation, as on the sync path.
+                    if (buildCount.incrementAndGet() == 1) {
+                        registryRef.get().invalidateForSecret(null);
+                    }
+                    return new StreamingChatModel() {
+                        @Override
+                        public void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                        }
+                    };
+                }
+            });
+
+            ChatModelRegistry reg = passThroughRegistry(builders);
+            registryRef.set(reg);
+            var params = Map.of("apiKey", "${vault:openai-key}");
+
+            StreamingChatModel racing = reg.getOrCreateStreaming("openai", params);
+            assertNotNull(racing, "the racing caller still receives its freshly built streaming model");
+
+            StreamingChatModel afterRace = reg.getOrCreateStreaming("openai", params);
+            assertNotSame(racing, afterRace,
+                    "a streaming model built from values a concurrent rotation made stale must NOT be cached");
+
+            StreamingChatModel stable = reg.getOrCreateStreaming("openai", params);
+            assertSame(afterRace, stable, "with no further invalidation, the rebuilt streaming model caches normally");
+
+            assertEquals(2, buildCount.get(),
+                    "exactly two builds: the discarded stale one, then the cached one — the third call is a cache hit");
         }
     }
 }


### PR DESCRIPTION
## Problem

`ChatModelRegistry.getOrCreate` / `getOrCreateStreaming` resolve global-variable and vault-secret values, build a model from them, then `put` it into the cache — all unsynchronised. A secret rotation (`invalidateForSecret` → `clear()`/`evictMatching`) or a global-variable edit (the invalidation listener → `clear()`) can land **between the resolve and the `put`**. The `clear()` finds nothing to evict (the entry doesn't exist yet), and the in-flight build then caches a model constructed from the **now-stale** secret. Every later turn keeps reusing that pre-rotation model until some *unrelated* invalidation happens to evict it — so a rotation can silently fail to take effect.

CodeRabbit flagged this on the #606 PR (`fix/backlog-defect-remediation`), rated Major / "Heavy lift", and it was deliberately deferred from that branch. It is **separate** from the C1 check-then-act race fixed there in `96eacacde` (which stopped a concurrent `clear()` turning a cache *hit* into a `null` return).

## Fix

- A process-wide `AtomicLong invalidationGeneration`, bumped by every invalidation (`invalidateForSecret` for both the bulk-clear and targeted-`evictMatching` paths, and the global-variable listener).
- A build snapshots the generation **before** resolving any value and publishes through `publishIfCurrent`, which caches the model **only if the generation is unchanged**; otherwise it discards it. The racing caller still receives the instance for its own turn (a one-turn window inherent to lock-free building); the next lookup misses and rebuilds from current values.
- The re-check and the `put` run under a new `publishLock` that the invalidation paths also hold around their bump-and-clear, so "re-check then put" and "bump then clear" cannot interleave — closing the check-then-act window a bare re-check would leave open.

### Design notes

- **Do-not-cache rather than rebuild-and-retry** — fully closes the reported persistent-staleness bug with no unbounded-retry surface under an invalidation storm.
- **The generation is a coarse, registry-wide signal** — an unrelated invalidation may cause a needless rebuild (wasteful but always correct); invalidations are rare.
- **`publishLock` scope is minimal** — builds stay fully concurrent; the lock covers only the cheap re-check+`put` and the clear/evict. Both resolvers fire listeners outside any lock, so taking `publishLock` in the callbacks adds no lock-ordering/deadlock risk.
- The class stays `@ApplicationScoped` and per-conversation-stateless; the generation and lock are process-global memoization-cache concerns.

## Tests

`ChatModelRegistryTest` gains a nested `StaleRebuildDuringInvalidationTests` (C5) with a sync and a streaming case. Each installs a builder that fires `invalidateForSecret(null)` from inside `build()`/`buildStreaming()` — deterministically the interleaving "clear lands between build-start and publish" — then asserts the racing model is **not** served to the next caller (it rebuilds) and that caching resumes normally afterwards, with an exact build-count assertion.

Mutation-checked twice:
- against the pre-fix code both tests fail with `expected: not same but was: <same instance>`;
- reverting *only* the generation guard in `publishIfCurrent` (unconditional `put`) fails exactly those two tests and no others.

All 43 tests in the class pass (including the existing C1 tests). Formatter clean; Checkstyle introduces no new violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated chat models from being reused after secret or configuration invalidations.
  * Improved consistency for both standard and streaming model requests during concurrent updates.
  * Ensured fresh models are rebuilt when an invalidation occurs while a model is being created.
* **Tests**
  * Added coverage for concurrent invalidation scenarios across synchronous and streaming model workflows.
* **Documentation**
  * Added a changelog entry describing the cache consistency fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->