### PR TITLE
docs: add Javadoc to datastore core interfaces

### DIFF
--- a/src/main/java/ai/labs/eddi/datastore/IResourceFilter.java
+++ b/src/main/java/ai/labs/eddi/datastore/IResourceFilter.java
@@ -10,9 +10,10 @@ import java.util.List;
  * Query surface for listing resources by field, on top of the id-addressed
  * reads {@link IResourceStore} provides.
  * <p>
- * A caller passes {@link QueryFilters} groups; filters inside a group combine
- * under that group's {@link QueryFilters.ConnectingType} (AND or OR), and the
- * groups themselves are then combined. Paging is index/limit, with the same
+ * A caller passes {@link QueryFilters} groups. Filters inside a group combine
+ * under that group's {@link QueryFilters.ConnectingType} (AND or OR); the
+ * groups themselves are always combined with AND, so a group's connector never
+ * affects how it joins the other groups. Paging is index/limit, with the same
  * ceiling {@link IResourceStorage} enforces.
  * <p>
  * Used by the REST layer to back list endpoints and their search parameters.

--- a/src/main/java/ai/labs/eddi/datastore/IResourceFilter.java
+++ b/src/main/java/ai/labs/eddi/datastore/IResourceFilter.java
@@ -7,7 +7,18 @@ package ai.labs.eddi.datastore;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Query surface for listing resources by field, on top of the id-addressed
+ * reads {@link IResourceStore} provides.
+ * <p>
+ * A caller passes {@link QueryFilters} groups; filters inside a group combine
+ * under that group's {@link QueryFilters.ConnectingType} (AND or OR), and the
+ * groups themselves are then combined. Paging is index/limit, with the same
+ * ceiling {@link IResourceStorage} enforces.
+ * <p>
+ * Used by the REST layer to back list endpoints and their search parameters.
+ *
+ * @param <T>
+ *            the configuration model being queried
  */
 public interface IResourceFilter<T> {
     List<T> readResources(QueryFilters[] queryFilters, Integer index, Integer limit, String... sortTypes)

--- a/src/main/java/ai/labs/eddi/datastore/IResourceStorage.java
+++ b/src/main/java/ai/labs/eddi/datastore/IResourceStorage.java
@@ -10,7 +10,21 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Backend-facing half of the versioned store contract: raw persistence of
+ * resource revisions and their history, without the validation or interception
+ * {@link IResourceStore} adds on top.
+ * <p>
+ * Implementations are database-specific (MongoDB by default, PostgreSQL as an
+ * alternative) and are obtained through {@link IResourceStorageFactory} rather
+ * than injected directly. Reads are version-addressed, {@link #store} appends a
+ * revision, and history is written separately so a superseded revision stays
+ * retrievable.
+ * <p>
+ * {@link #MAX_RESULT_LIMIT} and {@link #resolveLimit} live here so every
+ * backend clamps unbounded queries identically.
+ *
+ * @param <T>
+ *            the configuration model being stored
  */
 public interface IResourceStorage<T> {
 

--- a/src/main/java/ai/labs/eddi/datastore/IResourceStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/IResourceStore.java
@@ -23,7 +23,10 @@ import java.lang.annotation.Target;
  * Nested here because they belong to the contract rather than any one
  * implementation: {@link IResourceId} (the id/version pair), the checked
  * exceptions callers are expected to handle, and {@link ConfigurationUpdate},
- * the interceptor binding that fires when a store mutates a configuration.
+ * which marks the store methods that mutate a stored configuration. It is
+ * declared as an {@link InterceptorBinding}, but nothing implements that
+ * interceptor today, so the annotation has no runtime behaviour: it documents
+ * intent, and callers that need a cache refreshed invalidate it themselves.
  *
  * @param <T>
  *            the configuration model this store persists

--- a/src/main/java/ai/labs/eddi/datastore/IResourceStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/IResourceStore.java
@@ -11,7 +11,22 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * @author ginccc
+ * Versioned CRUD contract every configuration store in the project extends.
+ * <p>
+ * A resource is identified by an id plus an integer version: {@link #update}
+ * returns the new version rather than mutating in place, and {@link #read}
+ * takes the version it wants, so a conversation pinned to an older
+ * configuration keeps resolving that exact revision. {@link #delete} marks a
+ * version deleted and leaves it readable through {@link #readIncludingDeleted};
+ * only {@link #deleteAllPermanently} removes the history.
+ * <p>
+ * Nested here because they belong to the contract rather than any one
+ * implementation: {@link IResourceId} (the id/version pair), the checked
+ * exceptions callers are expected to handle, and {@link ConfigurationUpdate},
+ * the interceptor binding that fires when a store mutates a configuration.
+ *
+ * @param <T>
+ *            the configuration model this store persists
  */
 public interface IResourceStore<T> {
 

--- a/src/main/java/ai/labs/eddi/datastore/serialization/IDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/serialization/IDescriptorStore.java
@@ -10,7 +10,17 @@ import ai.labs.eddi.datastore.IResourceStore;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Store for the document descriptors that carry a resource's metadata — display
+ * name, description, timestamps and the user who last touched it — separately
+ * from the configuration document itself.
+ * <p>
+ * This is what the UI lists: browsing configurations reads descriptors rather
+ * than deserializing every underlying document. {@link #NO_LIMIT} and
+ * {@link #DEFAULT_LIMIT} keep paging intent explicit at the call site and
+ * aligned with the default the REST layer declares.
+ *
+ * @param <T>
+ *            the descriptor model this store persists
  */
 public interface IDescriptorStore<T> {
 

--- a/src/main/java/ai/labs/eddi/datastore/serialization/IDocumentBuilder.java
+++ b/src/main/java/ai/labs/eddi/datastore/serialization/IDocumentBuilder.java
@@ -10,7 +10,12 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * @author ginccc
+ * Converts between database documents and the project's model classes.
+ * <p>
+ * {@link #build} maps a raw document map onto a typed model on read, and
+ * {@link #toDocument} goes the other way on write. Sits between the storage
+ * implementations and the configuration models so persistence code never
+ * hand-rolls that mapping.
  */
 public interface IDocumentBuilder {
     <T> T build(Map<?, ?> doc, Class<T> type) throws IOException;

--- a/src/main/java/ai/labs/eddi/datastore/serialization/IJsonSerialization.java
+++ b/src/main/java/ai/labs/eddi/datastore/serialization/IJsonSerialization.java
@@ -7,7 +7,12 @@ package ai.labs.eddi.datastore.serialization;
 import java.io.IOException;
 
 /**
- * @author ginccc
+ * JSON serialization for model objects.
+ * <p>
+ * Thin, shared wrapper over the configured object mapper so serialization
+ * settings are declared once rather than per call site. Used wherever a model
+ * crosses a boundary as JSON — REST payloads, stored documents, and values
+ * handed to external systems.
  */
 public interface IJsonSerialization {
     String serialize(Object model) throws IOException;


### PR DESCRIPTION
Fixes #546

Documents the seven interfaces listed in the issue. Six carried an `@author`-only Javadoc block — the case the issue calls out as needing replacement — and `IResourceStorageFactory` already had prose, so only its `@author` tag is removed.

Each one was written from the interface's own method set plus its implementation (`ResourceFilter`, `PostgresResourceStorage`, `HistorizedResourceStore`/`AbstractResourceStore`, `DescriptorStore`, `DocumentBuilder`, `JsonSerialization`), following the house style already set by `IResourceStorageFactory`.

| Interface | What the doc says |
|---|---|
| `IResourceStore` | The versioned CRUD contract: id + integer version, `update` returns a new version rather than mutating, `delete` marks a version while leaving it readable via `readIncludingDeleted`, `deleteAllPermanently` is the only history-removing call. Also why `IResourceId`, the checked exceptions and `ConfigurationUpdate` are nested in the contract. |
| `IResourceStorage` | The backend-facing half — raw revision persistence without the validation/interception `IResourceStore` layers on top, obtained through the factory rather than injected, and why `MAX_RESULT_LIMIT`/`resolveLimit` live here so backends can't drift. |
| `IResourceFilter` | The query surface on top of id-addressed reads: how `QueryFilters` groups combine via `ConnectingType`, index/limit paging, and that it backs the REST list endpoints. |
| `IDescriptorStore` | Metadata held separately from the configuration document, and that browsing reads descriptors instead of deserializing every document — plus why `NO_LIMIT`/`DEFAULT_LIMIT` exist. |
| `IDocumentBuilder` | The mapping seam between database documents and model classes, so persistence code never hand-rolls it. |
| `IJsonSerialization` | The shared wrapper so mapper settings are declared once rather than per call site. |

## Verification

```
./mvnw compile   →  BUILD SUCCESS
```

Every `{@link}` target was checked to resolve (members against the declaring interface, types against the source tree) — 20 references, none dangling.

Docs only, no behavior change, no `@author` tags left in the seven files.

## One note on the sibling issues

While scoping this I checked #544 and #545 against `main` as well. Their state is mixed rather than open or done:

- **#544** — 7 of 8 still `@author`-only; `IMcpCallsStore` already has prose
- **#545** — only 3 of 8 still need it (`IDeploymentStore`, `IDocumentDescriptorStore`, `IPropertySetterStore`); the other five are already documented

Worth trimming those file lists so the next contributor doesn't rewrite documentation that already exists — that appears to be what happened on #547, where the interfaces turned out to be done. Happy to take either of them next if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified versioned resource store behavior, including revision reads, history writing, and how backend limit clamping works.
  * Expanded resource filtering documentation, including how groups are combined during listing/search (within-group AND/OR; groups joined with AND).
  * Improved guidance for store interception configuration, noting the current lack of runtime interceptor behavior.
  * Refined descriptor store, document-to-model mapping, and shared JSON serialization documentation.
  * No functional behavior or public interfaces changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->