### PR TITLE
fix(docker): bump UBI base digest to pick up the OpenJDK 25.0.4 rebuild

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,28 @@
 
 ---
 
+## 🔒 fix(docker): move to the republished UBI base and retire the microdnf stopgap (2026-08-04)
+
+**Repo:** EDDI (`fix/base-image-cve-2026-47063`)
+
+The Trivy gate on `main` fails the image push: `CVE-2026-47063` (HIGH, "Enhance Jar handling", Oracle CPU 2026-07) against `java-25-openjdk-headless` and `java-25-openjdk-crypto-adapter` at `1:25.0.3.0.9-1.el9`, fixed in `1:25.0.4.0.7-1.1.el9`. The JDK is baked into the base layer, so nothing in our own build could have introduced it.
+
+**Digest update, not a second stopgap.** Red Hat republished `ubi9/openjdk-25-runtime:1.24` on 2026-07-29 (build `1.24-3`); the tag now resolves to `sha256:de073e98…` instead of the pinned `sha256:a0c3ecb2…`. Its errata list carries `RHSA-2026:42899`, which is exactly the JDK rebuild Trivy asks for. Per the remediation procedure in AGENTS.md this is the clean fix — the pin moves, it is never dropped.
+
+**The temporary `microdnf update` line is gone.** It was added when no fixed digest existed for glib2/libacl/python3. The new base bakes all three fixes, verified against Red Hat security data rather than assumed:
+
+| CVE | Fixed in | Advisory in the new image |
+| --- | -------- | ------------------------- |
+| CVE-2026-58016 (glib2) | `glib2-2.68.4-19.el9_8.2` | RHSA-2026:42089 ✓ |
+| CVE-2026-54369 (libacl) | `acl-2.4.0-1.el9_8` | RHSA-2026:42736 ✓ |
+| CVE-2026-15308 (python3) | `python3.9-3.9.25-7.el9_8.2` | RHSA-2026:39798 ✓ |
+
+Retiring it also removes a build-time network dependency and a layer from the runtime image. The risk of going back to baked packages — that an erratum newer than the 2026-07-29 build exists, which `microdnf` would have pulled and the base would not — was checked: the Red Hat CVE feed lists nothing for `glib2`, `acl`, `python3.9` or `java-25-openjdk` after 2026-07-25.
+
+**Verification.** Reproduced the CI gate locally — `mvnw package`, `docker build`, then Trivy 0.70.0 with the exact settings from `ci.yml` (`--severity CRITICAL,HIGH --ignore-unfixed --exit-code 1`): **exit 0, redhat 9.8 row clean**, against the previous run's 2 HIGH. The runtime image reports `openjdk version "25.0.4" (Red_Hat-25.0.4.0.7-1)`, and `rpm -q` in the built image confirms `glib2-2.68.4-19.el9_8.2`, `libacl-2.4.0-1.el9_8` and `python3-3.9.25-7.el9_8.2` — the stopgap versions, now inherited rather than installed. `1.24` is still the newest tag stream (`1.25`–`1.29` and `2.0` all 404). No other file pins the old digest; `ContainerBaseIT` references the tag only.
+
+---
+
 ## 🎚️ feat(hitl): per-endpoint approval friction (2026-08-01)
 
 **Repo:** EDDI (`feat/operator-write-capability`)

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -78,7 +78,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24@sha256:a0c3ecb2af6e1100394721417ba412a9c9088dfadce53b8d98bb95a7bb4d23ea
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24@sha256:de073e98f1bb4be12f1454e1685c37db876af845896e0495f4eab0931154f9e4
 
 ### Red Hat Container Certification — required labels
 ARG EDDI_VERSION=6.2.0
@@ -104,17 +104,6 @@ LABEL name="labsai/eddi" \
 ENV LANG='C.utf8' LANGUAGE='C.utf8'
 
 USER root
-
-# TEMPORARY CVE STOPGAP - remove once the base image ships the fixes.
-# ubi9/openjdk-25-runtime:1.24 has not been republished with these, so there is no
-# newer digest to move to (verified against the registry: the tag still resolves to
-# the digest pinned above). Per the Trivy remediation procedure in AGENTS.md, patch
-# the packages in place rather than dropping the digest pin.
-#   CVE-2026-58016  glib2    integer underflow in gio/gdbusintrospection.c
-#   CVE-2026-54369  libacl   symlink traversal privilege escalation
-#   CVE-2026-15308  python3  CPU denial of service in the HTML parser
-# These block the image push now that the Trivy gate enforces (exit-code: 1).
-RUN microdnf update -y glib2 libacl python3 && microdnf clean all
 
 RUN mkdir -p /deployments/tmp/import && \
       chown -R 185:0 /deployments/tmp && \


### PR DESCRIPTION
## Why `main` is red

The Trivy image gate in `ci.yml` (`severity: CRITICAL,HIGH`, `exit-code: 1`, `ignore-unfixed: true`) fails the push of `labsai/eddi:6.2.0-b788`:

| Package | CVE | Installed | Fixed |
| ------- | --- | --------- | ----- |
| `java-25-openjdk-headless` | CVE-2026-47063 (HIGH) | `1:25.0.3.0.9-1.el9` | `1:25.0.4.0.7-1.1.el9` |
| `java-25-openjdk-crypto-adapter` | CVE-2026-47063 (HIGH) | `1:25.0.3.0.9-1.el9` | `1:25.0.4.0.7-1.1.el9` |

Both come from the base layer — "Enhance Jar handling", Oracle CPU 2026-07. Nothing in our build introduced them, and because the gate sits *before* the Docker Hub login, it also blocks the `:latest` retag, the cosign signature and the SLSA attestation.

## The fix: move the pin, don't drop it

Red Hat republished `ubi9/openjdk-25-runtime:1.24` on 2026-07-29 (build `1.24-3`) carrying `RHSA-2026:42899` — exactly the JDK rebuild Trivy asks for. Per the *Trivy CVE Remediation Procedure* in `AGENTS.md` this is the clean fix, so the digest moves and the pin stays:

```
-FROM …/ubi9/openjdk-25-runtime:1.24@sha256:a0c3ecb2…
+FROM …/ubi9/openjdk-25-runtime:1.24@sha256:de073e98…
```

## The `microdnf` stopgap is retired

It was added when no fixed digest existed for glib2/libacl/python3. The new base bakes all three, verified against Red Hat security data rather than assumed — and then confirmed with `rpm -q` inside the built image:

| CVE | Fixed version | In the new base |
| --- | ------------- | --------------- |
| CVE-2026-58016 (glib2) | `2.68.4-19.el9_8.2` | ✅ RHSA-2026:42089 |
| CVE-2026-54369 (libacl) | `acl-2.4.0-1.el9_8` | ✅ RHSA-2026:42736 |
| CVE-2026-15308 (python3) | `python3.9-3.9.25-7.el9_8.2` | ✅ RHSA-2026:39798 |

The one real risk in dropping it — an erratum newer than the 2026-07-29 build that `microdnf` would pull and the baked image would not — was checked: the Red Hat CVE feed lists nothing for `glib2`, `acl`, `python3.9` or `java-25-openjdk` after 2026-07-25. Removing it also drops a build-time network dependency and a layer from the runtime image.

## Verification

The CI gate was reproduced locally, not inferred:

- `mvnw package` → `docker build -f src/main/docker/Dockerfile` → Trivy **0.70.0** (the version CI runs) with `--severity CRITICAL,HIGH --ignore-unfixed --exit-code 1` → **exit 0, `redhat 9.8` row clean**, against 2 HIGH before.
- Runtime image reports `openjdk version "25.0.4" 2026-07-21 LTS (Red_Hat-25.0.4.0.7-1)`.
- `rpm -q` in the built image: `glib2-2.68.4-19.el9_8.2`, `libacl-2.4.0-1.el9_8`, `python3-3.9.25-7.el9_8.2` — the stopgap versions, now inherited instead of installed.
- `1.24` is still the newest tag stream: `1.25`–`1.29` and `2.0` all 404 on the registry.
- No other file pins the old digest; `ContainerBaseIT` references the bare tag only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Docker runtime image to address known security vulnerabilities.
  * Removed the temporary in-container package update step.

* **Documentation**
  * Added changelog details covering the security updates and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->