### PR TITLE
fix(groups): pre-feature defects N1-N3 - plain-call pricing, schema sentinel, transcript windowing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,20 @@
 
 ---
 
+## 🧮 fix(groups): nested-group cost is summed per child discussion, not overwritten (2026-08-07)
+
+**Repo:** EDDI (`fix/group-pre-feature-defects`)
+
+The N1 fold-in flagged in `planning/group-collaboration-NEXT.md` §4. `GroupCostLedger.accumulateNestedGroupCost` keyed `memberCosts` by the GROUP member's `agentId`, but every turn of a GROUP member spawns a **fresh child discussion** whose `totalCost` starts at 0 — and the map records by replacement (idempotency invariant: one key = one conversation's cumulative cost). So child N's total replaced child N−1's, only the last child's spend survived the re-sum, and the parent's ceiling checks ran against an undercount.
+
+Fix keeps the replacement invariant instead of breaking it with deltas: the attribution key is now `agentId:childConversationId` — one key per child conversation, replacement stays idempotent, multiple children of the same member sum. A child without an id falls back to the plain agentId (old behaviour). No production reader indexes `memberCosts` by agentId — the map is serialized whole.
+
+`MemberTurnExecutorTest.executeGroupMemberTurn_rollsUpChildDiscussionCost` pinned the old single-key shape and was updated to the new contract. New `GroupCostLedgerTest` case: two children ($1.00, $0.50) of one member total $1.50, not $0.50. **Mutation-checked:** reverting to the agentId key fails exactly that new test.
+
+**Files:** `GroupCostLedger.java`, `GroupCostLedgerTest.java`, `MemberTurnExecutorTest.java`.
+
+---
+
 ## 💰 fix(llm): N1 — price ordinary model calls so the ledger's common case is no longer $0 (2026-08-07)
 
 **Repo:** EDDI (`fix/group-pre-feature-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,25 @@
 
 ---
 
+## 🪜 fix(schema): N3 — legacy documents now enter the migration ladder at the bottom (2026-08-07)
+
+**Repo:** EDDI (`fix/group-pre-feature-defects`)
+
+Second pre-feature defect from `planning/group-collaboration-NEXT.md` §2, filed by the round-5 review of #626. `GroupConversation.schemaVersion` was initialised to `CURRENT_SCHEMA_VERSION` (3). Every pre-F6 production document has no `schemaVersion` key, Jackson leaves the initialiser standing, so those documents loaded **claiming schema 3 while being version-1-shaped** — and `prepareForResume`'s ladder ran `for (v = 3; v < 3; ...)`: zero iterations on exactly the documents it exists for. Fixed now, while it is free: no released build has ever written a versioned document, so nothing in production carries a wrong claim to migrate away from.
+
+- **Test first, watched it fail:** `documentWithoutVersionKey_claimsLegacyVersionNotCurrent` deserialises `{}` and asserts version 1 — failed with `expected: <1> but was: <3>` before the fix, exactly the round-5 finding. This is the case none of the four previous review rounds' tests covered (they all *set* a version).
+- **The fix is a split, not a re-initialisation:** new `LEGACY_SCHEMA_VERSION = 1` is the field initialiser (the version a key-less document claims — it never moves), and the single creation point (`GroupConversationService.createGroupConversation`) stamps `CURRENT_SCHEMA_VERSION` explicitly. The initialiser alone cannot distinguish "absent" from "current" — Jackson runs the no-arg constructor either way — so the stamp must live at creation.
+- **`ConversationMemorySnapshot` got the identical split** even though its `CURRENT` is still 1 (correct only by coincidence — first bump to 2 would have silently re-created the group side's bug). Its stamp lives in `ConversationMemoryUtilities.getMemorySnapshot`, the one place snapshots are built from live memory. A pinning test asserts `LEGACY_SCHEMA_VERSION` stays 1 when `CURRENT` bumps.
+- **(b) Stale Javadoc fixed:** `GroupConversationSchemaMigrations.MIGRATIONS` claimed `CURRENT_SCHEMA_VERSION` is 1 and "there is nothing yet to migrate from" — it is 3, and the identity-default path has already been exercised twice. Rewritten (plus the single-conversation mirror and the stale test-class Javadoc).
+
+**Mutation-checked:** removing the creation stamp fails exactly `discuss_stampsCurrentSchemaVersionOnTheCreatedDocument` (a fresh document would persist claiming legacy). Deserialisation side proven by the red→green cycle above. 133 tests across the six touched classes green.
+
+⚠️ **Surefire note for the next session:** `-Dtest=ClassName` prints `Tests run: 0` for the parent of `@Nested` tests while the nested groups report under their `@DisplayName` — read the run TOTAL, not the class line, before concluding nothing ran.
+
+**Files:** `GroupConversation.java`, `GroupConversationService.java`, `ConversationMemorySnapshot.java`, `ConversationMemoryUtilities.java`, both `*SchemaMigrations.java`, tests.
+
+---
+
 ## 🧮 fix(groups): nested-group cost is summed per child discussion, not overwritten (2026-08-07)
 
 **Repo:** EDDI (`fix/group-pre-feature-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 🔍 fix(review): PR #636 review findings — NaN cost guard, ceiling-gated summarizer, visible-entry boundary (2026-08-08)
+
+**Repo:** EDDI (`fix/group-pre-feature-defects`, PR [#636](https://github.com/labsai/EDDI/pull/636))
+
+Every reviewer finding on #636 triaged; the real ones fixed, each with a pinning test:
+
+- **NaN poisons the cost ledger (CodeRabbit, real).** Both `GroupCostLedger.recordSystemCost` and `LlmTask.accumulateCost` guarded with `delta <= 0.0` — NaN fails *every* comparison, so it slipped through, made `totalCost` NaN, and every ceiling comparison against NaN is false: the ceiling silently never fires again. Now `!Double.isFinite(x) || !(x > 0.0)`. Tests: NaN/∞/non-positive rejected in both accumulators.
+- **Summarizer spend must be ceiling-gated (Copilot, real).** The I9 boundary call now runs behind `GroupCostLedger.wouldExceedCeiling`, exactly like the convergence judge and the dissent round. The pinning test needed care — the first attempt was vacuous because the per-turn gate fired before any boundary could (mutation survived); rebuilt so the first phase completes under the gate while blowing the ceiling cumulatively. **Mutation-checked: removing the guard fails exactly this test.**
+- **Summary boundary counts raw entries, not visible ones (Copilot, real).** Bookkeeping rows (SKIPPED/CONVERGENCE/…) in the tail shrank the verbatim window below `maxRecentEntries` while newer real contributions got summarized away. New `summaryBoundary` walks back over `isSummarizable` entries (one shared predicate with `renderForSummarizer`). Test: bookkeeping interleaved in the tail keeps the 3 newest *visible* entries verbatim.
+- **Blank summarizer identifiers (CodeRabbit, real-minor).** Whitespace-only `llmProvider`/`llmModel` bypassed the null checks and reached `SummarizationService`. Normalized to null in `ContextWindowConfig`'s compact constructor (the one choke point); the store warn simplifies to null checks. Test: blank identifiers → truncation fallback, `verifyNoInteractions(summarizer)`.
+- **CodeQL log injection ×4 (real).** `gc.getId()` and the group name are caller-influenced; the three windowing WARNs and the save-time warn now go through `LogSanitizer.sanitize`.
+- **Live-transcript iteration (CodeRabbit, partly right).** The `updateWindowSummary` copy already held the correct monitor (`Collections.synchronizedList`'s mutex IS the wrapper object — the PhaseExecutionEngine comment documents this), but the windowed `filterByScope`'s indexed walk over the LIVE list could interleave with tool-thread appends (recruitment's FACILITATION entries). It now copies under the wrapper monitor first.
+- **`memberCosts` key shape (CodeRabbit, documentation).** The "agentId → cost" Javadoc was stale *before* the nested-cost fix — I2's `__convergence_judge` and I4's `__dissent__*` conversation keys already live in that map. Rewritten to the actual invariant: one key = one conversation, `totalCost` = sum of everything. Copying a member total onto `memberCosts[agentId]` (the suggested fix) would double-count in the re-sum.
+
+144 tests across the touched classes green; checkstyle clean.
+
+---
+
 ## 🪟 feat(groups): N2/I9 — transcript windowing for rendered member context (2026-08-07)
 
 **Repo:** EDDI (`fix/group-pre-feature-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 🪟 feat(groups): N2/I9 — transcript windowing for rendered member context (2026-08-07)
+
+**Repo:** EDDI (`fix/group-pre-feature-defects`)
+
+Third and last pre-feature item from `planning/group-collaboration-NEXT.md` §2 — a live cost bug, not a new collaboration mode: FULL-scope phases re-fed the entire transcript to every member every turn (~quadratic prompt cost), and every queued Wave 2/3 item makes transcripts longer. Landed in `GroupContextBuilder` per the plan (`### I9`, plan line ~337).
+
+- **Config:** `AgentGroupConfiguration.ContextWindowConfig` (`contextWindow`) — `enabled=false`, `maxRecentEntries=30`, `summarizeOverflow=true`, plus `llmProvider`/`llmModel` for the summarizer and optional `inputPricePer1M`/`outputPricePer1M` (I1 attribution, reusing N1's shared `TokenPricing`). Boolean-not-boolean for `summarizeOverflow` so an omitted JSON key means true; compact-constructor normalization in the `GroupTaskConfig` style. Save-time warn in `AgentGroupStore` when summarization is on but no model is named.
+- **Rendering:** windowed `filterByScope` overload — when the FULL/ANONYMOUS scope-filtered context exceeds the cap, older entries collapse into one leading "System" pseudo-entry: the rolling summary when it covers the omitted range, else the `[n earlier entries omitted]` truncation marker (the `summarizeOverflow=false` path and the failure fallback). The verbatim/summary split is the summary's **raw-transcript boundary**, so there is never a gap or duplication; between boundaries the tail may grow a few entries past the cap and the next boundary re-tightens. The stored transcript is never modified; signing verifies raw entries as before.
+- **Summaries:** extended **incrementally at phase boundaries only** (`updateWindowSummary`, called from the discussion loop before each repeat — never per member turn), previous summary + new slice, mirroring `ConversationSummarizer`'s self-correcting algorithm via the shared `SummarizationService` (unification rule). Failure or empty answer leaves stored state untouched: WARN, truncation fallback, next boundary catches up with a larger batch. Summarizer spend lands on the discussion ledger via `GroupCostLedger.recordSystemCost` keyed `system:summarizer:{variant}:{boundary}` (idempotent per extension, distinct extensions sum).
+- **One deliberate deviation from the plan text:** the plan named a single `transcriptSummary`/`summaryUpToIndex` pair *and* required ANONYMOUS summarizer input to use "Anonymous" labels. One shared summary cannot satisfy both — a FULL-built summary carries real names and would de-anonymize an ANONYMOUS phase through the back door. `GroupConversation` therefore carries a second, lazily-built pair (`anonymousTranscriptSummary`/`anonymousSummaryUpToIndex`); a group that never uses ANONYMOUS never pays for it. Fields are additive with correct defaults — no `CURRENT_SCHEMA_VERSION` bump (a legacy document simply starts summarizing at its next boundary).
+- **Wiring:** `PhaseExecutionEngine`'s three `buildPhaseInput` call sites pass `config.getContextWindow()` + gc; `SummarizationService` reaches the facade by the established field-injection pattern (null in direct-construction unit tests → truncation fallback). The I2 convergence judge's input is untouched (already bounded to two rounds); SYNTHESIS deliberately keeps the full picture.
+
+**Tests** (`GroupContextBuilderWindowingTest`, 13): boundary at exactly the cap (must exceed, not meet); truncation marker; summary + boundary-split tail (no gap/duplication); ANONYMOUS uses the anonymous summary and labels (the named FULL summary must not surface); incremental extension (second call sees previous summary + only the new slice); failure/empty-answer state untouched + rendering falls back; priced summarization reaches `totalCost`; no summarizer call outside its remit (wrong phase type/scope, below cap, summarization off); config normalization. **Mutation-checked:** re-feeding the whole prefix instead of the new slice fails exactly the incremental test. `PhaseExecutionEngineTest`'s input stub updated to the new 9-arg overload (same reasoning as its own comment: a shorter stub silently nulls every input). Full `engine.internal` suite: 1438 green; checkstyle clean.
+
+**Files:** `AgentGroupConfiguration.java`, `GroupConversation.java`, `GroupContextBuilder.java`, `PhaseExecutionEngine.java`, `GroupConversationService.java`, `GroupCostLedger.java`, `AgentGroupStore.java`, `TokenPricing.java` (now public), `docs/group-conversations.md`, `planning/group-collaboration-NEXT.md` (all three §2 items marked done), tests.
+
+---
+
 ## 🪜 fix(schema): N3 — legacy documents now enter the migration ladder at the bottom (2026-08-07)
 
 **Repo:** EDDI (`fix/group-pre-feature-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 💰 fix(llm): N1 — price ordinary model calls so the ledger's common case is no longer $0 (2026-08-07)
+
+**Repo:** EDDI (`fix/group-pre-feature-defects`)
+
+First of the three pre-feature defects from `planning/group-collaboration-NEXT.md` §2. `AUDIT_COST` was written from `cascadeCostUsd + toolCostUsd` only, so a plain model call — no cascade, no priced tool — contributed **$0.00**: I1's `maxCostPerDiscussion` ceiling could never trip for an ordinary group, and `memberCosts`/`totalCost` were served over REST as if authoritative.
+
+- **`LlmConfiguration.Task` gains `inputPricePer1M`/`outputPricePer1M`** — same names and nullable semantics as the cascade fields (null = unpriced, contributes $0), so nothing changes for anyone not setting prices. Config-driven per Golden Rule 1: no hardcoded provider price table — it would be wrong within weeks.
+- **The pricing arithmetic now lives once, in `TokenPricing.cost()`.** `CascadingModelExecutor.computeCost` (step→cascade price resolution) and `LlmTask.accumulateAuditEvidence` (task-level prices for plain calls) both delegate — the formula cannot drift between paths (§4.7 unification rule).
+- **Precedence is explicit, not accidental:** `accumulateAuditEvidence` discriminates on the presence of the `cascadeCostUsd` metadata key, which the cascade branch always writes. A cascade run is priced by its steps alone; task-level prices apply only to non-cascade calls — cascade steps may target entirely different models, so inheriting the task price would price the wrong model. (This matches the precedence concern pre-filed in `docs/superpowers/specs/2026-07-21-manager-coverage-backend-design.md`.) Pinned by a test with deliberately absurd task prices on a cascade turn.
+- **Validation:** negative task-level prices fail deployment (`CascadeConfigValidator`, same new-field hard-error rationale as cascade pricing; the validator now also runs its task-level block for cascade-less tasks).
+- **`GroupCostLedger`'s "Known gap (V1)" Javadoc** rewritten — the gap is closed; `totalCost` remains a lower bound only for members whose configs carry no prices.
+
+**Tests** (`LlmTaskAuditLedgerTest`, `CascadeConfigValidatorTest`): plain priced legacy call accumulates the expected dollars; priced agent-mode turn sums token + tool cost; unpriced call still writes no cost key; cascade with absurd task prices set is priced by the cascade alone; negative task price throws at deploy. **Mutation-checked:** reverting the pricing line to `0.0` fails exactly the two new priced-plain-call tests and nothing else.
+
+The group-side chain (AUDIT_COST → `GroupCostLedger` → ceiling policies ABORT/SYNTHESIZE_NOW) was already pinned end-to-end by `GroupConversationServiceCostCeilingTest` with stubbed member cost; what could not exist before this fix — a plain call producing nonzero AUDIT_COST — is now the pinned link.
+
+**Files:** `LlmConfiguration.java`, `TokenPricing.java` (new), `CascadingModelExecutor.java`, `LlmTask.java`, `CascadeConfigValidator.java`, `GroupCostLedger.java`, `docs/langchain.md`, tests.
+
+---
+
 ## 🔀 merge: bring `origin/main` (PR #627 HITL request pinning) into the branch (2026-08-07)
 
 **Repo:** EDDI (`refactor/group-service-split`, PR [#626](https://github.com/labsai/EDDI/pull/626))

--- a/docs/group-conversations.md
+++ b/docs/group-conversations.md
@@ -155,6 +155,43 @@ tools.
 a second writer racing it would corrupt the state machine that decides what runs
 next. Filing is the only agent-side write.
 
+## Transcript windowing
+
+A `FULL`- or `ANONYMOUS`-scope discussion phase re-feeds the transcript to every
+member every turn, so a long discussion grows roughly quadratically in prompt
+tokens. `contextWindow` bounds what each turn *renders* — the stored transcript
+is never modified, and signing verification still runs on the raw entries:
+
+```json
+"contextWindow": {
+  "enabled": true,
+  "maxRecentEntries": 30,
+  "summarizeOverflow": true,
+  "llmProvider": "openai",
+  "llmModel": "gpt-4o-mini",
+  "inputPricePer1M": 0.15,
+  "outputPricePer1M": 0.60
+}
+```
+
+When the scope-filtered context exceeds `maxRecentEntries`, the older entries
+collapse into a single leading block: a rolling **summary** (extended
+incrementally at phase boundaries via the shared summarization service — never
+per member turn), or, with `summarizeOverflow: false`, a plain
+`[n earlier entries omitted]` marker that costs no LLM call. A summarization
+failure never blocks the discussion — the turn renders with the truncation
+marker and the next boundary catches up.
+
+- Applies to `FULL` and `ANONYMOUS` scopes only. The `ANONYMOUS` variant keeps
+  its own summary, built from the same `"Anonymous"` labels the scope filter
+  produces — the summary can never de-anonymize a peer.
+- `llmProvider`/`llmModel` name the summarizer; without them, overflow falls
+  back to the truncation marker (a save-time warning says so).
+- The optional prices attribute the summarizer's own spend to the discussion's
+  cost ledger, where `maxCostPerDiscussion` sees it.
+- The convergence judge's input is not windowed — it is already bounded to the
+  last two rounds.
+
 Both caps are enforced independently: `maxPerTurn` bounds a runaway single turn,
 `maxAgentAddedTasksPerDiscussion` bounds slow drift across a long discussion. The
 discussion cap counts only agent-filed tasks, so a large planned backlog does not

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -519,6 +519,7 @@ Both stored shapes therefore keep working: a config that sets only `streamingTim
 | `maxBudgetPerConversation` | number   | Ceiling on accumulated **tool** cost per conversation, in USD. Records cost; only refuses calls when `enforceBudget` is on | (unlimited) |
 | `enforceBudget`            | boolean  | Refuse tool calls once `maxBudgetPerConversation` is passed. **Opt-in** — a ceiling without it is report-only, and is named in a startup WARN | false (`eddi.tools.budget.enforce-by-default`) |
 | `toolPricing`              | map      | Per-call tool prices in USD. Keyed on the built-in slug (`{"websearch": 0.005}`) or on a single dispatch name (`{"searchNews": 0.01}`), which takes precedence — so one operation can be priced apart from its siblings | (built-in defaults) |
+| `inputPricePer1M` / `outputPricePer1M` | number | Token prices in USD per 1M tokens for this task's **model calls**, feeding the conversation's tracked cost (and any group cost ceiling). Applies to non-cascade calls; a [model cascade](model-cascade.md) prices its steps via its own fields of the same name. Negative values fail deployment | (unpriced — $0) |
 | `enableToolCaching`        | boolean  | Cache tool results to reduce API calls           | true                   |
 | `toolCacheScopes`          | map      | Per-tool cache partition: `user`/`conversation`/`global` | (all `user`)   |
 | `defaultToolCacheScope`    | string   | Cache partition for tools without an override    | `user`                 |

--- a/planning/group-collaboration-NEXT.md
+++ b/planning/group-collaboration-NEXT.md
@@ -5,7 +5,7 @@
 > holds the **design** for each item and does not repeat status — go there only for the one
 > item you are about to build, using the section pointers below.
 >
-> **Last updated:** 2026-08-04 · after PR [#626](https://github.com/labsai/EDDI/pull/626) (`refactor/group-service-split`)
+> **Last updated:** 2026-08-07 · after the `fix/group-pre-feature-defects` branch (N1 + N2/I9 + N3, §2 below — all three done)
 
 ---
 
@@ -21,7 +21,8 @@ builds on (F1–F6), and shipped six feature items.
 | **Wave 0** — F1 `LiveDiscussionRegistry`, F2 speaker-level `ResumePoint`, F3 `DecisionRecord`, F4 entry types + visibility, F5 cost ledger, F6 schema versioning | ✅ Done |
 | **Wave 1** — I1 cost ceiling, I2 convergence + early exit, I3 structured verdicts, I4 abstention + minority report | ✅ Done |
 | **Wave 2** — I5 agent-filed tasks, I7 recruitment + delegation timeout | ✅ Done |
-| **Wave 2** — I6, I8, I9, I14, I17 | ⬜ Queued (see §3) |
+| **Pre-feature defects** — N1 plain-call pricing, N2/I9 transcript windowing, N3 schema sentinel (§2) | ✅ Done (2026-08-07, `fix/group-pre-feature-defects`) |
+| **Wave 2** — I6, I8, I14, I17 | ⬜ Queued (see §3) |
 | **Wave 3** — I10, I11, I12, I13, I18 | ⬜ Queued (see §3) |
 | **Excluded — do not start** — I15 cross-team process DAGs, I16 A2A remote members | ❌ Out of scope |
 
@@ -32,7 +33,12 @@ tool surfaces → a `ToolSourceProvider`.
 
 ---
 
-## 2. Do these three first
+## 2. Do these three first — ✅ ALL DONE (2026-08-07, branch `fix/group-pre-feature-defects`)
+
+> N1, N2 and N3 below all shipped on that branch, each mutation-checked; the §4
+> nested-group cost gap was folded into N1 as planned. The section is kept for
+> the reasoning record — do not redo any of it. Details in `docs/changelog.md`
+> (entries of 2026-08-07). **Next up: §3's queue, starting with I17 / I14 / I8.**
 
 These are not new features. They are **defects in what already shipped**, and later items depend
 on them. Do them as one small PR before starting any Wave 2 feature.
@@ -171,9 +177,8 @@ Recorded so they are not rediscovered. Fix opportunistically, or fold into a rel
 - **`decision_reached` never fires.** I3 writes `DecisionRecord`, but no producer calls the sink
   event, so verdicts reach REST/MCP and never SSE or Slack.
   `SlackGroupDiscussionListener.onDecisionReached` is dead code today. *(Natural fold-in: I14.)*
-- **Nested-group cost is overwritten, not accumulated.** `accumulateNestedGroupCost` keys by
-  `agentId`, and each nested turn is a fresh child discussion starting at 0, so only the last
-  child's spend survives. *(Natural fold-in: N1.)*
+- ~~**Nested-group cost is overwritten, not accumulated.**~~ ✅ Fixed with N1 (2026-08-07):
+  attribution is keyed per child discussion (`agentId:childId`), so children sum.
 - **`allowAbstention` on a SYNTHESIS phase** yields a `COMPLETED` discussion with no answer.
 - **Parallel-phase late entries are lost.** After the batch deadline a member finishing
   milliseconds late has its real entry replaced by `SKIPPED`. **Both obvious fixes were tried

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -92,6 +92,78 @@ public class AgentGroupConfiguration {
     }
 
     /**
+     * Transcript windowing for rendered member context (I9). {@code null} means
+     * windowing is off — every FULL/ANONYMOUS-scope turn renders the whole
+     * scope-filtered transcript, exactly as before the feature existed.
+     */
+    private ContextWindowConfig contextWindow;
+
+    public ContextWindowConfig getContextWindow() {
+        return contextWindow;
+    }
+
+    public void setContextWindow(ContextWindowConfig contextWindow) {
+        this.contextWindow = contextWindow;
+    }
+
+    /**
+     * Bounds what a FULL/ANONYMOUS-scope member turn renders from the transcript
+     * (I9). Without it, every such turn re-feeds the entire transcript to every
+     * member — ~quadratic cost as the discussion grows. When the scope-filtered
+     * context exceeds {@link #maxRecentEntries}, the rendered context becomes
+     * {@code [summary of the older entries] + [the recent entries verbatim]} — a
+     * derived view only; the stored transcript is never modified and signing
+     * verification still operates on the raw entries.
+     *
+     * @param enabled
+     *            master switch, default off — a config that does not opt in renders
+     *            exactly as before
+     * @param maxRecentEntries
+     *            how many of the newest scope-filtered entries stay verbatim.
+     *            Non-positive falls back to {@link #DEFAULT_MAX_RECENT_ENTRIES} (an
+     *            accidental 0 must not blank the whole context)
+     * @param summarizeOverflow
+     *            {@code true} (default) compresses the older entries into a rolling
+     *            summary via the shared summarization service; {@code false}
+     *            replaces them with a plain "[n earlier entries omitted]" marker
+     *            and never calls an LLM
+     * @param llmProvider
+     *            provider for the summarization calls (e.g. "openai"). Required for
+     *            summarization — without it (or {@code llmModel}) the overflow
+     *            falls back to the truncation marker with a warning
+     * @param llmModel
+     *            model name for the summarization calls
+     * @param inputPricePer1M
+     *            optional USD price per 1M input tokens for the summarizer's own
+     *            calls, so their cost counts toward the discussion's I1 ledger.
+     *            Null or negative = unpriced ($0), same semantics as the LLM task
+     *            pricing fields
+     * @param outputPricePer1M
+     *            optional USD price per 1M output tokens, same semantics
+     */
+    public record ContextWindowConfig(boolean enabled, int maxRecentEntries, Boolean summarizeOverflow,
+            String llmProvider, String llmModel,
+            Double inputPricePer1M, Double outputPricePer1M) {
+
+        public static final int DEFAULT_MAX_RECENT_ENTRIES = 30;
+
+        /**
+         * Normalizes at the one choke point every reader passes through — same shape as
+         * {@link GroupTaskConfig}. {@code summarizeOverflow} is a Boolean rather than a
+         * boolean so an omitted JSON key defaults to {@code true} instead of silently
+         * disabling summarization.
+         */
+        public ContextWindowConfig {
+            if (maxRecentEntries <= 0) {
+                maxRecentEntries = DEFAULT_MAX_RECENT_ENTRIES;
+            }
+            summarizeOverflow = summarizeOverflow == null || summarizeOverflow;
+            inputPricePer1M = inputPricePer1M == null || inputPricePer1M < 0 ? null : inputPricePer1M;
+            outputPricePer1M = outputPricePer1M == null || outputPricePer1M < 0 ? null : outputPricePer1M;
+        }
+    }
+
+    /**
      * Governs agent-filed tasks (I5). The task list is otherwise written only by
      * the PLAN phase and by config, so work an agent <em>discovers</em> while
      * executing — a missing migration, an untested edge case — dies in prose. The

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -158,6 +158,11 @@ public class AgentGroupConfiguration {
                 maxRecentEntries = DEFAULT_MAX_RECENT_ENTRIES;
             }
             summarizeOverflow = summarizeOverflow == null || summarizeOverflow;
+            // Blank identifiers ARE absent — every reader null-checks, and a
+            // whitespace-only provider reaching the summarization service would
+            // bypass the documented truncation fallback.
+            llmProvider = llmProvider == null || llmProvider.isBlank() ? null : llmProvider;
+            llmModel = llmModel == null || llmModel.isBlank() ? null : llmModel;
             inputPricePer1M = inputPricePer1M == null || inputPricePer1M < 0 ? null : inputPricePer1M;
             outputPricePer1M = outputPricePer1M == null || outputPricePer1M < 0 ? null : outputPricePer1M;
         }

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
@@ -145,6 +145,63 @@ public class GroupConversation {
     public void setRoundStartTranscriptIndex(int roundStartTranscriptIndex) {
         this.roundStartTranscriptIndex = roundStartTranscriptIndex;
     }
+
+    /**
+     * Rolling summary of transcript entries {@code [0, summaryUpToIndex)} for
+     * FULL-scope windowed rendering (I9), extended incrementally at phase
+     * boundaries by {@code GroupContextBuilder.updateWindowSummary}. A derived view
+     * only — the transcript itself is never modified. {@code null} until windowing
+     * first summarizes; legacy documents deserialize to exactly that state and
+     * simply start summarizing at the next boundary, so this is additive and needs
+     * no {@code CURRENT_SCHEMA_VERSION} bump.
+     */
+    private String transcriptSummary;
+    /** Exclusive raw-transcript index {@link #transcriptSummary} covers through. */
+    private int summaryUpToIndex;
+    /**
+     * The ANONYMOUS-scope twin of {@link #transcriptSummary}, built from
+     * "Anonymous"-labelled input so an ANONYMOUS phase's summary can never leak
+     * attribution (no de-anonymization). Kept separately rather than reusing the
+     * FULL summary, which contains real speaker names.
+     */
+    private String anonymousTranscriptSummary;
+    /**
+     * Exclusive raw-transcript index {@link #anonymousTranscriptSummary} covers
+     * through.
+     */
+    private int anonymousSummaryUpToIndex;
+
+    public String getTranscriptSummary() {
+        return transcriptSummary;
+    }
+
+    public void setTranscriptSummary(String transcriptSummary) {
+        this.transcriptSummary = transcriptSummary;
+    }
+
+    public int getSummaryUpToIndex() {
+        return summaryUpToIndex;
+    }
+
+    public void setSummaryUpToIndex(int summaryUpToIndex) {
+        this.summaryUpToIndex = summaryUpToIndex;
+    }
+
+    public String getAnonymousTranscriptSummary() {
+        return anonymousTranscriptSummary;
+    }
+
+    public void setAnonymousTranscriptSummary(String anonymousTranscriptSummary) {
+        this.anonymousTranscriptSummary = anonymousTranscriptSummary;
+    }
+
+    public int getAnonymousSummaryUpToIndex() {
+        return anonymousSummaryUpToIndex;
+    }
+
+    public void setAnonymousSummaryUpToIndex(int anonymousSummaryUpToIndex) {
+        this.anonymousSummaryUpToIndex = anonymousSummaryUpToIndex;
+    }
     private SharedTaskList taskList;
     /** Agents dynamically added during the discussion (recruited or created). */
     private List<AgentGroupConfiguration.GroupMember> dynamicMembers = new CopyOnWriteArrayList<>();

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
@@ -83,14 +83,18 @@ public class GroupConversation {
     // turns a successful discussion into a FAILED one.
     private Map<String, String> memberDisplayNames = new ConcurrentHashMap<>();
     /**
-     * Per-member dollar-cost attribution (Wave 0, F5): agentId → that member's cost
-     * so far. For an individual agent, its own private conversation's cumulative
-     * tracked cost; for a {@code MemberType.GROUP} member, the child discussion's
-     * own {@link #totalCost} rolled up whole. See {@code GroupCostLedger}'s Javadoc
-     * for the known gap this reflects (V1: a non-cascade member turn's own
-     * model-completion cost is not tracked anywhere yet — I1 closes that).
-     * Thread-safe: PARALLEL phases accumulate from multiple member turns
-     * concurrently.
+     * Per-conversation dollar-cost attribution (Wave 0, F5): attribution key → that
+     * conversation's cumulative tracked cost. The invariant is <b>one key = one
+     * conversation</b> (recording is by replacement, which is only idempotent under
+     * that reading), so keys are NOT uniformly agent ids: an ordinary member's key
+     * is its agentId, a separate-conversation turn uses its conversation key (I2's
+     * {@code __convergence_judge}, I4's {@code __dissent__*}), and a nested GROUP
+     * member's children are keyed {@code agentId:childConversationId} — each turn
+     * of a GROUP member is a fresh child discussion, and a per-agent key would
+     * replace child N−1's whole spend with child N's. Consumers wanting a member's
+     * total must sum matching keys; {@link #totalCost} is always the sum of
+     * everything. Thread-safe: PARALLEL phases accumulate from multiple member
+     * turns concurrently.
      */
     private Map<String, Double> memberCosts = new ConcurrentHashMap<>();
     /**

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
@@ -33,6 +33,19 @@ public class GroupConversation {
      */
     public static final int CURRENT_SCHEMA_VERSION = 3;
     /**
+     * The version a stored document claims when its JSON carries no
+     * {@code schemaVersion} key — i.e. it was written before F6 existed, which is
+     * every pre-F6 production document. Jackson runs the no-arg constructor and
+     * leaves the field initialiser standing either way, so the initialiser cannot
+     * distinguish "absent" from "current": it MUST be this legacy floor, and the
+     * single creation point ({@code GroupConversationService}) stamps
+     * {@link #CURRENT_SCHEMA_VERSION} explicitly. Initialising the field to CURRENT
+     * instead made key-less documents claim the current version and
+     * {@code prepareForResume}'s ladder run zero iterations on exactly the
+     * documents it exists for.
+     */
+    public static final int LEGACY_SCHEMA_VERSION = 1;
+    /**
      * The shape this specific document was last written in. Checked before a
      * resume: newer than {@link #CURRENT_SCHEMA_VERSION} refuses (this deployment
      * predates the document), older runs registered migrations forward. A pause can
@@ -41,7 +54,7 @@ public class GroupConversation {
      * per-resume config-drift check (bookmarked phase vs. current config) that
      * guards a different axis. See {@code GroupConversationSchemaMigrations}.
      */
-    private int schemaVersion = CURRENT_SCHEMA_VERSION;
+    private int schemaVersion = LEGACY_SCHEMA_VERSION;
     private String id;
     private String groupId;
     private String userId;

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
@@ -14,6 +14,7 @@ import ai.labs.eddi.datastore.AbstractResourceStore;
 import ai.labs.eddi.datastore.IResourceStorageFactory;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
+import ai.labs.eddi.utils.LogSanitizer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -118,9 +119,9 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
         if (window == null || !window.enabled() || !Boolean.TRUE.equals(window.summarizeOverflow())) {
             return;
         }
-        if (window.llmProvider() == null || window.llmProvider().isBlank() || window.llmModel() == null || window.llmModel().isBlank()) {
+        if (window.llmProvider() == null || window.llmModel() == null) {
             LOGGER.warnf("Group '%s' enables contextWindow summarization but names no llmProvider/llmModel — "
-                    + "overflow will fall back to a plain truncation marker", groupConfiguration.getName());
+                    + "overflow will fall back to a plain truncation marker", LogSanitizer.sanitize(groupConfiguration.getName()));
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
@@ -43,6 +43,7 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
         HitlConfigValidation.validate(groupConfiguration.getHitlConfig());
         normalizeNonPositiveCostCeiling(groupConfiguration);
         warnOnModeratorlessPhases(groupConfiguration);
+        warnOnSummarizerlessWindow(groupConfiguration);
         return super.create(groupConfiguration);
     }
 
@@ -54,6 +55,7 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
         HitlConfigValidation.validate(groupConfiguration.getHitlConfig());
         normalizeNonPositiveCostCeiling(groupConfiguration);
         warnOnModeratorlessPhases(groupConfiguration);
+        warnOnSummarizerlessWindow(groupConfiguration);
         return super.update(id, version, groupConfiguration);
     }
 
@@ -101,6 +103,25 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
                 .filter(p -> p != null && "MODERATOR".equalsIgnoreCase(p.participants()))
                 .map(DiscussionPhase::name)
                 .toList();
+    }
+
+    /**
+     * I9: a window that asks for summarization but names no summarizer model will
+     * silently degrade to the plain truncation marker at discussion time. Worth
+     * telling the author at save time, when they can still add
+     * {@code llmProvider}/{@code llmModel}. A warning, not a rejection — the
+     * truncation fallback is well-defined behaviour, same warn-not-reject shape as
+     * {@link #warnOnModeratorlessPhases}.
+     */
+    private void warnOnSummarizerlessWindow(AgentGroupConfiguration groupConfiguration) {
+        var window = groupConfiguration.getContextWindow();
+        if (window == null || !window.enabled() || !Boolean.TRUE.equals(window.summarizeOverflow())) {
+            return;
+        }
+        if (window.llmProvider() == null || window.llmProvider().isBlank() || window.llmModel() == null || window.llmModel().isBlank()) {
+            LOGGER.warnf("Group '%s' enables contextWindow summarization but names no llmProvider/llmModel — "
+                    + "overflow will fall back to a plain truncation marker", groupConfiguration.getName());
+        }
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationSchemaMigrations.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationSchemaMigrations.java
@@ -33,8 +33,11 @@ public final class ConversationSchemaMigrations {
 
     /**
      * Migration functions, keyed by the version they upgrade <em>from</em>. Empty
-     * today for the same reason as the group side's registry: version {@code 1} is
-     * the first that has ever existed. See
+     * today: on this surface version {@code 1} really is the only version that has
+     * ever existed. When bumping
+     * {@link ConversationMemorySnapshot#CURRENT_SCHEMA_VERSION} for the first time,
+     * note that key-less stored documents claim
+     * {@link ConversationMemorySnapshot#LEGACY_SCHEMA_VERSION} — see
      * {@code GroupConversationSchemaMigrations#MIGRATIONS}'s Javadoc.
      */
     private static final Map<Integer, UnaryOperator<ConversationMemorySnapshot>> MIGRATIONS = Map.of();

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -38,6 +38,7 @@ import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.internal.groups.DebateVerdictParser;
 import ai.labs.eddi.engine.internal.groups.GroupAttachmentBinder;
 import ai.labs.eddi.engine.internal.groups.GroupContextBuilder;
+import ai.labs.eddi.engine.internal.groups.GroupCostLedger;
 import ai.labs.eddi.engine.internal.groups.GroupHitlCoordinator;
 import ai.labs.eddi.engine.internal.groups.LiveDiscussionRegistry;
 import ai.labs.eddi.engine.internal.groups.GroupLifecycleOps;
@@ -741,7 +742,13 @@ public class GroupConversationService implements IGroupConversationService {
                     // per member turn — that per-turn re-feeding is the quadratic
                     // cost the window exists to stop. A no-op unless the window is
                     // enabled and the transcript outgrew it since the last extension.
-                    contextBuilder.updateWindowSummary(gc, phase, config.getContextWindow(), summarizationService);
+                    // Ceiling-gated like the convergence judge and the dissent round:
+                    // summarization is optional spend, and a discussion that already
+                    // blew its budget must not pay for one more LLM call the next
+                    // executor's own gate is about to stop anyway.
+                    if (!GroupCostLedger.wouldExceedCeiling(gc, protocol)) {
+                        contextBuilder.updateWindowSummary(gc, phase, config.getContextWindow(), summarizationService);
+                    }
 
                     // I2: mark where this repeat's entries begin. TranscriptEntry
                     // carries phaseIndex but no repeat index, so with repeats > 1 the

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -1690,6 +1690,9 @@ public class GroupConversationService implements IGroupConversationService {
             throws IResourceStore.ResourceStoreException {
 
         GroupConversation gc = new GroupConversation();
+        // The field initialiser is the LEGACY sentinel so key-less stored documents
+        // read as legacy — a genuinely new document must claim current explicitly.
+        gc.setSchemaVersion(GroupConversation.CURRENT_SCHEMA_VERSION);
         gc.setGroupId(groupId);
         gc.setUserId(userId);
         gc.setState(GroupConversationState.IN_PROGRESS);

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -51,6 +51,7 @@ import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.runtime.internal.GracefulShutdownService;
+import ai.labs.eddi.modules.llm.impl.SummarizationService;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -207,6 +208,15 @@ public class GroupConversationService implements IGroupConversationService {
      */
     @Inject
     LiveDiscussionRegistry liveDiscussionRegistry;
+
+    /**
+     * Shared LLM summarization for I9 transcript windowing. Same field-injection
+     * pattern and null-safety as {@link #attachmentStore} — {@code null} in the
+     * direct-construction unit tests, where an enabled window falls back to the
+     * plain truncation marker instead of summarizing.
+     */
+    @Inject
+    SummarizationService summarizationService;
 
     // In-node fast-fail guard for concurrent post-discussion operations
     // (follow-up, continue, close) on the same conversation: a second
@@ -725,6 +735,13 @@ public class GroupConversationService implements IGroupConversationService {
                             startSpeakerIdx = resumePoint.speakerIdx();
                         }
                     }
+
+                    // I9: extend the rolling window summary this repeat's FULL/
+                    // ANONYMOUS-scope turns will render with. At the boundary, never
+                    // per member turn — that per-turn re-feeding is the quadratic
+                    // cost the window exists to stop. A no-op unless the window is
+                    // enabled and the transcript outgrew it since the last extension.
+                    contextBuilder.updateWindowSummary(gc, phase, config.getContextWindow(), summarizationService);
 
                     // I2: mark where this repeat's entries begin. TranscriptEntry
                     // carries phaseIndex but no repeat index, so with repeats > 1 the

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
@@ -18,6 +18,7 @@ import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.modules.llm.impl.SummarizationService;
 import ai.labs.eddi.modules.llm.impl.TokenPricing;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
+import ai.labs.eddi.utils.LogSanitizer;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
@@ -335,12 +336,23 @@ public class GroupContextBuilder {
             return List.of();
         }
 
+        // Sequential phases hand in the LIVE synchronized transcript, which tool
+        // threads (e.g. a recruit's FACILITATION entry) can append to mid-render.
+        // Copy under the wrapper's own monitor — Collections.synchronizedList's
+        // add() locks the wrapper object, which is exactly what this locks — so
+        // the indexed walk below runs over one consistent view. Copying a
+        // snapshot the parallel path already made is a cheap re-wrap.
+        List<TranscriptEntry> entries;
+        synchronized (transcript) {
+            entries = List.copyOf(transcript);
+        }
+
         // Raw transcript indices ride along because the rolling summary's
         // summaryUpToIndex is a raw-transcript boundary, not a filtered-list one.
         List<Integer> rawIndices = new ArrayList<>();
         List<TranscriptEntry> filtered = new ArrayList<>();
-        for (int i = 0; i < transcript.size(); i++) {
-            TranscriptEntry e = transcript.get(i);
+        for (int i = 0; i < entries.size(); i++) {
+            TranscriptEntry e = entries.get(i);
             boolean included = e.content() != null && e.type() != TranscriptEntryType.ERROR && e.type() != TranscriptEntryType.SKIPPED
                     && e.type() != TranscriptEntryType.QUESTION && isVisibleToPeers(e, currentPhaseIdx) && switch (scope) {
                         case FULL -> true;
@@ -472,14 +484,18 @@ public class GroupContextBuilder {
         synchronized (gc.getTranscript()) {
             transcript = List.copyOf(gc.getTranscript());
         }
-        int coverThrough = transcript.size() - window.maxRecentEntries();
+        // The boundary counts VISIBLE (summarizable) entries back from the tail,
+        // not raw entries: bookkeeping rows (SKIPPED, CONVERGENCE, …) in the tail
+        // would otherwise shrink the verbatim window below maxRecentEntries while
+        // newer real contributions get summarized away.
+        int coverThrough = summaryBoundary(transcript, window.maxRecentEntries());
         int alreadyCovered = anonymous ? gc.getAnonymousSummaryUpToIndex() : gc.getSummaryUpToIndex();
         if (coverThrough <= alreadyCovered) {
             return;
         }
         if (summarizationService == null || window.llmProvider() == null || window.llmModel() == null) {
             LOGGER.warnf("Group %s: contextWindow.summarizeOverflow is on but no summarizer %s — falling back to plain truncation",
-                    gc.getId(), summarizationService == null ? "service is available" : "llmProvider/llmModel is configured");
+                    LogSanitizer.sanitize(gc.getId()), summarizationService == null ? "service is available" : "llmProvider/llmModel is configured");
             return;
         }
 
@@ -496,7 +512,8 @@ public class GroupContextBuilder {
             var result = summarizationService.summarizeWithUsage(content, WINDOW_SUMMARY_INSTRUCTIONS,
                     window.llmProvider(), window.llmModel());
             if (result.summary().isBlank()) {
-                LOGGER.warnf("Group %s: window summarization returned empty — keeping previous state, will retry next boundary", gc.getId());
+                LOGGER.warnf("Group %s: window summarization returned empty — keeping previous state, will retry next boundary",
+                        LogSanitizer.sanitize(gc.getId()));
                 return;
             }
             if (anonymous) {
@@ -513,22 +530,52 @@ public class GroupContextBuilder {
                     Map.of("inputTokens", result.inputTokens(), "outputTokens", result.outputTokens()));
             GroupCostLedger.recordSystemCost(gc, "system:summarizer:" + (anonymous ? "anon" : "full") + ":" + coverThrough, cost);
         } catch (Exception e) {
-            LOGGER.warnf("Group %s: window summarization failed (%s) — falling back to plain truncation for this window", gc.getId(),
-                    e.getMessage());
+            LOGGER.warnf("Group %s: window summarization failed (%s) — falling back to plain truncation for this window",
+                    LogSanitizer.sanitize(gc.getId()), e.getMessage());
         }
     }
 
     /**
-     * Renders transcript entries as summarizer input. Applies the same content
-     * exclusions the peer-visibility matrix applies to rendered context —
-     * bookkeeping a member never sees must not leak into a summary a member reads.
+     * The raw index the summary should cover through (exclusive): the position of
+     * the {@code maxRecentEntries}-th <em>summarizable</em> entry counted from the
+     * tail. {@code 0} when the transcript holds fewer than the cap — nothing to
+     * summarize yet.
+     */
+    static int summaryBoundary(List<TranscriptEntry> transcript, int maxRecentEntries) {
+        int visibleSeen = 0;
+        for (int i = transcript.size() - 1; i >= 0; i--) {
+            if (isSummarizable(transcript.get(i))) {
+                visibleSeen++;
+                if (visibleSeen == maxRecentEntries) {
+                    return i;
+                }
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * The shared content predicate for windowing: what counts toward the verbatim
+     * tail and what may enter a summary. The same exclusions the peer-visibility
+     * matrix applies to rendered context — bookkeeping a member never sees must not
+     * leak into a summary a member reads. (VOTE/BID need no phase check here:
+     * summaries are extended at phase boundaries, where every ballot on the
+     * transcript belongs to a completed phase.)
+     */
+    private static boolean isSummarizable(TranscriptEntry e) {
+        return e != null && e.content() != null && e.type() != TranscriptEntryType.ERROR && e.type() != TranscriptEntryType.SKIPPED
+                && e.type() != TranscriptEntryType.QUESTION && e.type() != TranscriptEntryType.ABSTAINED
+                && e.type() != TranscriptEntryType.CONVERGENCE && e.type() != TranscriptEntryType.FACILITATION;
+    }
+
+    /**
+     * Renders transcript entries as summarizer input, {@link #isSummarizable}
+     * entries only.
      */
     private static String renderForSummarizer(List<TranscriptEntry> entries, boolean anonymous) {
         var sb = new StringBuilder();
         for (TranscriptEntry e : entries) {
-            if (e.content() == null || e.type() == TranscriptEntryType.ERROR || e.type() == TranscriptEntryType.SKIPPED
-                    || e.type() == TranscriptEntryType.QUESTION || e.type() == TranscriptEntryType.ABSTAINED
-                    || e.type() == TranscriptEntryType.CONVERGENCE || e.type() == TranscriptEntryType.FACILITATION) {
+            if (!isSummarizable(e)) {
                 continue;
             }
             String label = anonymous ? "Anonymous" : e.speakerDisplayName();

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
@@ -5,17 +5,22 @@
 package ai.labs.eddi.engine.internal.groups;
 
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextWindowConfig;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
 import ai.labs.eddi.configs.groups.model.DiscussionStylePresets;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
 import ai.labs.eddi.engine.memory.ConversationOutputExtractor;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.modules.llm.impl.SummarizationService;
+import ai.labs.eddi.modules.llm.impl.TokenPricing;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import org.jboss.logging.Logger;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -51,6 +56,11 @@ public class GroupContextBuilder {
         return buildPhaseInput(phase, speaker, question, transcript, phaseIdx, target, null);
     }
 
+    public String buildPhaseInput(DiscussionPhase phase, GroupMember speaker, String question, List<TranscriptEntry> transcript, int phaseIdx,
+                                  GroupMember target, List<GroupMember> allMembers) {
+        return buildPhaseInput(phase, speaker, question, transcript, phaseIdx, target, allMembers, null, null);
+    }
+
     /**
      * @param allMembers
      *            the full group roster, used only by {@code ARGUE}/{@code
@@ -60,9 +70,16 @@ public class GroupContextBuilder {
      *            the not-me filter, which is only correct for a 2-member debate —
      *            existing callers that never reach those two phase types are
      *            unaffected either way.
+     * @param window
+     *            I9 transcript windowing, applied to the FULL/ANONYMOUS
+     *            scope-filtered context only. {@code null} disables windowing
+     *            (every pre-I9 caller).
+     * @param gc
+     *            the discussion carrying the rolling window summaries; only read
+     *            when {@code window} is enabled
      */
     public String buildPhaseInput(DiscussionPhase phase, GroupMember speaker, String question, List<TranscriptEntry> transcript, int phaseIdx,
-                                  GroupMember target, List<GroupMember> allMembers) {
+                                  GroupMember target, List<GroupMember> allMembers, ContextWindowConfig window, GroupConversation gc) {
 
         String template = phase.inputTemplate() != null
                 ? phase.inputTemplate()
@@ -79,7 +96,7 @@ public class GroupContextBuilder {
         // Phase-type specific variables
         switch (phase.type()) {
             case OPINION -> {
-                List<Map<String, Object>> prev = filterByScope(transcript, phase.contextScope(), phaseIdx, speaker);
+                List<Map<String, Object>> prev = filterByScope(transcript, phase.contextScope(), phaseIdx, speaker, window, gc);
                 data.put("previousResponses", prev);
             }
             case CRITIQUE -> {
@@ -299,29 +316,229 @@ public class GroupContextBuilder {
     }
 
     public List<Map<String, Object>> filterByScope(List<TranscriptEntry> transcript, ContextScope scope, int currentPhaseIdx, GroupMember speaker) {
+        return filterByScope(transcript, scope, currentPhaseIdx, speaker, null, null);
+    }
+
+    /**
+     * As {@link #filterByScope(List, ContextScope, int, GroupMember)}, windowed
+     * (I9): when {@code window} is enabled, the scope is {@code FULL} or
+     * {@code ANONYMOUS}, and the filtered context exceeds {@code maxRecentEntries},
+     * the older entries collapse into a single leading pseudo-entry — the rolling
+     * summary {@code gc} carries when one covers the omitted range, otherwise a
+     * plain "[n earlier entries omitted]" marker (the truncation fallback for
+     * {@code summarizeOverflow=false} and for summarizer failure). The recent
+     * entries render verbatim; the stored transcript is never modified.
+     */
+    public List<Map<String, Object>> filterByScope(List<TranscriptEntry> transcript, ContextScope scope, int currentPhaseIdx, GroupMember speaker,
+                                                   ContextWindowConfig window, GroupConversation gc) {
         if (scope == null || scope == ContextScope.NONE) {
             return List.of();
         }
 
-        return transcript.stream().filter(e -> e.content() != null && e.type() != TranscriptEntryType.ERROR && e.type() != TranscriptEntryType.SKIPPED
-                && e.type() != TranscriptEntryType.QUESTION).filter(e -> isVisibleToPeers(e, currentPhaseIdx)).filter(e -> switch (scope) {
-                    case FULL -> true;
-                    case LAST_PHASE -> e.phaseIndex() >= currentPhaseIdx - 1;
-                    case ANONYMOUS -> true; // Content included, attribution stripped
-                    case OWN_FEEDBACK -> speaker.agentId().equals(e.targetAgentId());
-                    case NONE -> false;
-                    case TASK_ONLY, TASK_WITH_DEPS -> false; // Handled by task-specific logic
-                }).map(e -> {
-                    Map<String, Object> entry = new LinkedHashMap<>();
-                    if (scope == ContextScope.ANONYMOUS) {
-                        entry.put("speaker", "Anonymous");
-                    } else {
-                        entry.put("speaker", e.speakerDisplayName());
-                    }
-                    entry.put("content", e.content());
-                    entry.put("phaseName", e.phaseName() != null ? e.phaseName() : "");
-                    return entry;
-                }).collect(Collectors.toList());
+        // Raw transcript indices ride along because the rolling summary's
+        // summaryUpToIndex is a raw-transcript boundary, not a filtered-list one.
+        List<Integer> rawIndices = new ArrayList<>();
+        List<TranscriptEntry> filtered = new ArrayList<>();
+        for (int i = 0; i < transcript.size(); i++) {
+            TranscriptEntry e = transcript.get(i);
+            boolean included = e.content() != null && e.type() != TranscriptEntryType.ERROR && e.type() != TranscriptEntryType.SKIPPED
+                    && e.type() != TranscriptEntryType.QUESTION && isVisibleToPeers(e, currentPhaseIdx) && switch (scope) {
+                        case FULL -> true;
+                        case LAST_PHASE -> e.phaseIndex() >= currentPhaseIdx - 1;
+                        case ANONYMOUS -> true; // Content included, attribution stripped
+                        case OWN_FEEDBACK -> speaker.agentId().equals(e.targetAgentId());
+                        case NONE -> false;
+                        case TASK_ONLY, TASK_WITH_DEPS -> false; // Handled by task-specific logic
+                    };
+            if (included) {
+                rawIndices.add(i);
+                filtered.add(e);
+            }
+        }
+
+        boolean windowed = window != null && window.enabled() && gc != null
+                && (scope == ContextScope.FULL || scope == ContextScope.ANONYMOUS)
+                && filtered.size() > window.maxRecentEntries();
+        if (!windowed) {
+            return renderEntries(filtered, scope);
+        }
+
+        String summary = scope == ContextScope.ANONYMOUS ? gc.getAnonymousTranscriptSummary() : gc.getTranscriptSummary();
+        int summaryUpTo = scope == ContextScope.ANONYMOUS ? gc.getAnonymousSummaryUpToIndex() : gc.getSummaryUpToIndex();
+
+        if (summary != null && !summary.isBlank() && summaryUpTo > 0) {
+            // Verbatim tail = everything the summary does not cover. Split on the raw
+            // boundary rather than "last maxRecentEntries" so there is never a gap
+            // (entries neither summarized nor shown) and never duplication (entries
+            // both summarized and shown). Between phase boundaries the tail can grow
+            // a few entries past the cap; the next boundary's summary extension
+            // re-tightens it.
+            List<TranscriptEntry> verbatim = new ArrayList<>();
+            int omitted = 0;
+            for (int i = 0; i < filtered.size(); i++) {
+                if (rawIndices.get(i) >= summaryUpTo) {
+                    verbatim.add(filtered.get(i));
+                } else {
+                    omitted++;
+                }
+            }
+            if (omitted == 0) {
+                return renderEntries(filtered, scope);
+            }
+            List<Map<String, Object>> result = new ArrayList<>();
+            result.add(syntheticEntry("Summary of the earlier discussion:\n" + summary));
+            result.addAll(renderEntries(verbatim, scope));
+            return result;
+        }
+
+        // Truncation fallback — summarizeOverflow=false, no summarizer configured,
+        // or every summarization attempt so far failed.
+        int omitted = filtered.size() - window.maxRecentEntries();
+        List<Map<String, Object>> result = new ArrayList<>();
+        result.add(syntheticEntry("[%d earlier entries omitted]".formatted(omitted)));
+        result.addAll(renderEntries(filtered.subList(omitted, filtered.size()), scope));
+        return result;
+    }
+
+    private static List<Map<String, Object>> renderEntries(List<TranscriptEntry> entries, ContextScope scope) {
+        return entries.stream().map(e -> {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            if (scope == ContextScope.ANONYMOUS) {
+                entry.put("speaker", "Anonymous");
+            } else {
+                entry.put("speaker", e.speakerDisplayName());
+            }
+            entry.put("content", e.content());
+            entry.put("phaseName", e.phaseName() != null ? e.phaseName() : "");
+            return entry;
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * The windowing pseudo-entry. "System" as the speaker, never a member name —
+     * under ANONYMOUS scope it must not read as an attribution.
+     */
+    private static Map<String, Object> syntheticEntry(String content) {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("speaker", "System");
+        entry.put("content", content);
+        entry.put("phaseName", "(earlier discussion)");
+        return entry;
+    }
+
+    /**
+     * Summarization instructions for the I9 window summary. Tag-style constraint
+     * header rather than instruction prose, per the plan's research-adopted
+     * template note.
+     */
+    static final String WINDOW_SUMMARY_INSTRUCTIONS = """
+            Summarize the group discussion entries below for a participant who must continue the discussion.
+            Preserve: each speaker's position and key arguments, decisions reached, open disagreements, and task outcomes.
+            [format: bullet points] [limit: 500 tokens]""";
+
+    /**
+     * Extends the discussion's rolling window summary (I9), called from the
+     * discussion loop at phase boundaries only — never per member turn, which is
+     * exactly the quadratic re-feeding this feature exists to stop.
+     * <p>
+     * A no-op unless the upcoming phase is an OPINION phase with FULL or ANONYMOUS
+     * scope (the only context {@link #filterByScope} windows), the window is
+     * enabled with {@code summarizeOverflow=true}, and the transcript has outgrown
+     * {@code maxRecentEntries} beyond what the summary already covers. The
+     * extension is incremental: the summarizer is handed the previous summary plus
+     * only the new slice, mirroring {@code ConversationSummarizer}'s algorithm —
+     * and like it, a failed call leaves the stored state untouched (WARN, never
+     * blocks the discussion), so rendering falls back to the truncation marker and
+     * the next boundary catches up with a larger batch.
+     * <p>
+     * The ANONYMOUS variant is summarized from "Anonymous"-labelled input — the
+     * same labels the scope filter itself produces — so the stored anonymous
+     * summary can never de-anonymize a peer. Summarizer spend is attributed to the
+     * discussion's cost ledger (I1) when the window config carries prices.
+     */
+    public void updateWindowSummary(GroupConversation gc, DiscussionPhase phase, ContextWindowConfig window,
+                                    SummarizationService summarizationService) {
+        if (window == null || !window.enabled() || !Boolean.TRUE.equals(window.summarizeOverflow())
+                || gc == null || phase == null || phase.type() != PhaseType.OPINION) {
+            return;
+        }
+        ContextScope scope = phase.contextScope();
+        if (scope != ContextScope.FULL && scope != ContextScope.ANONYMOUS) {
+            return;
+        }
+        boolean anonymous = scope == ContextScope.ANONYMOUS;
+
+        List<TranscriptEntry> transcript;
+        synchronized (gc.getTranscript()) {
+            transcript = List.copyOf(gc.getTranscript());
+        }
+        int coverThrough = transcript.size() - window.maxRecentEntries();
+        int alreadyCovered = anonymous ? gc.getAnonymousSummaryUpToIndex() : gc.getSummaryUpToIndex();
+        if (coverThrough <= alreadyCovered) {
+            return;
+        }
+        if (summarizationService == null || window.llmProvider() == null || window.llmModel() == null) {
+            LOGGER.warnf("Group %s: contextWindow.summarizeOverflow is on but no summarizer %s — falling back to plain truncation",
+                    gc.getId(), summarizationService == null ? "service is available" : "llmProvider/llmModel is configured");
+            return;
+        }
+
+        String newSlice = renderForSummarizer(transcript.subList(alreadyCovered, coverThrough), anonymous);
+        if (newSlice.isBlank()) {
+            return;
+        }
+        String previousSummary = anonymous ? gc.getAnonymousTranscriptSummary() : gc.getTranscriptSummary();
+        String content = previousSummary != null && !previousSummary.isBlank()
+                ? "## Summary of entries 1-" + alreadyCovered + ":\n" + previousSummary + "\n\n## New entries:\n" + newSlice
+                : newSlice;
+
+        try {
+            var result = summarizationService.summarizeWithUsage(content, WINDOW_SUMMARY_INSTRUCTIONS,
+                    window.llmProvider(), window.llmModel());
+            if (result.summary().isBlank()) {
+                LOGGER.warnf("Group %s: window summarization returned empty — keeping previous state, will retry next boundary", gc.getId());
+                return;
+            }
+            if (anonymous) {
+                gc.setAnonymousTranscriptSummary(result.summary());
+                gc.setAnonymousSummaryUpToIndex(coverThrough);
+            } else {
+                gc.setTranscriptSummary(result.summary());
+                gc.setSummaryUpToIndex(coverThrough);
+            }
+            // I1: the summarizer's own spend is discussion spend. Keyed per variant
+            // and boundary so a re-run of the same extension replaces (idempotent)
+            // while distinct extensions sum.
+            double cost = TokenPricing.cost(window.inputPricePer1M(), window.outputPricePer1M(),
+                    Map.of("inputTokens", result.inputTokens(), "outputTokens", result.outputTokens()));
+            GroupCostLedger.recordSystemCost(gc, "system:summarizer:" + (anonymous ? "anon" : "full") + ":" + coverThrough, cost);
+        } catch (Exception e) {
+            LOGGER.warnf("Group %s: window summarization failed (%s) — falling back to plain truncation for this window", gc.getId(),
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * Renders transcript entries as summarizer input. Applies the same content
+     * exclusions the peer-visibility matrix applies to rendered context —
+     * bookkeeping a member never sees must not leak into a summary a member reads.
+     */
+    private static String renderForSummarizer(List<TranscriptEntry> entries, boolean anonymous) {
+        var sb = new StringBuilder();
+        for (TranscriptEntry e : entries) {
+            if (e.content() == null || e.type() == TranscriptEntryType.ERROR || e.type() == TranscriptEntryType.SKIPPED
+                    || e.type() == TranscriptEntryType.QUESTION || e.type() == TranscriptEntryType.ABSTAINED
+                    || e.type() == TranscriptEntryType.CONVERGENCE || e.type() == TranscriptEntryType.FACILITATION) {
+                continue;
+            }
+            String label = anonymous ? "Anonymous" : e.speakerDisplayName();
+            sb.append("- ").append(label);
+            if (e.phaseName() != null) {
+                sb.append(" (").append(e.phaseName()).append(')');
+            }
+            sb.append(": ").append(e.content()).append('\n');
+        }
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupConversationSchemaMigrations.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupConversationSchemaMigrations.java
@@ -28,13 +28,16 @@ public final class GroupConversationSchemaMigrations {
     /**
      * Migration functions, keyed by the version they upgrade <em>from</em> (so
      * entry {@code N} takes a version-{@code N} document to version {@code N+1}).
-     * Empty today — {@link GroupConversation#CURRENT_SCHEMA_VERSION} is {@code 1},
-     * the first version that has ever existed, so there is nothing yet to migrate
-     * from. Every future Wave item that adds a resume-relevant field bumps
-     * {@code CURRENT_SCHEMA_VERSION} and registers its own entry here. A version
-     * hop with no registered entry defaults to identity (see
-     * {@link #prepareForResume}) — the documented, common case for a bump whose new
-     * fields default correctly via Jackson without any transformation.
+     * Empty today: every bump so far ({@code 1→2→3}) was additive — the new fields
+     * default correctly via Jackson, so those hops ride the identity fallback below
+     * rather than a registered entry. That fallback path has therefore already been
+     * exercised; do not read the empty map as "no version has ever changed". Every
+     * future Wave item that adds a resume-relevant field bumps
+     * {@link GroupConversation#CURRENT_SCHEMA_VERSION} and registers an entry here
+     * only when the hop actually needs a transformation. Documents stored without a
+     * {@code schemaVersion} key deserialize claiming
+     * {@link GroupConversation#LEGACY_SCHEMA_VERSION} and enter the ladder at the
+     * bottom.
      */
     private static final Map<Integer, UnaryOperator<GroupConversation>> MIGRATIONS = Map.of();
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupCostLedger.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupCostLedger.java
@@ -114,7 +114,11 @@ public final class GroupCostLedger {
      * is idempotent while distinct operations sum.
      */
     public static void recordSystemCost(GroupConversation gc, String key, double cost) {
-        if (key == null || cost <= 0.0) {
+        // !(cost > 0.0) rather than cost <= 0.0: NaN fails every comparison, so
+        // the latter would let a NaN through, poison totalCost, and silently
+        // disable the ceiling checks (NaN comparisons are all false). Infinity is
+        // rejected for the same reason — no finite ceiling could ever bind again.
+        if (key == null || !Double.isFinite(cost) || !(cost > 0.0)) {
             return;
         }
         recordAndReSum(gc, key, cost);

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupCostLedger.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupCostLedger.java
@@ -107,6 +107,20 @@ public final class GroupCostLedger {
     }
 
     /**
+     * Attribution for spend the discussion's own machinery incurs — today the I9
+     * transcript summarizer. {@code key} must be unique per priced operation (e.g.
+     * {@code "system:summarizer:full:42"}, suffixed with the boundary it covered
+     * through): the map records by replacement, so a re-run of the same operation
+     * is idempotent while distinct operations sum.
+     */
+    public static void recordSystemCost(GroupConversation gc, String key, double cost) {
+        if (key == null || cost <= 0.0) {
+            return;
+        }
+        recordAndReSum(gc, key, cost);
+    }
+
+    /**
      * The pre-turn/pre-wave ceiling check (I1). If
      * {@code protocol.maxCostPerDiscussion()} is set and {@code gc.getTotalCost()}
      * has passed it, records a {@code SKIPPED} transcript entry naming the ceiling

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupCostLedger.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupCostLedger.java
@@ -87,12 +87,23 @@ public final class GroupCostLedger {
      * this group's attribution, whole — the child's own {@code totalCost} already
      * reflects everything its own members accumulated (recursively, via this same
      * method for individual members).
+     * <p>
+     * Keyed per <em>child discussion</em>, not per member: {@code memberCosts}
+     * records by replacement, which is only idempotent when one key means one
+     * conversation's cumulative cost. Every turn of a GROUP member spawns a fresh
+     * child discussion whose {@code totalCost} starts at 0, so keying by agentId
+     * alone replaced child N−1's whole spend with child N's and only the last child
+     * survived the sum. The suffix restores the map's invariant; a child without an
+     * id (not yet persisted) falls back to the plain agentId.
      */
     public static void accumulateNestedGroupCost(GroupConversation gc, GroupMember member, GroupConversation subConversation) {
         if (subConversation == null) {
             return;
         }
-        recordAndReSum(gc, member.agentId(), subConversation.getTotalCost());
+        String attributionKey = subConversation.getId() != null
+                ? member.agentId() + ":" + subConversation.getId()
+                : member.agentId();
+        recordAndReSum(gc, attributionKey, subConversation.getTotalCost());
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupCostLedger.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupCostLedger.java
@@ -22,17 +22,13 @@ import java.util.Locale;
  * {@code memberCosts}/{@code totalCost} (Wave 0, F5), and enforces
  * {@code ProtocolConfig#maxCostPerDiscussion} against it (I1).
  * <p>
- * <b>Known gap (V1, confirmed):</b> {@link MemoryKeys#AUDIT_COST} — the value
- * this class reads — is written by {@code LlmTask.accumulateCost} from
- * {@code cascadeCostUsd + toolCostUsd} only. There is no dollar price table for
- * a non-cascade model completion anywhere in this codebase today
- * ({@code LlmTask}'s own Javadoc says so directly), so a member's own turn
- * contributes {@code $0} here unless the group's LLM config uses the
- * multi-model cascade (priced) or the turn called a priced tool. This is a
- * real, known undercount for the common case, not a bug in this class — I1 is
- * where model-call cost recording gets added, reusing whatever price source it
- * settles on. Until then, {@code totalCost} is a lower bound, not the true
- * total.
+ * <b>Coverage note:</b> {@link MemoryKeys#AUDIT_COST} — the value this class
+ * reads — sums the member conversation's LLM token spend (cascade step pricing,
+ * or the task-level {@code inputPricePer1M}/{@code outputPricePer1M} for plain
+ * calls) and its tracked tool cost. Pricing is config-driven with no built-in
+ * provider price table, so a member whose LLM config carries no prices still
+ * contributes {@code $0} of token cost here — for such members
+ * {@code totalCost} remains a lower bound.
  * <p>
  * Both {@code memberCosts} and the recomputed {@code totalCost} are set, never
  * incremented by a delta — each call replaces the member's entry with its

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
@@ -511,7 +511,7 @@ public class PhaseExecutionEngine {
                         new GroupConversationEventSink.SpeakerStartEvent(speaker.agentId(), speaker.displayName(), phaseIdx, phase.name()));
             }
             String input = contextBuilder.buildPhaseInput(phase, speaker, question, gc.getTranscript(), phaseIdx, null,
-                    GroupConversationService.rosterWithRecruits(config, gc));
+                    GroupConversationService.rosterWithRecruits(config, gc), config.getContextWindow(), gc);
             TranscriptEntry entry = memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, null, listener);
             gc.getTranscript().add(entry);
             if (listener != null) {
@@ -586,7 +586,7 @@ public class PhaseExecutionEngine {
                 .map(speaker -> CompletableFuture.supplyAsync(callerIdentityContext.withIdentitySupplying(phaseCaller, () -> {
                     try {
                         String input = contextBuilder.buildPhaseInput(phase, speaker, question, snapshotTranscript, phaseIdx, null,
-                                GroupConversationService.rosterWithRecruits(config, gc));
+                                GroupConversationService.rosterWithRecruits(config, gc), config.getContextWindow(), gc);
                         return memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, null, listener, cancellation);
                     } catch (MemberTurnCancelledException e) {
                         // The orchestrator stopped waiting for this batch — surface the
@@ -715,7 +715,7 @@ public class PhaseExecutionEngine {
                             new GroupConversationEventSink.SpeakerStartEvent(speaker.agentId(), speaker.displayName(), phaseIdx, phase.name()));
                 }
                 String input = contextBuilder.buildPhaseInput(phase, speaker, question, gc.getTranscript(), phaseIdx, target,
-                        GroupConversationService.rosterWithRecruits(config, gc));
+                        GroupConversationService.rosterWithRecruits(config, gc), config.getContextWindow(), gc);
                 TranscriptEntry entry = memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, target.agentId(),
                         listener);
                 gc.getTranscript().add(entry);

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilities.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilities.java
@@ -64,6 +64,10 @@ public class ConversationMemoryUtilities {
 
     private static ConversationMemorySnapshot getMemorySnapshot(IConversationMemory conversationMemory) {
         var snapshot = new ConversationMemorySnapshot();
+        // The field initialiser is the LEGACY sentinel so key-less stored documents
+        // read as legacy — a snapshot built from live memory is current by
+        // definition and must say so explicitly.
+        snapshot.setSchemaVersion(ConversationMemorySnapshot.CURRENT_SCHEMA_VERSION);
 
         if (conversationMemory.getUserId() != null) {
             snapshot.setUserId(conversationMemory.getUserId());

--- a/src/main/java/ai/labs/eddi/engine/memory/model/ConversationMemorySnapshot.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/model/ConversationMemorySnapshot.java
@@ -27,12 +27,25 @@ public class ConversationMemorySnapshot {
      */
     public static final int CURRENT_SCHEMA_VERSION = 1;
     /**
+     * The version a stored document claims when its JSON carries no
+     * {@code schemaVersion} key. Mirrors
+     * {@code GroupConversation#LEGACY_SCHEMA_VERSION} and exists for the same
+     * reason: Jackson leaves the field initialiser standing for key-less documents,
+     * so the initialiser must be the legacy floor and the creation path
+     * ({@code ConversationMemoryUtilities}) stamps {@link #CURRENT_SCHEMA_VERSION}
+     * explicitly. While {@code CURRENT} is also {@code 1} this is indistinguishable
+     * from initialising to CURRENT — but only by coincidence, and the first bump to
+     * {@code 2} would silently re-create the group side's zero-iteration migration
+     * bug without this split.
+     */
+    public static final int LEGACY_SCHEMA_VERSION = 1;
+    /**
      * The shape this specific document was last written in. Checked before a
      * resume: newer than {@link #CURRENT_SCHEMA_VERSION} refuses (this deployment
      * predates the document), older runs registered migrations forward. See
      * {@code ConversationSchemaMigrations}.
      */
-    private int schemaVersion = CURRENT_SCHEMA_VERSION;
+    private int schemaVersion = LEGACY_SCHEMA_VERSION;
     private String conversationId;
     private String agentId;
     private Integer agentVersion;

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/CascadeConfigValidator.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/CascadeConfigValidator.java
@@ -17,9 +17,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Deploy-time validation for {@link ModelCascadeConfig}. Runs from
- * {@code LlmTask.configure()} so misconfigurations surface at agent deployment
- * rather than per-turn mid-conversation.
+ * Deploy-time validation for {@link ModelCascadeConfig} and the task-level
+ * pricing fields. Runs from {@code LlmTask.configure()} so misconfigurations
+ * surface at agent deployment rather than per-turn mid-conversation.
  * <p>
  * <b>Backward compatibility:</b> conditions that older releases tolerated at
  * load (they still failed/degraded at runtime exactly as before — unknown
@@ -53,12 +53,18 @@ final class CascadeConfigValidator {
     }
 
     private static void validateTask(LlmConfiguration.Task task) throws WorkflowConfigurationException {
+        String taskId = task.getId() != null ? task.getId() : "<unnamed>";
+
+        // Task-level pricing is NEW (same rationale as the cascade pricing below:
+        // no stored config predating it can carry the field) — hard error on a
+        // negative value, cascade or not.
+        requireNonNegativeTaskPrice(taskId, "inputPricePer1M", task.getInputPricePer1M());
+        requireNonNegativeTaskPrice(taskId, "outputPricePer1M", task.getOutputPricePer1M());
+
         ModelCascadeConfig cascade = task.getModelCascade();
         if (cascade == null || !cascade.isEnabled()) {
             return;
         }
-
-        String taskId = task.getId() != null ? task.getId() : "<unnamed>";
 
         List<CascadeStep> steps = cascade.getSteps();
         if (steps == null || steps.isEmpty()) {
@@ -157,6 +163,12 @@ final class CascadeConfigValidator {
     private static void requireNonNegativePrice(String taskId, String what, Double price) throws WorkflowConfigurationException {
         if (price != null && price < 0) {
             throw fail(taskId, what + " must be >= 0");
+        }
+    }
+
+    private static void requireNonNegativeTaskPrice(String taskId, String what, Double price) throws WorkflowConfigurationException {
+        if (price != null && price < 0) {
+            throw new WorkflowConfigurationException("Invalid LLM task '" + taskId + "': " + what + " must be >= 0");
         }
     }
 

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutor.java
@@ -717,19 +717,7 @@ class CascadingModelExecutor {
     static double computeCost(CascadeStep step, ModelCascadeConfig cascade, Map<String, Object> tokenUsage) {
         Double inPrice = step.getInputPricePer1M() != null ? step.getInputPricePer1M() : cascade.getInputPricePer1M();
         Double outPrice = step.getOutputPricePer1M() != null ? step.getOutputPricePer1M() : cascade.getOutputPricePer1M();
-        if (tokenUsage == null || (inPrice == null && outPrice == null)) {
-            return 0.0;
-        }
-        long inputTokens = asLong(tokenUsage.get("inputTokens"));
-        long outputTokens = asLong(tokenUsage.get("outputTokens"));
-        double cost = 0.0;
-        if (inPrice != null) {
-            cost += inputTokens / 1_000_000.0 * inPrice;
-        }
-        if (outPrice != null) {
-            cost += outputTokens / 1_000_000.0 * outPrice;
-        }
-        return cost;
+        return TokenPricing.cost(inPrice, outPrice, tokenUsage);
     }
 
     private static long asLong(Object value) {

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
@@ -697,7 +697,7 @@ public class LlmTask implements ILifecycleTask {
             var modelNameData = dataFactory.createData(MemoryKeys.AUDIT_MODEL_NAME, modelName);
             currentStep.storeData(modelNameData);
 
-            accumulateAuditEvidence(currentStep, responseMetadata, toolTrace, task.getId());
+            accumulateAuditEvidence(currentStep, responseMetadata, toolTrace, task);
         }
 
         // Store tool trace if available
@@ -785,19 +785,26 @@ public class LlmTask implements ILifecycleTask {
      * plus every escalated cascade step and tool-loop iteration inside each. The
      * ledger has to report the turn's total, but {@code getLatestData} is
      * last-write-wins, so each contributor read-modify-writes rather than
-     * overwriting. Cost is the sum of the two dollar signals that actually exist:
-     * configured cascade LLM pricing and tracked tool cost. There is no token price
-     * table for non-cascade tasks, so those contribute tool cost only.
+     * overwriting. Cost sums the LLM token spend and the tracked tool cost. A
+     * cascade run prices its own steps and reports the total as
+     * {@code cascadeCostUsd}; a plain call is priced here from the task-level
+     * {@code inputPricePer1M}/{@code outputPricePer1M} — the key presence
+     * discriminates, so cascade tokens are never priced twice. Unpriced configs
+     * contribute $0 exactly as before.
      */
     private void accumulateAuditEvidence(IWritableConversationStep currentStep, Map<String, Object> responseMetadata,
-                                         List<Map<String, Object>> toolTrace, String llmTaskId) {
+                                         List<Map<String, Object>> toolTrace, Task task) {
         if (responseMetadata != null) {
-            if (responseMetadata.get("tokenUsage") instanceof Map<?, ?> tokenUsage) {
+            Map<?, ?> tokenUsage = responseMetadata.get("tokenUsage") instanceof Map<?, ?> tu ? tu : null;
+            if (tokenUsage != null) {
                 accumulateTokenUsage(currentStep, tokenUsage);
             }
-            accumulateCost(currentStep, asDouble(responseMetadata.get("cascadeCostUsd")) + asDouble(responseMetadata.get("toolCostUsd")));
+            double llmCostUsd = responseMetadata.containsKey("cascadeCostUsd")
+                    ? asDouble(responseMetadata.get("cascadeCostUsd"))
+                    : TokenPricing.cost(task.getInputPricePer1M(), task.getOutputPricePer1M(), tokenUsage);
+            accumulateCost(currentStep, llmCostUsd + asDouble(responseMetadata.get("toolCostUsd")));
         }
-        accumulateToolCalls(currentStep, toolTrace, llmTaskId);
+        accumulateToolCalls(currentStep, toolTrace, task.getId());
     }
 
     private void accumulateTokenUsage(IWritableConversationStep currentStep, Map<?, ?> delta) {
@@ -1087,7 +1094,7 @@ public class LlmTask implements ILifecycleTask {
             // Known gap: the continuation's tokenUsage covers only the post-resume model
             // calls (see the comment above) — the pre-pause segment is not recoverable
             // here, so a paused turn's ledger entry under-reports by that segment.
-            accumulateAuditEvidence(currentStep, responseMetadata, toolTrace, task.getId());
+            accumulateAuditEvidence(currentStep, responseMetadata, toolTrace, task);
         }
 
         // Tool trace (mirror executeTask)

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
@@ -854,7 +854,10 @@ public class LlmTask implements ILifecycleTask {
     }
 
     private void accumulateCost(IWritableConversationStep currentStep, double delta) {
-        if (delta <= 0.0) {
+        // !(delta > 0.0), not delta <= 0.0: NaN fails every comparison, so the
+        // latter admits it — and one NaN poisons the running total forever,
+        // silently disabling every dollar ceiling that compares against it.
+        if (!Double.isFinite(delta) || !(delta > 0.0)) {
             return;
         }
         double total = delta;

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/TokenPricing.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/TokenPricing.java
@@ -16,8 +16,12 @@ import java.util.Map;
  * There is deliberately no built-in provider price table: prices are an
  * agent-designer concern and belong in configuration, where they can track
  * provider changes without a code release.
+ * <p>
+ * Public because the group transcript summarizer (I9,
+ * {@code GroupContextBuilder}) prices its own summarization calls with the same
+ * formula.
  */
-final class TokenPricing {
+public final class TokenPricing {
 
     private TokenPricing() {
     }
@@ -31,7 +35,7 @@ final class TokenPricing {
      *            the {@code tokenUsage} metadata map carrying
      *            {@code inputTokens}/{@code outputTokens} as numbers
      */
-    static double cost(Double inputPricePer1M, Double outputPricePer1M, Map<?, ?> tokenUsage) {
+    public static double cost(Double inputPricePer1M, Double outputPricePer1M, Map<?, ?> tokenUsage) {
         if (tokenUsage == null || (inputPricePer1M == null && outputPricePer1M == null)) {
             return 0.0;
         }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/TokenPricing.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/TokenPricing.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import java.util.Map;
+
+/**
+ * The single home of the configured-price token-cost arithmetic. Both dollar
+ * signals that price LLM token spend — cascade steps
+ * ({@code CascadingModelExecutor.computeCost}) and plain task-level pricing
+ * ({@code LlmTask.accumulateAuditEvidence}) — delegate here, so the formula
+ * cannot drift between the two paths.
+ * <p>
+ * There is deliberately no built-in provider price table: prices are an
+ * agent-designer concern and belong in configuration, where they can track
+ * provider changes without a code release.
+ */
+final class TokenPricing {
+
+    private TokenPricing() {
+    }
+
+    /**
+     * Dollar cost of one call from its reported token usage and configured
+     * per-1M-token prices. A null price means "unpriced" and contributes 0; with
+     * both prices null (or no usage reported) the call is free.
+     *
+     * @param tokenUsage
+     *            the {@code tokenUsage} metadata map carrying
+     *            {@code inputTokens}/{@code outputTokens} as numbers
+     */
+    static double cost(Double inputPricePer1M, Double outputPricePer1M, Map<?, ?> tokenUsage) {
+        if (tokenUsage == null || (inputPricePer1M == null && outputPricePer1M == null)) {
+            return 0.0;
+        }
+        long inputTokens = asLong(tokenUsage.get("inputTokens"));
+        long outputTokens = asLong(tokenUsage.get("outputTokens"));
+        double cost = 0.0;
+        if (inputPricePer1M != null) {
+            cost += inputTokens / 1_000_000.0 * inputPricePer1M;
+        }
+        if (outputPricePer1M != null) {
+            cost += outputTokens / 1_000_000.0 * outputPricePer1M;
+        }
+        return cost;
+    }
+
+    private static long asLong(Object value) {
+        return value instanceof Number n ? n.longValue() : 0L;
+    }
+}

--- a/src/main/java/ai/labs/eddi/modules/llm/model/LlmConfiguration.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/model/LlmConfiguration.java
@@ -314,6 +314,21 @@ public record LlmConfiguration(@JsonProperty("tasks") List<Task> tasks) {
          */
         private Map<String, Double> toolPricing;
 
+        /**
+         * Input price per 1M tokens in USD for this task's model calls. Null =
+         * unpriced, contributing $0 to the tracked conversation cost. Applies to
+         * non-cascade calls; a cascade run prices its steps via {@code modelCascade}'s
+         * own {@code inputPricePer1M}/{@code outputPricePer1M} (steps may target
+         * different models, so task-level prices are not inherited).
+         */
+        private Double inputPricePer1M;
+
+        /**
+         * Output price per 1M tokens in USD. Same semantics as
+         * {@link #inputPricePer1M}.
+         */
+        private Double outputPricePer1M;
+
         /** Enable cost tracking */
         private Boolean enableCostTracking = true;
 
@@ -773,6 +788,22 @@ public record LlmConfiguration(@JsonProperty("tasks") List<Task> tasks) {
 
         public void setToolPricing(Map<String, Double> toolPricing) {
             this.toolPricing = toolPricing;
+        }
+
+        public Double getInputPricePer1M() {
+            return inputPricePer1M;
+        }
+
+        public void setInputPricePer1M(Double inputPricePer1M) {
+            this.inputPricePer1M = inputPricePer1M;
+        }
+
+        public Double getOutputPricePer1M() {
+            return outputPricePer1M;
+        }
+
+        public void setOutputPricePer1M(Double outputPricePer1M) {
+            this.outputPricePer1M = outputPricePer1M;
         }
 
         public Boolean getEnableCostTracking() {

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationSchemaMigrationsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationSchemaMigrationsTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.internal;
 
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -24,6 +25,23 @@ class ConversationSchemaMigrationsTest {
         snapshot.setConversationId("conv-1");
         snapshot.setSchemaVersion(schemaVersion);
         return snapshot;
+    }
+
+    /**
+     * Pins the legacy sentinel under deserialization. Today {@code LEGACY} and
+     * {@code CURRENT} are both {@code 1}, so this cannot fail for the group side's
+     * reason yet — it exists so the first bump of {@code CURRENT} to {@code 2}
+     * fails THIS test if someone re-couples the field initialiser to
+     * {@code CURRENT}, instead of silently re-creating the zero-iteration migration
+     * bug the group side shipped.
+     */
+    @Test
+    void documentWithoutVersionKey_claimsLegacyVersion() throws Exception {
+        var legacy = new ObjectMapper().readValue("{}", ConversationMemorySnapshot.class);
+
+        assertEquals(ConversationMemorySnapshot.LEGACY_SCHEMA_VERSION, legacy.getSchemaVersion());
+        assertEquals(1, ConversationMemorySnapshot.LEGACY_SCHEMA_VERSION,
+                "the legacy floor is the first version that ever existed — it never moves, even when CURRENT bumps");
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceCostCeilingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceCostCeilingTest.java
@@ -34,6 +34,7 @@ import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
+import ai.labs.eddi.modules.llm.impl.SummarizationService;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -224,6 +225,38 @@ class GroupConversationServiceCostCeilingTest {
                 .filter(e -> e.type() != TranscriptEntryType.SKIPPED)
                 .map(e -> e.phaseName()).distinct().toList();
         assertFalse(phasesRun.contains("Summary"), "ABORT must not run synthesis — it fails outright");
+    }
+
+    /**
+     * Review finding (Copilot, PR #636): summarization is optional spend and must
+     * be ceiling-gated like the convergence judge and the dissent round. The
+     * scenario is built so the FIRST phase completes without tripping the per-turn
+     * gate (member A passes at $0, member B at $2 under the $3 ceiling) while its
+     * cumulative spend ends at $6 — so the SECOND Opinion phase's boundary is
+     * reached with the ceiling already blown and two summarizable entries on the
+     * transcript (cap 1 → a summarizer call is otherwise guaranteed).
+     * Mutation-checked: removing the guard fails this test.
+     */
+    @Test
+    @DisplayName("a blown ceiling also gates the I9 window summarizer — optional spend stops with the budget")
+    void blownCeiling_skipsWindowSummarization() throws Exception {
+        var phases = List.of(
+                phase("Opinion 1", PhaseType.OPINION),
+                phase("Opinion 2", PhaseType.OPINION),
+                phase("Summary", PhaseType.SYNTHESIS));
+        var config = buildConfig(phases, protocol(3.0, CostPolicy.SYNTHESIZE_NOW));
+        config.setMembers(List.of(new GroupMember(AGENT_A, "Agent A", 1, null), new GroupMember("agent-b", "Agent B", 2, null)));
+        config.setContextWindow(new AgentGroupConfiguration.ContextWindowConfig(true, 1, true, "openai", "gpt-4o-mini", null, null));
+        doReturn(mockResourceId()).when(groupStore).getCurrentResourceId(GROUP_ID);
+        doReturn(config).when(groupStore).read(GROUP_ID, 1);
+        doReturn("gc-window").when(conversationStore).create(any());
+        stubAgentSayCosting(2.0);
+        var summarizer = mock(SummarizationService.class);
+        service.summarizationService = summarizer;
+
+        service.discuss(GROUP_ID, "Q?", USER_ID, 0);
+
+        verifyNoInteractions(summarizer);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceExtendedTest.java
@@ -296,6 +296,29 @@ class GroupConversationServiceExtendedTest {
             verify(listener).onGroupError(any(GroupConversationEventSink.GroupErrorEvent.class));
         }
 
+        /**
+         * F6/N3: the field initialiser is the LEGACY sentinel (so key-less stored
+         * documents read as legacy), which means a freshly created document only claims
+         * the current schema because the creation path stamps it. Drop the stamp and
+         * every NEW document would persist claiming legacy shape.
+         */
+        @Test
+        void discuss_stampsCurrentSchemaVersionOnTheCreatedDocument() throws Exception {
+            var cfg = config(DiscussionStyle.ROUND_TABLE, 1,
+                    new GroupMember("a1", "Alice", 1, null));
+            cfg.setModeratorAgentId("mod");
+            setupStore(cfg);
+            stubAgent("a1", "Opinion");
+            stubAgent("mod", "Synthesis");
+
+            service.discuss(GROUP_ID, QUESTION, USER_ID, 0, null);
+
+            var created = ArgumentCaptor.forClass(GroupConversation.class);
+            verify(conversationStore).create(created.capture());
+            assertEquals(GroupConversation.CURRENT_SCHEMA_VERSION, created.getValue().getSchemaVersion(),
+                    "a new document must be stamped current at creation — the initialiser deliberately is not");
+        }
+
         @Test
         void discuss_withNullListener_doesNotThrow() throws Exception {
             var cfg = config(DiscussionStyle.ROUND_TABLE, 1,

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderWindowingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderWindowingTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextWindowConfig;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TurnOrder;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import ai.labs.eddi.modules.llm.impl.SummarizationService;
+import ai.labs.eddi.modules.llm.impl.SummarizationService.SummarizationResult;
+import ai.labs.eddi.modules.templating.ITemplatingEngine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * I9 — transcript windowing in {@link GroupContextBuilder}: the windowed
+ * {@code filterByScope} rendering (summary pseudo-entry, truncation fallback,
+ * ANONYMOUS label preservation) and the phase-boundary
+ * {@code updateWindowSummary} extension (incremental slices, failure fallback,
+ * I1 cost attribution).
+ *
+ * @author tests
+ */
+class GroupContextBuilderWindowingTest {
+
+    @Mock
+    private ITemplatingEngine templatingEngine;
+    @Mock
+    private SummarizationService summarizationService;
+
+    private GroupContextBuilder builder;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        builder = new GroupContextBuilder(templatingEngine);
+    }
+
+    private GroupMember member() {
+        return new GroupMember("agent-a", "Agent A", 1, null);
+    }
+
+    private DiscussionPhase opinionPhase(ContextScope scope) {
+        return new DiscussionPhase("Discussion", PhaseType.OPINION, "ALL", TurnOrder.SEQUENTIAL, scope, false, null, 1, false);
+    }
+
+    private TranscriptEntry entry(String name, String content) {
+        return new TranscriptEntry("id-" + name, name, content, 0, "P", TranscriptEntryType.OPINION, Instant.now(), null, null);
+    }
+
+    /** enabled, cap 3, summarize on, summarizer model configured, unpriced. */
+    private ContextWindowConfig window() {
+        return new ContextWindowConfig(true, 3, true, "openai", "gpt-4o-mini", null, null);
+    }
+
+    private GroupConversation gcWith(TranscriptEntry... entries) {
+        var gc = new GroupConversation();
+        gc.setId("gc-1");
+        for (var e : entries) {
+            gc.getTranscript().add(e);
+        }
+        return gc;
+    }
+
+    // =================================================================
+    // windowed filterByScope — rendering
+    // =================================================================
+
+    @Test
+    @DisplayName("at exactly maxRecentEntries the context is untouched — the cap must be exceeded, not met")
+    void atExactlyTheCap_noWindowing() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"));
+
+        var result = builder.filterByScope(gc.getTranscript(), ContextScope.FULL, 1, member(), window(), gc);
+
+        assertEquals(3, result.size());
+        assertTrue(result.stream().noneMatch(e -> "System".equals(e.get("speaker"))), "no synthetic entry at the boundary");
+    }
+
+    @Test
+    @DisplayName("over the cap with no summary yet: truncation marker + the recent entries verbatim")
+    void overTheCap_noSummary_truncationMarker() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"), entry("D", "c4"), entry("E", "c5"));
+
+        var result = builder.filterByScope(gc.getTranscript(), ContextScope.FULL, 1, member(), window(), gc);
+
+        assertEquals(4, result.size(), "marker + the 3 recent entries");
+        assertEquals("System", result.get(0).get("speaker"));
+        assertEquals("[2 earlier entries omitted]", result.get(0).get("content"));
+        assertEquals("c3", result.get(1).get("content"));
+        assertEquals("c5", result.get(3).get("content"));
+    }
+
+    @Test
+    @DisplayName("over the cap with a summary: summary pseudo-entry + everything past its boundary verbatim")
+    void overTheCap_withSummary_summaryPlusTail() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"), entry("D", "c4"), entry("E", "c5"));
+        gc.setTranscriptSummary("A and B agreed on X");
+        gc.setSummaryUpToIndex(2);
+
+        var result = builder.filterByScope(gc.getTranscript(), ContextScope.FULL, 1, member(), window(), gc);
+
+        assertEquals(4, result.size(), "summary + the 3 entries past its boundary");
+        assertEquals("System", result.get(0).get("speaker"));
+        assertTrue(result.get(0).get("content").toString().contains("A and B agreed on X"));
+        assertEquals("c3", result.get(1).get("content"), "the split is the summary's raw boundary — no gap, no duplication");
+        assertTrue(result.stream().skip(1).noneMatch(e -> "c1".equals(e.get("content")) || "c2".equals(e.get("content"))),
+                "summarized entries must not also render verbatim");
+    }
+
+    @Test
+    @DisplayName("ANONYMOUS scope windows with the anonymous summary and keeps Anonymous labels")
+    void anonymousScope_usesAnonymousSummaryAndLabels() {
+        var gc = gcWith(entry("Alice", "c1"), entry("Bob", "c2"), entry("Carol", "c3"), entry("Dave", "c4"), entry("Eve", "c5"));
+        gc.setTranscriptSummary("Alice said c1, Bob said c2"); // named — must NOT surface
+        gc.setSummaryUpToIndex(2);
+        gc.setAnonymousTranscriptSummary("Two participants proposed X");
+        gc.setAnonymousSummaryUpToIndex(2);
+
+        var result = builder.filterByScope(gc.getTranscript(), ContextScope.ANONYMOUS, 1, member(), window(), gc);
+
+        assertTrue(result.get(0).get("content").toString().contains("Two participants proposed X"));
+        assertFalse(result.get(0).get("content").toString().contains("Alice"),
+                "an ANONYMOUS phase must never render the named FULL summary — that would de-anonymize");
+        assertTrue(result.stream().skip(1).allMatch(e -> "Anonymous".equals(e.get("speaker"))));
+    }
+
+    @Test
+    @DisplayName("a null or disabled window renders exactly as before the feature existed")
+    void disabledWindow_fullList() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"), entry("D", "c4"), entry("E", "c5"));
+
+        assertEquals(5, builder.filterByScope(gc.getTranscript(), ContextScope.FULL, 1, member(), null, gc).size());
+        var disabled = new ContextWindowConfig(false, 3, true, null, null, null, null);
+        assertEquals(5, builder.filterByScope(gc.getTranscript(), ContextScope.FULL, 1, member(), disabled, gc).size());
+    }
+
+    // =================================================================
+    // updateWindowSummary — the phase-boundary extension
+    // =================================================================
+
+    @Test
+    @DisplayName("first boundary summarizes exactly the overflow slice; the next extends with only the new slice")
+    void incrementalExtension_summarizerSeesOnlyTheNewSlice() {
+        var gc = gcWith(entry("A", "aaa-1"), entry("B", "bbb-2"), entry("C", "ccc-3"), entry("D", "ddd-4"), entry("E", "eee-5"));
+        when(summarizationService.summarizeWithUsage(anyString(), anyString(), eq("openai"), eq("gpt-4o-mini")))
+                .thenReturn(new SummarizationResult("SUMMARY-1", 10, 5));
+
+        builder.updateWindowSummary(gc, opinionPhase(ContextScope.FULL), window(), summarizationService);
+
+        var content = ArgumentCaptor.forClass(String.class);
+        verify(summarizationService).summarizeWithUsage(content.capture(), anyString(), eq("openai"), eq("gpt-4o-mini"));
+        assertTrue(content.getValue().contains("aaa-1") && content.getValue().contains("bbb-2"),
+                "the overflow slice [0, size-cap) is what gets summarized");
+        assertFalse(content.getValue().contains("ccc-3"), "entries inside the recent window must not be summarized");
+        assertEquals("SUMMARY-1", gc.getTranscriptSummary());
+        assertEquals(2, gc.getSummaryUpToIndex());
+
+        // Discussion grows; the next boundary extends incrementally.
+        gc.getTranscript().add(entry("F", "fff-6"));
+        gc.getTranscript().add(entry("G", "ggg-7"));
+        when(summarizationService.summarizeWithUsage(anyString(), anyString(), eq("openai"), eq("gpt-4o-mini")))
+                .thenReturn(new SummarizationResult("SUMMARY-2", 10, 5));
+
+        builder.updateWindowSummary(gc, opinionPhase(ContextScope.FULL), window(), summarizationService);
+
+        verify(summarizationService, times(2)).summarizeWithUsage(content.capture(), anyString(), eq("openai"), eq("gpt-4o-mini"));
+        String secondContent = content.getValue();
+        assertTrue(secondContent.contains("SUMMARY-1"), "the previous summary is the compressed form of the old slice");
+        assertTrue(secondContent.contains("ccc-3") && secondContent.contains("ddd-4"), "only the new slice rides along verbatim");
+        assertFalse(secondContent.contains("aaa-1"), "already-summarized entries must not be re-fed — that is the incremental contract");
+        assertEquals("SUMMARY-2", gc.getTranscriptSummary());
+        assertEquals(4, gc.getSummaryUpToIndex());
+    }
+
+    @Test
+    @DisplayName("a summarizer failure leaves the stored state untouched — rendering falls back to truncation")
+    void summarizerFailure_stateUntouched() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"), entry("D", "c4"), entry("E", "c5"));
+        when(summarizationService.summarizeWithUsage(anyString(), anyString(), anyString(), anyString()))
+                .thenThrow(new RuntimeException("provider down"));
+
+        assertDoesNotThrow(() -> builder.updateWindowSummary(gc, opinionPhase(ContextScope.FULL), window(), summarizationService),
+                "a summarization failure must never block the discussion");
+        assertNull(gc.getTranscriptSummary());
+        assertEquals(0, gc.getSummaryUpToIndex());
+
+        // And rendering degrades to the plain truncation marker, not an error.
+        var rendered = builder.filterByScope(gc.getTranscript(), ContextScope.FULL, 1, member(), window(), gc);
+        assertEquals("[2 earlier entries omitted]", rendered.get(0).get("content"));
+    }
+
+    @Test
+    @DisplayName("an empty summarizer answer is not adopted — the boundary index must not advance past unsummarized entries")
+    void emptySummary_notAdopted() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"), entry("D", "c4"), entry("E", "c5"));
+        when(summarizationService.summarizeWithUsage(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new SummarizationResult("", 10, 5));
+
+        builder.updateWindowSummary(gc, opinionPhase(ContextScope.FULL), window(), summarizationService);
+
+        assertNull(gc.getTranscriptSummary());
+        assertEquals(0, gc.getSummaryUpToIndex());
+    }
+
+    @Test
+    @DisplayName("ANONYMOUS boundary: the summarizer input carries Anonymous labels, never real names")
+    void anonymousBoundary_inputIsAnonymized() {
+        var gc = gcWith(entry("Alice", "c1"), entry("Bob", "c2"), entry("Carol", "c3"), entry("Dave", "c4"), entry("Eve", "c5"));
+        when(summarizationService.summarizeWithUsage(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new SummarizationResult("anon summary", 10, 5));
+
+        builder.updateWindowSummary(gc, opinionPhase(ContextScope.ANONYMOUS), window(), summarizationService);
+
+        var content = ArgumentCaptor.forClass(String.class);
+        verify(summarizationService).summarizeWithUsage(content.capture(), anyString(), anyString(), anyString());
+        assertFalse(content.getValue().contains("Alice") || content.getValue().contains("Bob"),
+                "no de-anonymization: the summarizer must not even SEE the names");
+        assertTrue(content.getValue().contains("Anonymous"));
+        assertEquals("anon summary", gc.getAnonymousTranscriptSummary());
+        assertNull(gc.getTranscriptSummary(), "the FULL variant is a separate summary and must stay untouched");
+    }
+
+    @Test
+    @DisplayName("a priced window attributes the summarizer's own spend to the discussion's I1 ledger")
+    void pricedSummarization_costReachesTheLedger() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"), entry("D", "c4"), entry("E", "c5"));
+        var priced = new ContextWindowConfig(true, 3, true, "openai", "gpt-4o-mini", 1.0, 2.0);
+        when(summarizationService.summarizeWithUsage(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new SummarizationResult("S", 1000, 500));
+
+        builder.updateWindowSummary(gc, opinionPhase(ContextScope.FULL), priced, summarizationService);
+
+        // 1000/1M * $1.00 + 500/1M * $2.00
+        assertEquals(0.002, gc.getTotalCost(), 1e-9, "summarization cost counts toward the discussion (I1)");
+    }
+
+    @Test
+    @DisplayName("no boundary work outside its remit: wrong phase type, wrong scope, below cap, or summarization off")
+    void noCallOutsideItsRemit() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"), entry("D", "c4"), entry("E", "c5"));
+
+        var critique = new DiscussionPhase("Critique", PhaseType.CRITIQUE, "ALL", TurnOrder.SEQUENTIAL, ContextScope.FULL, false, null, 1, false);
+        builder.updateWindowSummary(gc, critique, window(), summarizationService);
+        builder.updateWindowSummary(gc, opinionPhase(ContextScope.LAST_PHASE), window(), summarizationService);
+        var noSummarize = new ContextWindowConfig(true, 3, false, "openai", "gpt-4o-mini", null, null);
+        builder.updateWindowSummary(gc, opinionPhase(ContextScope.FULL), noSummarize, summarizationService);
+        var smallGc = gcWith(entry("A", "c1"), entry("B", "c2"));
+        builder.updateWindowSummary(smallGc, opinionPhase(ContextScope.FULL), window(), summarizationService);
+
+        verifyNoInteractions(summarizationService);
+    }
+
+    @Test
+    @DisplayName("no summarizer service (unit-test wiring) degrades to truncation instead of throwing")
+    void nullService_noThrow() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"), entry("D", "c4"), entry("E", "c5"));
+
+        assertDoesNotThrow(() -> builder.updateWindowSummary(gc, opinionPhase(ContextScope.FULL), window(), null));
+        assertNull(gc.getTranscriptSummary());
+    }
+
+    // =================================================================
+    // config normalization
+    // =================================================================
+
+    @Test
+    @DisplayName("config normalization: non-positive cap falls back to the default, omitted summarizeOverflow means true")
+    void configNormalization() {
+        var window = new ContextWindowConfig(true, 0, null, null, null, -1.0, null);
+
+        assertEquals(ContextWindowConfig.DEFAULT_MAX_RECENT_ENTRIES, window.maxRecentEntries(),
+                "an accidental 0 must not blank the whole context");
+        assertEquals(Boolean.TRUE, window.summarizeOverflow(), "summarization is the default overflow behaviour");
+        assertNull(window.inputPricePer1M(), "negative prices normalize to unpriced");
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderWindowingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderWindowingTest.java
@@ -67,6 +67,14 @@ class GroupContextBuilderWindowingTest {
         return new TranscriptEntry("id-" + name, name, content, 0, "P", TranscriptEntryType.OPINION, Instant.now(), null, null);
     }
 
+    /**
+     * A process bookkeeping row — carries content but must never be windowed or
+     * summarized.
+     */
+    private TranscriptEntry bookkeeping(TranscriptEntryType type) {
+        return new TranscriptEntry(null, "System", "bookkeeping", 0, "P", type, Instant.now(), null, null);
+    }
+
     /** enabled, cap 3, summarize on, summarizer model configured, unpriced. */
     private ContextWindowConfig window() {
         return new ContextWindowConfig(true, 3, true, "openai", "gpt-4o-mini", null, null);
@@ -190,6 +198,44 @@ class GroupContextBuilderWindowingTest {
         assertFalse(secondContent.contains("aaa-1"), "already-summarized entries must not be re-fed — that is the incremental contract");
         assertEquals("SUMMARY-2", gc.getTranscriptSummary());
         assertEquals(4, gc.getSummaryUpToIndex());
+    }
+
+    /**
+     * Review finding (Copilot, PR #636): the boundary must count VISIBLE entries
+     * back from the tail, not raw entries — bookkeeping rows in the tail would
+     * otherwise shrink the verbatim window below the cap while newer real
+     * contributions get summarized away.
+     */
+    @Test
+    @DisplayName("the summary boundary counts visible entries — bookkeeping in the tail does not eat the verbatim window")
+    void boundaryCountsVisibleEntries_notRawOnes() {
+        var gc = gcWith(
+                entry("A", "aaa-1"), entry("B", "bbb-2"),
+                bookkeeping(TranscriptEntryType.SKIPPED), entry("C", "ccc-3"),
+                bookkeeping(TranscriptEntryType.CONVERGENCE), entry("D", "ddd-4"), entry("E", "eee-5"));
+        when(summarizationService.summarizeWithUsage(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new SummarizationResult("S", 10, 5));
+
+        builder.updateWindowSummary(gc, opinionPhase(ContextScope.FULL), window(), summarizationService);
+
+        var content = ArgumentCaptor.forClass(String.class);
+        verify(summarizationService).summarizeWithUsage(content.capture(), anyString(), anyString(), anyString());
+        // Cap 3 → the verbatim tail must be the 3 newest VISIBLE entries
+        // (ccc-3, ddd-4, eee-5); only aaa-1 and bbb-2 may be summarized.
+        assertTrue(content.getValue().contains("aaa-1") && content.getValue().contains("bbb-2"), content.getValue());
+        assertFalse(content.getValue().contains("ccc-3"),
+                "counting raw entries would summarize ccc-3 because bookkeeping rows sit in the tail: " + content.getValue());
+    }
+
+    @Test
+    @DisplayName("a whitespace-only provider/model is absent — truncation fallback, never a summarizer call")
+    void blankSummarizerIdentifiers_meanAbsent() {
+        var gc = gcWith(entry("A", "c1"), entry("B", "c2"), entry("C", "c3"), entry("D", "c4"), entry("E", "c5"));
+        var blank = new ContextWindowConfig(true, 3, true, "  ", "\t", null, null);
+
+        builder.updateWindowSummary(gc, opinionPhase(ContextScope.FULL), blank, summarizationService);
+
+        verifyNoInteractions(summarizationService);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupConversationSchemaMigrationsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupConversationSchemaMigrationsTest.java
@@ -6,16 +6,17 @@ package ai.labs.eddi.engine.internal.groups;
 
 import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for {@link GroupConversationSchemaMigrations} (Wave 0, F6). Per the
- * plan's own testing instruction, fixture documents are constructed at
- * artificial version numbers — there is no real "older version" today, since
- * {@link GroupConversation#CURRENT_SCHEMA_VERSION} ({@code 1}) is the first
- * version that has ever existed.
+ * Tests for {@link GroupConversationSchemaMigrations} (Wave 0, F6). Fixture
+ * documents are constructed at explicit version numbers; the key-less fixtures
+ * go through Jackson because the field-initialiser semantics under
+ * deserialization are exactly what is under test — every pre-F6 production
+ * document has no {@code schemaVersion} key.
  *
  * @author tests
  */
@@ -26,6 +27,33 @@ class GroupConversationSchemaMigrationsTest {
         gc.setId("gc-1");
         gc.setSchemaVersion(schemaVersion);
         return gc;
+    }
+
+    /**
+     * The case that is every document in production: written before F6 existed, so
+     * the stored JSON has no {@code schemaVersion} key at all. Jackson runs the
+     * no-arg constructor and leaves the field initialiser standing — so the
+     * initialiser IS the version such a document claims. It must be the legacy
+     * floor ({@code 1}), not {@code CURRENT_SCHEMA_VERSION}: a key-less document
+     * claiming current makes {@code prepareForResume}'s ladder run zero iterations
+     * on exactly the documents it exists for.
+     */
+    @Test
+    void documentWithoutVersionKey_claimsLegacyVersionNotCurrent() throws Exception {
+        var legacy = new ObjectMapper().readValue("{}", GroupConversation.class);
+
+        assertEquals(1, legacy.getSchemaVersion(),
+                "a stored document with no schemaVersion key predates F6 and must claim the legacy floor, "
+                        + "so the migration ladder walks every hop instead of zero");
+    }
+
+    @Test
+    void documentWithoutVersionKey_isMigratedForwardOnResume() throws Exception {
+        var legacy = new ObjectMapper().readValue("{}", GroupConversation.class);
+
+        var result = GroupConversationSchemaMigrations.prepareForResume(legacy);
+
+        assertEquals(GroupConversation.CURRENT_SCHEMA_VERSION, result.getSchemaVersion());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupCostLedgerTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupCostLedgerTest.java
@@ -173,6 +173,26 @@ class GroupCostLedgerTest {
     }
 
     @Test
+    void accumulateNestedGroupCost_multipleChildDiscussions_sumRatherThanOverwrite() {
+        var gc = gc();
+        // Two turns of the same GROUP member = two FRESH child discussions, each
+        // starting its own totalCost at 0. Keyed by agentId alone, child 2's $0.50
+        // would replace child 1's $1.00 and the group would under-report by half.
+        var firstChild = gc();
+        firstChild.setId("child-1");
+        firstChild.setTotalCost(1.00);
+        var secondChild = gc();
+        secondChild.setId("child-2");
+        secondChild.setTotalCost(0.50);
+
+        GroupCostLedger.accumulateNestedGroupCost(gc, AGENT_A, firstChild);
+        GroupCostLedger.accumulateNestedGroupCost(gc, AGENT_A, secondChild);
+
+        assertEquals(1.50, gc.getTotalCost(), 1e-9,
+                "each child discussion is separate spend — a member's later child must not erase its earlier one");
+    }
+
+    @Test
     void accumulateNestedGroupCost_mixesWithIndividualMembers() {
         var gc = gc();
         GroupCostLedger.accumulateMemberCost(gc, AGENT_A, buildSnapshot(new ConversationStepData(MemoryKeys.AUDIT_COST, 0.10, null, null)));

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupCostLedgerTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupCostLedgerTest.java
@@ -205,6 +205,36 @@ class GroupCostLedgerTest {
     }
 
     // =================================================================
+    // recordSystemCost (I9 summarizer spend)
+    // =================================================================
+
+    @Test
+    void recordSystemCost_records_andDistinctKeysSum() {
+        var gc = gc();
+        GroupCostLedger.recordSystemCost(gc, "system:summarizer:full:10", 0.01);
+        GroupCostLedger.recordSystemCost(gc, "system:summarizer:full:20", 0.02);
+        // Idempotent re-run of the same operation replaces, never doubles.
+        GroupCostLedger.recordSystemCost(gc, "system:summarizer:full:20", 0.02);
+
+        assertEquals(0.03, gc.getTotalCost(), 1e-9);
+    }
+
+    @Test
+    void recordSystemCost_rejectsNaNInfinityAndNonPositive() {
+        var gc = gc();
+        GroupCostLedger.recordSystemCost(gc, "k", Double.NaN);
+        GroupCostLedger.recordSystemCost(gc, "k", Double.POSITIVE_INFINITY);
+        GroupCostLedger.recordSystemCost(gc, "k", 0.0);
+        GroupCostLedger.recordSystemCost(gc, "k", -1.0);
+        GroupCostLedger.recordSystemCost(gc, null, 1.0);
+
+        // One NaN in the map would make totalCost NaN, and every ceiling
+        // comparison against NaN is false — the ceiling silently stops firing.
+        assertTrue(gc.getMemberCosts().isEmpty());
+        assertEquals(0.0, gc.getTotalCost());
+    }
+
+    // =================================================================
     // wouldExceedCeiling — must agree with enforceCeiling, zero case and all
     // =================================================================
 

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutorTest.java
@@ -269,7 +269,9 @@ class MemberTurnExecutorTest {
                 null, null);
 
         assertEquals("Nested answer", entry.content());
-        assertEquals(0.42, gc.getMemberCosts().get("sub-group-1"));
+        // Attribution is keyed per child discussion (agentId:childId) so a member's
+        // later children add to — rather than replace — its earlier ones.
+        assertEquals(0.42, gc.getMemberCosts().get("sub-group-1:sub-gc-1"));
         assertEquals(0.42, gc.getTotalCost());
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
@@ -53,11 +53,12 @@ class PhaseExecutionEngineTest {
     private PhaseExecutionEngine engine() {
         memberTurnExecutor = mock(MemberTurnExecutor.class);
         contextBuilder = mock(GroupContextBuilder.class);
-        // The 7-ARG overload — the only one PhaseExecutionEngine calls. Stubbing the
-        // 6-arg one left every turn running with a null input, so a regression that
-        // dropped the phase rendering entirely and passed the raw question through
-        // would not have failed a single test here.
-        when(contextBuilder.buildPhaseInput(any(), any(), any(), any(), anyInt(), any(), any()))
+        // The 9-ARG overload (I9 added window + gc) — the only one
+        // PhaseExecutionEngine calls. Stubbing a shorter one left every turn running
+        // with a null input, so a regression that dropped the phase rendering
+        // entirely and passed the raw question through would not have failed a
+        // single test here.
+        when(contextBuilder.buildPhaseInput(any(), any(), any(), any(), anyInt(), any(), any(), any(), any()))
                 .thenReturn("rendered-input");
         return new PhaseExecutionEngine(memberTurnExecutor, contextBuilder,
                 Executors.newVirtualThreadPerTaskExecutor(), new CallerIdentityContext(null, null));

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesTest.java
@@ -127,6 +127,22 @@ class ConversationMemoryUtilitiesTest {
             assertEquals(5, restored.getAgentVersion());
             assertEquals("user-42", restored.getUserId());
         }
+
+        /**
+         * F6/N3: the snapshot field initialiser is the LEGACY sentinel so key-less
+         * stored documents read as legacy — a snapshot built from live memory is
+         * current-shaped by definition and must be stamped so explicitly here.
+         */
+        @Test
+        @DisplayName("a snapshot built from live memory is stamped with the current schema version")
+        void stampsCurrentSchemaVersion() {
+            var memory = new ConversationMemory("conv-id", "agent-1", 5, "user-42");
+
+            var snapshot = ConversationMemoryUtilities.convertConversationMemory(memory);
+
+            assertEquals(ConversationMemorySnapshot.CURRENT_SCHEMA_VERSION, snapshot.getSchemaVersion(),
+                    "a freshly built snapshot must claim current — the initialiser deliberately claims legacy");
+        }
     }
 
     // ─── convertSimpleConversationMemory ─────────────────────────

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/CascadeConfigValidatorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/CascadeConfigValidatorTest.java
@@ -51,6 +51,36 @@ class CascadeConfigValidatorTest {
     }
 
     @Test
+    @DisplayName("task-level pricing: a negative price is a hard error, even with no cascade at all")
+    void negativeTaskLevelPrice_throws() {
+        var task = new LlmConfiguration.Task();
+        task.setId("t1");
+        task.setType("openai");
+        task.setInputPricePer1M(-1.0);
+        var ex = assertThrows(WorkflowConfigurationException.class,
+                () -> CascadeConfigValidator.validate(new LlmConfiguration(List.of(task))));
+        assertTrue(ex.getMessage().contains("inputPricePer1M"));
+
+        var task2 = new LlmConfiguration.Task();
+        task2.setId("t1");
+        task2.setType("openai");
+        task2.setOutputPricePer1M(-0.5);
+        assertThrows(WorkflowConfigurationException.class,
+                () -> CascadeConfigValidator.validate(new LlmConfiguration(List.of(task2))));
+    }
+
+    @Test
+    @DisplayName("task-level pricing: valid or absent prices load fine without a cascade")
+    void taskLevelPrice_ok() {
+        var task = new LlmConfiguration.Task();
+        task.setId("t1");
+        task.setType("openai");
+        task.setInputPricePer1M(1.25);
+        task.setOutputPricePer1M(0.0);
+        assertDoesNotThrow(() -> CascadeConfigValidator.validate(new LlmConfiguration(List.of(task))));
+    }
+
+    @Test
     @DisplayName("disabled cascade — never validated")
     void disabledCascade_ok() {
         var c = new ModelCascadeConfig();

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskAuditLedgerTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskAuditLedgerTest.java
@@ -312,6 +312,48 @@ class LlmTaskAuditLedgerTest {
         assertNull(stored.get(MemoryKeys.AUDIT_COST));
     }
 
+    @Test
+    @DisplayName("a plain priced model call accumulates its token cost — the common case is no longer $0")
+    void plainPricedCallAccumulatesTokenCost() throws Exception {
+        when(agentOrchestrator.executeIfToolsEnabled(any(), any(), any(), any(), any(), any(), anyInt(), anyInt(), any())).thenReturn(null);
+        when(chatModel.chat(anyList())).thenReturn(response("answer", 1000, 500, 1500));
+
+        var t = task("taskA");
+        t.setInputPricePer1M(1.0);
+        t.setOutputPricePer1M(2.0);
+        llmTask.execute(memory, new LlmConfiguration(List.of(t)));
+
+        // 1000/1M * $1.00 + 500/1M * $2.00
+        assertEquals(0.002, auditCost(), 1e-9,
+                "an ordinary model call with configured prices must reach the ledger — I1's group ceiling reads this");
+    }
+
+    @Test
+    @DisplayName("a priced agent-mode turn sums its token cost with the tracked tool spend")
+    void plainPricedAgentModeSumsTokenAndToolCost() throws Exception {
+        agentReturns("done", new ArrayList<>(),
+                Map.of("tokenUsage", Map.of("inputTokens", 1000, "outputTokens", 500, "totalTokens", 1500),
+                        "toolCostUsd", 0.005));
+
+        var t = task("taskA");
+        t.setInputPricePer1M(1.0);
+        t.setOutputPricePer1M(2.0);
+        llmTask.execute(memory, new LlmConfiguration(List.of(t)));
+
+        assertEquals(0.007, auditCost(), 1e-9, "token cost and tool cost are both real spend and must both be counted");
+    }
+
+    @Test
+    @DisplayName("an unpriced plain call still contributes exactly $0 — no behaviour change without prices")
+    void unpricedPlainCallStaysFree() throws Exception {
+        when(agentOrchestrator.executeIfToolsEnabled(any(), any(), any(), any(), any(), any(), anyInt(), anyInt(), any())).thenReturn(null);
+        when(chatModel.chat(anyList())).thenReturn(response("answer", 1000, 500, 1500));
+
+        llmTask.execute(memory, new LlmConfiguration(List.of(task("taskA"))));
+
+        assertNull(stored.get(MemoryKeys.AUDIT_COST), "null prices mean unpriced — the cost key must stay absent");
+    }
+
     // ==================== cascade ====================
 
     @Test
@@ -346,6 +388,33 @@ class LlmTaskAuditLedgerTest {
         var tokenUsage = auditMap(MemoryKeys.AUDIT_TOKEN_USAGE);
         assertNotNull(tokenUsage);
         assertEquals(1000L, tokenUsage.get("inputTokens"));
+    }
+
+    @Test
+    @DisplayName("a cascade run with task-level prices set is priced by the cascade alone — never twice")
+    void cascadeIgnoresTaskLevelPricesSoTokensAreNeverPricedTwice() throws Exception {
+        var cascade = new ModelCascadeConfig();
+        cascade.setEnabled(true);
+        cascade.setEvaluationStrategy("none");
+        cascade.setInputPricePer1M(1.0);
+        cascade.setOutputPricePer1M(2.0);
+        var step = new CascadeStep();
+        step.setType("openai");
+        step.setTimeoutMs(5000L);
+        cascade.setSteps(List.of(step));
+
+        when(chatModel.chat(anyList())).thenReturn(response("cascade answer", 1000, 500, 1500));
+
+        var t = task("taskA");
+        // Deliberately absurd task-level prices: if the plain-call pricing path also
+        // ran for a cascade turn, the assertion below would be off by dollars.
+        t.setInputPricePer1M(1000.0);
+        t.setOutputPricePer1M(1000.0);
+        t.setModelCascade(cascade);
+        llmTask.execute(memory, new LlmConfiguration(List.of(t)));
+
+        assertEquals(0.002, auditCost(), 1e-9,
+                "cascade steps price themselves; task-level prices apply to plain calls only");
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskAuditLedgerTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskAuditLedgerTest.java
@@ -313,6 +313,16 @@ class LlmTaskAuditLedgerTest {
     }
 
     @Test
+    @DisplayName("a NaN cost signal is rejected — one NaN would poison the running total and disable every ceiling")
+    void nanCostIsNeverAccumulated() throws Exception {
+        agentReturns("done", new ArrayList<>(), Map.of("toolCostUsd", Double.NaN));
+
+        llmTask.execute(memory, new LlmConfiguration(List.of(task("taskA"))));
+
+        assertNull(stored.get(MemoryKeys.AUDIT_COST), "NaN fails every comparison, so a <=0 guard admits it");
+    }
+
+    @Test
     @DisplayName("a plain priced model call accumulates its token cost — the common case is no longer $0")
     void plainPricedCallAccumulatesTokenCost() throws Exception {
         when(agentOrchestrator.executeIfToolsEnabled(any(), any(), any(), any(), any(), any(), anyInt(), anyInt(), any())).thenReturn(null);


### PR DESCRIPTION
Closes out the three pre-feature defects from `planning/group-collaboration-NEXT.md` §2 (plus the §4 nested-cost gap flagged as N1's natural fold-in), unblocking the Wave 2/3 queue.

## N1 — Price ordinary model calls (`11d0812fb`, fold-in `89f2b15b4`)

`AUDIT_COST` was written from `cascadeCostUsd + toolCostUsd` only, so a plain model call — no cascade, no priced tool — contributed **$0.00**: I1's `maxCostPerDiscussion` ceiling could never trip for ordinary members, and `memberCosts`/`totalCost` were served over REST as if authoritative.

- `LlmConfiguration.Task` gains `inputPricePer1M`/`outputPricePer1M` — same nullable semantics as the cascade fields (null = unpriced → $0; **no behaviour change for anyone not setting prices**). Config-driven per Golden Rule 1: no hardcoded provider price table.
- The pricing arithmetic now lives once in `TokenPricing`, shared by the cascade path and the new plain-call path (§4.7 unification).
- Cascade turns keep pricing themselves — key-presence discrimination on `cascadeCostUsd` prevents double counting; pinned by a test with deliberately absurd task-level prices on a cascade turn.
- Negative prices fail at deployment (same new-field hard-error rationale as cascade pricing).
- Fold-in: `accumulateNestedGroupCost` keyed by agentId, but every GROUP-member turn spawns a fresh child discussion starting at $0, so only the last child's spend survived the re-sum. Attribution is now keyed per child discussion (`agentId:childId`) — replacement stays idempotent, children sum.

## N3 — Schema-version legacy sentinel (`65b00b600`)

Every pre-F6 document has no `schemaVersion` key; Jackson leaves the field initialiser (`= CURRENT_SCHEMA_VERSION`, i.e. 3) standing, so legacy documents loaded claiming **schema 3 while being version-1-shaped** and `prepareForResume`'s ladder ran zero iterations on exactly the documents it exists for. Test written first (deserialise `{}` → failed with `expected: <1> but was: <3>`), then fixed: initialiser is now `LEGACY_SCHEMA_VERSION = 1`, and the single creation point stamps `CURRENT` explicitly. `ConversationMemorySnapshot` got the identical split (correct only by coincidence while its CURRENT == 1). Stale Javadoc in both migration registries corrected. Free only while no released build has written a versioned document — hence before this ships.

## N2/I9 — Transcript windowing (`b6c0eb4c4`)

FULL/ANONYMOUS-scope phases re-fed the whole transcript to every member every turn (~quadratic prompt cost, compounding with every queued item). New `contextWindow` group config: beyond `maxRecentEntries`, older entries collapse into a rolling summary — extended **incrementally at phase boundaries only** via the shared `SummarizationService` — or a plain `[n earlier entries omitted]` marker when summarization is off/unconfigured/failing (WARN, never blocks). ANONYMOUS keeps its own summary built from "Anonymous"-labelled input so it can never de-anonymize (deliberate deviation from the plan's single-field wording, recorded in the changelog). Summarizer spend lands on the I1 ledger when priced. The stored transcript is never modified; signing verifies raw entries.

## Verification

- Every fix mutation-checked: reverting each fix fails exactly its intended tests and nothing else.
- Full `ai.labs.eddi.engine.internal` suite: 1438 green. LLM-module suites green apart from the known environmental HttpClient/socket failures. Checkstyle clean.
- Changelog entries ride in the same commits as the work (§2 rule 8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable transcript windows for group conversations, with recent-entry limits, optional overflow summaries, anonymized summaries, and truncation fallback.
  - Added task-level input and output token pricing for non-cascaded model calls.
- **Bug Fixes**
  - Improved migration handling for older conversation and memory records.
  - Fixed nested-group cost tracking so costs from multiple child discussions are combined correctly.
  - Added validation to reject negative pricing values.
- **Documentation**
  - Updated configuration, cost accounting, changelog, and group collaboration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->