### PR TITLE
feat(groups): shared artifacts - typed co-edited documents with CAS and validators (I17)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,27 @@
 
 ---
 
+## 📄 feat(groups): I17 — shared artifacts (blackboard-lite) (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i17-shared-artifacts`)
+
+First Wave 2 queue item from `planning/group-collaboration-NEXT.md` §3. Agents can now **co-edit typed documents** instead of only talking: four member tools — `createArtifact`, `readArtifact`, `proposeArtifactUpdate`, `listArtifacts` — gated by a new `artifactConfig` on the group config.
+
+**Design decisions, per the plan (and the plan's own rejections honored):**
+
+- **Own collection, never embedded.** `SharedArtifact` + `ISharedArtifactStore`/`SharedArtifactStore` follow `GroupConversationStore`'s single-version runtime-document pattern. The discussion loop's whole-document stale-snapshot persists cannot clobber artifact writes, which is also why — unlike I5's task tools — the artifact tools write **through the store directly**. The live registry is still consulted: membership at assembly (`getForMember`, the caller-supplied-id IDOR guard), liveness at write time, and accepted writes ride a new transient change queue on the live `GroupConversation`.
+- **Deterministic CAS-and-retry, explicitly not an LLM fusion arbiter.** The version CAS needed a storage primitive that doesn't exist for numbers: `storeIfFieldEquals(String)` text-compares, which "works" on Postgres (`data->>` renders JSON numbers as text) and **silently never matches on Mongo** (typed BSON equality). New `storeIfFieldEquals(…, long)` overload on `IResourceStorage` + both backends, same no-silent-degrade contract (the default throws). Stale writers get the plan's sentence: *"artifact changed since you read it (now vN); re-read and merge your change."*
+- **Declarative validators only.** `JSON_SCHEMA` (new dependency `com.networknt:json-schema-validator` — the victools libraries only *generate* schemas), `REGEX`, `MAX_LENGTH`. Specs hard-fail the config save (`ArtifactValidators.requireValidSpecs` from `AgentGroupStore`, `HitlConfigValidation`'s contract); write-time failures are rejection sentences and the gate fails closed on a broken spec. Content ≤ 256 KB.
+- **Events without a listener reference:** tools can't fire SSE/Slack events (`ToolAssemblyContext` carries no listener — the structural gap that left I5's planned `task_added_by_agent` unfired). Accepted writes queue an `ArtifactChange` on the live instance; `MemberTurnExecutor` drains the queue in a `finally` after every turn and fires the new `artifact_updated` event (sink constant + record + SSE forward + Slack line + OpenAPI description lists). Drained even with a null listener so the queue cannot grow unbounded.
+- **Lifecycle:** artifacts are attached to the discussion status payload at read time in the service (so REST *and* MCP `read_group_conversation` carry them — `availableActions` idiom, `READ_ONLY`, never trusted back from storage); close/delete cascade removes them (`GroupLifecycleOps`, warn-and-continue so a broken artifact store can't make discussions undeletable); GDPR erasure sweeps them **user-keyed** via a stamped `ownerUserId` (page/exact-recheck/fail-loud contract copied from the group store) as a new `GdprComplianceService` cascade step.
+- **Caps:** `maxArtifactsPerDiscussion` (default 5) counted inside a `synchronized (liveInstance)` block — creation is check-then-act and PARALLEL phases genuinely race; updates need no lock, the CAS decides.
+
+**Tests (148 across 8 classes, all green):** tools against a real in-memory CAS store (stale-version retry sentence with the CURRENT version, concurrent same-version writers → exactly one winner, FINAL freeze, foreign-discussion ids don't resolve, validator chain, refusals leave no side effect); provider gate matrix (every uncertainty → contribute nothing, membership not existence, `enableBuiltInTools` still applies); store CAS through the numeric overload with `verify(never()).store(…)`; anchored+escaped filters with Java exact-recheck; erasure paging/fail-loud; lifecycle cascade ordering (`inOrder` artifact-delete before document-delete) + cascade-failure-still-deletes; GDPR step + not-resolvable skip + failure-continues; turn-executor drain (exactly once, null-listener drain); Slack lines incl. degenerate-payload skip. **Mutation notes:** degrading the store CAS to an unconditional store does not even compile (the gone-document catch becomes unreachable) — the CAS call is structurally load-bearing; the Mockito-verified negatives (`never().store`, `specs().isEmpty()`) pin the rest.
+
+**Files:** `SharedArtifact`, `ISharedArtifactStore`, `SharedArtifactStore`, `ArtifactValidators`, `ArtifactTools`, `ArtifactToolsProvider` (+ `AgentOrchestrator` phase-1 wiring), `AgentGroupConfiguration` (`ArtifactConfig`/`ArtifactValidator`/`ValidatorKind`), `GroupConversation` (change queue + read-time `artifacts`), `IResourceStorage` + Mongo/Postgres (numeric CAS), `GroupConversationEventSink`/listener/SSE/Slack, `GroupLifecycleOps`, `GroupConversationService`, `GdprComplianceService`, `AgentGroupStore`, `pom.xml`, `docs/group-conversations.md`, 8 test classes.
+
+---
+
 ## 🔀 merge: bring `origin/main` (PR #627 HITL request pinning) into the branch (2026-08-07)
 
 **Repo:** EDDI (`refactor/group-service-split`, PR [#626](https://github.com/labsai/EDDI/pull/626))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,19 @@
 
 ---
 
+## 🔎 fix(groups): I17 PR #637 review round 2 (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i17-shared-artifacts`)
+
+Two comments triaged:
+
+- **Announce mutex no longer held across listener callbacks (CodeRabbit Major, accepted):** `announceArtifactChanges` held `artifactAnnounceMutex` through `onArtifactUpdated`, so one slow/backpressured SSE client blocked every other turn's end-of-turn drain. Now the mutex guards only the HANDOFF: exactly one thread at a time is the publisher — it drains under the mutex, releases it, fires the callbacks, and loops for late arrivals; every other thread sees the publisher flag and leaves, its changes guaranteed to ride the publisher's next pass. Write order preserved (single announcer, FIFO queue), no caller ever blocks on a listener. New test drives a write + reentrant announce from INSIDE a callback: published exactly once, in order, nothing stranded, no deadlock.
+- **CodeQL log-injection (stale):** raised against the initial commit 6aeba1393; the flagged attach-artifacts log was sanitized in round 1 (74c0acaf7). Reply-only.
+
+`MemberTurnExecutorTest` (14) + artifact suites green.
+
+---
+
 ## 🔎 fix(groups): I17 PR #637 review round 1 (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i17-shared-artifacts`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 🔎 fix(groups): I17 PR #637 review round 1 (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i17-shared-artifacts`)
+
+All 11 review comments (CodeRabbit ×9, Copilot/CodeQL ×2) triaged; every one accepted and fixed:
+
+- **Meta-schema validation at save time** (`ArtifactValidators.schemaSpecProblem`): `getSchema(spec)` only parses — `{"type":"strng"}` passed and misbehaved at write time. Specs now also validate *as instances* against the bundled 2020-12 meta-schema (no network I/O; degrades to parse-only with a WARN if the bundled resource can't load, rather than rejecting every config).
+- **ReDoS bound on REGEX validators**: config-authored pattern × 256 KB LLM content could backtrack catastrophically and pin the member turn. `checkRegex` now matches through a deadline-guarded `CharSequence` (500 ms, sampled every 1024 char accesses) and refuses the write on expiry — fails closed, like every other broken-spec path.
+- **`[null]` validator entries**: `List.copyOf` NPE'd during config deserialization, preempting `requireValidSpecs`' positional message; now an unmodifiable null-tolerant copy.
+- **Artifact event ordering + late writes**: drain+announce now holds a per-conversation mutex (two PARALLEL turns ending together could split the queue and publish v2 before v1), and `executeDiscussion`'s `finally` runs one **final announce pass per leg** so a write accepted by a timed-out member's still-running agent is announced instead of stranded. A write after even that pass keeps the artifact — only its live event is best-effort, by design.
+- **`listByGroupConversationId` order**: both backends sort DESC; the interface promises oldest-first. Now re-sorted in Java per the contract.
+- **`deleteByGroupConversationId`**: same processed-set/no-progress guard as `deleteAllForUser` — an undislodgeable row is counted once and ends the loop instead of spinning `MAX_ERASURE_PASSES` times and inflating the count.
+- **Slack mrkdwn injection**: artifact name/editor id are LLM-authored; `<!channel>` in a name rendered as a real broadcast. Both fields now `&`/`<`/`>`-escaped.
+- **Oversize refusal rounds up** (`Math.ceilDiv`): MAX+1 bytes no longer reads "256 KB is over the 256 KB limit".
+- **GDPR cascade Javadoc** now names the shared-artifact step; **CodeQL log injection** at `populateArtifacts` sanitized.
+
+**Tests:** +7 (meta-schema reject, null-entry positional message, catastrophic-regex deadline, late-write announce pass, single-pass write order, oldest-first sort, no-spin cascade delete). Touched suites 1961 tests — green except the 27 known environmental socket-bound errors (SafeHttpClient/SlackWebApi/Weather/WebScraper), which fail identically on an untouched tree.
+
+---
+
 ## 📄 feat(groups): I17 — shared artifacts (blackboard-lite) (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i17-shared-artifacts`)

--- a/docs/group-conversations.md
+++ b/docs/group-conversations.md
@@ -160,6 +160,46 @@ Both caps are enforced independently: `maxPerTurn` bounds a runaway single turn,
 discussion cap counts only agent-filed tasks, so a large planned backlog does not
 exhaust it. A rejected call does not consume the per-turn budget.
 
+## Shared artifacts (blackboard-lite)
+
+Without artifacts, the transcript is the only medium — every structured thing an
+agent produces is prose the next agent re-parses. `artifactConfig` gives members
+four tools to **create together**: `createArtifact(name, type, content)`,
+`readArtifact(nameOrId)`, `proposeArtifactUpdate(nameOrId, content,
+expectedVersion, markFinal?)` and `listArtifacts()`. Artifacts are typed
+documents (`TEXT`, `MARKDOWN`, `JSON`) in their own collection, listed on the
+discussion's REST/MCP status payload as `artifacts`, and announced over SSE and
+Slack as `artifact_updated` events.
+
+```json
+"artifactConfig": {
+  "allowArtifactTools": true,
+  "maxArtifactsPerDiscussion": 5,
+  "validators": [
+    { "kind": "JSON_SCHEMA", "spec": "{\"type\":\"object\",\"required\":[\"title\"]}" },
+    { "kind": "MAX_LENGTH", "spec": "20000" }
+  ]
+}
+```
+
+**Concurrency is deterministic compare-and-set, not an LLM merge.** Every update
+presents the version it read; a stale writer is told *"artifact changed since
+you read it (now v3); re-read and merge your change"* and retries against fresh
+content. The failure mode is a retry, never a silent bad merge.
+
+**Validators are declarative only** — `JSON_SCHEMA`, `REGEX` (content must
+contain a match), `MAX_LENGTH` (characters) — never code. Specs are checked at
+config save time; at write time a failing validator refuses the write with its
+message and stores nothing. Content is additionally capped at 256 KB per
+artifact.
+
+Off by default with the same absence discipline as the task tools: no opt-in
+means the tools are never assembled. The member agent's own
+`enableBuiltInTools` switch still applies. `markFinal: true` freezes an
+artifact — FINAL artifacts accept no further updates. Artifacts are deleted
+with their discussion (close/delete cascade) and by GDPR erasure; the durable
+trace of the work is the transcript.
+
 ## Nested Groups (Group-of-Groups)
 
 Members can be other groups. The sub-group runs its own discussion and its synthesized answer becomes the member's response.

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,13 @@
             <artifactId>jsonschema-module-jackson</artifactId>
             <version>4.38.0</version>
         </dependency>
+        <!-- JSON Schema VALIDATION (victools above only GENERATES schemas) — used
+             by the declarative shared-artifact validators (I17). -->
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>1.5.4</version>
+        </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>

--- a/src/main/java/ai/labs/eddi/configs/groups/ArtifactValidators.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/ArtifactValidators.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ArtifactConfig;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ArtifactValidator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+/**
+ * The declarative artifact validation chain (I17) — JSON Schema, regex and
+ * length checks a group config can gate artifact writes behind. Declarative
+ * <em>only</em>: there is deliberately no way to configure code execution here.
+ * <p>
+ * Two entry points, one per failure audience: {@link #requireValidSpecs} runs
+ * at config save time and throws so a typo'd spec fails the save (the author's
+ * problem, at the moment they can fix it); {@link #firstRejection} runs at
+ * write time and returns a rejection <em>sentence</em> for the model (the write
+ * is refused, nothing is stored).
+ *
+ * @author ginccc
+ */
+public final class ArtifactValidators {
+
+    /** Bound on schema violation messages quoted back to the model. */
+    private static final int MAX_QUOTED_VIOLATIONS = 3;
+
+    /**
+     * Validation-only mapper: parses candidate content and schema documents, never
+     * persists anything.
+     */
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+
+    private ArtifactValidators() {
+    }
+
+    /**
+     * Save-time spec check: every validator must carry a kind and a spec its kind
+     * can actually use. Throws {@link IllegalArgumentException} (the same contract
+     * as {@code HitlConfigValidation}) so the config save fails with an actionable
+     * message rather than every future artifact write failing at runtime.
+     */
+    public static void requireValidSpecs(ArtifactConfig config) {
+        if (config == null || config.validators().isEmpty()) {
+            return;
+        }
+        List<ArtifactValidator> validators = config.validators();
+        for (int i = 0; i < validators.size(); i++) {
+            ArtifactValidator validator = validators.get(i);
+            String path = "artifactConfig.validators[" + i + "]";
+            if (validator == null || validator.kind() == null) {
+                throw new IllegalArgumentException(path + " must name a kind (JSON_SCHEMA, REGEX or MAX_LENGTH)");
+            }
+            String spec = validator.spec();
+            if (spec == null || spec.isBlank()) {
+                throw new IllegalArgumentException(path + " (" + validator.kind() + ") needs a spec");
+            }
+            switch (validator.kind()) {
+                case JSON_SCHEMA -> {
+                    try {
+                        SCHEMA_FACTORY.getSchema(spec);
+                    } catch (Exception e) {
+                        throw new IllegalArgumentException(path + " is not a valid JSON schema: " + e.getMessage());
+                    }
+                }
+                case REGEX -> {
+                    try {
+                        Pattern.compile(spec);
+                    } catch (PatternSyntaxException e) {
+                        throw new IllegalArgumentException(path + " is not a valid regex: " + e.getMessage());
+                    }
+                }
+                case MAX_LENGTH -> {
+                    int max;
+                    try {
+                        max = Integer.parseInt(spec.trim());
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException(path + " (MAX_LENGTH) spec must be a positive integer, not '" + spec + "'");
+                    }
+                    if (max <= 0) {
+                        throw new IllegalArgumentException(path + " (MAX_LENGTH) must be > 0");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Write-time gate: runs the chain in config order and returns the first failure
+     * as a rejection sentence for the model, or {@code null} when every validator
+     * passes. A broken spec that slipped past save-time validation (hand-edited
+     * storage) rejects the write rather than admitting it — the gate fails closed.
+     */
+    public static String firstRejection(List<ArtifactValidator> validators, String content) {
+        if (validators == null || validators.isEmpty()) {
+            return null;
+        }
+        String candidate = content != null ? content : "";
+        for (ArtifactValidator validator : validators) {
+            if (validator == null || validator.kind() == null || validator.spec() == null) {
+                return "This discussion's artifact validation is misconfigured; the write was refused.";
+            }
+            String rejection = switch (validator.kind()) {
+                case MAX_LENGTH -> checkMaxLength(validator.spec(), candidate);
+                case REGEX -> checkRegex(validator.spec(), candidate);
+                case JSON_SCHEMA -> checkJsonSchema(validator.spec(), candidate);
+            };
+            if (rejection != null) {
+                return rejection;
+            }
+        }
+        return null;
+    }
+
+    private static String checkMaxLength(String spec, String content) {
+        int max;
+        try {
+            max = Integer.parseInt(spec.trim());
+        } catch (NumberFormatException e) {
+            return "This discussion's artifact length validator is misconfigured; the write was refused.";
+        }
+        if (content.length() > max) {
+            return "The content is %d characters, over this discussion's %d-character limit for artifacts. Shorten it."
+                    .formatted(content.length(), max);
+        }
+        return null;
+    }
+
+    private static String checkRegex(String spec, String content) {
+        try {
+            if (!Pattern.compile(spec, Pattern.DOTALL).matcher(content).find()) {
+                return "The content does not match this discussion's required pattern for artifacts. Expected to find a match of: " + spec;
+            }
+        } catch (PatternSyntaxException e) {
+            return "This discussion's artifact pattern validator is misconfigured; the write was refused.";
+        }
+        return null;
+    }
+
+    private static String checkJsonSchema(String spec, String content) {
+        JsonSchema schema;
+        try {
+            schema = SCHEMA_FACTORY.getSchema(spec);
+        } catch (Exception e) {
+            return "This discussion's artifact schema validator is misconfigured; the write was refused.";
+        }
+        JsonNode node;
+        try {
+            node = MAPPER.readTree(content);
+        } catch (Exception e) {
+            return "The content must be valid JSON to pass this discussion's artifact schema, and it is not. Fix the JSON and retry.";
+        }
+        Set<ValidationMessage> violations = schema.validate(node);
+        if (!violations.isEmpty()) {
+            String quoted = violations.stream()
+                    .limit(MAX_QUOTED_VIOLATIONS)
+                    .map(ValidationMessage::getMessage)
+                    .collect(Collectors.joining("; "));
+            String suffix = violations.size() > MAX_QUOTED_VIOLATIONS
+                    ? " (and " + (violations.size() - MAX_QUOTED_VIOLATIONS) + " more)"
+                    : "";
+            return "The content does not satisfy this discussion's artifact schema: " + quoted + suffix + ". Fix it and retry.";
+        }
+        return null;
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/groups/ArtifactValidators.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/ArtifactValidators.java
@@ -10,11 +10,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaId;
+import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
+import org.jboss.logging.Logger;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -45,6 +49,34 @@ public final class ArtifactValidators {
 
     private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
 
+    /**
+     * The 2020-12 meta-schema, resolved from the library's bundled copy (no network
+     * I/O). {@code getSchema(spec)} alone only parses — it accepts schemas with
+     * invalid keyword values — so save-time validation additionally validates the
+     * spec <em>as an instance</em> against this. Null only if the bundled resource
+     * could not load, in which case save-time validation degrades to parse-only
+     * rather than rejecting every config.
+     */
+    private static final JsonSchema META_SCHEMA;
+
+    static {
+        JsonSchema metaSchema = null;
+        try {
+            metaSchema = SCHEMA_FACTORY.getSchema(SchemaLocation.of(SchemaId.V202012));
+        } catch (Exception e) {
+            Logger.getLogger(ArtifactValidators.class)
+                    .warnf("2020-12 meta-schema unavailable; schema specs are checked by parse only: %s", e.getMessage());
+        }
+        META_SCHEMA = metaSchema;
+    }
+
+    /**
+     * Wall-clock budget for one config-authored regex against one artifact's
+     * content. A catastrophically backtracking pattern must abort instead of
+     * pinning the member turn for its full timeout.
+     */
+    private static final long REGEX_DEADLINE_NANOS = TimeUnit.MILLISECONDS.toNanos(500);
+
     private ArtifactValidators() {
     }
 
@@ -71,10 +103,9 @@ public final class ArtifactValidators {
             }
             switch (validator.kind()) {
                 case JSON_SCHEMA -> {
-                    try {
-                        SCHEMA_FACTORY.getSchema(spec);
-                    } catch (Exception e) {
-                        throw new IllegalArgumentException(path + " is not a valid JSON schema: " + e.getMessage());
+                    String problem = schemaSpecProblem(spec);
+                    if (problem != null) {
+                        throw new IllegalArgumentException(path + " is not a valid JSON schema: " + problem);
                     }
                 }
                 case REGEX -> {
@@ -142,13 +173,91 @@ public final class ArtifactValidators {
 
     private static String checkRegex(String spec, String content) {
         try {
-            if (!Pattern.compile(spec, Pattern.DOTALL).matcher(content).find()) {
+            if (!Pattern.compile(spec, Pattern.DOTALL).matcher(deadlineGuarded(content)).find()) {
                 return "The content does not match this discussion's required pattern for artifacts. Expected to find a match of: " + spec;
             }
         } catch (PatternSyntaxException e) {
             return "This discussion's artifact pattern validator is misconfigured; the write was refused.";
+        } catch (MatchDeadlineExceededException e) {
+            return "This discussion's artifact pattern validator did not finish in time; the write was refused.";
         }
         return null;
+    }
+
+    /**
+     * Save-time schema check, two layers: the spec must parse, and it must itself
+     * satisfy the 2020-12 meta-schema — {@code getSchema(spec)} alone accepts e.g.
+     * {@code {"type": "strng"}} and only misbehaves at write time. Returns the
+     * problem, or {@code null} for a valid spec.
+     */
+    private static String schemaSpecProblem(String spec) {
+        JsonNode schemaNode;
+        try {
+            schemaNode = MAPPER.readTree(spec);
+        } catch (Exception e) {
+            return e.getMessage();
+        }
+        if (META_SCHEMA != null) {
+            Set<ValidationMessage> violations = META_SCHEMA.validate(schemaNode);
+            if (!violations.isEmpty()) {
+                return violations.stream()
+                        .limit(MAX_QUOTED_VIOLATIONS)
+                        .map(ValidationMessage::getMessage)
+                        .collect(Collectors.joining("; "));
+            }
+        }
+        try {
+            SCHEMA_FACTORY.getSchema(spec);
+        } catch (Exception e) {
+            return e.getMessage();
+        }
+        return null;
+    }
+
+    /**
+     * Thrown by {@link #deadlineGuarded}'s wrapper when the match budget is spent.
+     */
+    private static final class MatchDeadlineExceededException extends RuntimeException {
+        MatchDeadlineExceededException() {
+            super("regex match exceeded its time budget", null, false, false);
+        }
+    }
+
+    /**
+     * Wraps content so a regex match aborts once {@link #REGEX_DEADLINE_NANOS} is
+     * spent. Backtracking re-reads characters, so the deadline check in
+     * {@code charAt} (sampled, to keep the fast path cheap) is hit constantly by
+     * exactly the pathological patterns it exists to stop. Single-matcher use only
+     * — the sampling counter is not thread-safe, matching a Matcher's own contract.
+     */
+    private static CharSequence deadlineGuarded(String content) {
+        long deadline = System.nanoTime() + REGEX_DEADLINE_NANOS;
+        return new CharSequence() {
+            private int accesses;
+
+            @Override
+            public int length() {
+                return content.length();
+            }
+
+            @Override
+            public char charAt(int index) {
+                if ((++accesses & 0x3FF) == 0 && System.nanoTime() > deadline) {
+                    throw new MatchDeadlineExceededException();
+                }
+                return content.charAt(index);
+            }
+
+            @Override
+            public CharSequence subSequence(int start, int end) {
+                return content.subSequence(start, end);
+            }
+
+            @Override
+            public String toString() {
+                return content;
+            }
+        };
     }
 
     private static String checkJsonSchema(String spec, String content) {

--- a/src/main/java/ai/labs/eddi/configs/groups/ISharedArtifactStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/ISharedArtifactStore.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups;
+
+import ai.labs.eddi.configs.groups.model.SharedArtifact;
+import ai.labs.eddi.datastore.IResourceStore;
+
+import java.util.List;
+
+/**
+ * Store for {@link SharedArtifact}s (I17) — runtime documents in their own
+ * collection, one per co-edited artifact of a group discussion. Same
+ * single-version, DB-agnostic shape as {@link IGroupConversationStore}.
+ *
+ * @author ginccc
+ */
+public interface ISharedArtifactStore {
+
+    /**
+     * Persists a new artifact and assigns its id.
+     *
+     * @return the new artifact's id
+     */
+    String create(SharedArtifact artifact) throws IResourceStore.ResourceStoreException;
+
+    SharedArtifact read(String id) throws IResourceStore.ResourceNotFoundException, IResourceStore.ResourceStoreException;
+
+    /**
+     * Persists {@code artifact} only if the stored document's {@code version} still
+     * equals {@code expectedVersion} — the deterministic CAS every accepted edit
+     * goes through. The caller applies the edit (which bumps the in-memory version)
+     * and presents the version it <em>read</em>.
+     *
+     * @throws IResourceStore.ResourceModifiedException
+     *             lost the race — someone else's edit landed first (retry after a
+     *             fresh read)
+     * @throws ArtifactGoneException
+     *             the artifact was deleted concurrently
+     */
+    void updateIfVersion(SharedArtifact artifact, long expectedVersion)
+            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceModifiedException;
+
+    void delete(String id) throws IResourceStore.ResourceStoreException;
+
+    /**
+     * All artifacts of one discussion, oldest first. Bounded by the group config's
+     * {@code maxArtifactsPerDiscussion}, so no pagination surface.
+     */
+    List<SharedArtifact> listByGroupConversationId(String groupConversationId) throws IResourceStore.ResourceStoreException;
+
+    /**
+     * Cascade delete for a closing/deleted discussion.
+     *
+     * @return how many artifacts were removed
+     */
+    long deleteByGroupConversationId(String groupConversationId) throws IResourceStore.ResourceStoreException;
+
+    /**
+     * GDPR erasure sweep: permanently removes every artifact whose
+     * {@code ownerUserId} is {@code userId}. Follows the group-conversation store's
+     * erasure contract — pages until an empty pass, re-checks ownership by exact
+     * match in Java, and throws rather than reporting a partial erasure as success.
+     *
+     * @return how many artifacts were removed
+     */
+    long deleteAllForUser(String userId) throws IResourceStore.ResourceStoreException;
+
+    /**
+     * Unchecked "deleted concurrently" — thrown by {@link #updateIfVersion} so CAS
+     * call sites can distinguish a retryable conflict (409) from a gone document
+     * (404) without a checked-exception cascade.
+     */
+    class ArtifactGoneException extends RuntimeException {
+        public ArtifactGoneException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -145,6 +145,71 @@ public class AgentGroupConfiguration {
     }
 
     /**
+     * Whether members may create and co-edit shared artifacts mid-discussion (I17).
+     * {@code null} means the artifact tools are absent entirely.
+     */
+    private ArtifactConfig artifactConfig;
+
+    public ArtifactConfig getArtifactConfig() {
+        return artifactConfig;
+    }
+
+    public void setArtifactConfig(ArtifactConfig artifactConfig) {
+        this.artifactConfig = artifactConfig;
+    }
+
+    /**
+     * Governs shared artifacts (I17, blackboard-lite): typed documents members
+     * co-edit through tools instead of re-parsing each other's prose. Same
+     * opt-in-by-absence discipline as {@link GroupTaskConfig}: off means the tools
+     * are never assembled, and there is no permissive standalone default.
+     *
+     * @param allowArtifactTools
+     *            master switch, default off
+     * @param maxArtifactsPerDiscussion
+     *            ceiling on artifacts per discussion (default 5). Non-positive
+     *            falls back to the default — 0 must never mean unlimited for an LLM
+     *            write surface
+     * @param validators
+     *            declarative validation chain every accepted write must pass —
+     *            {@link ValidatorKind#JSON_SCHEMA}, {@link ValidatorKind#REGEX} or
+     *            {@link ValidatorKind#MAX_LENGTH} with a {@code spec}. Declarative
+     *            <em>only</em>, never arbitrary code. Failed validation rejects the
+     *            write with the validator's message; nothing is stored
+     */
+    public record ArtifactConfig(boolean allowArtifactTools, int maxArtifactsPerDiscussion, List<ArtifactValidator> validators) {
+
+        public static final int DEFAULT_MAX_ARTIFACTS = 5;
+
+        /** Same normalization choke point as {@link GroupTaskConfig}. */
+        public ArtifactConfig {
+            if (maxArtifactsPerDiscussion <= 0) {
+                maxArtifactsPerDiscussion = DEFAULT_MAX_ARTIFACTS;
+            }
+            validators = validators == null ? List.of() : List.copyOf(validators);
+        }
+
+        /** Disabled, cap at its default, no validators. */
+        public ArtifactConfig() {
+            this(false, DEFAULT_MAX_ARTIFACTS, List.of());
+        }
+    }
+
+    /**
+     * One declarative artifact validator (I17): {@code kind} selects the check,
+     * {@code spec} parameterizes it — a JSON schema document, a regex the content
+     * must match, or a maximum character count. Specs are validated at save time so
+     * a typo fails the config save, not a member's turn.
+     */
+    public record ArtifactValidator(ValidatorKind kind, String spec) {
+    }
+
+    /** The closed set of declarative artifact validators (I17). */
+    public enum ValidatorKind {
+        JSON_SCHEMA, REGEX, MAX_LENGTH
+    }
+
+    /**
      * A member of the group. Members can be individual agents or nested groups.
      * <p>
      * For {@code MemberType.GROUP} members, the {@code agentId} field contains the

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Size;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -186,7 +187,9 @@ public class AgentGroupConfiguration {
             if (maxArtifactsPerDiscussion <= 0) {
                 maxArtifactsPerDiscussion = DEFAULT_MAX_ARTIFACTS;
             }
-            validators = validators == null ? List.of() : List.copyOf(validators);
+            // Not List.copyOf: it NPEs on a null ELEMENT ("validators": [null]),
+            // preempting ArtifactValidators.requireValidSpecs' actionable message.
+            validators = validators == null ? List.of() : Collections.unmodifiableList(new ArrayList<>(validators));
         }
 
         /** Disabled, cap at its default, no validators. */

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
@@ -243,11 +243,12 @@ public class GroupConversation {
     private final transient Queue<ArtifactChange> pendingArtifactChanges = new ConcurrentLinkedQueue<>();
 
     /**
-     * Serializes drain-and-announce over {@link #pendingArtifactChanges}. The queue
+     * Serializes the drain HANDOFF over {@link #pendingArtifactChanges}. The queue
      * itself is safe, but two PARALLEL turns ending together would split it between
-     * their drains and could then publish v2's event before v1's; holding this
-     * mutex across the whole drain+announce keeps events in write order. See
-     * {@code MemberTurnExecutor#announceArtifactChanges}.
+     * their drains and could then publish v2's event before v1's. The mutex is held
+     * only around the drain and the publisher flag — never across the listener
+     * callbacks, so a slow SSE client cannot block other turns' end-of-turn drains.
+     * See {@code MemberTurnExecutor#announceArtifactChanges}.
      */
     @JsonIgnore
     private final transient Object artifactAnnounceMutex = new Object();
@@ -256,6 +257,26 @@ public class GroupConversation {
     @JsonIgnore
     public Object artifactAnnounceMutex() {
         return artifactAnnounceMutex;
+    }
+
+    /**
+     * Whether a thread is currently PUBLISHING drained artifact changes. Guarded by
+     * {@link #artifactAnnounceMutex} (never read or written outside it) — this flag
+     * is what lets the mutex be released during the listener callbacks themselves:
+     * the active publisher keeps looping over late arrivals, and every other thread
+     * hands off and leaves instead of blocking on a slow SSE client. Deliberately
+     * not {@code isX}-named: runtime coordination state, invisible to Jackson.
+     */
+    private transient boolean artifactAnnouncePublishing;
+
+    @JsonIgnore
+    public boolean artifactAnnouncePublishing() {
+        return artifactAnnouncePublishing;
+    }
+
+    @JsonIgnore
+    public void artifactAnnouncePublishing(boolean publishing) {
+        this.artifactAnnouncePublishing = publishing;
     }
 
     /** Queues an accepted artifact write for the turn executor to announce. */

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
@@ -242,6 +242,22 @@ public class GroupConversation {
     @JsonIgnore
     private final transient Queue<ArtifactChange> pendingArtifactChanges = new ConcurrentLinkedQueue<>();
 
+    /**
+     * Serializes drain-and-announce over {@link #pendingArtifactChanges}. The queue
+     * itself is safe, but two PARALLEL turns ending together would split it between
+     * their drains and could then publish v2's event before v1's; holding this
+     * mutex across the whole drain+announce keeps events in write order. See
+     * {@code MemberTurnExecutor#announceArtifactChanges}.
+     */
+    @JsonIgnore
+    private final transient Object artifactAnnounceMutex = new Object();
+
+    /** The monitor {@code MemberTurnExecutor} serializes announce passes on. */
+    @JsonIgnore
+    public Object artifactAnnounceMutex() {
+        return artifactAnnounceMutex;
+    }
+
     /** Queues an accepted artifact write for the turn executor to announce. */
     @JsonIgnore
     public void queueArtifactChange(ArtifactChange change) {

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
@@ -14,10 +14,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Transcript record for a group conversation. Persisted with a single-version
@@ -224,6 +226,62 @@ public class GroupConversation {
      */
     @JsonIgnore
     private transient AgentGroupConfiguration.ProtocolConfig.CostPolicy costCeilingOutcome;
+
+    /**
+     * One accepted artifact write (I17), queued by the artifact tools on the LIVE
+     * instance and drained by {@code MemberTurnExecutor} after the turn to fire the
+     * {@code artifact_updated} event. This indirection exists because tools have no
+     * listener reference — {@code ToolAssemblyContext} carries none — while the
+     * turn executor does. Transient and concurrent: PARALLEL phases run members
+     * (and so their tools) concurrently.
+     */
+    public record ArtifactChange(String artifactId, String name, String type, long version, String editorAgentId,
+            String status, boolean created) {
+    }
+
+    @JsonIgnore
+    private final transient Queue<ArtifactChange> pendingArtifactChanges = new ConcurrentLinkedQueue<>();
+
+    /** Queues an accepted artifact write for the turn executor to announce. */
+    @JsonIgnore
+    public void queueArtifactChange(ArtifactChange change) {
+        if (change != null) {
+            pendingArtifactChanges.add(change);
+        }
+    }
+
+    /** Drains queued artifact writes — each drained exactly once. */
+    @JsonIgnore
+    public List<ArtifactChange> drainArtifactChanges() {
+        List<ArtifactChange> drained = new ArrayList<>();
+        ArtifactChange change;
+        while ((change = pendingArtifactChanges.poll()) != null) {
+            drained.add(change);
+        }
+        return drained;
+    }
+
+    /**
+     * The discussion's shared artifacts (I17), populated at READ time by
+     * {@code GroupConversationService.readGroupConversation} from the artifact
+     * store — never persisted with this document (artifacts have their own
+     * collection; see {@link SharedArtifact}). Serialized when populated so REST's
+     * status payload and MCP's {@code read_group_conversation} both carry it;
+     * {@code READ_ONLY} because a stored copy must never be trusted back. Mirrors
+     * the {@code availableActions} idiom.
+     */
+    @JsonIgnore
+    private transient List<SharedArtifact> artifacts;
+
+    @JsonProperty(value = "artifacts", access = JsonProperty.Access.READ_ONLY)
+    public List<SharedArtifact> getArtifacts() {
+        return artifacts;
+    }
+
+    @JsonIgnore
+    public void setArtifacts(List<SharedArtifact> artifacts) {
+        this.artifacts = artifacts;
+    }
 
     /**
      * A parent discussion's remaining cost budget at the moment it dispatched this

--- a/src/main/java/ai/labs/eddi/configs/groups/model/SharedArtifact.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/SharedArtifact.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups.model;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A typed document a group discussion's members create and co-edit through the
+ * artifact tools (I17, blackboard-lite) — state that lives <em>outside</em> the
+ * dialogue, so a structured thing an agent produces stops being prose the next
+ * agent re-parses.
+ * <p>
+ * Persisted in its <b>own collection</b> ({@code sharedartifacts}), never
+ * embedded in the {@link GroupConversation} document: the discussion loop
+ * persists that document whole from stale snapshots after each phase, which
+ * would silently clobber concurrent artifact writes. Because artifacts have
+ * their own collection, tools write them through the store directly — the F1
+ * live-instance rule that governs task-list writes does not apply here.
+ * <p>
+ * Concurrency is deterministic compare-and-set on {@link #version} (see
+ * {@code ISharedArtifactStore.updateIfVersion}): a stale writer gets a "re-read
+ * and merge" rejection and retries — explicitly <em>not</em> an LLM fusion
+ * arbiter, whose failure mode is a silent bad merge rather than a retry.
+ *
+ * @author ginccc
+ */
+public class SharedArtifact {
+
+    /**
+     * Hard ceiling on {@link #content}, in UTF-8 bytes. An LLM handed a write tool
+     * can write in a loop; the cap bounds a single document while staying far above
+     * any deliberated draft.
+     */
+    public static final int MAX_CONTENT_BYTES = 256 * 1024;
+
+    /**
+     * How many prior revisions ride on the document. A bounded tail, oldest dropped
+     * — full history is the transcript's job, this exists so a bad edit one or two
+     * turns back is recoverable without archaeology.
+     */
+    public static final int HISTORY_CAP = 10;
+
+    /** The artifact's content type — how consumers should read {@link #content}. */
+    public enum ArtifactType {
+        TEXT, MARKDOWN, JSON
+    }
+
+    /** Editing lifecycle: DRAFT while being worked, FINAL once frozen. */
+    public enum ArtifactStatus {
+        DRAFT, FINAL
+    }
+
+    /**
+     * One superseded revision. {@code version} is the version this content carried
+     * while current.
+     */
+    public record ArtifactRevision(String content, String editorAgentId, long version, Instant at) {
+    }
+
+    private String id;
+    private String groupConversationId;
+    /**
+     * The owning discussion's {@code userId}, stamped at creation so GDPR erasure
+     * can sweep artifacts by user exactly like group conversations — independent of
+     * whether the parent document still exists at erasure time.
+     */
+    private String ownerUserId;
+    private String name;
+    private ArtifactType type;
+    private String content;
+    /**
+     * Monotonic edit counter, starting at 1 on creation — the CAS token every
+     * update must present. Serialized as a JSON number; the store's version CAS
+     * uses the numeric {@code storeIfFieldEquals} overload for exactly that reason.
+     */
+    private long version;
+    private String lastEditorAgentId;
+    private ArtifactStatus status = ArtifactStatus.DRAFT;
+    private List<ArtifactRevision> history = new ArrayList<>();
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    /**
+     * Applies an accepted edit: archives the current content into {@link #history}
+     * (capped, oldest dropped), then installs the new content and bumps
+     * {@link #version}. Pure in-memory mutation — persistence and the CAS happen at
+     * the store.
+     */
+    public void applyEdit(String newContent, String editorAgentId, Instant at) {
+        history.add(new ArtifactRevision(content, lastEditorAgentId, version, updatedAt != null ? updatedAt : createdAt));
+        while (history.size() > HISTORY_CAP) {
+            history.remove(0);
+        }
+        content = newContent;
+        lastEditorAgentId = editorAgentId;
+        version = version + 1;
+        updatedAt = at;
+    }
+
+    /**
+     * UTF-8 byte length of {@code content}, for the {@link #MAX_CONTENT_BYTES} cap.
+     */
+    public static int contentBytes(String content) {
+        return content == null ? 0 : content.getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getGroupConversationId() {
+        return groupConversationId;
+    }
+
+    public void setGroupConversationId(String groupConversationId) {
+        this.groupConversationId = groupConversationId;
+    }
+
+    public String getOwnerUserId() {
+        return ownerUserId;
+    }
+
+    public void setOwnerUserId(String ownerUserId) {
+        this.ownerUserId = ownerUserId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ArtifactType getType() {
+        return type;
+    }
+
+    public void setType(ArtifactType type) {
+        this.type = type;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public void setVersion(long version) {
+        this.version = version;
+    }
+
+    public String getLastEditorAgentId() {
+        return lastEditorAgentId;
+    }
+
+    public void setLastEditorAgentId(String lastEditorAgentId) {
+        this.lastEditorAgentId = lastEditorAgentId;
+    }
+
+    public ArtifactStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ArtifactStatus status) {
+        this.status = status;
+    }
+
+    public List<ArtifactRevision> getHistory() {
+        return history;
+    }
+
+    public void setHistory(List<ArtifactRevision> history) {
+        this.history = history != null ? history : new ArrayList<>();
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.groups.mongo;
 
 import ai.labs.eddi.configs.hitl.HitlConfigValidation;
+import ai.labs.eddi.configs.groups.ArtifactValidators;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
@@ -41,6 +42,7 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
     public IResourceStore.IResourceId create(AgentGroupConfiguration groupConfiguration)
             throws IResourceStore.ResourceStoreException {
         HitlConfigValidation.validate(groupConfiguration.getHitlConfig());
+        ArtifactValidators.requireValidSpecs(groupConfiguration.getArtifactConfig());
         normalizeNonPositiveCostCeiling(groupConfiguration);
         warnOnModeratorlessPhases(groupConfiguration);
         return super.create(groupConfiguration);
@@ -52,6 +54,7 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
             throws IResourceStore.ResourceStoreException, IResourceStore.ResourceModifiedException,
             IResourceStore.ResourceNotFoundException {
         HitlConfigValidation.validate(groupConfiguration.getHitlConfig());
+        ArtifactValidators.requireValidSpecs(groupConfiguration.getArtifactConfig());
         normalizeNonPositiveCostCeiling(groupConfiguration);
         warnOnModeratorlessPhases(groupConfiguration);
         return super.update(id, version, groupConfiguration);

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/SharedArtifactStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/SharedArtifactStore.java
@@ -17,6 +17,7 @@ import org.jboss.logging.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -142,6 +143,9 @@ public class SharedArtifactStore implements ISharedArtifactStore {
                     LOGGER.warnf("Skipping unreadable shared artifact %s: %s", resourceId.getId(), e.getMessage());
                 }
             }
+            // findResources sorts DESC on both backends; the contract is oldest first.
+            artifacts.sort(Comparator.comparing(SharedArtifact::getCreatedAt,
+                    Comparator.nullsLast(Comparator.naturalOrder())));
             return artifacts;
         } catch (Exception e) {
             throw new IResourceStore.ResourceStoreException("Failed to list shared artifacts: " + e.getMessage(), e);
@@ -154,16 +158,29 @@ public class SharedArtifactStore implements ISharedArtifactStore {
             return 0;
         }
         long deleted = 0;
+        var processed = new HashSet<String>();
         // maxArtifactsPerDiscussion bounds a discussion's artifacts far below one
-        // page, but the loop stays honest anyway: delete until a pass finds nothing.
+        // page, but the loop stays honest anyway: delete until a pass finds
+        // nothing — with the same processed-set/no-progress guard as
+        // deleteAllForUser, so a row removeAllPermanently cannot dislodge is
+        // counted once and ends the loop instead of spinning it.
         for (int pass = 0; pass < MAX_ERASURE_PASSES; pass++) {
             List<SharedArtifact> artifacts = listByGroupConversationId(groupConversationId);
             if (artifacts.isEmpty()) {
                 return deleted;
             }
+            long newThisPass = 0;
             for (SharedArtifact artifact : artifacts) {
+                if (!processed.add(artifact.getId())) {
+                    continue;
+                }
+                newThisPass++;
                 delete(artifact.getId());
                 deleted++;
+            }
+            if (newThisPass == 0) {
+                LOGGER.warnf("Cascade delete made no progress; %d shared artifact(s) may remain", artifacts.size());
+                return deleted;
             }
         }
         return deleted;

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/SharedArtifactStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/SharedArtifactStore.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups.mongo;
+
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
+import ai.labs.eddi.configs.groups.model.SharedArtifact;
+import ai.labs.eddi.datastore.IResourceFilter;
+import ai.labs.eddi.datastore.IResourceStorage;
+import ai.labs.eddi.datastore.IResourceStorageFactory;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * DB-agnostic store for {@link SharedArtifact}s (I17). Mirrors
+ * {@link GroupConversationStore}'s single-version runtime-document shape (the
+ * {@code mongo} package name is historic — this class is backend-neutral via
+ * {@link IResourceStorageFactory}).
+ * <p>
+ * The version CAS goes through the numeric
+ * {@code storeIfFieldEquals(resource, "version", long)} overload: the
+ * artifact's {@code version} is a JSON number, and MongoDB's typed BSON
+ * equality would never match it against a string.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class SharedArtifactStore implements ISharedArtifactStore {
+
+    private static final Logger LOGGER = Logger.getLogger(SharedArtifactStore.class);
+
+    private static final int SINGLE_VERSION = 1;
+
+    /**
+     * Both backends turn a String filter into an UNANCHORED regex — ids must be
+     * validated before they are interpolated into one. Group-conversation ids are
+     * Mongo ObjectIds or UUIDs on the two backends, both within this set.
+     */
+    private static final Pattern SAFE_ID = Pattern.compile("[A-Za-z0-9-]+");
+
+    /** Same spin bound and rationale as {@code GroupConversationStore}. */
+    private static final int MAX_ERASURE_PASSES = 1_000;
+
+    private final IResourceStorage<SharedArtifact> storage;
+
+    @Inject
+    public SharedArtifactStore(IResourceStorageFactory storageFactory, IDocumentBuilder documentBuilder) {
+        this.storage = storageFactory.create("sharedartifacts", documentBuilder, SharedArtifact.class,
+                "groupConversationId", "ownerUserId");
+    }
+
+    @Override
+    public String create(SharedArtifact artifact) throws IResourceStore.ResourceStoreException {
+        try {
+            IResourceStorage.IResource<SharedArtifact> resource = storage.newResource(artifact);
+            storage.store(resource);
+            String id = resource.getId();
+            artifact.setId(id);
+            return id;
+        } catch (IOException e) {
+            throw new IResourceStore.ResourceStoreException("Failed to create shared artifact: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public SharedArtifact read(String id) throws IResourceStore.ResourceNotFoundException, IResourceStore.ResourceStoreException {
+        try {
+            IResourceStorage.IResource<SharedArtifact> resource = storage.read(id, SINGLE_VERSION);
+            if (resource == null) {
+                // Deliberately does not embed the caller-supplied id — reflected-value
+                // sink, same rule as GroupConversationStore.read.
+                throw new IResourceStore.ResourceNotFoundException("Shared artifact not found.");
+            }
+            SharedArtifact artifact = resource.getData();
+            artifact.setId(id);
+            return artifact;
+        } catch (IOException e) {
+            throw new IResourceStore.ResourceStoreException("Failed to read shared artifact: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void updateIfVersion(SharedArtifact artifact, long expectedVersion)
+            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceModifiedException {
+        try {
+            IResourceStorage.IResource<SharedArtifact> resource = storage.newResource(artifact.getId(), SINGLE_VERSION, artifact);
+            storage.storeIfFieldEquals(resource, "version", expectedVersion);
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            // Unchecked, so CAS call sites can tell "gone" (404) from a genuine
+            // version conflict (409) — same shape as GroupConversationGoneException.
+            throw new ArtifactGoneException("Shared artifact no longer exists.", e);
+        } catch (IOException e) {
+            throw new IResourceStore.ResourceStoreException("Failed to update shared artifact: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void delete(String id) throws IResourceStore.ResourceStoreException {
+        try {
+            storage.removeAllPermanently(id);
+        } catch (Exception e) {
+            throw new IResourceStore.ResourceStoreException("Failed to delete shared artifact: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<SharedArtifact> listByGroupConversationId(String groupConversationId) throws IResourceStore.ResourceStoreException {
+        if (groupConversationId == null || !SAFE_ID.matcher(groupConversationId).matches()) {
+            return List.of();
+        }
+        try {
+            var filter = new IResourceFilter.QueryFilters(
+                    List.of(new IResourceFilter.QueryFilter("groupConversationId", "^" + groupConversationId + "$")));
+            var resourceIds = storage.findResources(
+                    new IResourceFilter.QueryFilters[]{filter}, "createdAt", 0, IResourceStorage.MAX_RESULT_LIMIT);
+            List<SharedArtifact> artifacts = new ArrayList<>();
+            for (var resourceId : resourceIds) {
+                try {
+                    var resource = storage.read(resourceId.getId(), SINGLE_VERSION);
+                    if (resource == null) {
+                        continue;
+                    }
+                    SharedArtifact artifact = resource.getData();
+                    // The anchored regex only narrows; equality decides — same
+                    // narrow-then-recheck rule as every other cross-document filter.
+                    if (!groupConversationId.equals(artifact.getGroupConversationId())) {
+                        continue;
+                    }
+                    artifact.setId(resourceId.getId());
+                    artifacts.add(artifact);
+                } catch (IOException e) {
+                    LOGGER.warnf("Skipping unreadable shared artifact %s: %s", resourceId.getId(), e.getMessage());
+                }
+            }
+            return artifacts;
+        } catch (Exception e) {
+            throw new IResourceStore.ResourceStoreException("Failed to list shared artifacts: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public long deleteByGroupConversationId(String groupConversationId) throws IResourceStore.ResourceStoreException {
+        if (groupConversationId == null || !SAFE_ID.matcher(groupConversationId).matches()) {
+            return 0;
+        }
+        long deleted = 0;
+        // maxArtifactsPerDiscussion bounds a discussion's artifacts far below one
+        // page, but the loop stays honest anyway: delete until a pass finds nothing.
+        for (int pass = 0; pass < MAX_ERASURE_PASSES; pass++) {
+            List<SharedArtifact> artifacts = listByGroupConversationId(groupConversationId);
+            if (artifacts.isEmpty()) {
+                return deleted;
+            }
+            for (SharedArtifact artifact : artifacts) {
+                delete(artifact.getId());
+                deleted++;
+            }
+        }
+        return deleted;
+    }
+
+    @Override
+    public long deleteAllForUser(String userId) throws IResourceStore.ResourceStoreException {
+        if (userId == null || userId.isBlank()) {
+            return 0;
+        }
+        long deleted = 0;
+        var processed = new HashSet<String>();
+        try {
+            var filter = new IResourceFilter.QueryFilters(
+                    List.of(new IResourceFilter.QueryFilter("ownerUserId", "^" + escapeRegex(userId) + "$")));
+
+            // Page until an empty pass, always from offset 0 (rows are removed as we
+            // go); fail loudly on an owned row that will not delete. Contract and
+            // reasoning identical to GroupConversationStore.deleteAllForUser.
+            for (int pass = 0; pass < MAX_ERASURE_PASSES; pass++) {
+                var resourceIds = storage.findResources(
+                        new IResourceFilter.QueryFilters[]{filter}, "createdAt", 0, IResourceStorage.MAX_RESULT_LIMIT);
+                if (resourceIds == null || resourceIds.isEmpty()) {
+                    return deleted;
+                }
+
+                long newThisPass = 0;
+                long failedToDelete = 0;
+                for (var resourceId : resourceIds) {
+                    if (!processed.add(resourceId.getId())) {
+                        continue;
+                    }
+                    newThisPass++;
+                    try {
+                        var resource = storage.read(resourceId.getId(), SINGLE_VERSION);
+                        if (resource == null) {
+                            continue;
+                        }
+                        if (!userId.equals(resource.getData().getOwnerUserId())) {
+                            // regex matched more than it should have — never delete on it
+                            LOGGER.warnf("Skipping shared artifact %s during erasure: ownerUserId is not an exact match", resourceId.getId());
+                            continue;
+                        }
+                        storage.removeAllPermanently(resourceId.getId());
+                        deleted++;
+                    } catch (IOException e) {
+                        failedToDelete++;
+                        LOGGER.warnf("Failed to erase shared artifact %s: %s", resourceId.getId(), e.getMessage());
+                    }
+                }
+
+                if (failedToDelete > 0) {
+                    throw new IResourceStore.ResourceStoreException(
+                            "Erasure incomplete: " + failedToDelete + " shared artifact(s) belonging to the user could not be deleted after "
+                                    + deleted + " successful deletion(s)");
+                }
+                if (newThisPass == 0) {
+                    return deleted;
+                }
+            }
+            LOGGER.warnf("Erasure stopped after %d passes; more shared artifacts may remain", MAX_ERASURE_PASSES);
+        } catch (IResourceStore.ResourceStoreException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IResourceStore.ResourceStoreException("Failed to delete shared artifacts for user: " + e.getMessage(), e);
+        }
+        return deleted;
+    }
+
+    /**
+     * Backslash-escape the regex metacharacters shared by both backends' engines.
+     * Not {@link Pattern#quote}: its {@code \Q...\E} form is Java-specific and
+     * PostgreSQL rejects it.
+     */
+    private static String escapeRegex(String value) {
+        StringBuilder sb = new StringBuilder(value.length() + 8);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if ("\\^$.|?*+()[]{}".indexOf(c) >= 0) {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/ai/labs/eddi/datastore/IResourceStorage.java
+++ b/src/main/java/ai/labs/eddi/datastore/IResourceStorage.java
@@ -154,6 +154,24 @@ public interface IResourceStorage<T> {
     }
 
     /**
+     * As {@link #storeIfFieldEquals(IResource, String, String)}, but comparing a
+     * JSON <em>number</em> field. A separate overload because the two backends
+     * disagree about text-comparing numbers: PostgreSQL's {@code data ->> field}
+     * renders a JSON number as text so {@code "3"} matches, but MongoDB's typed
+     * BSON equality never matches an int64 against a string — a string-typed CAS on
+     * a numeric field would "work" on one backend and silently never match on the
+     * other. Used by the shared-artifact store's version CAS (I17).
+     * <p>
+     * Same no-fallback contract as the String overload.
+     */
+    default void storeIfFieldEquals(IResource<T> newResource, String fieldName, long expectedValue)
+            throws IResourceStore.ResourceModifiedException, IResourceStore.ResourceNotFoundException {
+        throw new UnsupportedOperationException(
+                "storeIfFieldEquals(long) is not implemented by " + getClass().getName()
+                        + " — a compare-and-swap must never silently degrade to an unconditional store");
+    }
+
+    /**
      * Archive {@code history} and apply the version-checked update as ONE unit of
      * work.
      * <p>

--- a/src/main/java/ai/labs/eddi/datastore/mongo/MongoResourceStorage.java
+++ b/src/main/java/ai/labs/eddi/datastore/mongo/MongoResourceStorage.java
@@ -148,6 +148,28 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
     }
 
     @Override
+    public void storeIfFieldEquals(IResource<T> newResource, String fieldName, long expectedValue)
+            throws IResourceStore.ResourceModifiedException, IResourceStore.ResourceNotFoundException {
+        Resource resource = checkInternalResource(newResource);
+        // Typed BSON equality — the String overload's Filters.eq(field, "3") never
+        // matches an int64 3, which is exactly why this overload exists.
+        var result = currentCollection.replaceOne(
+                Filters.and(
+                        Filters.eq(ID_FIELD, new ObjectId(resource.getId())),
+                        Filters.eq(fieldName, expectedValue)),
+                resource.getMongoDocument());
+        if (result.getMatchedCount() == 0) {
+            long exists = currentCollection.countDocuments(Filters.eq(ID_FIELD, new ObjectId(resource.getId())));
+            if (exists == 0) {
+                throw new IResourceStore.ResourceNotFoundException(
+                        String.format("Resource no longer exists (id=%s)", resource.getId()));
+            }
+            throw new IResourceStore.ResourceModifiedException(
+                    String.format("Resource field '%s' was not %d (id=%s)", fieldName, expectedValue, resource.getId()));
+        }
+    }
+
+    @Override
     public void createNew(IResource<T> currentResource) {
         Resource resource = checkInternalResource(currentResource);
         currentCollection.insertOne(resource.getMongoDocument());

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorage.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorage.java
@@ -305,6 +305,16 @@ public class PostgresResourceStorage<T> implements IResourceStorage<T> {
     }
 
     @Override
+    public void storeIfFieldEquals(IResource<T> newResource, String fieldName, long expectedValue)
+            throws IResourceStore.ResourceModifiedException, IResourceStore.ResourceNotFoundException {
+        // data ->> field renders a JSON number as its canonical text ("3"), so on
+        // this backend the numeric CAS is a text comparison against the rendered
+        // number. The overload exists for MongoDB, whose typed BSON equality has
+        // no such coincidence — see IResourceStorage's Javadoc.
+        storeIfFieldEquals(newResource, fieldName, String.valueOf(expectedValue));
+    }
+
+    @Override
     public void createNew(IResource<T> resource) {
         Resource pgResource = checkInternalResource(resource);
         String sql = "INSERT INTO resources (id, collection_name, version, data) " + "VALUES (?::uuid, ?, ?, ?::jsonb)";

--- a/src/main/java/ai/labs/eddi/engine/api/IGroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IGroupConversationService.java
@@ -210,6 +210,8 @@ public interface IGroupConversationService {
         }
         default void onConvergenceReached(GroupConversationEventSink.ConvergenceReachedEvent event) {
         }
+        default void onArtifactUpdated(GroupConversationEventSink.ArtifactUpdatedEvent event) {
+        }
     }
 
     // --- Exceptions ---

--- a/src/main/java/ai/labs/eddi/engine/api/IRestGroupConversation.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IRestGroupConversation.java
@@ -99,8 +99,8 @@ public interface IRestGroupConversation {
     @Operation(summary = "Start a group discussion with SSE streaming",
                description = "Starts a group discussion asynchronously and streams progress events "
                        + "(group_start, phase_start, speaker_start, speaker_complete, "
-                       + "phase_complete, synthesis_start, group_complete, group_error) "
-                       + "via Server-Sent Events.")
+                       + "phase_complete, synthesis_start, group_complete, group_error, "
+                       + "artifact_updated) via Server-Sent Events.")
     @APIResponse(responseCode = "200", description = "SSE event stream of discussion progress.")
     @APIResponse(responseCode = "400", description = "Missing/blank or oversized 'question', or an oversized attachment.")
     @APIResponse(responseCode = "404", description = "Group not found.")
@@ -183,8 +183,8 @@ public interface IRestGroupConversation {
                description = "Re-run all discussion phases with SSE event streaming for progress. "
                        + "Emits round_start (new round marker) followed by the same events as the "
                        + "initial stream (phase_start, speaker_start, speaker_complete, phase_complete, "
-                       + "synthesis_start, group_complete, group_error), plus the HITL events "
-                       + "(awaiting_approval, hitl_resume, cancelled, member_pause_skipped). NOTE: "
+                       + "synthesis_start, group_complete, group_error, artifact_updated), plus the HITL "
+                       + "events (awaiting_approval, hitl_resume, cancelled, member_pause_skipped). NOTE: "
                        + "'attachments' are NOT supported on a continuation and are rejected with a "
                        + "terminal group_error event rather than silently ignored.")
     @APIResponse(responseCode = "200", description = "SSE event stream of continuation progress.")

--- a/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.gdpr;
 
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
 import ai.labs.eddi.configs.groups.mongo.GroupConversationStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.model.Property;
@@ -62,6 +63,7 @@ public class GdprComplianceService {
     private final IConversationDescriptorStore conversationDescriptorStore;
     private final IConversationCheckpointStore checkpointStore;
     private final Instance<GroupConversationStore> groupConversationStoreInstance;
+    private final Instance<ISharedArtifactStore> sharedArtifactStoreInstance;
     private final IScheduleStore scheduleStore;
     private final ICache<String, UserConversation> userConversationCache;
 
@@ -77,6 +79,7 @@ public class GdprComplianceService {
             IConversationDescriptorStore conversationDescriptorStore,
             IConversationCheckpointStore checkpointStore,
             Instance<GroupConversationStore> groupConversationStoreInstance,
+            Instance<ISharedArtifactStore> sharedArtifactStoreInstance,
             IScheduleStore scheduleStore,
             ICacheFactory cacheFactory) {
         this.userMemoryStore = userMemoryStore;
@@ -90,6 +93,7 @@ public class GdprComplianceService {
         this.conversationDescriptorStore = conversationDescriptorStore;
         this.checkpointStore = checkpointStore;
         this.groupConversationStoreInstance = groupConversationStoreInstance;
+        this.sharedArtifactStoreInstance = sharedArtifactStoreInstance;
         this.scheduleStore = scheduleStore;
         this.userConversationCache = cacheFactory.getCache(USER_CONVERSATION_CACHE_NAME);
     }
@@ -306,6 +310,23 @@ public class GdprComplianceService {
                     pseudonym);
         }
 
+        // 5c2. Delete shared artifacts (I17). Artifacts carry ownerUserId (the
+        // owning discussion's user) precisely so this sweep works even when the
+        // parent discussion document is already gone.
+        long sharedArtifactsDeleted = 0;
+        try {
+            if (sharedArtifactStoreInstance.isResolvable()) {
+                sharedArtifactsDeleted = sharedArtifactStoreInstance.get().deleteAllForUser(userId);
+                if (sharedArtifactsDeleted > 0) {
+                    LOGGER.infof("[GDPR] Deleted %d shared artifacts [%s]",
+                            sharedArtifactsDeleted, pseudonym);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.errorf(e, "[GDPR] Failed to delete shared artifacts [%s]",
+                    pseudonym);
+        }
+
         // 5d. Delete schedules owned by the user. Left behind, they keep firing new
         // conversations under the erased identity — recreating the data forever.
         long schedulesDeleted = 0;
@@ -346,9 +367,9 @@ public class GdprComplianceService {
 
         LOGGER.infof("[GDPR] Erasure cascade complete [%s]: "
                 + "memories=%d, conversations=%d, checkpoints=%d, mappings=%d, "
-                + "groupConversations=%d, schedules=%d, logs=%d, audit=%d",
+                + "groupConversations=%d, sharedArtifacts=%d, schedules=%d, logs=%d, audit=%d",
                 pseudonym, memoriesDeleted, conversationsDeleted, checkpointsDeleted,
-                mappingsDeleted, groupConversationsDeleted, schedulesDeleted,
+                mappingsDeleted, groupConversationsDeleted, sharedArtifactsDeleted, schedulesDeleted,
                 logsPseudonymized, auditPseudonymized);
 
         // Write compliance event to immutable audit ledger
@@ -360,6 +381,7 @@ public class GdprComplianceService {
         auditDetails.put("conversationsDeleted", conversationsDeleted);
         auditDetails.put("mappingsDeleted", mappingsDeleted);
         auditDetails.put("groupConversationsDeleted", groupConversationsDeleted);
+        auditDetails.put("sharedArtifactsDeleted", sharedArtifactsDeleted);
         auditDetails.put("schedulesDeleted", schedulesDeleted);
         auditDetails.put("logsPseudonymized", logsPseudonymized);
         auditDetails.put("auditPseudonymized", auditPseudonymized);

--- a/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
@@ -134,6 +134,7 @@ public class GdprComplianceService {
      * <li>Delete all managed conversation mappings (and invalidate their
      * cache)</li>
      * <li>Delete all group conversation transcripts</li>
+     * <li>Delete all shared artifacts owned by the user</li>
      * <li>Delete all schedules owned by the user</li>
      * <li>Pseudonymize database log entries</li>
      * <li>Pseudonymize audit ledger entries</li>

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -14,6 +14,7 @@ import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
 
 import ai.labs.eddi.configs.groups.IGroupConversationStore;
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
@@ -207,6 +208,14 @@ public class GroupConversationService implements IGroupConversationService {
      */
     @Inject
     LiveDiscussionRegistry liveDiscussionRegistry;
+
+    /**
+     * I17's artifact store. Same field-injection pattern and null-safety as
+     * {@link #attachmentStore} — {@code null} in direct-construction unit tests,
+     * where reads simply carry no artifacts and lifecycle cascades no-op.
+     */
+    @Inject
+    ISharedArtifactStore sharedArtifactStore;
 
     // In-node fast-fail guard for concurrent post-discussion operations
     // (follow-up, continue, close) on the same conversation: a second
@@ -1188,7 +1197,29 @@ public class GroupConversationService implements IGroupConversationService {
     @Override
     public GroupConversation readGroupConversation(String groupConversationId)
             throws IResourceStore.ResourceNotFoundException, IResourceStore.ResourceStoreException {
-        return lifecycleOps().readGroupConversation(groupConversationId);
+        GroupConversation gc = lifecycleOps().readGroupConversation(groupConversationId);
+        populateArtifacts(gc);
+        return gc;
+    }
+
+    /**
+     * I17: attaches the discussion's shared artifacts as a read-time derived field,
+     * here in the service so REST's status payload and MCP's
+     * {@code read_group_conversation} both carry them. Best-effort — a status read
+     * must not fail because the artifact store hiccuped.
+     */
+    private void populateArtifacts(GroupConversation gc) {
+        if (sharedArtifactStore == null || gc == null || gc.getId() == null) {
+            return;
+        }
+        try {
+            var artifacts = sharedArtifactStore.listByGroupConversationId(gc.getId());
+            if (!artifacts.isEmpty()) {
+                gc.setArtifacts(artifacts);
+            }
+        } catch (Exception e) {
+            LOGGER.warnf("Could not attach shared artifacts to group conversation %s: %s", gc.getId(), e.getMessage());
+        }
     }
 
     @Override
@@ -1242,7 +1273,7 @@ public class GroupConversationService implements IGroupConversationService {
 
     private GroupLifecycleOps lifecycleOps() {
         return new GroupLifecycleOps(conversationStore, groupStore, conversationService, agentFactory, agentStore,
-                deploymentStore, operationsInProgress, activeTokens, this,
+                deploymentStore, sharedArtifactStore, operationsInProgress, activeTokens, this,
                 counterGroupFollowUp, counterGroupContinue, counterGroupClose, counterGroupFailure);
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -1092,6 +1092,13 @@ public class GroupConversationService implements IGroupConversationService {
             throw new GroupExecutionException("Group discussion failed: " + e.getMessage(), e);
         } finally {
             timerGroupDiscussion.record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+            // I17: last announce pass for this leg. A member turn that timed out
+            // drained an empty queue in ITS finally, while its still-running agent
+            // could accept an artifact write afterwards; without this, that write's
+            // event is stranded until (unless) another turn runs. A write accepted
+            // after even this pass keeps the artifact (the store write already
+            // committed) — only its live event is best-effort, by design.
+            MemberTurnExecutor.announceArtifactChanges(gc, listener);
             // I1: fold this leg's spend into the lifetime gauge. Recorded as a delta
             // against what this leg started with, so a resumed leg (whose gc arrives
             // already carrying the pre-pause total) contributes only what it newly
@@ -1218,7 +1225,8 @@ public class GroupConversationService implements IGroupConversationService {
                 gc.setArtifacts(artifacts);
             }
         } catch (Exception e) {
-            LOGGER.warnf("Could not attach shared artifacts to group conversation %s: %s", gc.getId(), e.getMessage());
+            LOGGER.warnf("Could not attach shared artifacts to group conversation %s: %s",
+                    LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(e.getMessage()));
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
@@ -875,6 +875,12 @@ public class RestGroupConversation implements IRestGroupConversation {
                 // debate verdict before a later synthesis phase).
                 sendEvent(eventSink, sse, GroupConversationEventSink.EVENT_DECISION_REACHED, toJson(event));
             }
+
+            @Override
+            public void onArtifactUpdated(GroupConversationEventSink.ArtifactUpdatedEvent event) {
+                // Not terminal — artifacts are edited throughout the discussion.
+                sendEvent(eventSink, sse, GroupConversationEventSink.EVENT_ARTIFACT_UPDATED, toJson(event));
+            }
         };
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOps.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOps.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
 import ai.labs.eddi.configs.groups.IGroupConversationStore;
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.LifecyclePolicy;
@@ -83,6 +84,7 @@ public class GroupLifecycleOps {
     private final IAgentFactory agentFactory;
     private final IAgentStore agentStore;
     private final IDeploymentStore deploymentStore;
+    private final ISharedArtifactStore sharedArtifactStore;
     private final Set<String> operationsInProgress;
     private final ConcurrentHashMap<String, DiscussionControlToken> activeTokens;
     private final GroupConversationService groupConversationService;
@@ -93,7 +95,7 @@ public class GroupLifecycleOps {
 
     public GroupLifecycleOps(IGroupConversationStore conversationStore, IAgentGroupStore groupStore,
             IConversationService conversationService, IAgentFactory agentFactory, IAgentStore agentStore,
-            IDeploymentStore deploymentStore, Set<String> operationsInProgress,
+            IDeploymentStore deploymentStore, ISharedArtifactStore sharedArtifactStore, Set<String> operationsInProgress,
             ConcurrentHashMap<String, DiscussionControlToken> activeTokens,
             GroupConversationService groupConversationService, Counter counterGroupFollowUp,
             Counter counterGroupContinue, Counter counterGroupClose, Counter counterGroupFailure) {
@@ -103,6 +105,7 @@ public class GroupLifecycleOps {
         this.agentFactory = agentFactory;
         this.agentStore = agentStore;
         this.deploymentStore = deploymentStore;
+        this.sharedArtifactStore = sharedArtifactStore;
         this.operationsInProgress = operationsInProgress;
         this.activeTokens = activeTokens;
         this.groupConversationService = groupConversationService;
@@ -153,6 +156,10 @@ public class GroupLifecycleOps {
             // operations. Delete is terminal, so reclaim any dynamically-created agents
             // here; otherwise deleting a COMPLETED conversation would orphan them.
             cleanupEphemeralAgentsForGroup(gc);
+            // I17: artifacts live in their own collection keyed by this conversation
+            // — remove them with their discussion, before the document goes (while
+            // the id is still provably a discussion the caller could delete).
+            deleteArtifactsForGroupConversation(groupConversationId);
             conversationStore.delete(groupConversationId);
         } catch (IResourceStore.ResourceNotFoundException e) {
             LOGGER.warnf("Group conversation %s not found for deletion", LogSanitizer.sanitize(groupConversationId));
@@ -476,6 +483,11 @@ public class GroupLifecycleOps {
             // Ephemeral agent cleanup (deferred from executeDiscussion)
             cleanupEphemeralAgentsForGroup(gc);
 
+            // I17: close is a lifecycle end — the working artifacts go with it.
+            // Their durable trace is the transcript (accepted updates are announced
+            // there and a synthesis quotes what mattered), not the working copies.
+            deleteArtifactsForGroupConversation(groupConversationId);
+
             LOGGER.infof("Group conversation %s closed — member conversations ended, ephemeral agents cleaned up",
                     LogSanitizer.sanitize(groupConversationId));
 
@@ -483,6 +495,27 @@ public class GroupLifecycleOps {
             return conversationStore.read(groupConversationId);
         } finally {
             operationsInProgress.remove(groupConversationId);
+        }
+    }
+
+    /**
+     * I17 cascade: removes the discussion's shared artifacts. Warn-and-continue on
+     * failure — a broken artifact store must not make discussions undeletable; the
+     * user-keyed GDPR erasure sweep (which fails loudly) is the completeness
+     * guarantee, this is the tidy path.
+     */
+    private void deleteArtifactsForGroupConversation(String groupConversationId) {
+        if (sharedArtifactStore == null) {
+            return;
+        }
+        try {
+            long removed = sharedArtifactStore.deleteByGroupConversationId(groupConversationId);
+            if (removed > 0) {
+                LOGGER.infof("Removed %d shared artifact(s) of group conversation %s", removed, LogSanitizer.sanitize(groupConversationId));
+            }
+        } catch (Exception e) {
+            LOGGER.warnf("Failed to remove shared artifacts of group conversation %s: %s",
+                    LogSanitizer.sanitize(groupConversationId), e.getMessage());
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutor.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutor.java
@@ -152,6 +152,36 @@ public class MemberTurnExecutor {
                                             DiscussionPhase phase, String targetAgentId, GroupDiscussionEventListener listener,
                                             GroupConversationService.MemberTurnCancellation cancellation, String conversationKey)
             throws GroupDiscussionException {
+        try {
+            return doExecuteAgentTurn(member, gc, input, protocol, phaseIdx, phase, targetAgentId, listener, cancellation, conversationKey);
+        } finally {
+            // I17: announce artifact writes this turn made. In a finally because an
+            // accepted write already happened whatever the turn's own outcome —
+            // a timeout or cancellation after the write must not swallow the event.
+            // Drained even with a null listener so the queue never grows unbounded.
+            announceArtifactChanges(gc, listener);
+        }
+    }
+
+    /**
+     * I17: fires {@code artifact_updated} for every write queued during the turn.
+     */
+    private static void announceArtifactChanges(GroupConversation gc, GroupDiscussionEventListener listener) {
+        List<GroupConversation.ArtifactChange> changes = gc.drainArtifactChanges();
+        if (listener == null || changes.isEmpty()) {
+            return;
+        }
+        for (GroupConversation.ArtifactChange change : changes) {
+            listener.onArtifactUpdated(new GroupConversationEventSink.ArtifactUpdatedEvent(
+                    change.artifactId(), change.name(), change.type(), change.version(),
+                    change.editorAgentId(), change.status(), change.created()));
+        }
+    }
+
+    private TranscriptEntry doExecuteAgentTurn(GroupMember member, GroupConversation gc, String input, ProtocolConfig protocol, int phaseIdx,
+                                               DiscussionPhase phase, String targetAgentId, GroupDiscussionEventListener listener,
+                                               GroupConversationService.MemberTurnCancellation cancellation, String conversationKey)
+            throws GroupDiscussionException {
 
         if (cancellation != null && cancellation.isCancelled()) {
             throw new GroupConversationService.MemberTurnCancelledException();

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutor.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutor.java
@@ -165,16 +165,24 @@ public class MemberTurnExecutor {
 
     /**
      * I17: fires {@code artifact_updated} for every write queued during the turn.
+     * The whole drain+announce holds the conversation's announce mutex: PARALLEL
+     * turns ending together would otherwise split the queue between their drains
+     * and could publish v2's event before v1's. Public (not just the per-turn
+     * finally) because the discussion loop calls it once more when the leg ends, so
+     * a write accepted by a timed-out member's still-running agent — whose own turn
+     * already drained — is announced rather than stranded in the queue.
      */
-    private static void announceArtifactChanges(GroupConversation gc, GroupDiscussionEventListener listener) {
-        List<GroupConversation.ArtifactChange> changes = gc.drainArtifactChanges();
-        if (listener == null || changes.isEmpty()) {
-            return;
-        }
-        for (GroupConversation.ArtifactChange change : changes) {
-            listener.onArtifactUpdated(new GroupConversationEventSink.ArtifactUpdatedEvent(
-                    change.artifactId(), change.name(), change.type(), change.version(),
-                    change.editorAgentId(), change.status(), change.created()));
+    public static void announceArtifactChanges(GroupConversation gc, GroupDiscussionEventListener listener) {
+        synchronized (gc.artifactAnnounceMutex()) {
+            List<GroupConversation.ArtifactChange> changes = gc.drainArtifactChanges();
+            if (listener == null || changes.isEmpty()) {
+                return;
+            }
+            for (GroupConversation.ArtifactChange change : changes) {
+                listener.onArtifactUpdated(new GroupConversationEventSink.ArtifactUpdatedEvent(
+                        change.artifactId(), change.name(), change.type(), change.version(),
+                        change.editorAgentId(), change.status(), change.created()));
+            }
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutor.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutor.java
@@ -165,24 +165,52 @@ public class MemberTurnExecutor {
 
     /**
      * I17: fires {@code artifact_updated} for every write queued during the turn.
-     * The whole drain+announce holds the conversation's announce mutex: PARALLEL
-     * turns ending together would otherwise split the queue between their drains
-     * and could publish v2's event before v1's. Public (not just the per-turn
-     * finally) because the discussion loop calls it once more when the leg ends, so
-     * a write accepted by a timed-out member's still-running agent — whose own turn
-     * already drained — is announced rather than stranded in the queue.
+     * Public (not just the per-turn finally) because the discussion loop calls it
+     * once more when the leg ends, so a write accepted by a timed-out member's
+     * still-running agent — whose own turn already drained — is announced rather
+     * than stranded in the queue.
+     * <p>
+     * <b>The mutex guards the HANDOFF, never the callbacks.</b> PARALLEL turns
+     * ending together must not split the queue between their drains and publish
+     * v2's event before v1's — but holding the monitor across
+     * {@code listener.onArtifactUpdated} would let one slow, backpressured SSE
+     * client block every other turn's end-of-turn drain. So exactly one thread at a
+     * time is the <em>publisher</em>: it drains under the mutex, releases it, fires
+     * the callbacks, and loops for anything that arrived meanwhile; every other
+     * thread sees the publisher flag and leaves, its changes guaranteed to ride the
+     * publisher's next loop. Write order is preserved (single announcer, FIFO
+     * queue) and no caller ever blocks on a listener.
      */
     public static void announceArtifactChanges(GroupConversation gc, GroupDiscussionEventListener listener) {
-        synchronized (gc.artifactAnnounceMutex()) {
-            List<GroupConversation.ArtifactChange> changes = gc.drainArtifactChanges();
-            if (listener == null || changes.isEmpty()) {
-                return;
+        while (true) {
+            List<GroupConversation.ArtifactChange> changes;
+            synchronized (gc.artifactAnnounceMutex()) {
+                if (gc.artifactAnnouncePublishing()) {
+                    // The active publisher's next loop iteration drains our
+                    // changes — leaving keeps this thread off the slow path.
+                    return;
+                }
+                changes = gc.drainArtifactChanges();
+                if (changes.isEmpty()) {
+                    return;
+                }
+                gc.artifactAnnouncePublishing(true);
             }
-            for (GroupConversation.ArtifactChange change : changes) {
-                listener.onArtifactUpdated(new GroupConversationEventSink.ArtifactUpdatedEvent(
-                        change.artifactId(), change.name(), change.type(), change.version(),
-                        change.editorAgentId(), change.status(), change.created()));
+            try {
+                if (listener != null) {
+                    for (GroupConversation.ArtifactChange change : changes) {
+                        listener.onArtifactUpdated(new GroupConversationEventSink.ArtifactUpdatedEvent(
+                                change.artifactId(), change.name(), change.type(), change.version(),
+                                change.editorAgentId(), change.status(), change.created()));
+                    }
+                }
+            } finally {
+                synchronized (gc.artifactAnnounceMutex()) {
+                    gc.artifactAnnouncePublishing(false);
+                }
             }
+            // Loop: drain-and-publish anything queued while the callbacks ran —
+            // a thread that handed off above relies on exactly this pass.
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/GroupConversationEventSink.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/GroupConversationEventSink.java
@@ -61,6 +61,13 @@ public final class GroupConversationEventSink {
      * Always preceded by an {@link #EVENT_CONVERGENCE_CHECKED} for the same repeat.
      */
     public static final String EVENT_CONVERGENCE_REACHED = "convergence_reached";
+    /**
+     * A member created or updated a shared artifact (I17). Fired by the turn
+     * executor after the turn that made the write — tools have no listener
+     * reference, so accepted writes ride the live discussion's artifact-change
+     * queue until the executor drains it.
+     */
+    public static final String EVENT_ARTIFACT_UPDATED = "artifact_updated";
 
     // --- Event payloads ---
 
@@ -158,5 +165,18 @@ public final class GroupConversationEventSink {
      *            run — the concrete saving
      */
     public record ConvergenceReachedEvent(int phaseIndex, String phaseName, int repeat, int repeatsSkipped, String reason) {
+    }
+
+    /**
+     * A member created or updated a shared artifact (I17). Carries metadata only,
+     * never the content — an SSE observer reads the artifact through the REST
+     * payload, and content can be a quarter megabyte.
+     *
+     * @param created
+     *            {@code true} for a fresh artifact (v1), {@code false} for an
+     *            accepted update
+     */
+    public record ArtifactUpdatedEvent(String artifactId, String name, String type, long version, String editorAgentId,
+            String status, boolean created) {
     }
 }

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
@@ -295,6 +295,28 @@ public class SlackGroupDiscussionListener implements GroupDiscussionEventListene
         postSafe(channelId, threadTs, sb.toString().stripTrailing());
     }
 
+    @Override
+    public void onArtifactUpdated(GroupConversationEventSink.ArtifactUpdatedEvent event) {
+        // Degenerate payload → skip rather than posting noise, same as
+        // onDecisionReached's NONE guard.
+        if (event == null || event.name() == null) {
+            return;
+        }
+        String emoji = event.created() ? "📄" : "✏️";
+        String verb = event.created() ? "created" : "updated";
+        var sb = new StringBuilder();
+        sb.append(String.format("%s *Artifact \"%s\"* %s (v%d)", emoji, event.name(), verb, event.version()));
+        if (event.editorAgentId() != null && !event.editorAgentId().isBlank()) {
+            sb.append(String.format(" by %s", event.editorAgentId()));
+        }
+        if ("FINAL".equals(event.status())) {
+            sb.append(" — FINAL");
+        }
+
+        String threadTs = expandedMode ? null : userThreadTs;
+        postSafe(channelId, threadTs, sb.toString().stripTrailing());
+    }
+
     // ─── HITL (human-in-the-loop) ───
 
     @Override

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
@@ -305,9 +305,9 @@ public class SlackGroupDiscussionListener implements GroupDiscussionEventListene
         String emoji = event.created() ? "📄" : "✏️";
         String verb = event.created() ? "created" : "updated";
         var sb = new StringBuilder();
-        sb.append(String.format("%s *Artifact \"%s\"* %s (v%d)", emoji, event.name(), verb, event.version()));
+        sb.append(String.format("%s *Artifact \"%s\"* %s (v%d)", emoji, escapeMrkdwn(event.name()), verb, event.version()));
         if (event.editorAgentId() != null && !event.editorAgentId().isBlank()) {
-            sb.append(String.format(" by %s", event.editorAgentId()));
+            sb.append(String.format(" by %s", escapeMrkdwn(event.editorAgentId())));
         }
         if ("FINAL".equals(event.status())) {
             sb.append(" — FINAL");
@@ -315,6 +315,17 @@ public class SlackGroupDiscussionListener implements GroupDiscussionEventListene
 
         String threadTs = expandedMode ? null : userThreadTs;
         postSafe(channelId, threadTs, sb.toString().stripTrailing());
+    }
+
+    /**
+     * Escapes Slack's three mrkdwn control characters. Without this, an
+     * LLM-authored artifact name (or an agent id) containing e.g.
+     * {@code <!channel>} renders as a real channel broadcast.
+     */
+    private static String escapeMrkdwn(String value) {
+        return value == null
+                ? null
+                : value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
     // ─── HITL (human-in-the-loop) ───

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/AgentOrchestrator.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/AgentOrchestrator.java
@@ -49,6 +49,7 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import jakarta.enterprise.context.ApplicationScoped;
 import ai.labs.eddi.engine.internal.groups.LiveDiscussionRegistry;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
@@ -266,6 +267,13 @@ class AgentOrchestrator implements IAgentOrchestrator {
 
     @Inject
     volatile IAgentGroupStore agentGroupStore;
+
+    /**
+     * I17's store, field-injected for the same reason as the two above.
+     * {@code ArtifactToolsProvider} treats null as "no artifact tools".
+     */
+    @Inject
+    volatile ISharedArtifactStore sharedArtifactStore;
 
     /**
      * Test seam for supplying the attachment services to a directly-constructed
@@ -644,6 +652,7 @@ class AgentOrchestrator implements IAgentOrchestrator {
         var contextual = contextualToolsProvider();
         merger.addAll(List.of(builtinToolsProvider, contextual, dynamicAgentToolsProvider(),
                 new GroupTaskToolsProvider(liveDiscussionRegistry, agentGroupStore),
+                new ArtifactToolsProvider(liveDiscussionRegistry, agentGroupStore, sharedArtifactStore),
                 new AttachmentToolsProvider(contextual)), ctx);
 
         // LAZY registers every built-in's executor but shows the model only

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ArtifactToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ArtifactToolsProvider.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ArtifactConfig;
+import ai.labs.eddi.engine.internal.groups.LiveDiscussionRegistry;
+import ai.labs.eddi.modules.llm.tools.impl.ArtifactTools;
+import ai.labs.eddi.modules.llm.tools.spi.ToolAssemblyContext;
+import ai.labs.eddi.modules.llm.tools.spi.ToolContribution;
+import ai.labs.eddi.modules.llm.tools.spi.ToolSourceProvider;
+import org.jboss.logging.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Contributes the shared-artifact tools (I17) — {@code createArtifact},
+ * {@code readArtifact}, {@code proposeArtifactUpdate}, {@code listArtifacts} —
+ * when, and only when, the turn belongs to a live group discussion whose config
+ * sets {@code artifactConfig.allowArtifactTools}.
+ * <p>
+ * Gate discipline is identical to {@link GroupTaskToolsProvider}, and for the
+ * same reasons: membership (not existence) via
+ * {@code LiveDiscussionRegistry#getForMember} because the group conversation id
+ * is a caller-supplied context variable; the member agent's own
+ * {@code enableBuiltInTools} switch still applies; and every uncertainty —
+ * missing config, unreadable group, absent store — resolves to "contribute
+ * nothing" (fail-closed, gate by absence).
+ *
+ * @author ginccc
+ */
+class ArtifactToolsProvider implements ToolSourceProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(ArtifactToolsProvider.class);
+
+    private final LiveDiscussionRegistry liveDiscussionRegistry;
+    private final IAgentGroupStore groupStore;
+    private final ISharedArtifactStore artifactStore;
+
+    ArtifactToolsProvider(LiveDiscussionRegistry liveDiscussionRegistry, IAgentGroupStore groupStore,
+            ISharedArtifactStore artifactStore) {
+        this.liveDiscussionRegistry = liveDiscussionRegistry;
+        this.groupStore = groupStore;
+        this.artifactStore = artifactStore;
+    }
+
+    @Override
+    public String source() {
+        return "builtin";
+    }
+
+    @Override
+    public ToolContribution contribute(ToolAssemblyContext ctx) {
+        String groupConversationId = ctx.groupConversationId();
+        if (groupConversationId == null || liveDiscussionRegistry == null || groupStore == null || artifactStore == null) {
+            return ToolContribution.empty();
+        }
+        Boolean enableBuiltInTools = ctx.task() != null ? ctx.task().getEnableBuiltInTools() : null;
+        if (enableBuiltInTools == null || !enableBuiltInTools) {
+            return ToolContribution.empty();
+        }
+        String callerConversationId = ctx.memory() != null ? ctx.memory().getConversationId() : null;
+        var live = liveDiscussionRegistry.getForMember(groupConversationId, callerConversationId);
+        if (live.isEmpty()) {
+            return ToolContribution.empty();
+        }
+        AgentGroupConfiguration groupConfiguration = resolveGroup(live.get().getGroupId());
+        ArtifactConfig config = groupConfiguration != null ? groupConfiguration.getArtifactConfig() : null;
+        if (config == null || !config.allowArtifactTools()) {
+            return ToolContribution.empty();
+        }
+
+        var tools = List.<Object>of(new ArtifactTools(liveDiscussionRegistry, groupConversationId, config, ctx.agentId(),
+                artifactStore));
+        var reflected = ToolObjectReflector.reflect(tools);
+        return new ToolContribution(reflected.specs(), reflected.executors(), reflected.toolSources(), Map.of(),
+                List.of(), reflected.toolCanonicalNames());
+    }
+
+    /**
+     * The group config, or {@code null} if it cannot be read — a store failure
+     * withholds the write tools (fail-closed), logged so the operator sees why they
+     * vanished.
+     */
+    private AgentGroupConfiguration resolveGroup(String groupId) {
+        if (groupId == null) {
+            return null;
+        }
+        try {
+            var resourceId = groupStore.getCurrentResourceId(groupId);
+            if (resourceId == null) {
+                return null;
+            }
+            return groupStore.read(groupId, resourceId.getVersion());
+        } catch (Exception e) {
+            LOGGER.warnf("Could not read artifact policy for group '%s' — withholding the artifact tools: %s", groupId, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/impl/ArtifactTools.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/impl/ArtifactTools.java
@@ -272,8 +272,10 @@ public class ArtifactTools {
         }
         int bytes = SharedArtifact.contentBytes(content);
         if (bytes > SharedArtifact.MAX_CONTENT_BYTES) {
+            // Ceil, not truncate: MAX+1 bytes must not read "256 KB is over the
+            // 256 KB limit" — the model retries at the same size on that sentence.
             return "The content is %d KB, over the %d KB limit for a single artifact. Split it or shorten it."
-                    .formatted(bytes / 1024, SharedArtifact.MAX_CONTENT_BYTES / 1024);
+                    .formatted(Math.ceilDiv(bytes, 1024), SharedArtifact.MAX_CONTENT_BYTES / 1024);
         }
         return ArtifactValidators.firstRejection(config.validators(), content);
     }

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/impl/ArtifactTools.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/impl/ArtifactTools.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.tools.impl;
+
+import ai.labs.eddi.configs.groups.ArtifactValidators;
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
+import ai.labs.eddi.configs.groups.ISharedArtifactStore.ArtifactGoneException;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ArtifactConfig;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.ArtifactChange;
+import ai.labs.eddi.configs.groups.model.SharedArtifact;
+import ai.labs.eddi.configs.groups.model.SharedArtifact.ArtifactStatus;
+import ai.labs.eddi.configs.groups.model.SharedArtifact.ArtifactType;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.internal.groups.LiveDiscussionRegistry;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import jakarta.enterprise.inject.Vetoed;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Lets group members create and co-edit shared artifacts (I17, blackboard-lite)
+ * — typed documents that live <em>outside</em> the dialogue, so structured work
+ * stops being prose the next agent re-parses.
+ * <p>
+ * <b>Writes go through the artifact store directly.</b> Artifacts have their
+ * own collection, so the F1 rule that task-list writes must mutate the live
+ * {@link GroupConversation} instance (or be clobbered by the loop's next
+ * whole-document persist) does not apply. The live registry is still consulted
+ * — a write against a finished or paused discussion is refused, and the
+ * creation/edit is announced through the live instance's artifact-change queue
+ * so the discussion loop can fire {@code artifact_updated}.
+ * <p>
+ * <b>Concurrency is deterministic CAS-and-retry, not an LLM merge.</b> Every
+ * update presents the version it read; a stale version gets a "re-read and
+ * merge" sentence and the model retries against fresh content. Creation
+ * (duplicate-name + count cap) is a check-then-act, so it synchronizes on the
+ * live discussion instance — PARALLEL phases genuinely run members at once.
+ * <p>
+ * Constructed per-turn with runtime values — NOT a CDI bean. {@code @Vetoed} is
+ * load-bearing for the same deployment-failure reason as
+ * {@link GroupTaskTools}.
+ *
+ * @author ginccc
+ */
+@Vetoed
+public class ArtifactTools {
+
+    private static final Logger LOGGER = Logger.getLogger(ArtifactTools.class);
+
+    static final int MAX_NAME_LENGTH = 200;
+
+    private final LiveDiscussionRegistry registry;
+    private final String groupConversationId;
+    private final ArtifactConfig config;
+    private final String agentId;
+    private final ISharedArtifactStore artifactStore;
+
+    public ArtifactTools(LiveDiscussionRegistry registry, String groupConversationId, ArtifactConfig config, String agentId,
+            ISharedArtifactStore artifactStore) {
+        this.registry = registry;
+        this.groupConversationId = groupConversationId;
+        this.config = config;
+        this.agentId = agentId;
+        this.artifactStore = artifactStore;
+    }
+
+    @Tool("Create a new shared artifact — a named document the whole team can read and propose changes to. "
+            + "Use listArtifacts first to avoid duplicating one that already exists.")
+    public String createArtifact(
+                                 @P("Short unique name, how the team refers to this artifact") String name,
+                                 @P("Content type: TEXT, MARKDOWN or JSON") String type,
+                                 @P("The initial content") String content) {
+
+        GroupConversation gc = liveDiscussion();
+        if (gc == null) {
+            return "This discussion is no longer accepting artifact changes (it has finished or is paused).";
+        }
+        if (name == null || name.isBlank()) {
+            return "An artifact needs a name.";
+        }
+        String trimmedName = name.trim();
+        if (trimmedName.length() > MAX_NAME_LENGTH) {
+            return "The name is too long (%d chars, max %d). Put the detail in the content.".formatted(trimmedName.length(), MAX_NAME_LENGTH);
+        }
+        ArtifactType artifactType = parseType(type);
+        if (artifactType == null) {
+            return "Unknown artifact type \"%s\". Use TEXT, MARKDOWN or JSON.".formatted(type);
+        }
+        String rejection = checkContent(content);
+        if (rejection != null) {
+            return rejection;
+        }
+
+        // Check-then-act (duplicate name + count cap) under one monitor: the live
+        // instance is the one object every member of this discussion shares in
+        // this JVM, so it is the natural lock for creation races. Updates need no
+        // lock — the store's version CAS decides those.
+        synchronized (gc) {
+            List<SharedArtifact> existing;
+            try {
+                existing = artifactStore.listByGroupConversationId(groupConversationId);
+            } catch (IResourceStore.ResourceStoreException e) {
+                LOGGER.warnf("Could not list artifacts for %s — refusing the create: %s", groupConversationId, e.getMessage());
+                return "The artifact store is unavailable right now; try again next turn.";
+            }
+            if (existing.stream().anyMatch(a -> trimmedName.equalsIgnoreCase(a.getName()))) {
+                return "An artifact named \"%s\" already exists. Read it with readArtifact and use proposeArtifactUpdate to change it."
+                        .formatted(trimmedName);
+            }
+            if (existing.size() >= config.maxArtifactsPerDiscussion()) {
+                return "This discussion already has %d artifacts, which is the limit. Update an existing one instead of creating more."
+                        .formatted(existing.size());
+            }
+
+            var artifact = new SharedArtifact();
+            artifact.setGroupConversationId(groupConversationId);
+            artifact.setOwnerUserId(gc.getUserId());
+            artifact.setName(trimmedName);
+            artifact.setType(artifactType);
+            artifact.setContent(content);
+            artifact.setVersion(1);
+            artifact.setLastEditorAgentId(agentId);
+            artifact.setStatus(ArtifactStatus.DRAFT);
+            artifact.setCreatedAt(Instant.now());
+            artifact.setUpdatedAt(artifact.getCreatedAt());
+            try {
+                artifactStore.create(artifact);
+            } catch (IResourceStore.ResourceStoreException e) {
+                LOGGER.warnf("Could not create artifact '%s' for %s: %s", trimmedName, groupConversationId, e.getMessage());
+                return "The artifact store is unavailable right now; try again next turn.";
+            }
+
+            gc.queueArtifactChange(new ArtifactChange(artifact.getId(), trimmedName, artifactType.name(), 1, agentId,
+                    ArtifactStatus.DRAFT.name(), true));
+            LOGGER.infof("Agent '%s' created artifact '%s' (v1) on group conversation %s", agentId, trimmedName, groupConversationId);
+            return "Created artifact \"%s\" (v1). The team can read it with readArtifact and change it with proposeArtifactUpdate."
+                    .formatted(trimmedName);
+        }
+    }
+
+    @Tool("Read a shared artifact's current content and version. You need the version to propose an update.")
+    public String readArtifact(@P("The artifact's name (or id)") String nameOrId) {
+        SharedArtifact artifact = resolve(nameOrId);
+        if (artifact == null) {
+            return "No artifact named \"%s\" here. Use listArtifacts to see what exists.".formatted(nameOrId != null ? nameOrId.trim() : "");
+        }
+        return "Artifact \"%s\" (%s, %s, v%d, last edited by %s):\n%s".formatted(
+                artifact.getName(), artifact.getType(), artifact.getStatus(), artifact.getVersion(),
+                artifact.getLastEditorAgentId() != null ? artifact.getLastEditorAgentId() : "unknown",
+                artifact.getContent() != null ? artifact.getContent() : "");
+    }
+
+    @Tool("Propose new content for a shared artifact. You must pass the version you READ — if someone changed the "
+            + "artifact since, your update is rejected and you re-read, merge your change into theirs, and retry.")
+    public String proposeArtifactUpdate(
+                                        @P("The artifact's name (or id)") String nameOrId,
+                                        @P("The complete new content (it replaces the old content)") String content,
+                                        @P("The version you read, from readArtifact") long expectedVersion,
+                                        @P(value = "Pass true to freeze the artifact as FINAL after this update. "
+                                                + "A FINAL artifact accepts no further updates.",
+                                           required = false) Boolean markFinal) {
+
+        GroupConversation gc = liveDiscussion();
+        if (gc == null) {
+            return "This discussion is no longer accepting artifact changes (it has finished or is paused).";
+        }
+        SharedArtifact artifact = resolve(nameOrId);
+        if (artifact == null) {
+            return "No artifact named \"%s\" here. Use listArtifacts to see what exists.".formatted(nameOrId != null ? nameOrId.trim() : "");
+        }
+        if (artifact.getStatus() == ArtifactStatus.FINAL) {
+            return "Artifact \"%s\" is FINAL and accepts no further updates.".formatted(artifact.getName());
+        }
+        String rejection = checkContent(content);
+        if (rejection != null) {
+            return rejection;
+        }
+        if (artifact.getVersion() != expectedVersion) {
+            return staleVersion(artifact.getName(), artifact.getVersion());
+        }
+
+        artifact.applyEdit(content, agentId, Instant.now());
+        if (Boolean.TRUE.equals(markFinal)) {
+            artifact.setStatus(ArtifactStatus.FINAL);
+        }
+        try {
+            artifactStore.updateIfVersion(artifact, expectedVersion);
+        } catch (IResourceStore.ResourceModifiedException e) {
+            // Lost the race after our read — report the CURRENT version so the
+            // retry is usable. A failed re-read still yields the retry instruction.
+            long nowVersion = currentVersionOf(artifact.getId());
+            return nowVersion > 0
+                    ? staleVersion(artifact.getName(), nowVersion)
+                    : "Artifact \"%s\" changed since you read it; re-read and merge your change.".formatted(artifact.getName());
+        } catch (ArtifactGoneException e) {
+            return "Artifact \"%s\" no longer exists.".formatted(artifact.getName());
+        } catch (IResourceStore.ResourceStoreException e) {
+            LOGGER.warnf("Could not update artifact '%s' for %s: %s", artifact.getName(), groupConversationId, e.getMessage());
+            return "The artifact store is unavailable right now; try again next turn.";
+        }
+
+        gc.queueArtifactChange(new ArtifactChange(artifact.getId(), artifact.getName(), artifact.getType().name(),
+                artifact.getVersion(), agentId, artifact.getStatus().name(), false));
+        LOGGER.infof("Agent '%s' updated artifact '%s' to v%d on group conversation %s",
+                agentId, artifact.getName(), artifact.getVersion(), groupConversationId);
+        return "Updated \"%s\" to v%d.%s".formatted(artifact.getName(), artifact.getVersion(),
+                artifact.getStatus() == ArtifactStatus.FINAL ? " It is now FINAL." : "");
+    }
+
+    @Tool("List this discussion's shared artifacts with their type, status and current version.")
+    public String listArtifacts() {
+        List<SharedArtifact> artifacts;
+        try {
+            artifacts = artifactStore.listByGroupConversationId(groupConversationId);
+        } catch (IResourceStore.ResourceStoreException e) {
+            return "The artifact store is unavailable right now; try again next turn.";
+        }
+        if (artifacts.isEmpty()) {
+            return "No artifacts yet. Create one with createArtifact.";
+        }
+        var sb = new StringBuilder("Shared artifacts:\n");
+        for (SharedArtifact a : artifacts) {
+            sb.append("- \"").append(a.getName()).append("\" (").append(a.getType()).append(", ").append(a.getStatus())
+                    .append(", v").append(a.getVersion()).append(')');
+            if (a.getLastEditorAgentId() != null) {
+                sb.append(" — last edited by ").append(a.getLastEditorAgentId());
+            }
+            sb.append('\n');
+        }
+        return sb.toString().stripTrailing();
+    }
+
+    /** The plan-specified stale-CAS sentence, verbatim shape. */
+    private static String staleVersion(String name, long currentVersion) {
+        return "Artifact \"%s\" changed since you read it (now v%d); re-read and merge your change.".formatted(name, currentVersion);
+    }
+
+    /**
+     * Resolves an artifact by name or id — but only among THIS discussion's
+     * artifacts. Never a raw store read of a caller-supplied id: the id is
+     * model-controlled text, and resolving it globally would read another
+     * discussion's artifact.
+     */
+    private SharedArtifact resolve(String nameOrId) {
+        if (nameOrId == null || nameOrId.isBlank()) {
+            return null;
+        }
+        String wanted = nameOrId.trim();
+        List<SharedArtifact> artifacts;
+        try {
+            artifacts = artifactStore.listByGroupConversationId(groupConversationId);
+        } catch (IResourceStore.ResourceStoreException e) {
+            LOGGER.warnf("Could not resolve artifact '%s' for %s: %s", wanted, groupConversationId, e.getMessage());
+            return null;
+        }
+        return artifacts.stream()
+                .filter(a -> wanted.equalsIgnoreCase(a.getName()) || wanted.equals(a.getId()))
+                .findFirst().orElse(null);
+    }
+
+    /** Size cap first (cheap), then the config's declarative validator chain. */
+    private String checkContent(String content) {
+        if (content == null || content.isBlank()) {
+            return "An artifact needs content.";
+        }
+        int bytes = SharedArtifact.contentBytes(content);
+        if (bytes > SharedArtifact.MAX_CONTENT_BYTES) {
+            return "The content is %d KB, over the %d KB limit for a single artifact. Split it or shorten it."
+                    .formatted(bytes / 1024, SharedArtifact.MAX_CONTENT_BYTES / 1024);
+        }
+        return ArtifactValidators.firstRejection(config.validators(), content);
+    }
+
+    private static ArtifactType parseType(String type) {
+        if (type == null || type.isBlank()) {
+            return null;
+        }
+        try {
+            return ArtifactType.valueOf(type.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Live-instance lookup for writes. Authorization happened at assembly time (the
+     * provider resolves membership via {@code getForMember}); this lookup only
+     * answers "is the discussion still running", so a paused or finished discussion
+     * refuses instead of accepting a write nobody will announce.
+     */
+    private GroupConversation liveDiscussion() {
+        return registry.get(groupConversationId).orElse(null);
+    }
+
+    /** The stored artifact's current version, or 0 when unreadable. */
+    private long currentVersionOf(String artifactId) {
+        try {
+            return artifactStore.read(artifactId).getVersion();
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/groups/ArtifactValidatorsTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/ArtifactValidatorsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ArtifactConfig;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ArtifactValidator;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ValidatorKind;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * I17 — the declarative artifact validation chain: save-time spec checks fail
+ * the config save with an actionable path, write-time failures come back as
+ * rejection sentences for the model, and a broken spec fails closed.
+ *
+ * @author tests
+ */
+class ArtifactValidatorsTest {
+
+    private static final String SCHEMA = """
+            {"type":"object","required":["title"],"properties":{"title":{"type":"string"}}}""";
+
+    private static ArtifactConfig config(ArtifactValidator... validators) {
+        return new ArtifactConfig(true, 5, List.of(validators));
+    }
+
+    // =================================================================
+    // save-time: requireValidSpecs
+    // =================================================================
+
+    @Test
+    @DisplayName("valid specs of all three kinds pass the save-time check")
+    void validSpecs_pass() {
+        assertDoesNotThrow(() -> ArtifactValidators.requireValidSpecs(config(
+                new ArtifactValidator(ValidatorKind.JSON_SCHEMA, SCHEMA),
+                new ArtifactValidator(ValidatorKind.REGEX, "^#"),
+                new ArtifactValidator(ValidatorKind.MAX_LENGTH, "1000"))));
+    }
+
+    @Test
+    @DisplayName("null config or empty chain is a no-op")
+    void absentConfig_noOp() {
+        assertDoesNotThrow(() -> ArtifactValidators.requireValidSpecs(null));
+        assertDoesNotThrow(() -> ArtifactValidators.requireValidSpecs(new ArtifactConfig(true, 5, null)));
+    }
+
+    @Test
+    @DisplayName("a broken spec fails the save and names the validator's position")
+    void brokenSpecs_throwWithPath() {
+        var badRegex = assertThrows(IllegalArgumentException.class,
+                () -> ArtifactValidators.requireValidSpecs(config(new ArtifactValidator(ValidatorKind.REGEX, "[unclosed"))));
+        assertTrue(badRegex.getMessage().contains("validators[0]"), badRegex.getMessage());
+
+        var badLength = assertThrows(IllegalArgumentException.class,
+                () -> ArtifactValidators.requireValidSpecs(config(
+                        new ArtifactValidator(ValidatorKind.REGEX, "ok"),
+                        new ArtifactValidator(ValidatorKind.MAX_LENGTH, "lots"))));
+        assertTrue(badLength.getMessage().contains("validators[1]"), badLength.getMessage());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> ArtifactValidators.requireValidSpecs(config(new ArtifactValidator(ValidatorKind.MAX_LENGTH, "0"))));
+        assertThrows(IllegalArgumentException.class,
+                () -> ArtifactValidators.requireValidSpecs(config(new ArtifactValidator(null, "x"))));
+        assertThrows(IllegalArgumentException.class,
+                () -> ArtifactValidators.requireValidSpecs(config(new ArtifactValidator(ValidatorKind.JSON_SCHEMA, " "))));
+    }
+
+    // =================================================================
+    // write-time: firstRejection
+    // =================================================================
+
+    @Test
+    @DisplayName("content passing the whole chain yields null")
+    void passingContent_null() {
+        var validators = List.of(
+                new ArtifactValidator(ValidatorKind.MAX_LENGTH, "100"),
+                new ArtifactValidator(ValidatorKind.REGEX, "title"),
+                new ArtifactValidator(ValidatorKind.JSON_SCHEMA, SCHEMA));
+
+        assertNull(ArtifactValidators.firstRejection(validators, "{\"title\":\"ok\"}"));
+    }
+
+    @Test
+    @DisplayName("MAX_LENGTH rejection names both counts so the model can act")
+    void maxLength_rejects() {
+        String rejection = ArtifactValidators.firstRejection(
+                List.of(new ArtifactValidator(ValidatorKind.MAX_LENGTH, "5")), "123456");
+
+        assertNotNull(rejection);
+        assertTrue(rejection.contains("6") && rejection.contains("5"), rejection);
+    }
+
+    @Test
+    @DisplayName("REGEX requires a match somewhere in the content")
+    void regex_rejectsAndPasses() {
+        var validators = List.of(new ArtifactValidator(ValidatorKind.REGEX, "^# .+"));
+
+        assertNull(ArtifactValidators.firstRejection(validators, "# Heading\nbody"));
+        String rejection = ArtifactValidators.firstRejection(validators, "no heading here");
+        assertNotNull(rejection);
+        assertTrue(rejection.contains("pattern"), rejection);
+    }
+
+    @Test
+    @DisplayName("JSON_SCHEMA distinguishes 'not JSON' from 'JSON that violates the schema'")
+    void jsonSchema_rejections() {
+        var validators = List.of(new ArtifactValidator(ValidatorKind.JSON_SCHEMA, SCHEMA));
+
+        String notJson = ArtifactValidators.firstRejection(validators, "plain prose");
+        assertNotNull(notJson);
+        assertTrue(notJson.contains("valid JSON"), notJson);
+
+        String violates = ArtifactValidators.firstRejection(validators, "{\"other\":1}");
+        assertNotNull(violates);
+        assertTrue(violates.contains("title"), "the violation message must name what is missing: " + violates);
+
+        assertNull(ArtifactValidators.firstRejection(validators, "{\"title\":\"x\"}"));
+    }
+
+    @Test
+    @DisplayName("the chain runs in config order — the first failure wins")
+    void chainOrder_firstFailureWins() {
+        var validators = List.of(
+                new ArtifactValidator(ValidatorKind.MAX_LENGTH, "3"),
+                new ArtifactValidator(ValidatorKind.REGEX, "nope"));
+
+        String rejection = ArtifactValidators.firstRejection(validators, "12345");
+        assertNotNull(rejection);
+        assertTrue(rejection.contains("character"), "the length failure comes first: " + rejection);
+    }
+
+    @Test
+    @DisplayName("a broken spec at write time fails closed — the write is refused, never admitted")
+    void brokenSpecAtWriteTime_failsClosed() {
+        assertNotNull(ArtifactValidators.firstRejection(
+                List.of(new ArtifactValidator(ValidatorKind.REGEX, "[unclosed")), "anything"));
+        assertNotNull(ArtifactValidators.firstRejection(
+                List.of(new ArtifactValidator(ValidatorKind.MAX_LENGTH, "many")), "anything"));
+        assertNotNull(ArtifactValidators.firstRejection(
+                List.of(new ArtifactValidator(null, null)), "anything"));
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/groups/ArtifactValidatorsTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/ArtifactValidatorsTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ValidatorKind;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -69,6 +70,29 @@ class ArtifactValidatorsTest {
                 () -> ArtifactValidators.requireValidSpecs(config(new ArtifactValidator(null, "x"))));
         assertThrows(IllegalArgumentException.class,
                 () -> ArtifactValidators.requireValidSpecs(config(new ArtifactValidator(ValidatorKind.JSON_SCHEMA, " "))));
+    }
+
+    @Test
+    @DisplayName("a schema with an invalid keyword VALUE fails the save — parse alone would admit it")
+    void invalidKeywordValue_failsMetaSchema() {
+        // {"type":"strng"} is perfectly valid JSON and getSchema() parses it;
+        // only meta-schema validation catches the typo'd simple type.
+        var e = assertThrows(IllegalArgumentException.class,
+                () -> ArtifactValidators.requireValidSpecs(config(
+                        new ArtifactValidator(ValidatorKind.JSON_SCHEMA, "{\"type\":\"strng\"}"))));
+        assertTrue(e.getMessage().contains("validators[0]"), e.getMessage());
+    }
+
+    @Test
+    @DisplayName("a null validator ENTRY fails the save with the positional message, not an NPE")
+    void nullValidatorEntry_actionableNotNpe() {
+        // Arrays.asList permits the null element; the config copy must too
+        // (List.copyOf would NPE during deserialization, preempting this message).
+        var config = new ArtifactConfig(true, 5, Arrays.asList(
+                new ArtifactValidator(ValidatorKind.MAX_LENGTH, "10"), null));
+
+        var e = assertThrows(IllegalArgumentException.class, () -> ArtifactValidators.requireValidSpecs(config));
+        assertTrue(e.getMessage().contains("validators[1]"), e.getMessage());
     }
 
     // =================================================================
@@ -133,6 +157,23 @@ class ArtifactValidatorsTest {
         String rejection = ArtifactValidators.firstRejection(validators, "12345");
         assertNotNull(rejection);
         assertTrue(rejection.contains("character"), "the length failure comes first: " + rejection);
+    }
+
+    @Test
+    @DisplayName("a catastrophically backtracking pattern aborts on its deadline instead of pinning the turn")
+    void catastrophicRegex_abortsOnDeadline() {
+        // (a+)+$ against a long non-matching tail backtracks exponentially —
+        // unguarded it runs for astronomical time, not the ~500ms budget.
+        var validators = List.of(new ArtifactValidator(ValidatorKind.REGEX, "(a+)+$"));
+        String content = "a".repeat(60_000) + "b";
+
+        long start = System.nanoTime();
+        String rejection = ArtifactValidators.firstRejection(validators, content);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertNotNull(rejection, "a runaway match must refuse the write, not admit it");
+        assertTrue(rejection.contains("did not finish in time"), rejection);
+        assertTrue(elapsedMs < 5_000, "the deadline guard must abort far below the member-turn timeout, took " + elapsedMs + "ms");
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/groups/mongo/SharedArtifactStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/mongo/SharedArtifactStoreTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -170,6 +171,26 @@ class SharedArtifactStoreTest {
     }
 
     @Test
+    @DisplayName("the listing honors the interface contract: oldest first, whatever order the backend returns")
+    void list_sortsOldestFirst() throws Exception {
+        var newer = artifact("a-new", "gc-1", "user-1", 1);
+        newer.setCreatedAt(Instant.parse("2026-02-02T00:00:00Z"));
+        var older = artifact("a-old", "gc-1", "user-1", 1);
+        older.setCreatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+        var newerResource = resource("a-new", newer);
+        var olderResource = resource("a-old", older);
+        // Both backends sort DESC on the sort field — the store must re-sort.
+        when(storage.findResources(any(IResourceFilter.QueryFilters[].class), eq("createdAt"), eq(0), anyInt()))
+                .thenReturn(List.of(resourceId("a-new"), resourceId("a-old")));
+        when(storage.read("a-new", 1)).thenReturn(newerResource);
+        when(storage.read("a-old", 1)).thenReturn(olderResource);
+
+        List<SharedArtifact> result = store.listByGroupConversationId("gc-1");
+
+        assertEquals(List.of("a-old", "a-new"), result.stream().map(SharedArtifact::getId).toList());
+    }
+
+    @Test
     @DisplayName("an id that fails the SAFE_ID gate is never interpolated into a query")
     void list_unsafeId_neverQueries() throws Exception {
         assertTrue(store.listByGroupConversationId("gc.*injection").isEmpty());
@@ -250,5 +271,22 @@ class SharedArtifactStoreTest {
 
         verify(storage).removeAllPermanently("a-1");
         verify(storage).removeAllPermanently("a-2");
+    }
+
+    @Test
+    @DisplayName("a row the backend will not dislodge is counted once and ends the loop — no spin, no inflated count")
+    void cascadeDelete_undeletableRow_noSpinNoOvercount() throws Exception {
+        var stuck = artifact("a-1", "gc-1", "user-1", 1);
+        var r1 = resource("a-1", stuck);
+        // removeAllPermanently "succeeds" but the row keeps appearing in listings
+        // — the backend path that motivated the processed-set guard.
+        when(storage.findResources(any(IResourceFilter.QueryFilters[].class), eq("createdAt"), eq(0), anyInt()))
+                .thenReturn(List.of(resourceId("a-1")));
+        when(storage.read("a-1", 1)).thenReturn(r1);
+
+        assertEquals(1, store.deleteByGroupConversationId("gc-1"),
+                "the count must reflect distinct artifacts, not delete attempts");
+
+        verify(storage, times(1)).removeAllPermanently("a-1");
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/groups/mongo/SharedArtifactStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/mongo/SharedArtifactStoreTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups.mongo;
+
+import ai.labs.eddi.configs.groups.ISharedArtifactStore.ArtifactGoneException;
+import ai.labs.eddi.configs.groups.model.SharedArtifact;
+import ai.labs.eddi.datastore.IResourceFilter;
+import ai.labs.eddi.datastore.IResourceStorage;
+import ai.labs.eddi.datastore.IResourceStorageFactory;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * I17 — {@link SharedArtifactStore}: the version CAS goes through the numeric
+ * {@code storeIfFieldEquals} overload (never an unconditional store), filters
+ * are anchored and re-checked in Java, and the GDPR erasure sweep follows the
+ * group-conversation store's page/re-check/fail-loud contract.
+ *
+ * @author tests
+ */
+@SuppressWarnings("unchecked")
+class SharedArtifactStoreTest {
+
+    private IResourceStorage<SharedArtifact> storage;
+    private SharedArtifactStore store;
+
+    @BeforeEach
+    void setUp() {
+        IResourceStorageFactory storageFactory = mock(IResourceStorageFactory.class);
+        IDocumentBuilder documentBuilder = mock(IDocumentBuilder.class);
+        storage = mock(IResourceStorage.class);
+        // Must mirror the production create() call EXACTLY, index-hint varargs
+        // included — a mismatch silently leaves the internal storage null.
+        when(storageFactory.create(eq("sharedartifacts"), eq(documentBuilder), eq(SharedArtifact.class),
+                eq("groupConversationId"), eq("ownerUserId"))).thenReturn(storage);
+        store = new SharedArtifactStore(storageFactory, documentBuilder);
+    }
+
+    private static SharedArtifact artifact(String id, String gcId, String owner, long version) {
+        var a = new SharedArtifact();
+        a.setId(id);
+        a.setGroupConversationId(gcId);
+        a.setOwnerUserId(owner);
+        a.setName("draft");
+        a.setVersion(version);
+        return a;
+    }
+
+    private IResourceStorage.IResource<SharedArtifact> resource(String id, SharedArtifact data) throws IOException {
+        IResourceStorage.IResource<SharedArtifact> resource = mock(IResourceStorage.IResource.class);
+        when(resource.getId()).thenReturn(id);
+        when(resource.getData()).thenReturn(data);
+        return resource;
+    }
+
+    private IResourceStore.IResourceId resourceId(String id) {
+        return new IResourceStore.IResourceId() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return 1;
+            }
+        };
+    }
+
+    // =================================================================
+    // CAS
+    // =================================================================
+
+    @Test
+    @DisplayName("updateIfVersion goes through the NUMERIC CAS overload, never an unconditional store")
+    void updateIfVersion_usesNumericCas() throws Exception {
+        var a = artifact("a-1", "gc-1", "user-1", 3);
+        IResourceStorage.IResource<SharedArtifact> writeResource = resource("a-1", a);
+        when(storage.newResource("a-1", 1, a)).thenReturn(writeResource);
+
+        store.updateIfVersion(a, 2);
+
+        verify(storage).storeIfFieldEquals(writeResource, "version", 2L);
+        verify(storage, never()).store(any(IResourceStorage.IResource.class));
+        verify(storage, never()).storeIfFieldEquals(any(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("a CAS conflict propagates as ResourceModifiedException (retry), a gone document as ArtifactGoneException")
+    void updateIfVersion_distinguishesConflictFromGone() throws Exception {
+        var a = artifact("a-1", "gc-1", "user-1", 3);
+        IResourceStorage.IResource<SharedArtifact> writeResource = resource("a-1", a);
+        when(storage.newResource("a-1", 1, a)).thenReturn(writeResource);
+
+        doThrow(new IResourceStore.ResourceModifiedException("conflict"))
+                .when(storage).storeIfFieldEquals(writeResource, "version", 2L);
+        assertThrows(IResourceStore.ResourceModifiedException.class, () -> store.updateIfVersion(a, 2));
+
+        doThrow(new IResourceStore.ResourceNotFoundException("gone"))
+                .when(storage).storeIfFieldEquals(writeResource, "version", 2L);
+        assertThrows(ArtifactGoneException.class, () -> store.updateIfVersion(a, 2));
+    }
+
+    // =================================================================
+    // read / create
+    // =================================================================
+
+    @Test
+    @DisplayName("read maps a missing document to a not-found whose message does NOT embed the caller-supplied id")
+    void readNotFound_messageDoesNotEmbedTheId() {
+        when(storage.read("attacker<script>", 1)).thenReturn(null);
+
+        var ex = assertThrows(IResourceStore.ResourceNotFoundException.class, () -> store.read("attacker<script>"));
+
+        assertFalse(ex.getMessage().contains("attacker"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("create stores, adopts the assigned id, and returns it")
+    void create_assignsId() throws Exception {
+        var a = artifact(null, "gc-1", "user-1", 1);
+        IResourceStorage.IResource<SharedArtifact> resource = resource("new-id", a);
+        when(storage.newResource(a)).thenReturn(resource);
+
+        String id = store.create(a);
+
+        verify(storage).store(resource);
+        assertEquals("new-id", id);
+        assertEquals("new-id", a.getId());
+    }
+
+    // =================================================================
+    // listing
+    // =================================================================
+
+    @Test
+    @DisplayName("listByGroupConversationId anchors the filter and re-checks by exact match in Java")
+    void list_anchorsAndRechecks() throws Exception {
+        var mine = artifact("a-1", "gc-1", "user-1", 1);
+        // The unanchored-regex nightmare: an id that CONTAINS the wanted id.
+        var other = artifact("a-2", "gc-12", "user-2", 1);
+        var mineResource = resource("a-1", mine);
+        var otherResource = resource("a-2", other);
+        when(storage.findResources(any(IResourceFilter.QueryFilters[].class), eq("createdAt"), eq(0), anyInt()))
+                .thenReturn(List.of(resourceId("a-1"), resourceId("a-2")));
+        when(storage.read("a-1", 1)).thenReturn(mineResource);
+        when(storage.read("a-2", 1)).thenReturn(otherResource);
+
+        List<SharedArtifact> result = store.listByGroupConversationId("gc-1");
+
+        assertEquals(1, result.size(), "the regex only narrows; equality decides");
+        assertEquals("a-1", result.get(0).getId());
+
+        var captor = ArgumentCaptor.forClass(IResourceFilter.QueryFilters[].class);
+        verify(storage).findResources(captor.capture(), eq("createdAt"), eq(0), anyInt());
+        assertEquals("^gc-1$", captor.getValue()[0].getQueryFilters().get(0).getFilter(), "filters must be anchored");
+    }
+
+    @Test
+    @DisplayName("an id that fails the SAFE_ID gate is never interpolated into a query")
+    void list_unsafeId_neverQueries() throws Exception {
+        assertTrue(store.listByGroupConversationId("gc.*injection").isEmpty());
+        assertTrue(store.listByGroupConversationId(null).isEmpty());
+        verify(storage, never()).findResources(any(), anyString(), anyInt(), anyInt());
+    }
+
+    // =================================================================
+    // GDPR erasure
+    // =================================================================
+
+    @Test
+    @DisplayName("deleteAllForUser pages from offset 0, re-checks ownership exactly, and skips near-miss users")
+    void erasure_exactMatchDecides() throws Exception {
+        var owned = artifact("a-1", "gc-1", "user-1", 1);
+        var nearMiss = artifact("a-2", "gc-2", "user-10", 1);
+        var ownedResource = resource("a-1", owned);
+        var nearMissResource = resource("a-2", nearMiss);
+        when(storage.findResources(any(IResourceFilter.QueryFilters[].class), eq("createdAt"), eq(0), eq(IResourceStorage.MAX_RESULT_LIMIT)))
+                .thenReturn(List.of(resourceId("a-1"), resourceId("a-2")))
+                .thenReturn(List.of());
+        when(storage.read("a-1", 1)).thenReturn(ownedResource);
+        when(storage.read("a-2", 1)).thenReturn(nearMissResource);
+
+        long deleted = store.deleteAllForUser("user-1");
+
+        assertEquals(1, deleted);
+        verify(storage).removeAllPermanently("a-1");
+        verify(storage, never()).removeAllPermanently("a-2");
+    }
+
+    @Test
+    @DisplayName("an owned row that cannot be read fails the erasure loudly — never a partial success")
+    void erasure_unreadableRow_failsLoudly() throws Exception {
+        when(storage.findResources(any(IResourceFilter.QueryFilters[].class), eq("createdAt"), eq(0), eq(IResourceStorage.MAX_RESULT_LIMIT)))
+                .thenReturn(List.of(resourceId("a-1")));
+        IResourceStorage.IResource<SharedArtifact> broken = mock(IResourceStorage.IResource.class);
+        when(broken.getId()).thenReturn("a-1");
+        when(broken.getData()).thenThrow(new IOException("corrupt"));
+        when(storage.read("a-1", 1)).thenReturn(broken);
+
+        var thrown = assertThrows(IResourceStore.ResourceStoreException.class, () -> store.deleteAllForUser("user-1"));
+
+        assertTrue(thrown.getMessage().contains("Erasure incomplete"), thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("the erasure filter is anchored AND regex-escaped — a metacharacter user id cannot widen the sweep")
+    void erasure_escapesTheUserId() throws Exception {
+        when(storage.findResources(any(IResourceFilter.QueryFilters[].class), eq("createdAt"), eq(0), eq(IResourceStorage.MAX_RESULT_LIMIT)))
+                .thenReturn(List.of());
+
+        store.deleteAllForUser("user.1+x");
+
+        var captor = ArgumentCaptor.forClass(IResourceFilter.QueryFilters[].class);
+        verify(storage).findResources(captor.capture(), eq("createdAt"), eq(0), eq(IResourceStorage.MAX_RESULT_LIMIT));
+        assertEquals("^user\\.1\\+x$", captor.getValue()[0].getQueryFilters().get(0).getFilter());
+    }
+
+    // =================================================================
+    // cascade delete
+    // =================================================================
+
+    @Test
+    @DisplayName("deleteByGroupConversationId removes every artifact of the discussion and reports the count")
+    void cascadeDelete_removesAll() throws Exception {
+        var a1 = artifact("a-1", "gc-1", "user-1", 1);
+        var a2 = artifact("a-2", "gc-1", "user-1", 1);
+        var r1 = resource("a-1", a1);
+        var r2 = resource("a-2", a2);
+        when(storage.findResources(any(IResourceFilter.QueryFilters[].class), eq("createdAt"), eq(0), anyInt()))
+                .thenReturn(List.of(resourceId("a-1"), resourceId("a-2")))
+                .thenReturn(List.of());
+        when(storage.read("a-1", 1)).thenReturn(r1);
+        when(storage.read("a-2", 1)).thenReturn(r2);
+
+        assertEquals(2, store.deleteByGroupConversationId("gc-1"));
+
+        verify(storage).removeAllPermanently("a-1");
+        verify(storage).removeAllPermanently("a-2");
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.gdpr;
 
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
 import ai.labs.eddi.configs.groups.mongo.GroupConversationStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
@@ -61,6 +62,8 @@ class GdprComplianceServiceTest {
     private IConversationCheckpointStore checkpointStore;
     private GroupConversationStore groupConversationStore;
     private Instance<GroupConversationStore> groupConversationStoreInstance;
+    private ISharedArtifactStore sharedArtifactStore;
+    private Instance<ISharedArtifactStore> sharedArtifactStoreInstance;
     private IScheduleStore scheduleStore;
     private CacheFactory cacheFactory;
 
@@ -80,6 +83,10 @@ class GdprComplianceServiceTest {
         groupConversationStoreInstance = mock(Instance.class);
         when(groupConversationStoreInstance.isResolvable()).thenReturn(true);
         when(groupConversationStoreInstance.get()).thenReturn(groupConversationStore);
+        sharedArtifactStore = mock(ISharedArtifactStore.class);
+        sharedArtifactStoreInstance = mock(Instance.class);
+        when(sharedArtifactStoreInstance.isResolvable()).thenReturn(true);
+        when(sharedArtifactStoreInstance.get()).thenReturn(sharedArtifactStore);
         scheduleStore = mock(IScheduleStore.class);
         // A real cache factory, not a mock: the cache-invalidation test needs the
         // same Caffeine instance the REST store reads through.
@@ -98,7 +105,7 @@ class GdprComplianceServiceTest {
                 userConversationStore, databaseLogs, auditStore,
                 auditLedgerService, attachments, hitlToolJournalStore,
                 conversationDescriptorStore, checkpointStore,
-                groupConversationStoreInstance, scheduleStore, cacheFactory);
+                groupConversationStoreInstance, sharedArtifactStoreInstance, scheduleStore, cacheFactory);
     }
 
     @Test
@@ -863,6 +870,7 @@ class GdprComplianceServiceTest {
         when(conversationMemoryStore.getConversationIdsByUserId(USER_ID)).thenReturn(List.of("conv-1"));
         when(checkpointStore.deleteByConversationId("conv-1")).thenThrow(new RuntimeException("checkpoint store down"));
         when(groupConversationStore.deleteAllForUser(USER_ID)).thenThrow(new RuntimeException("group store down"));
+        when(sharedArtifactStore.deleteAllForUser(USER_ID)).thenThrow(new RuntimeException("artifact store down"));
         when(scheduleStore.deleteSchedulesByUserId(USER_ID)).thenThrow(new RuntimeException("schedule store down"));
         when(conversationMemoryStore.deleteConversationsByUserId(USER_ID)).thenReturn(1L);
         when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(0L);
@@ -873,5 +881,39 @@ class GdprComplianceServiceTest {
 
         assertEquals(1, result.conversationsDeleted());
         verify(scheduleStore).deleteSchedulesByUserId(USER_ID);
+    }
+
+    /**
+     * I17: shared artifacts carry ownerUserId, so the cascade sweeps them
+     * user-keyed — independent of whether their parent discussions still exist.
+     */
+    @Test
+    void deleteUserData_deletesSharedArtifacts() throws Exception {
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(0L);
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID)).thenReturn(List.of());
+        when(sharedArtifactStore.deleteAllForUser(USER_ID)).thenReturn(3L);
+        when(conversationMemoryStore.deleteConversationsByUserId(USER_ID)).thenReturn(0L);
+        when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(0L);
+        when(databaseLogs.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+        when(auditStore.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+
+        service.deleteUserData(USER_ID);
+
+        verify(sharedArtifactStore).deleteAllForUser(USER_ID);
+    }
+
+    @Test
+    void deleteUserData_skipsSharedArtifacts_whenStoreNotResolvable() throws Exception {
+        when(sharedArtifactStoreInstance.isResolvable()).thenReturn(false);
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(0L);
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID)).thenReturn(List.of());
+        when(conversationMemoryStore.deleteConversationsByUserId(USER_ID)).thenReturn(0L);
+        when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(0L);
+        when(databaseLogs.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+        when(auditStore.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+
+        assertDoesNotThrow(() -> service.deleteUserData(USER_ID));
+
+        verify(sharedArtifactStore, never()).deleteAllForUser(any());
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOpsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOpsTest.java
@@ -8,11 +8,13 @@ import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
 import ai.labs.eddi.configs.groups.IGroupConversationStore;
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DynamicAgentConfig;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.LifecyclePolicy;
 import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.internal.GroupConversationService;
 import ai.labs.eddi.engine.lifecycle.model.DiscussionControlToken;
@@ -53,12 +55,16 @@ class GroupLifecycleOpsTest {
     private IAgentStore agentStore;
     private IGroupConversationStore conversationStore;
 
+    private ISharedArtifactStore sharedArtifactStore;
+
     private GroupLifecycleOps ops() {
         agentFactory = mock(IAgentFactory.class);
         agentStore = mock(IAgentStore.class);
         conversationStore = mock(IGroupConversationStore.class);
+        sharedArtifactStore = mock(ISharedArtifactStore.class);
         return new GroupLifecycleOps(conversationStore, mock(IAgentGroupStore.class),
                 mock(IConversationService.class), agentFactory, agentStore, mock(IDeploymentStore.class),
+                sharedArtifactStore,
                 ConcurrentHashMap.newKeySet(), new ConcurrentHashMap<String, DiscussionControlToken>(),
                 Mockito.mock(GroupConversationService.class),
                 new SimpleMeterRegistry().counter("test.followup"),
@@ -148,6 +154,55 @@ class GroupLifecycleOpsTest {
         doThrow(new RuntimeException("undeploy failed")).when(agentFactory).undeployAgent(any(), eq(AGENT_A), isNull());
 
         assertDoesNotThrow(() -> ops.cleanupEphemeralAgents(gc(AGENT_A), configWithPolicy(LifecyclePolicy.EPHEMERAL)));
+    }
+
+    // =================================================================
+    // I17 — artifact cascade on lifecycle ends
+    // =================================================================
+
+    @Test
+    void deleteGroupConversation_cascadesToArtifacts_beforeTheDocumentGoes() throws Exception {
+        var ops = ops();
+        var gc = gc();
+        gc.setState(GroupConversationState.COMPLETED);
+        doReturn(gc).when(conversationStore).read("gc-1");
+
+        ops.deleteGroupConversation("gc-1");
+
+        var order = inOrder(sharedArtifactStore, conversationStore);
+        order.verify(sharedArtifactStore).deleteByGroupConversationId("gc-1");
+        order.verify(conversationStore).delete("gc-1");
+    }
+
+    @Test
+    void deleteGroupConversation_artifactCascadeFails_discussionIsStillDeleted() throws Exception {
+        var ops = ops();
+        var gc = gc();
+        gc.setState(GroupConversationState.COMPLETED);
+        doReturn(gc).when(conversationStore).read("gc-1");
+        doThrow(new IResourceStore.ResourceStoreException("artifact store down"))
+                .when(sharedArtifactStore).deleteByGroupConversationId("gc-1");
+
+        assertDoesNotThrow(() -> ops.deleteGroupConversation("gc-1"),
+                "a broken artifact store must not make discussions undeletable");
+        verify(conversationStore).delete("gc-1");
+    }
+
+    @Test
+    void closeGroupConversation_cascadesToArtifacts() throws Exception {
+        var ops = ops();
+        var gc = gc();
+        gc.setState(GroupConversationState.COMPLETED);
+        var closed = gc();
+        closed.setState(GroupConversationState.CLOSED);
+        // close re-reads after the CAS — the two-read stub is load-bearing.
+        when(conversationStore.read("gc-1")).thenReturn(gc, closed);
+        when(conversationStore.compareAndSetState("gc-1", GroupConversationState.COMPLETED, GroupConversationState.CLOSED))
+                .thenReturn(true);
+
+        ops.closeGroupConversation("gc-1");
+
+        verify(sharedArtifactStore).deleteByGroupConversationId("gc-1");
     }
 
     // =================================================================

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutorTest.java
@@ -143,6 +143,43 @@ class MemberTurnExecutorTest {
         assertEquals(2, captor.getAllValues().get(1).version(), "events must arrive in write order");
     }
 
+    /**
+     * PR #637 review round 2: the announce mutex guards the drain HANDOFF, not the
+     * listener callbacks — a slow SSE client must not block other turns'
+     * end-of-turn drains. A change queued WHILE the publisher is mid-callback
+     * (simulated here by queueing from inside the listener and re-entering the
+     * announce) rides the active publisher's next loop instead of blocking or being
+     * stranded, and the reentrant call returns immediately.
+     */
+    @Test
+    void announceArtifactChanges_arrivalDuringCallbacks_ridesThePublisherLoop() {
+        var gc = new GroupConversation();
+        gc.setId("gc-1");
+        gc.setGroupId("group-1");
+        var listener = Mockito.mock(GroupDiscussionEventListener.class);
+        Mockito.doAnswer(inv -> {
+            GroupConversationEventSink.ArtifactUpdatedEvent event = inv.getArgument(0);
+            if (event.version() == 1) {
+                // A write lands while the publisher is inside a callback; the
+                // writer's own announce call must hand off, not block or recurse.
+                gc.queueArtifactChange(new GroupConversation.ArtifactChange("art-1", "doc", "TEXT", 2,
+                        AGENT_A, "DRAFT", false));
+                MemberTurnExecutor.announceArtifactChanges(gc, listener);
+            }
+            return null;
+        }).when(listener).onArtifactUpdated(Mockito.any());
+
+        gc.queueArtifactChange(new GroupConversation.ArtifactChange("art-1", "doc", "TEXT", 1, AGENT_A, "DRAFT", true));
+        MemberTurnExecutor.announceArtifactChanges(gc, listener);
+
+        var captor = ArgumentCaptor.forClass(GroupConversationEventSink.ArtifactUpdatedEvent.class);
+        verify(listener, times(2)).onArtifactUpdated(captor.capture());
+        assertEquals(1, captor.getAllValues().get(0).version());
+        assertEquals(2, captor.getAllValues().get(1).version(),
+                "the mid-callback write is published exactly once, in order, by the active publisher's loop");
+        assertTrue(gc.drainArtifactChanges().isEmpty(), "nothing stranded");
+    }
+
     @Test
     void announceArtifactChanges_singlePass_preservesWriteOrder() {
         var gc = new GroupConversation();

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutorTest.java
@@ -17,8 +17,10 @@ import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResponseHandler;
+import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
 import ai.labs.eddi.engine.internal.GroupConversationService;
+import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.memory.MemoryKeys;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
@@ -28,6 +30,7 @@ import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -73,6 +76,46 @@ class MemberTurnExecutorTest {
 
     private ProtocolConfig protocol(MemberFailurePolicy failurePolicy) {
         return new ProtocolConfig(60, failurePolicy, 2, MemberUnavailablePolicy.SKIP);
+    }
+
+    /**
+     * I17: artifact tools have no listener reference, so accepted writes ride the
+     * live discussion's change queue until the turn executor drains it. Announced
+     * even for a turn that itself went sideways (here: agent not deployed →
+     * SKIPPED) — the write already happened.
+     */
+    @Test
+    void executeAgentTurn_announcesQueuedArtifactChanges_andDrainsExactlyOnce() throws Exception {
+        var executor = executor();
+        var gc = new GroupConversation();
+        gc.setId("gc-1");
+        gc.setGroupId("group-1");
+        gc.queueArtifactChange(new GroupConversation.ArtifactChange("art-1", "doc", "TEXT", 1, AGENT_A, "DRAFT", true));
+        var listener = Mockito.mock(GroupDiscussionEventListener.class);
+
+        executor.executeAgentTurn(member(), gc, "input", protocol(MemberFailurePolicy.SKIP), 0, phase(PhaseType.OPINION), null, listener);
+
+        var captor = ArgumentCaptor.forClass(GroupConversationEventSink.ArtifactUpdatedEvent.class);
+        verify(listener).onArtifactUpdated(captor.capture());
+        assertEquals("doc", captor.getValue().name());
+        assertTrue(captor.getValue().created());
+
+        // A second turn must not re-announce the same change.
+        executor.executeAgentTurn(member(), gc, "input", protocol(MemberFailurePolicy.SKIP), 0, phase(PhaseType.OPINION), null, listener);
+        verify(listener, times(1)).onArtifactUpdated(any());
+    }
+
+    @Test
+    void executeAgentTurn_nullListener_stillDrainsTheQueue() throws Exception {
+        var executor = executor();
+        var gc = new GroupConversation();
+        gc.setId("gc-1");
+        gc.setGroupId("group-1");
+        gc.queueArtifactChange(new GroupConversation.ArtifactChange("art-1", "doc", "TEXT", 1, AGENT_A, "DRAFT", true));
+
+        executor.executeAgentTurn(member(), gc, "input", protocol(MemberFailurePolicy.SKIP), 0, phase(PhaseType.OPINION), null, null);
+
+        assertTrue(gc.drainArtifactChanges().isEmpty(), "the queue must never grow unbounded on the no-listener path");
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutorTest.java
@@ -118,6 +118,48 @@ class MemberTurnExecutorTest {
         assertTrue(gc.drainArtifactChanges().isEmpty(), "the queue must never grow unbounded on the no-listener path");
     }
 
+    /**
+     * I17 review follow-up: a write accepted AFTER a turn's own drain (a timed-out
+     * member's still-running agent) is picked up by the discussion leg's final
+     * announce pass instead of being stranded in the queue.
+     */
+    @Test
+    void announceArtifactChanges_lateWrite_deliveredByLaterPass() {
+        var gc = new GroupConversation();
+        gc.setId("gc-1");
+        gc.setGroupId("group-1");
+        var listener = Mockito.mock(GroupDiscussionEventListener.class);
+
+        gc.queueArtifactChange(new GroupConversation.ArtifactChange("art-1", "doc", "TEXT", 1, AGENT_A, "DRAFT", true));
+        MemberTurnExecutor.announceArtifactChanges(gc, listener);
+
+        // The late write, after every turn's own finally already drained.
+        gc.queueArtifactChange(new GroupConversation.ArtifactChange("art-1", "doc", "TEXT", 2, AGENT_A, "DRAFT", false));
+        MemberTurnExecutor.announceArtifactChanges(gc, listener);
+
+        var captor = ArgumentCaptor.forClass(GroupConversationEventSink.ArtifactUpdatedEvent.class);
+        verify(listener, times(2)).onArtifactUpdated(captor.capture());
+        assertEquals(1, captor.getAllValues().get(0).version());
+        assertEquals(2, captor.getAllValues().get(1).version(), "events must arrive in write order");
+    }
+
+    @Test
+    void announceArtifactChanges_singlePass_preservesWriteOrder() {
+        var gc = new GroupConversation();
+        gc.setId("gc-1");
+        gc.setGroupId("group-1");
+        var listener = Mockito.mock(GroupDiscussionEventListener.class);
+        gc.queueArtifactChange(new GroupConversation.ArtifactChange("art-1", "doc", "TEXT", 1, AGENT_A, "DRAFT", true));
+        gc.queueArtifactChange(new GroupConversation.ArtifactChange("art-1", "doc", "TEXT", 2, AGENT_A, "DRAFT", false));
+
+        MemberTurnExecutor.announceArtifactChanges(gc, listener);
+
+        var captor = ArgumentCaptor.forClass(GroupConversationEventSink.ArtifactUpdatedEvent.class);
+        verify(listener, times(2)).onArtifactUpdated(captor.capture());
+        assertEquals(1, captor.getAllValues().get(0).version());
+        assertEquals(2, captor.getAllValues().get(1).version());
+    }
+
     @Test
     void errorEntry_nullMember_usesUnknownFallbacks() {
         var entry = executor().errorEntry(null, 0, phase(PhaseType.OPINION), "boom");

--- a/src/test/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListenerTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListenerTest.java
@@ -493,4 +493,40 @@ class SlackGroupDiscussionListenerTest {
 
         verify(slackApi, times(1)).postMessage(any(), any(), any(), any());
     }
+
+    // ─── Artifact updated (I17) ───
+
+    @Test
+    void onArtifactUpdated_created_postsNameVersionAndEditor() {
+        listener.onGroupStart(groupStart("ROUND_TABLE", 2));
+
+        listener.onArtifactUpdated(new GroupConversationEventSink.ArtifactUpdatedEvent(
+                "art-1", "design-doc", "MARKDOWN", 1, "agent-a", "DRAFT", true));
+
+        verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), isNull(), contains("design-doc"));
+        verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), isNull(), contains("created"));
+        verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), isNull(), contains("v1"));
+    }
+
+    @Test
+    void onArtifactUpdated_finalUpdate_marksFinal_inCompactThread() {
+        listener.onGroupStart(groupStart("SINGLE", 1));
+
+        listener.onArtifactUpdated(new GroupConversationEventSink.ArtifactUpdatedEvent(
+                "art-1", "design-doc", "MARKDOWN", 4, "agent-b", "FINAL", false));
+
+        verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), eq(USER_THREAD), contains("FINAL"));
+        verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), eq(USER_THREAD), contains("updated"));
+    }
+
+    @Test
+    void onArtifactUpdated_degeneratePayload_doesNotThrowOrPost() {
+        listener.onGroupStart(groupStart("ROUND_TABLE", 2));
+
+        assertDoesNotThrow(() -> listener.onArtifactUpdated(null));
+        assertDoesNotThrow(() -> listener.onArtifactUpdated(new GroupConversationEventSink.ArtifactUpdatedEvent(
+                null, null, null, 0, null, null, false)));
+
+        verify(slackApi, times(1)).postMessage(any(), any(), any(), any());
+    }
 }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/ArtifactToolsProviderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/ArtifactToolsProviderTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ArtifactConfig;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.internal.groups.LiveDiscussionRegistry;
+import ai.labs.eddi.engine.memory.IConversationMemory;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.modules.llm.tools.spi.ToolAssemblyContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link ArtifactToolsProvider} (I17). Same negative-gate discipline
+ * as {@link GroupTaskToolsProviderTest}: this provider hands an LLM a write
+ * surface, so every way of being unsure resolves to "contribute nothing".
+ *
+ * @author tests
+ */
+class ArtifactToolsProviderTest {
+
+    private static final String GC_ID = "gc-1";
+    private static final String GROUP_ID = "group-1";
+    private static final String MEMBER_CONV = "member-conv-1";
+
+    private LiveDiscussionRegistry registry;
+    private IAgentGroupStore groupStore;
+    private ISharedArtifactStore artifactStore;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        registry = new LiveDiscussionRegistry();
+        groupStore = mock(IAgentGroupStore.class);
+        artifactStore = mock(ISharedArtifactStore.class);
+        var gc = new GroupConversation();
+        gc.setId(GC_ID);
+        gc.setGroupId(GROUP_ID);
+        gc.getMemberConversationIds().put("agent-a", MEMBER_CONV);
+        registry.register(gc);
+        when(groupStore.getCurrentResourceId(GROUP_ID)).thenReturn(resourceId());
+    }
+
+    private IResourceStore.IResourceId resourceId() {
+        return new IResourceStore.IResourceId() {
+            @Override
+            public String getId() {
+                return GROUP_ID;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return 1;
+            }
+        };
+    }
+
+    private AgentGroupConfiguration groupWith(ArtifactConfig artifactConfig) {
+        var config = new AgentGroupConfiguration();
+        config.setName("G");
+        config.setArtifactConfig(artifactConfig);
+        return config;
+    }
+
+    private ToolAssemblyContext ctx(String groupConversationId) {
+        return ctx(groupConversationId, MEMBER_CONV, true);
+    }
+
+    private ToolAssemblyContext ctx(String groupConversationId, String callerConversationId, boolean builtInsEnabled) {
+        var memory = mock(IConversationMemory.class);
+        lenient().when(memory.getConversationId()).thenReturn(callerConversationId);
+        var task = new LlmConfiguration.Task();
+        task.setEnableBuiltInTools(builtInsEnabled);
+        return new ToolAssemblyContext(memory, task, null, null, "user-1", "agent-a", groupConversationId);
+    }
+
+    private ArtifactToolsProvider provider() {
+        return new ArtifactToolsProvider(registry, groupStore, artifactStore);
+    }
+
+    @Test
+    void enabledGroupDiscussion_contributesAllFourTools() throws Exception {
+        when(groupStore.read(GROUP_ID, 1)).thenReturn(groupWith(new ArtifactConfig(true, 5, List.of())));
+
+        var contribution = provider().contribute(ctx(GC_ID));
+
+        assertEquals(4, contribution.specs().size(), "createArtifact, readArtifact, proposeArtifactUpdate, listArtifacts");
+        for (String tool : List.of("createArtifact", "readArtifact", "proposeArtifactUpdate", "listArtifacts")) {
+            assertTrue(contribution.specs().stream().anyMatch(spec -> spec.name().equals(tool)), tool);
+        }
+    }
+
+    @Test
+    void notAGroupTurn_contributesNothing() {
+        assertTrue(provider().contribute(ctx(null)).specs().isEmpty());
+    }
+
+    @Test
+    void discussionNotLive_contributesNothing() throws Exception {
+        when(groupStore.read(GROUP_ID, 1)).thenReturn(groupWith(new ArtifactConfig(true, 5, List.of())));
+        registry.unregister(GC_ID);
+
+        assertTrue(provider().contribute(ctx(GC_ID)).specs().isEmpty());
+    }
+
+    @Test
+    void noArtifactConfig_contributesNothing() throws Exception {
+        when(groupStore.read(GROUP_ID, 1)).thenReturn(groupWith(null));
+
+        assertTrue(provider().contribute(ctx(GC_ID)).specs().isEmpty(),
+                "an absent policy is not a permissive policy");
+    }
+
+    @Test
+    void featureDisabled_contributesNothing() throws Exception {
+        when(groupStore.read(GROUP_ID, 1)).thenReturn(groupWith(new ArtifactConfig()));
+
+        assertTrue(provider().contribute(ctx(GC_ID)).specs().isEmpty(),
+                "the default ArtifactConfig is off, and off must mean absent");
+    }
+
+    @Test
+    void unreadableGroup_contributesNothing() throws Exception {
+        when(groupStore.read(GROUP_ID, 1)).thenThrow(new IResourceStore.ResourceStoreException("mongo is down"));
+
+        assertTrue(provider().contribute(ctx(GC_ID)).specs().isEmpty());
+    }
+
+    @Test
+    void missingGroup_contributesNothing() throws Exception {
+        when(groupStore.getCurrentResourceId(GROUP_ID)).thenReturn(null);
+
+        assertTrue(provider().contribute(ctx(GC_ID)).specs().isEmpty());
+        verify(groupStore, never()).read(anyString(), anyInt());
+    }
+
+    @Test
+    void missingDependencies_contributeNothing() {
+        assertTrue(new ArtifactToolsProvider(null, groupStore, artifactStore).contribute(ctx(GC_ID)).specs().isEmpty());
+        assertTrue(new ArtifactToolsProvider(registry, null, artifactStore).contribute(ctx(GC_ID)).specs().isEmpty());
+        assertTrue(new ArtifactToolsProvider(registry, groupStore, null).contribute(ctx(GC_ID)).specs().isEmpty());
+    }
+
+    @Test
+    void anotherUsersDiscussion_contributesNothing() throws Exception {
+        when(groupStore.read(GROUP_ID, 1)).thenReturn(groupWith(new ArtifactConfig(true, 5, List.of())));
+
+        assertTrue(provider().contribute(ctx(GC_ID, "not-a-member-conversation", true)).specs().isEmpty(),
+                "membership must be checked, not merely discussion existence");
+        assertTrue(provider().contribute(ctx(GC_ID, null, true)).specs().isEmpty());
+    }
+
+    @Test
+    void agentWithBuiltInToolsDisabled_contributesNothing() throws Exception {
+        when(groupStore.read(GROUP_ID, 1)).thenReturn(groupWith(new ArtifactConfig(true, 5, List.of())));
+
+        assertTrue(provider().contribute(ctx(GC_ID, MEMBER_CONV, false)).specs().isEmpty());
+    }
+
+    @Test
+    void source_isBuiltin() {
+        assertEquals("builtin", provider().source());
+    }
+}

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/impl/ArtifactToolsTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/impl/ArtifactToolsTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.tools.impl;
+
+import ai.labs.eddi.configs.groups.ISharedArtifactStore;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ArtifactConfig;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ArtifactValidator;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ValidatorKind;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.SharedArtifact;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.internal.groups.LiveDiscussionRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * I17 — {@link ArtifactTools}: create/read/update/list against a real in-memory
+ * store with genuine version-CAS semantics, so the stale-version retry contract
+ * and the concurrency claims are exercised for real rather than scripted into a
+ * mock.
+ *
+ * @author tests
+ */
+class ArtifactToolsTest {
+
+    private static final String GC_ID = "gc-1";
+    private static final String AGENT = "agent-a";
+
+    private LiveDiscussionRegistry registry;
+    private GroupConversation gc;
+    private InMemoryArtifactStore store;
+
+    /**
+     * Minimal but honest store: whole-document map with a synchronized version CAS
+     * — the same conflict semantics the real backends provide atomically.
+     */
+    static final class InMemoryArtifactStore implements ISharedArtifactStore {
+        final Map<String, SharedArtifact> byId = new ConcurrentHashMap<>();
+        final AtomicLong seq = new AtomicLong();
+        volatile boolean failing;
+
+        private void maybeFail() throws IResourceStore.ResourceStoreException {
+            if (failing) {
+                throw new IResourceStore.ResourceStoreException("store down");
+            }
+        }
+
+        /** Deep-enough copy so callers cannot mutate stored state in place. */
+        private static SharedArtifact copy(SharedArtifact a) {
+            var c = new SharedArtifact();
+            c.setId(a.getId());
+            c.setGroupConversationId(a.getGroupConversationId());
+            c.setOwnerUserId(a.getOwnerUserId());
+            c.setName(a.getName());
+            c.setType(a.getType());
+            c.setContent(a.getContent());
+            c.setVersion(a.getVersion());
+            c.setLastEditorAgentId(a.getLastEditorAgentId());
+            c.setStatus(a.getStatus());
+            c.setHistory(new ArrayList<>(a.getHistory()));
+            c.setCreatedAt(a.getCreatedAt());
+            c.setUpdatedAt(a.getUpdatedAt());
+            return c;
+        }
+
+        @Override
+        public String create(SharedArtifact artifact) throws IResourceStore.ResourceStoreException {
+            maybeFail();
+            String id = "art-" + seq.incrementAndGet();
+            artifact.setId(id);
+            byId.put(id, copy(artifact));
+            return id;
+        }
+
+        @Override
+        public SharedArtifact read(String id) throws IResourceStore.ResourceNotFoundException, IResourceStore.ResourceStoreException {
+            maybeFail();
+            SharedArtifact a = byId.get(id);
+            if (a == null) {
+                throw new IResourceStore.ResourceNotFoundException("Shared artifact not found.");
+            }
+            return copy(a);
+        }
+
+        @Override
+        public synchronized void updateIfVersion(SharedArtifact artifact, long expectedVersion)
+                throws IResourceStore.ResourceStoreException, IResourceStore.ResourceModifiedException {
+            maybeFail();
+            SharedArtifact current = byId.get(artifact.getId());
+            if (current == null) {
+                throw new ArtifactGoneException("Shared artifact no longer exists.", null);
+            }
+            if (current.getVersion() != expectedVersion) {
+                throw new IResourceStore.ResourceModifiedException("version conflict");
+            }
+            byId.put(artifact.getId(), copy(artifact));
+        }
+
+        @Override
+        public void delete(String id) {
+            byId.remove(id);
+        }
+
+        @Override
+        public List<SharedArtifact> listByGroupConversationId(String groupConversationId) throws IResourceStore.ResourceStoreException {
+            maybeFail();
+            return byId.values().stream()
+                    .filter(a -> groupConversationId.equals(a.getGroupConversationId()))
+                    .map(InMemoryArtifactStore::copy)
+                    .toList();
+        }
+
+        @Override
+        public long deleteByGroupConversationId(String groupConversationId) {
+            long before = byId.size();
+            byId.values().removeIf(a -> groupConversationId.equals(a.getGroupConversationId()));
+            return before - byId.size();
+        }
+
+        @Override
+        public long deleteAllForUser(String userId) {
+            long before = byId.size();
+            byId.values().removeIf(a -> userId.equals(a.getOwnerUserId()));
+            return before - byId.size();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        registry = new LiveDiscussionRegistry();
+        gc = new GroupConversation();
+        gc.setId(GC_ID);
+        gc.setGroupId("group-1");
+        gc.setUserId("user-1");
+        registry.register(gc);
+        store = new InMemoryArtifactStore();
+    }
+
+    private ArtifactTools tools() {
+        return tools(new ArtifactConfig(true, 5, List.of()));
+    }
+
+    private ArtifactTools tools(ArtifactConfig config) {
+        return new ArtifactTools(registry, GC_ID, config, AGENT, store);
+    }
+
+    // =================================================================
+    // create
+    // =================================================================
+
+    @Test
+    @DisplayName("a created artifact lands in the store at v1, owner-stamped, and queues an announce event")
+    void create_happyPath() throws Exception {
+        String reply = tools().createArtifact("design-doc", "markdown", "# Draft");
+
+        assertTrue(reply.startsWith("Created"), reply);
+        List<SharedArtifact> stored = store.listByGroupConversationId(GC_ID);
+        assertEquals(1, stored.size());
+        SharedArtifact a = stored.get(0);
+        assertEquals("design-doc", a.getName());
+        assertEquals(SharedArtifact.ArtifactType.MARKDOWN, a.getType());
+        assertEquals(1, a.getVersion());
+        assertEquals("user-1", a.getOwnerUserId(), "GDPR erasure sweeps by this stamp");
+        assertEquals(AGENT, a.getLastEditorAgentId());
+
+        var changes = gc.drainArtifactChanges();
+        assertEquals(1, changes.size());
+        assertTrue(changes.get(0).created());
+        assertEquals("design-doc", changes.get(0).name());
+        assertTrue(gc.drainArtifactChanges().isEmpty(), "each change is drained exactly once");
+    }
+
+    @Test
+    @DisplayName("duplicate names are refused with the way forward, and nothing is stored")
+    void create_duplicateName_refused() throws Exception {
+        tools().createArtifact("draft", "text", "one");
+
+        String reply = tools().createArtifact("DRAFT", "text", "two");
+
+        assertFalse(reply.startsWith("Created"), reply);
+        assertTrue(reply.contains("proposeArtifactUpdate"), "the refusal must teach the retry: " + reply);
+        assertEquals(1, store.listByGroupConversationId(GC_ID).size());
+    }
+
+    @Test
+    @DisplayName("the per-discussion count cap refuses creation past the limit")
+    void create_countCap() throws Exception {
+        var tools = tools(new ArtifactConfig(true, 2, List.of()));
+        tools.createArtifact("one", "text", "1");
+        tools.createArtifact("two", "text", "2");
+
+        String reply = tools.createArtifact("three", "text", "3");
+
+        assertFalse(reply.startsWith("Created"), reply);
+        assertTrue(reply.contains("limit"), reply);
+        assertEquals(2, store.listByGroupConversationId(GC_ID).size());
+    }
+
+    @Test
+    @DisplayName("bad inputs are refused as sentences: missing name, unknown type, empty content, oversized content")
+    void create_inputValidation() throws Exception {
+        assertTrue(tools().createArtifact(" ", "text", "x").contains("name"));
+        assertTrue(tools().createArtifact("a", "pdf", "x").contains("TEXT, MARKDOWN or JSON"));
+        assertTrue(tools().createArtifact("a", "text", " ").contains("content"));
+        String oversized = "x".repeat(SharedArtifact.MAX_CONTENT_BYTES + 1);
+        assertTrue(tools().createArtifact("a", "text", oversized).contains("KB"));
+        assertTrue(store.listByGroupConversationId(GC_ID).isEmpty(), "every refusal must leave the store untouched");
+    }
+
+    @Test
+    @DisplayName("the configured validator chain gates creation — a failing write stores nothing")
+    void create_validatorChain() throws Exception {
+        var config = new ArtifactConfig(true, 5, List.of(new ArtifactValidator(ValidatorKind.REGEX, "^# ")));
+
+        String rejected = tools(config).createArtifact("doc", "markdown", "no heading");
+        assertTrue(rejected.contains("pattern"), rejected);
+        assertTrue(store.listByGroupConversationId(GC_ID).isEmpty());
+
+        String accepted = tools(config).createArtifact("doc", "markdown", "# Heading");
+        assertTrue(accepted.startsWith("Created"), accepted);
+    }
+
+    @Test
+    @DisplayName("an unregistered (paused/finished) discussion refuses writes instead of writing anyway")
+    void create_unregisteredDiscussion_refuses() throws Exception {
+        registry.unregister(GC_ID);
+
+        String reply = tools().createArtifact("doc", "text", "x");
+
+        assertTrue(reply.contains("finished") || reply.contains("paused"), reply);
+        assertTrue(store.byId.isEmpty());
+    }
+
+    // =================================================================
+    // update (CAS)
+    // =================================================================
+
+    @Test
+    @DisplayName("an update presenting the version it read is accepted and bumps the version with history")
+    void update_happyPath() throws Exception {
+        tools().createArtifact("doc", "text", "v1 content");
+        gc.drainArtifactChanges();
+
+        String reply = tools().proposeArtifactUpdate("doc", "v2 content", 1, null);
+
+        assertTrue(reply.contains("v2"), reply);
+        SharedArtifact a = store.listByGroupConversationId(GC_ID).get(0);
+        assertEquals(2, a.getVersion());
+        assertEquals("v2 content", a.getContent());
+        assertEquals(1, a.getHistory().size(), "the superseded revision rides in the bounded history");
+        assertEquals("v1 content", a.getHistory().get(0).content());
+
+        var changes = gc.drainArtifactChanges();
+        assertEquals(1, changes.size());
+        assertFalse(changes.get(0).created());
+        assertEquals(2, changes.get(0).version());
+    }
+
+    @Test
+    @DisplayName("a stale version gets the plan's re-read-and-merge sentence naming the CURRENT version")
+    void update_staleVersion_retrySentence() throws Exception {
+        tools().createArtifact("doc", "text", "v1");
+        tools().proposeArtifactUpdate("doc", "v2", 1, null);
+
+        String reply = tools().proposeArtifactUpdate("doc", "based on v1", 1, null);
+
+        assertTrue(reply.contains("changed since you read it"), reply);
+        assertTrue(reply.contains("now v2"), reply);
+        assertEquals("v2", store.listByGroupConversationId(GC_ID).get(0).getContent(), "the stale write must not land");
+    }
+
+    @Test
+    @DisplayName("markFinal freezes the artifact; further updates are refused")
+    void update_finalFreezes() throws Exception {
+        tools().createArtifact("doc", "text", "v1");
+
+        String finalized = tools().proposeArtifactUpdate("doc", "final text", 1, true);
+        assertTrue(finalized.contains("FINAL"), finalized);
+
+        String afterFinal = tools().proposeArtifactUpdate("doc", "more", 2, null);
+        assertTrue(afterFinal.contains("FINAL"), afterFinal);
+        assertEquals("final text", store.listByGroupConversationId(GC_ID).get(0).getContent());
+    }
+
+    @Test
+    @DisplayName("unknown artifacts refuse with the discovery hint; ids from OTHER discussions do not resolve")
+    void update_scopedResolution() throws Exception {
+        // An artifact of a different discussion — resolvable by raw id only if the
+        // tool did a global store read, which would be an IDOR.
+        var foreign = new SharedArtifact();
+        foreign.setGroupConversationId("gc-other");
+        foreign.setOwnerUserId("someone-else");
+        foreign.setName("their-doc");
+        foreign.setVersion(1);
+        String foreignId = store.create(foreign);
+
+        String reply = tools().proposeArtifactUpdate(foreignId, "hijack", 1, null);
+
+        assertTrue(reply.contains("listArtifacts"), reply);
+        assertEquals("their-doc", store.read(foreignId).getName());
+    }
+
+    @Test
+    @DisplayName("two concurrent updates from the same version: exactly one wins, the loser gets the retry sentence")
+    void update_concurrentCas_oneWins() throws Exception {
+        tools().createArtifact("doc", "text", "base");
+        int writers = 2;
+        var start = new CountDownLatch(1);
+        var done = new CountDownLatch(writers);
+        var accepted = new AtomicInteger();
+        var retries = new AtomicInteger();
+
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < writers; i++) {
+            final int n = i;
+            threads.add(Thread.ofVirtual().unstarted(() -> {
+                try {
+                    start.await();
+                    String reply = tools().proposeArtifactUpdate("doc", "writer-" + n, 1, null);
+                    if (reply.startsWith("Updated")) {
+                        accepted.incrementAndGet();
+                    } else if (reply.contains("changed since you read it")) {
+                        retries.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    // collected via counts — an exception fails the totals below
+                } finally {
+                    done.countDown();
+                }
+            }));
+        }
+        threads.forEach(Thread::start);
+        start.countDown();
+        assertTrue(done.await(10, TimeUnit.SECONDS), "concurrent update deadlocked");
+
+        assertEquals(1, accepted.get(), "exactly one writer may win a CAS from the same version");
+        assertEquals(1, retries.get(), "the loser gets the deterministic retry, not an exception");
+        assertEquals(2, store.listByGroupConversationId(GC_ID).get(0).getVersion());
+    }
+
+    // =================================================================
+    // read / list
+    // =================================================================
+
+    @Test
+    @DisplayName("readArtifact hands back the version — the CAS token the model needs")
+    void read_carriesVersion() throws Exception {
+        tools().createArtifact("doc", "json", "{\"a\":1}");
+
+        String reply = tools().readArtifact("doc");
+
+        assertTrue(reply.contains("v1"), reply);
+        assertTrue(reply.contains("{\"a\":1}"), reply);
+    }
+
+    @Test
+    @DisplayName("listArtifacts shows name, type, status and version; empty case teaches createArtifact")
+    void list_formats() throws Exception {
+        assertTrue(tools().listArtifacts().contains("createArtifact"));
+
+        tools().createArtifact("doc", "text", "x");
+        String listing = tools().listArtifacts();
+        assertTrue(listing.contains("\"doc\""), listing);
+        assertTrue(listing.contains("v1"), listing);
+        assertTrue(listing.contains("DRAFT"), listing);
+    }
+
+    @Test
+    @DisplayName("a store outage yields a try-again sentence, never an exception into the tool loop")
+    void storeOutage_refusesGracefully() {
+        store.failing = true;
+
+        assertDoesNotThrow(() -> {
+            assertTrue(tools().createArtifact("doc", "text", "x").contains("unavailable"));
+            assertTrue(tools().listArtifacts().contains("unavailable"));
+        });
+    }
+}


### PR DESCRIPTION
First Wave 2 queue item from `planning/group-collaboration-NEXT.md` §3 (design: `planning/group-collaboration-improvements-plan.md` §I17). Agents can now **create together**: four member tools — `createArtifact`, `readArtifact`, `proposeArtifactUpdate`, `listArtifacts` — co-edit typed documents (TEXT/MARKDOWN/JSON) instead of every structured thing being prose the next agent re-parses.

## Design (the plan's decisions, and its rejections honored)

- **Own collection, never embedded.** `SharedArtifact` + `ISharedArtifactStore`/`SharedArtifactStore` follow `GroupConversationStore`'s single-version runtime-document pattern. The discussion loop persists the `GroupConversation` document whole from stale snapshots, so an embedded list would be clobbered — and because artifacts have their own collection, the tools write **through the store directly** (unlike I5's task tools, which must mutate the live instance). The F1 registry is still consulted: **membership** at assembly (`getForMember` — the group conversation id is caller-supplied, existence is not authorization), liveness at write time.
- **Deterministic CAS-and-retry — explicitly not an LLM fusion arbiter.** Updates present the version they read; stale writers get *"artifact changed since you read it (now vN); re-read and merge your change"*. The storage layer needed a numeric CAS primitive: `storeIfFieldEquals(String)` text-compares, which works on Postgres (`data ->> field` renders JSON numbers as text) and **silently never matches on MongoDB** (typed BSON equality). New `storeIfFieldEquals(…, long)` overload on `IResourceStorage` + both backends, same no-silent-degrade contract.
- **Declarative validators only** — `JSON_SCHEMA` / `REGEX` / `MAX_LENGTH`, never code. New dependency `com.networknt:json-schema-validator` (the victools libs only *generate* schemas). Specs hard-fail the config save; write-time failures reject with the validator's message; a broken spec fails closed. Content ≤ 256 KB; `maxArtifactsPerDiscussion` (default 5) counted under the live-instance monitor because PARALLEL phases genuinely race creation.
- **`artifact_updated` events without a listener reference.** `ToolAssemblyContext` carries no listener (the structural gap that left I5's planned `task_added_by_agent` unfired). Accepted writes queue an `ArtifactChange` on the live instance; `MemberTurnExecutor` drains it in a `finally` after every turn and fires the new sink event → SSE (non-terminal) + Slack line. Drained even with a null listener so the queue cannot grow.
- **Lifecycle + GDPR.** Artifacts ride the discussion status payload at read time (service-level population, so REST *and* MCP `read_group_conversation` carry them — `availableActions` idiom, `READ_ONLY`). Close/delete cascades to the artifact collection (warn-and-continue: a broken artifact store must not make discussions undeletable). GDPR erasure sweeps **user-keyed** via a stamped `ownerUserId` with the group store's page/exact-recheck/fail-loud contract, as a new `GdprComplianceService` step.
- `markFinal` on `proposeArtifactUpdate` freezes an artifact (FINAL accepts no further updates) — a small extension beyond the plan's 3-arg signature so the model's `status` field is reachable; recorded in the changelog.

## Tests

148 across 8 classes, all green; `engine.internal` + `gdpr` + orchestrator regression suites (1807) green; checkstyle clean.

- Tools against a **real in-memory CAS store**: stale-version retry names the CURRENT version; two concurrent same-version writers → exactly one winner, one deterministic retry; FINAL freeze; foreign-discussion ids don't resolve (IDOR guard); validator chain; every refusal leaves no side effect.
- Provider gate matrix: every uncertainty (no group id, not live, non-member, config off/absent/unreadable, missing store, `enableBuiltInTools` false) → contribute nothing.
- Store: CAS through the numeric overload with `verify(never()).store(…)`; anchored+escaped filters with Java exact-recheck; not-found message embeds no caller id; erasure paging/fail-loud. Mutation note: degrading the CAS to an unconditional store does not even compile — the gone-document catch becomes unreachable.
- Lifecycle: `inOrder` artifact-cascade before document delete; cascade-failure still deletes; close cascade. GDPR: new step verified, not-resolvable skip, failure-continues.
- Turn executor: queued changes announced exactly once, null-listener drain. Slack: created/updated/FINAL lines, degenerate-payload skip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in shared artifacts for group discussions, supporting text, Markdown, and JSON documents.
  * Added tools to create, read, update, list, and finalize artifacts.
  * Added configurable validation, size and artifact-count limits, revision history, and version conflict handling.
  * Added live artifact-update notifications through streaming events and Slack.
* **Data Management**
  * Artifacts appear when reading discussions and are removed with deleted discussions.
  * Added GDPR cleanup for artifacts owned by a user.
* **Documentation**
  * Added guidance covering configuration, tools, validation, events, storage, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->