### PR TITLE
feat(groups): voting with structural ballot independence (I14)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 🗳️ feat(groups): I14 — voting with structural ballot independence (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i14-voting`)
+
+Second Wave 2 queue item. A `VOTE` phase collects explicit ballots; the deliverable is the **auditable process artifact** (weighted tally, raw ballots, losing-side dissents), not epistemics — LLM ballots are correlated and the plan says so out loud.
+
+- **Model:** `PhaseType.VOTE` (the new enum value flushed every exhaustive switch at compile time — `mapPhaseToEntryType` now maps to F4's existing `TranscriptEntryType.VOTE`, so commit-reveal peer-hiding worked before any new code ran); `VoteConfig` (MAJORITY|APPROVAL, EXPLICIT|LAST_SYNTHESIS options, quorum, per-agent weights, `weightByConfidence` — default off with the correlated-self-report caveat in its Javadoc — and `tiePolicy`) as a 12th `DiscussionPhase` component with the usual compat constructor.
+- **Independence is enforced, not advised:** `AgentGroupStore.validateVotePhases` HARD-rejects a VOTE phase that is not PARALLEL + `ContextScope.NONE` (plus: `targetEachPeer`, EXPLICIT with <2 options, negative weights). `HUMAN_DECIDES` is **save-time rejected until I6 ships human members** — the plan sequences I14 before I6, so shipping a silently-degrading enum value would be a lie; the queue's I6 item wires it. Deviation recorded here.
+- **`VoteTallyEngine`:** three-tier ballot parse mirroring `DebateVerdictParser` (strict JSON with `FAIL_ON_TRAILING_TOKENS` → embedded JSON → exactly-one-option text scan; out-of-contract votes are non-ballots, never write-ins), `Option A:` line extraction from the newest synthesis, weighted tally, quorum with abstentions/garbage counting against the denominator, dissents from losing statements.
+- **Wiring:** the discussion loop tallies on the VOTE phase's last repeat; `PhaseExecutionEngine.recordVoteDecision` applies the tie policy — `MODERATOR_DECIDES` runs one moderator turn under `__vote_tiebreak` (the judge's separate-conversation-key rule: a "reply with ONLY the option" prompt must not become the moderator's recent history), resolved by the same exact-scan rule as a ballot.
+- **`decision_reached` finally fires (the §4 gap, folded in as planned):** `fireDecisionReached` runs for vote decisions AND for I3 debate verdicts — after the dissent round, so the event's record carries the merged dissents. Slack renders a bounded tally block for VOTE records (instanceof-guarded — the tally map crossed serialization).
+
+**Tests (121 across the touched classes green; full `engine.internal` suite green; checkstyle clean):** parse tiers incl. ambiguous-two-options and out-of-contract refusals; label voting ("Option B" → positional); LAST_SYNTHESIS extraction (newest synthesis, colon and dash forms); weighted majority; exact tie → unresolved (never a winner by list position); confidence weighting on/off flips a tie; quorum arithmetic pinned to the "2 of 5" message; dissents + raw-ballot audit; tiebreak choice resolution; save-time validation matrix (PARALLEL/NONE/options/weights/HUMAN_DECIDES); service-level E2E: majority vote records the decision and fires `decision_reached` with the winner; tie + MODERATOR_DECIDES resolves via one tiebreak turn with method `vote+moderator-tiebreak`; tie + NO_DECISION records an honest NONE and the discussion does not fail; ballots land as VOTE entries. Slack tally block + malformed-tally no-throw.
+
+**Files:** `AgentGroupConfiguration` (VOTE + VoteConfig/VoteMethod/OptionsSource/TiePolicy), `AgentGroupStore`, `DiscussionStylePresets` (TEMPLATE_VOTE), `GroupContextBuilder` (VOTE branch + entry-type mapping), `VoteTallyEngine` (new), `PhaseExecutionEngine` (recordVoteDecision + fireDecisionReached), `GroupConversationService` (loop wiring), `SlackGroupDiscussionListener` (tally block), `docs/group-conversations.md`, 4 test classes.
+
+---
+
 ## 🔀 merge: bring `origin/main` (PR #627 HITL request pinning) into the branch (2026-08-07)
 
 **Repo:** EDDI (`refactor/group-service-split`, PR [#626](https://github.com/labsai/EDDI/pull/626))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 🔎 fix(groups): I14 PR #638 review round 1 (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i14-voting`)
+
+All 14 review comments (CodeQL ×6, code-quality ×1, CodeRabbit ×6, + enum-count CI failure) triaged; every one accepted and fixed:
+
+- **CI failure**: `AgentGroupConfigurationTest.phaseType_allValues` pins the enum size at 11; VOTE is the 12th. Fixed here (and the same pin fixed for RETRO on the I8 branch — the local targeted regressions missed this class; noted for future enum-touching branches).
+- **The moderator tiebreak is now budget-gated** (the one real architecture defect): it is an LLM turn, and it ran unguarded after `maxTurns` was exhausted or the cost ceiling fired — the only extra call in `PhaseExecutionEngine` without the gate `checkConvergence` and `runDissentRound` both carry. `recordVoteDecision` now takes `(turnCounter, maxTurns)`, blocks the tiebreak on either budget (keeping the honest NO_DECISION), and counts the turn it does spend.
+- **Losing-side dissents survive a tie-policy resolution**: the unresolved tally's record necessarily has no dissents, and `moderatorTiebreak` reused it — so the minority report vanished for exactly the closest votes. `TallyOutcome` now carries the parsed ballots; the tiebreak computes `losingDissents(ballots, chosenOption)` against ITS choice.
+- **Weighted-total ties compare with an epsilon** (1e-9), not `==`: totals are sums of non-representable doubles, so 0.1+0.2 vs 0.3 — a genuine tie — silently crowned one side on the last bit.
+- **Ballot weights must be finite**: NaN passes every `<` comparison and poisons the totals; infinity decides every vote alone. Save-time rejection alongside the existing `>= 0`.
+- **Slack tally lines are width-bounded** (`buildPreview`, 120 chars): a LAST_SYNTHESIS option can be a paragraph, and six of those pushed the whole decision message past Slack's limit — `postSafe` then swallowed the loss, winner and all.
+- **CodeQL log injection ×6** in `PhaseExecutionEngine` sanitized (`LogSanitizer` on conversation/phase/outcome/exception values); the flagged useless null check in `moderatorTiebreak` removed (control flow guarantees non-null there).
+
+**Tests:** +6 (floating-point tie; outcome-carries-ballots + dissent-vs-choice; NaN/∞ weight rejection ×2 scenarios; tiebreak blocked at budget spends nothing; tiebreak within budget counts its turn AND carries the loser's dissent — the last one fails against the pre-fix code on both the counter and the dissent assertions). `engine.internal` + `configs.groups` suites: 1711 green; checkstyle clean.
+
+---
+
 ## 🗳️ feat(groups): I14 — voting with structural ballot independence (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i14-voting`)

--- a/docs/group-conversations.md
+++ b/docs/group-conversations.md
@@ -160,6 +160,50 @@ Both caps are enforced independently: `maxPerTurn` bounds a runaway single turn,
 discussion cap counts only agent-filed tasks, so a large planned backlog does not
 exhaust it. A rejected call does not consume the per-turn budget.
 
+## Voting
+
+A `VOTE` phase collects **explicit ballots** instead of another round of prose.
+LLM ballots are correlated (shared priors, sycophancy) — the durable value is
+the auditable artifact: the weighted tally, every raw ballot, and the losing
+side's statements recorded as dissents on the `DecisionRecord`.
+
+```json
+{
+  "name": "Ballot", "type": "VOTE",
+  "turnOrder": "PARALLEL", "contextScope": "NONE",
+  "voteConfig": {
+    "method": "MAJORITY",
+    "optionsSource": "EXPLICIT",
+    "options": ["Adopt PostgreSQL", "Stay on MongoDB"],
+    "quorum": 0.5,
+    "weights": { "senior-architect": 2.0 },
+    "weightByConfidence": false,
+    "tiePolicy": "MODERATOR_DECIDES"
+  }
+}
+```
+
+**Independence is enforced structurally, not advised.** Save-time validation
+rejects a VOTE phase that is not `PARALLEL` + `contextScope: NONE`; ballots are
+cast blind against the pre-fan-out snapshot, and `VOTE` entries stay
+peer-hidden until their phase completes (commit-reveal).
+
+- **Ballot contract:** `{"vote": "<exact option text>", "confidence": <0..1>,
+  "statement": "..."}` (`APPROVAL` uses `"votes": [...]`). Three-tier parse:
+  strict JSON → JSON embedded in prose → a reply naming exactly one option's
+  text. Anything else is a non-ballot and **counts against quorum** — as do
+  abstentions; a mostly-silent team has not reached quorum, and that is signal.
+- **Options:** `EXPLICIT` is the reliable path. `LAST_SYNTHESIS` extracts
+  `Option A: …` lines from the newest synthesis — instruct that synthesis to
+  emit them.
+- **Ties and quorum failures** go to `tiePolicy`: `MODERATOR_DECIDES` runs one
+  moderator turn choosing among the unresolved options (method
+  `vote+moderator-tiebreak`); `NO_DECISION` (default) records an honest
+  `type: NONE` and the discussion continues. `HUMAN_DECIDES` is reserved for
+  human group members (I6) and is rejected at save time until then.
+- The result fires the `decision_reached` SSE event (which this feature also
+  wires for debate verdicts) and renders a tally block in Slack.
+
 ## Nested Groups (Group-of-Groups)
 
 Members can be other groups. The sub-group runs its own discussion and its synthesized answer becomes the member's response.

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -208,7 +208,7 @@ public class AgentGroupConfiguration {
      */
     public record DiscussionPhase(String name, PhaseType type, String participants, TurnOrder turnOrder, ContextScope contextScope,
             boolean targetEachPeer, String inputTemplate, int repeats, boolean requiresApproval, ConvergenceConfig convergence,
-            boolean allowAbstention) {
+            boolean allowAbstention, VoteConfig voteConfig) {
 
         /**
          * Convenience constructor with defaults: participants=ALL,
@@ -248,6 +248,102 @@ public class AgentGroupConfiguration {
                 boolean targetEachPeer, String inputTemplate, int repeats, boolean requiresApproval, ConvergenceConfig convergence) {
             this(name, type, participants, turnOrder, contextScope, targetEachPeer, inputTemplate, repeats, requiresApproval, convergence, false);
         }
+
+        /**
+         * Backward-compatible constructor without {@code voteConfig} (I14) —
+         * {@code null} means a VOTE phase runs with {@link VoteConfig}'s defaults and
+         * every other phase type ignores it entirely.
+         */
+        public DiscussionPhase(String name, PhaseType type, String participants, TurnOrder turnOrder, ContextScope contextScope,
+                boolean targetEachPeer, String inputTemplate, int repeats, boolean requiresApproval, ConvergenceConfig convergence,
+                boolean allowAbstention) {
+            this(name, type, participants, turnOrder, contextScope, targetEachPeer, inputTemplate, repeats, requiresApproval, convergence,
+                    allowAbstention, null);
+        }
+    }
+
+    /**
+     * Ballot rules for a {@link PhaseType#VOTE} phase (I14).
+     * <p>
+     * LLM ballots are <b>correlated</b> — shared priors, sycophancy — so the
+     * durable value of a vote is the auditable process artifact (tally, raw
+     * ballots, losing-side dissents), not the epistemics. Independence is
+     * engineered structurally: save-time validation forces VOTE phases to
+     * {@code PARALLEL} + {@code ContextScope.NONE}, so ballots are cast blind
+     * against the pre-fan-out transcript snapshot — commit-reveal for LLM purposes,
+     * not an instruction the model could ignore.
+     *
+     * @param method
+     *            {@code MAJORITY} — one option per ballot, highest weighted count
+     *            wins; {@code APPROVAL} — a ballot may approve several options.
+     *            Default MAJORITY
+     * @param optionsSource
+     *            where the ballot options come from. {@code EXPLICIT} (the reliable
+     *            path) takes {@code options} verbatim; {@code LAST_SYNTHESIS}
+     *            extracts {@code Option A: …} lines from the latest SYNTHESIS entry
+     *            — instruct the synthesis to emit that shape. Default
+     *            LAST_SYNTHESIS
+     * @param options
+     *            the explicit option texts, required (≥ 2) for EXPLICIT
+     * @param quorum
+     *            the fraction of participants that must cast a valid ballot for the
+     *            vote to decide, in (0, 1]. Abstentions and unparseable replies
+     *            count toward the denominator only — a mostly-silent team has NOT
+     *            reached quorum, and that is signal. Out-of-range values fall back
+     *            to the default 0.5
+     * @param weights
+     *            per-agentId ballot weights, default 1.0 each. Negative weights are
+     *            rejected at save time
+     * @param weightByConfidence
+     *            multiply each ballot by its self-reported 0..1 confidence
+     *            (ReConcile-style). Default off — self-reported confidence is
+     *            exactly as correlated as the ballots themselves; treat the
+     *            weighted tally as process record, not probability
+     * @param tiePolicy
+     *            what resolves a tie or a quorum failure: {@code MODERATOR_DECIDES}
+     *            (one moderator turn choosing among the tied options),
+     *            {@code HUMAN_DECIDES} (reserved for I6 human members — rejected at
+     *            save time until that ships), or {@code NO_DECISION} (default:
+     *            record {@code type=NONE} and carry on)
+     */
+    public record VoteConfig(VoteMethod method, OptionsSource optionsSource, List<String> options, double quorum,
+            Map<String, Double> weights, boolean weightByConfidence, TiePolicy tiePolicy) {
+
+        public static final double DEFAULT_QUORUM = 0.5;
+
+        /** Same normalization choke point as {@link GroupTaskConfig}. */
+        public VoteConfig {
+            method = method == null ? VoteMethod.MAJORITY : method;
+            optionsSource = optionsSource == null ? OptionsSource.LAST_SYNTHESIS : optionsSource;
+            options = options == null ? List.of() : List.copyOf(options);
+            if (quorum <= 0.0 || quorum > 1.0) {
+                quorum = DEFAULT_QUORUM;
+            }
+            weights = weights == null ? Map.of() : Map.copyOf(weights);
+            tiePolicy = tiePolicy == null ? TiePolicy.NO_DECISION : tiePolicy;
+        }
+
+        /**
+         * All defaults: MAJORITY, LAST_SYNTHESIS, quorum 0.5, unweighted, NO_DECISION.
+         */
+        public VoteConfig() {
+            this(VoteMethod.MAJORITY, OptionsSource.LAST_SYNTHESIS, List.of(), DEFAULT_QUORUM, Map.of(), false, TiePolicy.NO_DECISION);
+        }
+    }
+
+    /** How a {@link VoteConfig} counts ballots (I14). */
+    public enum VoteMethod {
+        MAJORITY, APPROVAL
+    }
+
+    /** Where a {@link VoteConfig}'s ballot options come from (I14). */
+    public enum OptionsSource {
+        LAST_SYNTHESIS, EXPLICIT
+    }
+
+    /** What resolves a tied or quorum-failed vote (I14). */
+    public enum TiePolicy {
+        MODERATOR_DECIDES, HUMAN_DECIDES, NO_DECISION
     }
 
     /**
@@ -323,7 +419,15 @@ public class AgentGroupConfiguration {
         /** Task execution by assigned agents. */
         EXECUTE,
         /** Verification of task results. */
-        VERIFY
+        VERIFY,
+        /**
+         * Explicit ballots (I14). Save-time validation forces VOTE phases to
+         * {@code PARALLEL} + {@code ContextScope.NONE} — ballot independence is
+         * enforced structurally (the pre-fan-out snapshot plus the F4 peer-visibility
+         * matrix mean no ballot can see another cast this phase), not advised in a
+         * prompt.
+         */
+        VOTE
     }
 
     public enum TurnOrder {

--- a/src/main/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresets.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresets.java
@@ -272,6 +272,26 @@ public final class DiscussionStylePresets {
             ]
             ```""";
 
+    /**
+     * The ballot prompt (I14). The JSON contract line is what
+     * {@code VoteTallyEngine}'s three-tier parse reads; the "vote independently"
+     * line is honesty, not the mechanism — independence is enforced structurally
+     * (PARALLEL + NONE scope + the pre-fan-out snapshot), so a model ignoring the
+     * instruction still cannot see any ballot cast this phase.
+     */
+    public static final String TEMPLATE_VOTE = """
+            The group must decide:
+            "{question}"
+
+            The options are:
+            {#for option in options}
+            - {option}
+            {/for}
+
+            As {displayName}, vote independently — you cannot see anyone else's ballot.
+            Respond with ONLY this JSON, no other text:
+            {ballotContract}""";
+
     // Template lookup by phase type
     private static final Map<PhaseType, String> DEFAULT_TEMPLATES = Map.ofEntries(
             Map.entry(PhaseType.OPINION, TEMPLATE_OPINION_INDEPENDENT),
@@ -284,7 +304,8 @@ public final class DiscussionStylePresets {
             Map.entry(PhaseType.SYNTHESIS, TEMPLATE_SYNTHESIS),
             Map.entry(PhaseType.PLAN, TEMPLATE_PLAN),
             Map.entry(PhaseType.EXECUTE, TEMPLATE_EXECUTE),
-            Map.entry(PhaseType.VERIFY, TEMPLATE_VERIFY));
+            Map.entry(PhaseType.VERIFY, TEMPLATE_VERIFY),
+            Map.entry(PhaseType.VOTE, TEMPLATE_VOTE));
 
     /**
      * Returns the default template for a given phase type.

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
@@ -147,8 +147,10 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
                         + "not available yet — use MODERATOR_DECIDES or NO_DECISION");
             }
             for (Map.Entry<String, Double> weight : voteConfig.weights().entrySet()) {
-                if (weight.getValue() == null || weight.getValue() < 0) {
-                    throw new IllegalArgumentException(path + ".weights['" + weight.getKey() + "'] must be >= 0");
+                // isFinite: NaN passes every < comparison and would poison the
+                // weighted totals; infinity would decide every vote alone.
+                if (weight.getValue() == null || !Double.isFinite(weight.getValue()) || weight.getValue() < 0) {
+                    throw new IllegalArgumentException(path + ".weights['" + weight.getKey() + "'] must be finite and >= 0");
                 }
             }
         }

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
@@ -19,6 +19,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * DB-agnostic store for group configurations. Extends
@@ -41,6 +42,7 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
     public IResourceStore.IResourceId create(AgentGroupConfiguration groupConfiguration)
             throws IResourceStore.ResourceStoreException {
         HitlConfigValidation.validate(groupConfiguration.getHitlConfig());
+        validateVotePhases(groupConfiguration);
         normalizeNonPositiveCostCeiling(groupConfiguration);
         warnOnModeratorlessPhases(groupConfiguration);
         return super.create(groupConfiguration);
@@ -52,6 +54,7 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
             throws IResourceStore.ResourceStoreException, IResourceStore.ResourceModifiedException,
             IResourceStore.ResourceNotFoundException {
         HitlConfigValidation.validate(groupConfiguration.getHitlConfig());
+        validateVotePhases(groupConfiguration);
         normalizeNonPositiveCostCeiling(groupConfiguration);
         warnOnModeratorlessPhases(groupConfiguration);
         return super.update(id, version, groupConfiguration);
@@ -101,6 +104,54 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
                 .filter(p -> p != null && "MODERATOR".equalsIgnoreCase(p.participants()))
                 .map(DiscussionPhase::name)
                 .toList();
+    }
+
+    /**
+     * I14: VOTE phases are validated as HARD errors — the fields are new, so no
+     * stored config predating this release can trip them (same rationale as the
+     * cascade pricing validation). Ballot independence is the point of the PARALLEL
+     * + NONE requirement: enforced structurally at save time, not advised in a
+     * prompt at run time.
+     */
+    static void validateVotePhases(AgentGroupConfiguration groupConfiguration) {
+        List<DiscussionPhase> phases = groupConfiguration.getPhases();
+        if (phases == null) {
+            return;
+        }
+        for (int i = 0; i < phases.size(); i++) {
+            DiscussionPhase phase = phases.get(i);
+            if (phase == null || phase.type() != AgentGroupConfiguration.PhaseType.VOTE) {
+                continue;
+            }
+            String path = "phases[" + i + "] (VOTE)";
+            if (phase.turnOrder() != AgentGroupConfiguration.TurnOrder.PARALLEL) {
+                throw new IllegalArgumentException(path + " must use turnOrder PARALLEL — ballots are cast blind against the "
+                        + "pre-fan-out snapshot; a sequential vote lets later ballots read earlier ones");
+            }
+            if (phase.contextScope() != null && phase.contextScope() != AgentGroupConfiguration.ContextScope.NONE) {
+                throw new IllegalArgumentException(path + " must use contextScope NONE — ballot independence is enforced "
+                        + "structurally, not advised in the prompt");
+            }
+            if (phase.targetEachPeer()) {
+                throw new IllegalArgumentException(path + " must not use targetEachPeer");
+            }
+            var voteConfig = phase.voteConfig();
+            if (voteConfig == null) {
+                continue;
+            }
+            if (voteConfig.optionsSource() == AgentGroupConfiguration.OptionsSource.EXPLICIT && voteConfig.options().size() < 2) {
+                throw new IllegalArgumentException(path + " with optionsSource EXPLICIT needs at least 2 options");
+            }
+            if (voteConfig.tiePolicy() == AgentGroupConfiguration.TiePolicy.HUMAN_DECIDES) {
+                throw new IllegalArgumentException(path + ".tiePolicy HUMAN_DECIDES needs human group members (I6), which are "
+                        + "not available yet — use MODERATOR_DECIDES or NO_DECISION");
+            }
+            for (Map.Entry<String, Double> weight : voteConfig.weights().entrySet()) {
+                if (weight.getValue() == null || weight.getValue() < 0) {
+                    throw new IllegalArgumentException(path + ".weights['" + weight.getKey() + "'] must be >= 0");
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -862,7 +862,8 @@ public class GroupConversationService implements IGroupConversationService {
                     // as the verdict above — a re-balloting round's draft tally is not
                     // the decision.
                     if (phase.type() == PhaseType.VOTE && lastRepeat) {
-                        phaseExecutionEngine.recordVoteDecision(gc, config, phase, protocol, phaseIdx, repeatEntries, speakers, listener);
+                        phaseExecutionEngine.recordVoteDecision(gc, config, phase, protocol, phaseIdx, repeatEntries, speakers, listener,
+                                turnCounter, maxTurns);
                     }
 
                     gc.setLastModified(Instant.now());

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -843,11 +843,26 @@ public class GroupConversationService implements IGroupConversationService {
                         // verdict landing on top of a dissent-only record. Same
                         // last-repeat reasoning as below — a draft judgment is not the
                         // decision.
-                        phaseExecutionEngine.recordDebateVerdict(gc, config, phase, phaseIdx, speakers);
+                        boolean verdictRecorded = phaseExecutionEngine.recordDebateVerdict(gc, config, phase, phaseIdx, speakers);
                         if (config.isRecordDissents()) {
                             phaseExecutionEngine.runDissentRound(gc, config, phase, protocol, phaseIdx, speakers, listener,
                                     turnCounter, maxTurns);
                         }
+                        // I14 fold-in (§4 gap): decision_reached finally has a producer.
+                        // Fired AFTER the dissent round so the event's record carries the
+                        // merged dissents, and only for a real verdict — a prose-only
+                        // synthesis set no record worth announcing.
+                        if (verdictRecorded) {
+                            phaseExecutionEngine.fireDecisionReached(gc, listener);
+                        }
+                    }
+
+                    // I14: a completed VOTE phase tallies into a DecisionRecord (and
+                    // fires decision_reached itself). Last repeat only, same reasoning
+                    // as the verdict above — a re-balloting round's draft tally is not
+                    // the decision.
+                    if (phase.type() == PhaseType.VOTE && lastRepeat) {
+                        phaseExecutionEngine.recordVoteDecision(gc, config, phase, protocol, phaseIdx, repeatEntries, speakers, listener);
                     }
 
                     gc.setLastModified(Instant.now());

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.VoteConfig;
 import ai.labs.eddi.configs.groups.model.DiscussionStylePresets;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
@@ -184,6 +185,14 @@ public class GroupContextBuilder {
             }
             case VERIFY -> {
                 // Completed tasks populated by executeTaskPhase
+            }
+            case VOTE -> {
+                // I14: the ballot prompt renders the options and the JSON contract.
+                // Scope is NONE (save-time enforced), so no transcript context rides
+                // along — blindness is structural, not this template's doing.
+                var voteConfig = phase.voteConfig() != null ? phase.voteConfig() : new VoteConfig();
+                data.put("options", VoteTallyEngine.resolveOptions(voteConfig, transcript));
+                data.put("ballotContract", VoteTallyEngine.ballotContract(voteConfig.method()));
             }
             default -> {
                 // All PhaseType values handled above; default required by checkstyle
@@ -370,6 +379,9 @@ public class GroupContextBuilder {
             case PLAN -> TranscriptEntryType.PLAN;
             case EXECUTE -> TranscriptEntryType.TASK_RESULT;
             case VERIFY -> TranscriptEntryType.VERIFICATION;
+            // I14: ballots are VOTE entries — peer-hidden while their phase runs
+            // (F4's commit-reveal), public once it completes.
+            case VOTE -> TranscriptEntryType.VOTE;
         };
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
@@ -404,6 +404,134 @@ public class PhaseExecutionEngine {
     }
 
     /**
+     * The conversation key the vote tiebreaker's private conversation lives under
+     * (I14). Not the moderator's agent id, for exactly
+     * {@link #JUDGE_CONVERSATION_KEY}'s reason: the tiebreak prompt must not become
+     * the moderator's recent history.
+     */
+    static final String TIEBREAK_CONVERSATION_KEY = "__vote_tiebreak";
+
+    /**
+     * Tallies a completed VOTE phase into the discussion's {@link DecisionRecord}
+     * and fires {@code decision_reached} (I14).
+     * <p>
+     * Quorum failures and ties go to the phase's {@code tiePolicy}:
+     * {@code MODERATOR_DECIDES} runs one moderator turn choosing among the
+     * unresolved options (method {@code vote+moderator-tiebreak});
+     * {@code NO_DECISION} records the honest {@code NONE}. {@code
+     * HUMAN_DECIDES} is save-time rejected until I6 ships human members, so
+     * reaching it here means hand-edited storage — it degrades to NO_DECISION with
+     * a WARN rather than guessing.
+     * <p>
+     * Like every decision producer, failure is prose-only, never a failed
+     * discussion.
+     */
+    public void recordVoteDecision(GroupConversation gc, AgentGroupConfiguration config, DiscussionPhase phase, ProtocolConfig protocol,
+                                   int phaseIdx, List<TranscriptEntry> repeatEntries, List<GroupMember> speakers,
+                                   GroupDiscussionEventListener listener) {
+        var voteConfig = phase.voteConfig() != null ? phase.voteConfig() : new AgentGroupConfiguration.VoteConfig();
+        List<TranscriptEntry> transcriptSnapshot;
+        synchronized (gc.getTranscript()) {
+            transcriptSnapshot = List.copyOf(gc.getTranscript());
+        }
+        List<String> options = VoteTallyEngine.resolveOptions(voteConfig, transcriptSnapshot);
+        if (options.size() < 2) {
+            LOGGER.warnf("Group %s: VOTE phase '%s' resolved %d option(s) — a vote needs at least two; recording NONE",
+                    gc.getId(), phase.name(), options.size());
+            setDecisionCarryingDissents(gc, new DecisionRecord(DecisionType.NONE,
+                    "The vote could not run: only " + options.size() + " option(s) were available.",
+                    null, null, List.of(), VoteTallyEngine.METHOD_VOTE, phase.name(), null));
+            fireDecisionReached(gc, listener);
+            return;
+        }
+
+        List<TranscriptEntry> ballots = repeatEntries.stream().filter(e -> e != null && e.type() == TranscriptEntryType.VOTE).toList();
+        int participants = speakers != null ? speakers.size() : ballots.size();
+        var outcome = VoteTallyEngine.tally(ballots, participants, options, voteConfig, phase.name());
+
+        DecisionRecord decision = outcome.decision();
+        if (!outcome.unresolvedOptions().isEmpty()) {
+            decision = switch (voteConfig.tiePolicy()) {
+                case MODERATOR_DECIDES -> moderatorTiebreak(gc, config, phase, protocol, phaseIdx, outcome, listener);
+                case HUMAN_DECIDES -> {
+                    LOGGER.warnf("Group %s: VOTE phase '%s' has tiePolicy HUMAN_DECIDES, which needs human group members (I6) — "
+                            + "recording NO_DECISION", gc.getId(), phase.name());
+                    yield outcome.decision();
+                }
+                case NO_DECISION -> outcome.decision();
+            };
+        }
+
+        setDecisionCarryingDissents(gc, decision);
+        LOGGER.infof("Group %s: VOTE phase '%s' concluded: %s", gc.getId(), phase.name(),
+                decision.type() == DecisionType.VOTE ? decision.outcome() : "no decision (" + decision.outcome() + ")");
+        fireDecisionReached(gc, listener);
+    }
+
+    /**
+     * One moderator turn choosing among the unresolved options. The reply is
+     * resolved by the same exact-scan rule as a tier-2 ballot; an unreadable reply
+     * keeps the tally's honest NONE.
+     */
+    private DecisionRecord moderatorTiebreak(GroupConversation gc, AgentGroupConfiguration config, DiscussionPhase phase,
+                                             ProtocolConfig protocol, int phaseIdx, VoteTallyEngine.TallyOutcome outcome,
+                                             GroupDiscussionEventListener listener) {
+        String moderatorAgentId = config.getModeratorAgentId();
+        if (moderatorAgentId == null || moderatorAgentId.isBlank()) {
+            LOGGER.warnf("Group %s: tiePolicy MODERATOR_DECIDES but the group names no moderatorAgentId — keeping NO_DECISION", gc.getId());
+            return outcome.decision();
+        }
+        String reason = outcome.quorumReached() ? "The vote tied between" : "The vote did not reach quorum; decide among";
+        String input = """
+                %s these options:
+                %s
+
+                As the moderator, choose exactly ONE. Reply with ONLY the exact text of the option you choose.
+                """.formatted(reason, outcome.unresolvedOptions().stream().map(o -> "- " + o).collect(Collectors.joining("\n")));
+        try {
+            var moderator = new GroupMember(moderatorAgentId, "Vote Tiebreaker", 0, "MODERATOR");
+            TranscriptEntry reply = memberTurnExecutor.executeAgentTurn(moderator, gc, input, protocol, phaseIdx, phase, null, listener,
+                    null, TIEBREAK_CONVERSATION_KEY);
+            String choice = VoteTallyEngine.resolveChoice(reply != null ? reply.content() : null, outcome.unresolvedOptions());
+            if (choice == null) {
+                LOGGER.warnf("Group %s: the tiebreaker's reply named no single option — keeping NO_DECISION", gc.getId());
+                return outcome.decision();
+            }
+            DecisionRecord base = outcome.decision();
+            return new DecisionRecord(DecisionType.VOTE,
+                    "\"%s\" chosen by the moderator (%s).".formatted(choice,
+                            outcome.quorumReached() ? "tie break" : "quorum failure"),
+                    choice, base.tally(), base.dissents(), VoteTallyEngine.METHOD_TIEBREAK, phase.name(),
+                    reply != null ? reply.content() : null);
+        } catch (Exception e) {
+            LOGGER.warnf("Group %s: vote tiebreak failed (%s) — keeping NO_DECISION", gc.getId(), e.getMessage());
+            return outcome.decision();
+        }
+    }
+
+    /** Immutable-record merge: a new decision keeps dissents already collected. */
+    private static void setDecisionCarryingDissents(GroupConversation gc, DecisionRecord decision) {
+        DecisionRecord existing = gc.getDecision();
+        if (existing != null && existing.dissents() != null && !existing.dissents().isEmpty()
+                && (decision.dissents() == null || decision.dissents().isEmpty())) {
+            decision = new DecisionRecord(decision.type(), decision.outcome(), decision.winner(), decision.tally(),
+                    existing.dissents(), decision.method(), decision.decidedAtPhase(), decision.raw());
+        }
+        gc.setDecision(decision);
+    }
+
+    /**
+     * The {@code decision_reached} producer (the §4 gap, folded in with I14): fired
+     * whenever a {@link DecisionRecord} lands on the discussion. The Slack listener
+     * skips {@code NONE} records itself; SSE forwards everything.
+     */
+    public void fireDecisionReached(GroupConversation gc, GroupDiscussionEventListener listener) {
+        if (listener != null && gc.getDecision() != null) {
+            listener.onDecisionReached(new GroupConversationEventSink.DecisionReachedEvent(gc.getDecision()));
+        }
+    }
+
+    /**
      * Merges dissents into the discussion's {@code DecisionRecord}, creating a
      * {@code NONE}-type record when no decision-producing feature ran. Records are
      * immutable, so an existing one is rebuilt rather than mutated.

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
@@ -25,6 +25,7 @@ import ai.labs.eddi.engine.internal.GroupConversationService.MemberTurnCancelled
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.utils.LogSanitizer;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -428,7 +429,7 @@ public class PhaseExecutionEngine {
      */
     public void recordVoteDecision(GroupConversation gc, AgentGroupConfiguration config, DiscussionPhase phase, ProtocolConfig protocol,
                                    int phaseIdx, List<TranscriptEntry> repeatEntries, List<GroupMember> speakers,
-                                   GroupDiscussionEventListener listener) {
+                                   GroupDiscussionEventListener listener, AtomicInteger turnCounter, int maxTurns) {
         var voteConfig = phase.voteConfig() != null ? phase.voteConfig() : new AgentGroupConfiguration.VoteConfig();
         List<TranscriptEntry> transcriptSnapshot;
         synchronized (gc.getTranscript()) {
@@ -437,7 +438,7 @@ public class PhaseExecutionEngine {
         List<String> options = VoteTallyEngine.resolveOptions(voteConfig, transcriptSnapshot);
         if (options.size() < 2) {
             LOGGER.warnf("Group %s: VOTE phase '%s' resolved %d option(s) — a vote needs at least two; recording NONE",
-                    gc.getId(), phase.name(), options.size());
+                    LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phase.name()), options.size());
             setDecisionCarryingDissents(gc, new DecisionRecord(DecisionType.NONE,
                     "The vote could not run: only " + options.size() + " option(s) were available.",
                     null, null, List.of(), VoteTallyEngine.METHOD_VOTE, phase.name(), null));
@@ -452,10 +453,25 @@ public class PhaseExecutionEngine {
         DecisionRecord decision = outcome.decision();
         if (!outcome.unresolvedOptions().isEmpty()) {
             decision = switch (voteConfig.tiePolicy()) {
-                case MODERATOR_DECIDES -> moderatorTiebreak(gc, config, phase, protocol, phaseIdx, outcome, listener);
+                case MODERATOR_DECIDES -> {
+                    // The tiebreak is a real LLM call — same two budgets as the
+                    // convergence judge and the dissent round. Without this gate a
+                    // tied vote issued one uncounted turn even after the discussion
+                    // exhausted maxTurns or blew its cost ceiling.
+                    if ((maxTurns > 0 && turnCounter != null && turnCounter.get() >= maxTurns)
+                            || GroupCostLedger.wouldExceedCeiling(gc, protocol)) {
+                        LOGGER.warnf("Group %s: VOTE phase '%s' tied but the turn/cost budget is exhausted — keeping NO_DECISION",
+                                LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phase.name()));
+                        yield outcome.decision();
+                    }
+                    if (turnCounter != null) {
+                        turnCounter.incrementAndGet();
+                    }
+                    yield moderatorTiebreak(gc, config, phase, protocol, phaseIdx, outcome, listener);
+                }
                 case HUMAN_DECIDES -> {
                     LOGGER.warnf("Group %s: VOTE phase '%s' has tiePolicy HUMAN_DECIDES, which needs human group members (I6) — "
-                            + "recording NO_DECISION", gc.getId(), phase.name());
+                            + "recording NO_DECISION", LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phase.name()));
                     yield outcome.decision();
                 }
                 case NO_DECISION -> outcome.decision();
@@ -463,8 +479,10 @@ public class PhaseExecutionEngine {
         }
 
         setDecisionCarryingDissents(gc, decision);
-        LOGGER.infof("Group %s: VOTE phase '%s' concluded: %s", gc.getId(), phase.name(),
-                decision.type() == DecisionType.VOTE ? decision.outcome() : "no decision (" + decision.outcome() + ")");
+        LOGGER.infof("Group %s: VOTE phase '%s' concluded: %s", LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phase.name()),
+                decision.type() == DecisionType.VOTE
+                        ? LogSanitizer.sanitize(decision.outcome())
+                        : "no decision (" + LogSanitizer.sanitize(decision.outcome()) + ")");
         fireDecisionReached(gc, listener);
     }
 
@@ -478,7 +496,8 @@ public class PhaseExecutionEngine {
                                              GroupDiscussionEventListener listener) {
         String moderatorAgentId = config.getModeratorAgentId();
         if (moderatorAgentId == null || moderatorAgentId.isBlank()) {
-            LOGGER.warnf("Group %s: tiePolicy MODERATOR_DECIDES but the group names no moderatorAgentId — keeping NO_DECISION", gc.getId());
+            LOGGER.warnf("Group %s: tiePolicy MODERATOR_DECIDES but the group names no moderatorAgentId — keeping NO_DECISION",
+                    LogSanitizer.sanitize(gc.getId()));
             return outcome.decision();
         }
         String reason = outcome.quorumReached() ? "The vote tied between" : "The vote did not reach quorum; decide among";
@@ -494,17 +513,22 @@ public class PhaseExecutionEngine {
                     null, TIEBREAK_CONVERSATION_KEY);
             String choice = VoteTallyEngine.resolveChoice(reply != null ? reply.content() : null, outcome.unresolvedOptions());
             if (choice == null) {
-                LOGGER.warnf("Group %s: the tiebreaker's reply named no single option — keeping NO_DECISION", gc.getId());
+                LOGGER.warnf("Group %s: the tiebreaker's reply named no single option — keeping NO_DECISION",
+                        LogSanitizer.sanitize(gc.getId()));
                 return outcome.decision();
             }
             DecisionRecord base = outcome.decision();
+            // Dissents against the CHOSEN option, from the carried ballots — the
+            // unresolved record's own list is necessarily empty, and reusing it
+            // dropped the minority report for exactly the closest votes.
             return new DecisionRecord(DecisionType.VOTE,
                     "\"%s\" chosen by the moderator (%s).".formatted(choice,
                             outcome.quorumReached() ? "tie break" : "quorum failure"),
-                    choice, base.tally(), base.dissents(), VoteTallyEngine.METHOD_TIEBREAK, phase.name(),
-                    reply != null ? reply.content() : null);
+                    choice, base.tally(), VoteTallyEngine.losingDissents(outcome.ballots(), choice),
+                    VoteTallyEngine.METHOD_TIEBREAK, phase.name(), reply.content());
         } catch (Exception e) {
-            LOGGER.warnf("Group %s: vote tiebreak failed (%s) — keeping NO_DECISION", gc.getId(), e.getMessage());
+            LOGGER.warnf("Group %s: vote tiebreak failed (%s) — keeping NO_DECISION",
+                    LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(e.getMessage()));
             return outcome.decision();
         }
     }

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/VoteTallyEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/VoteTallyEngine.java
@@ -51,6 +51,9 @@ public final class VoteTallyEngine {
     /** The mechanism tag when a moderator broke the tie (or quorum failure). */
     public static final String METHOD_TIEBREAK = "vote+moderator-tiebreak";
 
+    /** Two weighted totals within this of each other are the same total (a tie). */
+    private static final double TALLY_EPSILON = 1e-9;
+
     /** {@code Option A: text} / {@code Option 2 - text} lines in a synthesis. */
     private static final Pattern OPTION_LINE = Pattern.compile("^\\s*Option\\s+([A-Za-z0-9]+)\\s*[:\\-]\\s*(.+?)\\s*$",
             Pattern.MULTILINE);
@@ -79,8 +82,15 @@ public final class VoteTallyEngine {
      *            every option on a quorum failure
      * @param quorumReached
      *            whether enough valid ballots arrived
+     * @param ballots
+     *            every parsed ballot. Carried so a tie policy that DOES pick a
+     *            winner can compute the losing side's dissents against its choice —
+     *            the unresolved decision's own dissent list is necessarily empty,
+     *            and reusing it silently dropped the minority report for exactly
+     *            the closest votes
      */
-    public record TallyOutcome(DecisionRecord decision, List<String> unresolvedOptions, boolean quorumReached) {
+    public record TallyOutcome(DecisionRecord decision, List<String> unresolvedOptions, boolean quorumReached,
+            List<Ballot> ballots) {
     }
 
     /**
@@ -236,19 +246,22 @@ public final class VoteTallyEngine {
                     "Quorum not reached: %d of %d participants cast a valid ballot (needed %.0f%%)."
                             .formatted(ballots.size(), participantCount, config.quorum() * 100),
                     null, tallyMap, List.of(), METHOD_VOTE, phaseName, null);
-            return new TallyOutcome(decision, List.copyOf(options), false);
+            return new TallyOutcome(decision, List.copyOf(options), false, List.copyOf(ballots));
         }
 
         double max = totals.values().stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
+        // Tolerance, not ==: weighted and confidence-weighted totals are sums of
+        // non-representable doubles, so two mathematically equal totals can differ
+        // in the last bit — and a real tie would then silently crown one side.
         List<String> leaders = totals.entrySet().stream()
-                .filter(e -> e.getValue() == max && max > 0.0)
+                .filter(e -> Math.abs(e.getValue() - max) < TALLY_EPSILON && max > 0.0)
                 .map(Map.Entry::getKey).toList();
 
         if (leaders.size() != 1) {
             var decision = new DecisionRecord(DecisionType.NONE,
                     leaders.isEmpty() ? "No option received any weighted vote." : "Tie between: " + String.join(" / ", leaders) + ".",
                     null, tallyMap, List.of(), METHOD_VOTE, phaseName, null);
-            return new TallyOutcome(decision, leaders.isEmpty() ? List.copyOf(options) : leaders, true);
+            return new TallyOutcome(decision, leaders.isEmpty() ? List.copyOf(options) : leaders, true, List.copyOf(ballots));
         }
 
         String winner = leaders.get(0);
@@ -256,14 +269,15 @@ public final class VoteTallyEngine {
                 "\"%s\" wins with %.2f of %.2f weighted votes.".formatted(winner, totals.get(winner),
                         totals.values().stream().mapToDouble(Double::doubleValue).sum()),
                 winner, tallyMap, losingDissents(ballots, winner), METHOD_VOTE, phaseName, null);
-        return new TallyOutcome(decision, List.of(), true);
+        return new TallyOutcome(decision, List.of(), true, List.copyOf(ballots));
     }
 
     /**
      * The minority report: losing-side ballots that carried a statement become the
-     * decision's dissents.
+     * decision's dissents. Package-visible so {@code PhaseExecutionEngine}'s
+     * moderator tiebreak can compute dissents against ITS chosen option.
      */
-    private static List<Dissent> losingDissents(List<Ballot> ballots, String winner) {
+    static List<Dissent> losingDissents(List<Ballot> ballots, String winner) {
         List<Dissent> dissents = new ArrayList<>();
         for (Ballot ballot : ballots) {
             if (!ballot.votes().contains(winner) && ballot.statement() != null && !ballot.statement().isBlank()) {

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/VoteTallyEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/VoteTallyEngine.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.OptionsSource;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.VoteConfig;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.VoteMethod;
+import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionRecord;
+import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionType;
+import ai.labs.eddi.configs.groups.model.GroupConversation.Dissent;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses ballots and produces the vote's {@link DecisionRecord} (I14).
+ * <p>
+ * LLM ballots are correlated (shared priors, sycophancy), so what this class
+ * protects is the <b>auditable process artifact</b>: the weighted tally, every
+ * raw ballot, and the losing side's statements as dissents. Epistemics are not
+ * claimed. Every parse failure degrades honestly — an unreadable reply is a
+ * non-ballot that counts against quorum, never a guessed vote.
+ * <p>
+ * Mirrors {@link DebateVerdictParser}'s discipline: three-tier parse (strict
+ * JSON → JSON embedded in prose/fence → give up), {@code
+ * FAIL_ON_TRAILING_TOKENS} so a reply carrying two ballots is ambiguous rather
+ * than first-wins, and no failure mode that kills the discussion.
+ *
+ * @author ginccc
+ */
+public final class VoteTallyEngine {
+
+    private static final Logger LOGGER = Logger.getLogger(VoteTallyEngine.class);
+
+    /** The mechanism tag on a decision produced purely by counting ballots. */
+    public static final String METHOD_VOTE = "vote";
+    /** The mechanism tag when a moderator broke the tie (or quorum failure). */
+    public static final String METHOD_TIEBREAK = "vote+moderator-tiebreak";
+
+    /** {@code Option A: text} / {@code Option 2 - text} lines in a synthesis. */
+    private static final Pattern OPTION_LINE = Pattern.compile("^\\s*Option\\s+([A-Za-z0-9]+)\\s*[:\\-]\\s*(.+?)\\s*$",
+            Pattern.MULTILINE);
+    /** A ballot voting by label ("Option A") instead of the option's text. */
+    private static final Pattern OPTION_LABEL = Pattern.compile("^\\s*Option\\s+([A-Za-z0-9]+)\\s*$", Pattern.CASE_INSENSITIVE);
+
+    private static final ObjectMapper MAPPER = JsonMapper.builder()
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .build();
+
+    private VoteTallyEngine() {
+    }
+
+    /** One parsed ballot. {@code votes} hold canonical option texts. */
+    public record Ballot(String agentId, String displayName, List<String> votes, Double confidence, String statement) {
+    }
+
+    /**
+     * The tally's verdict on what happened, before any tie policy runs.
+     *
+     * @param decision
+     *            the record to store when {@code unresolvedOptions} is empty — a
+     *            decided VOTE, or a {@code NONE} record explaining why not
+     * @param unresolvedOptions
+     *            non-empty when a tie policy must choose: the tied options, or
+     *            every option on a quorum failure
+     * @param quorumReached
+     *            whether enough valid ballots arrived
+     */
+    public record TallyOutcome(DecisionRecord decision, List<String> unresolvedOptions, boolean quorumReached) {
+    }
+
+    /**
+     * The ballot options: {@code EXPLICIT} takes the config verbatim;
+     * {@code LAST_SYNTHESIS} extracts {@code Option X: …} lines from the newest
+     * SYNTHESIS entry. An empty result means the vote cannot run.
+     */
+    public static List<String> resolveOptions(VoteConfig config, List<TranscriptEntry> transcript) {
+        if (config.optionsSource() == OptionsSource.EXPLICIT) {
+            return config.options();
+        }
+        for (int i = transcript.size() - 1; i >= 0; i--) {
+            TranscriptEntry entry = transcript.get(i);
+            if (entry != null && entry.type() == TranscriptEntryType.SYNTHESIS && entry.content() != null) {
+                List<String> options = new ArrayList<>();
+                Matcher matcher = OPTION_LINE.matcher(entry.content());
+                while (matcher.find()) {
+                    options.add(matcher.group(2).trim());
+                }
+                return options;
+            }
+        }
+        return List.of();
+    }
+
+    /** The JSON contract line rendered into the ballot prompt. */
+    public static String ballotContract(VoteMethod method) {
+        return method == VoteMethod.APPROVAL
+                ? "{\"votes\": [\"<exact option text>\", \"...\"], \"confidence\": <0..1>, \"statement\": \"<one sentence explaining your vote>\"}"
+                : "{\"vote\": \"<exact option text>\", \"confidence\": <0..1>, \"statement\": \"<one sentence explaining your vote>\"}";
+    }
+
+    /**
+     * Three-tier ballot parse. Returns {@code null} for a non-ballot — which counts
+     * against quorum, never as a guessed vote.
+     */
+    static Ballot parseBallot(TranscriptEntry entry, List<String> options, VoteMethod method) {
+        if (entry == null || entry.content() == null || entry.content().isBlank()) {
+            return null;
+        }
+        String content = entry.content();
+
+        JsonNode node = readJson(content);
+        if (node == null) {
+            node = readJson(embeddedJson(content));
+        }
+        if (node != null && node.isObject()) {
+            List<String> votes = new ArrayList<>();
+            if (method == VoteMethod.APPROVAL && node.path("votes").isArray()) {
+                for (JsonNode vote : node.path("votes")) {
+                    String canonical = canonicalOption(vote.asText(), options);
+                    if (canonical == null) {
+                        return null; // an out-of-contract vote makes the whole ballot unreadable
+                    }
+                    if (!votes.contains(canonical)) {
+                        votes.add(canonical);
+                    }
+                }
+            } else if (node.path("vote").isTextual()) {
+                String canonical = canonicalOption(node.path("vote").asText(), options);
+                if (canonical == null) {
+                    return null;
+                }
+                votes.add(canonical);
+            }
+            if (!votes.isEmpty()) {
+                Double confidence = node.path("confidence").isNumber()
+                        ? Math.max(0.0, Math.min(1.0, node.path("confidence").asDouble()))
+                        : null;
+                String statement = node.path("statement").isTextual() ? node.path("statement").asText() : null;
+                return new Ballot(entry.speakerAgentId(), entry.speakerDisplayName(), List.copyOf(votes), confidence, statement);
+            }
+        }
+
+        // Tier 2: exactly ONE option's text appears in the reply. Two or more is
+        // ambiguous — refusing to pick by position is the point of this tier.
+        String scanned = null;
+        String lower = content.toLowerCase(Locale.ROOT);
+        for (String option : options) {
+            if (lower.contains(option.toLowerCase(Locale.ROOT))) {
+                if (scanned != null) {
+                    return null;
+                }
+                scanned = option;
+            }
+        }
+        if (scanned != null) {
+            return new Ballot(entry.speakerAgentId(), entry.speakerDisplayName(), List.of(scanned), null, null);
+        }
+        return null;
+    }
+
+    /**
+     * Weighted tally over one VOTE phase repeat.
+     *
+     * @param voteEntries
+     *            the repeat's VOTE transcript entries (one per participant that
+     *            replied)
+     * @param participantCount
+     *            the quorum denominator — everyone who was ASKED, so abstentions
+     *            and unparseable replies count against quorum
+     */
+    public static TallyOutcome tally(List<TranscriptEntry> voteEntries, int participantCount, List<String> options,
+                                     VoteConfig config, String phaseName) {
+        List<Ballot> ballots = new ArrayList<>();
+        for (TranscriptEntry entry : voteEntries) {
+            Ballot ballot = parseBallot(entry, options, config.method());
+            if (ballot != null) {
+                ballots.add(ballot);
+            } else if (entry != null) {
+                LOGGER.debugf("Non-ballot reply from '%s' counts against quorum", entry.speakerAgentId());
+            }
+        }
+
+        Map<String, Double> totals = new LinkedHashMap<>();
+        for (String option : options) {
+            totals.put(option, 0.0);
+        }
+        List<Map<String, Object>> rawBallots = new ArrayList<>();
+        for (Ballot ballot : ballots) {
+            double weight = config.weights().getOrDefault(ballot.agentId(), 1.0);
+            if (config.weightByConfidence() && ballot.confidence() != null) {
+                weight *= ballot.confidence();
+            }
+            for (String vote : ballot.votes()) {
+                totals.merge(vote, weight, Double::sum);
+            }
+            Map<String, Object> raw = new LinkedHashMap<>();
+            raw.put("agentId", ballot.agentId());
+            raw.put("votes", ballot.votes());
+            if (ballot.confidence() != null) {
+                raw.put("confidence", ballot.confidence());
+            }
+            raw.put("weight", weight);
+            if (ballot.statement() != null && !ballot.statement().isBlank()) {
+                raw.put("statement", ballot.statement());
+            }
+            rawBallots.add(raw);
+        }
+
+        Map<String, Object> tallyMap = new LinkedHashMap<>();
+        tallyMap.put("totals", totals);
+        tallyMap.put("ballots", rawBallots);
+        tallyMap.put("participants", participantCount);
+        tallyMap.put("validBallots", ballots.size());
+        tallyMap.put("quorum", config.quorum());
+
+        boolean quorumReached = participantCount > 0 && (double) ballots.size() / participantCount >= config.quorum();
+        tallyMap.put("quorumReached", quorumReached);
+
+        if (!quorumReached) {
+            var decision = new DecisionRecord(DecisionType.NONE,
+                    "Quorum not reached: %d of %d participants cast a valid ballot (needed %.0f%%)."
+                            .formatted(ballots.size(), participantCount, config.quorum() * 100),
+                    null, tallyMap, List.of(), METHOD_VOTE, phaseName, null);
+            return new TallyOutcome(decision, List.copyOf(options), false);
+        }
+
+        double max = totals.values().stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
+        List<String> leaders = totals.entrySet().stream()
+                .filter(e -> e.getValue() == max && max > 0.0)
+                .map(Map.Entry::getKey).toList();
+
+        if (leaders.size() != 1) {
+            var decision = new DecisionRecord(DecisionType.NONE,
+                    leaders.isEmpty() ? "No option received any weighted vote." : "Tie between: " + String.join(" / ", leaders) + ".",
+                    null, tallyMap, List.of(), METHOD_VOTE, phaseName, null);
+            return new TallyOutcome(decision, leaders.isEmpty() ? List.copyOf(options) : leaders, true);
+        }
+
+        String winner = leaders.get(0);
+        var decision = new DecisionRecord(DecisionType.VOTE,
+                "\"%s\" wins with %.2f of %.2f weighted votes.".formatted(winner, totals.get(winner),
+                        totals.values().stream().mapToDouble(Double::doubleValue).sum()),
+                winner, tallyMap, losingDissents(ballots, winner), METHOD_VOTE, phaseName, null);
+        return new TallyOutcome(decision, List.of(), true);
+    }
+
+    /**
+     * The minority report: losing-side ballots that carried a statement become the
+     * decision's dissents.
+     */
+    private static List<Dissent> losingDissents(List<Ballot> ballots, String winner) {
+        List<Dissent> dissents = new ArrayList<>();
+        for (Ballot ballot : ballots) {
+            if (!ballot.votes().contains(winner) && ballot.statement() != null && !ballot.statement().isBlank()) {
+                dissents.add(new Dissent(ballot.agentId(), ballot.displayName(), ballot.statement()));
+            }
+        }
+        return dissents;
+    }
+
+    /**
+     * A tiebreaker's free-text choice, resolved by the same exact-scan rule as
+     * ballot tier 2: exactly one option named, or no choice at all.
+     */
+    public static String resolveChoice(String reply, List<String> options) {
+        if (reply == null || reply.isBlank()) {
+            return null;
+        }
+        String canonical = canonicalOption(reply.trim(), options);
+        if (canonical != null) {
+            return canonical;
+        }
+        String lower = reply.toLowerCase(Locale.ROOT);
+        String scanned = null;
+        for (String option : options) {
+            if (lower.contains(option.toLowerCase(Locale.ROOT))) {
+                if (scanned != null) {
+                    return null;
+                }
+                scanned = option;
+            }
+        }
+        return scanned;
+    }
+
+    /**
+     * Matches a vote string to its canonical option — by text, or by "Option X"
+     * label position.
+     */
+    private static String canonicalOption(String vote, List<String> options) {
+        if (vote == null) {
+            return null;
+        }
+        String trimmed = vote.trim();
+        for (String option : options) {
+            if (option.equalsIgnoreCase(trimmed)) {
+                return option;
+            }
+        }
+        Matcher label = OPTION_LABEL.matcher(trimmed);
+        if (label.matches()) {
+            String index = label.group(1).toUpperCase(Locale.ROOT);
+            int position = index.length() == 1 && Character.isLetter(index.charAt(0))
+                    ? index.charAt(0) - 'A'
+                    : parseIndex(index);
+            if (position >= 0 && position < options.size()) {
+                return options.get(position);
+            }
+        }
+        return null;
+    }
+
+    private static int parseIndex(String index) {
+        try {
+            return Integer.parseInt(index) - 1;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private static JsonNode readJson(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        try {
+            return MAPPER.readTree(text.trim());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** The first balanced-looking JSON object embedded in prose or a fence. */
+    private static String embeddedJson(String content) {
+        int start = content.indexOf('{');
+        int end = content.lastIndexOf('}');
+        return start >= 0 && end > start ? content.substring(start, end + 1) : null;
+    }
+}

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.integrations.slack;
 
+import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionRecord;
 import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionType;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
@@ -287,6 +288,7 @@ public class SlackGroupDiscussionListener implements GroupDiscussionEventListene
         if (decision.winner() != null && !decision.winner().isBlank()) {
             sb.append(String.format("Winner: *%s*\n", decision.winner()));
         }
+        appendVoteTally(sb, decision);
         if (decision.dissents() != null && !decision.dissents().isEmpty()) {
             sb.append(String.format("Dissents: %d\n", decision.dissents().size()));
         }
@@ -294,6 +296,34 @@ public class SlackGroupDiscussionListener implements GroupDiscussionEventListene
         String threadTs = expandedMode ? null : userThreadTs;
         postSafe(channelId, threadTs, sb.toString().stripTrailing());
     }
+
+    /**
+     * The per-option tally block for VOTE decisions (I14). Bounded and defensive:
+     * the tally map is model-shaped data that crossed serialization, so every read
+     * is instanceof-guarded rather than cast.
+     */
+    private static void appendVoteTally(StringBuilder sb, DecisionRecord decision) {
+        if (decision.type() != DecisionType.VOTE || decision.tally() == null) {
+            return;
+        }
+        Object totals = decision.tally().get("totals");
+        if (totals instanceof Map<?, ?> totalsMap && !totalsMap.isEmpty()) {
+            sb.append("Tally:\n");
+            totalsMap.entrySet().stream().limit(MAX_TALLY_LINES).forEach(entry -> sb.append(String.format("• %s — %s\n",
+                    entry.getKey(), entry.getValue())));
+            if (totalsMap.size() > MAX_TALLY_LINES) {
+                sb.append(String.format("… and %d more option(s)\n", totalsMap.size() - MAX_TALLY_LINES));
+            }
+        }
+        Object valid = decision.tally().get("validBallots");
+        Object participants = decision.tally().get("participants");
+        if (valid instanceof Number && participants instanceof Number) {
+            sb.append(String.format("Ballots: %s of %s\n", valid, participants));
+        }
+    }
+
+    /** Slack messages are skimmed, not scrolled — a ten-option tally is noise. */
+    private static final int MAX_TALLY_LINES = 6;
 
     // ─── HITL (human-in-the-loop) ───
 

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
@@ -310,7 +310,7 @@ public class SlackGroupDiscussionListener implements GroupDiscussionEventListene
         if (totals instanceof Map<?, ?> totalsMap && !totalsMap.isEmpty()) {
             sb.append("Tally:\n");
             totalsMap.entrySet().stream().limit(MAX_TALLY_LINES).forEach(entry -> sb.append(String.format("• %s — %s\n",
-                    entry.getKey(), entry.getValue())));
+                    buildPreview(String.valueOf(entry.getKey()), MAX_TALLY_OPTION_CHARS), entry.getValue())));
             if (totalsMap.size() > MAX_TALLY_LINES) {
                 sb.append(String.format("… and %d more option(s)\n", totalsMap.size() - MAX_TALLY_LINES));
             }
@@ -324,6 +324,14 @@ public class SlackGroupDiscussionListener implements GroupDiscussionEventListene
 
     /** Slack messages are skimmed, not scrolled — a ten-option tally is noise. */
     private static final int MAX_TALLY_LINES = 6;
+
+    /**
+     * Same reasoning per line: a LAST_SYNTHESIS-derived option is whatever text
+     * followed "Option X:", which can be a paragraph — six of those could push the
+     * whole decision message past Slack's per-message limit, and postSafe would
+     * swallow the loss.
+     */
+    private static final int MAX_TALLY_OPTION_CHARS = 120;
 
     // ─── HITL (human-in-the-loop) ───
 

--- a/src/test/java/ai/labs/eddi/configs/groups/model/AgentGroupConfigurationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/model/AgentGroupConfigurationTest.java
@@ -136,7 +136,7 @@ class AgentGroupConfigurationTest {
 
     @Test
     void phaseType_allValues() {
-        assertEquals(11, PhaseType.values().length);
+        assertEquals(12, PhaseType.values().length);
         assertNotNull(PhaseType.valueOf("OPINION"));
         assertNotNull(PhaseType.valueOf("CRITIQUE"));
         assertNotNull(PhaseType.valueOf("REVISION"));
@@ -148,6 +148,7 @@ class AgentGroupConfigurationTest {
         assertNotNull(PhaseType.valueOf("PLAN"));
         assertNotNull(PhaseType.valueOf("EXECUTE"));
         assertNotNull(PhaseType.valueOf("VERIFY"));
+        assertNotNull(PhaseType.valueOf("VOTE"));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStoreTest.java
@@ -157,6 +157,19 @@ class AgentGroupStoreTest {
     }
 
     @Test
+    void votePhase_nonFiniteWeight_isRejected() {
+        // NaN passes every < comparison; infinity would decide every vote alone.
+        for (double bad : new double[]{Double.NaN, Double.POSITIVE_INFINITY}) {
+            var ex = assertThrows(IllegalArgumentException.class, () -> AgentGroupStore.validateVotePhases(voteGroup(
+                    votePhase(TurnOrder.PARALLEL, ContextScope.NONE,
+                            new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT, List.of("A", "B"), 0.5,
+                                    Map.of("a1", bad), false, TiePolicy.NO_DECISION)))),
+                    "weight " + bad + " must be rejected");
+            assertTrue(ex.getMessage().contains("finite"), ex.getMessage());
+        }
+    }
+
+    @Test
     void nonVotePhases_areNeverTouchedByVoteValidation() {
         assertDoesNotThrow(() -> AgentGroupStore.validateVotePhases(config(DiscussionStyle.CUSTOM,
                 List.of(phase("Open", "ALL")), null)));

--- a/src/test/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStoreTest.java
@@ -8,11 +8,16 @@ import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionStyle;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.OptionsSource;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TiePolicy;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TurnOrder;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.VoteConfig;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.VoteMethod;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -86,5 +91,75 @@ class AgentGroupStoreTest {
         var phases = List.of(phase("Open", "ALL"), phase("Roles", "ROLE:PRO"));
 
         assertTrue(AgentGroupStore.moderatorlessPhaseNames(config(DiscussionStyle.CUSTOM, phases, null)).isEmpty());
+    }
+
+    // =================================================================
+    // I14 — VOTE phase validation: independence enforced, not advised
+    // =================================================================
+
+    private DiscussionPhase votePhase(TurnOrder turnOrder, ContextScope scope, VoteConfig voteConfig) {
+        return new DiscussionPhase("Ballot", PhaseType.VOTE, "ALL", turnOrder, scope, false, null, 1, false, null, false, voteConfig);
+    }
+
+    private AgentGroupConfiguration voteGroup(DiscussionPhase phase) {
+        return config(DiscussionStyle.CUSTOM, List.of(phase), "mod");
+    }
+
+    @Test
+    void votePhase_parallelAndNone_isAccepted() {
+        assertDoesNotThrow(() -> AgentGroupStore.validateVotePhases(voteGroup(
+                votePhase(TurnOrder.PARALLEL, ContextScope.NONE,
+                        new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT, List.of("A", "B"), 0.5, Map.of(), false,
+                                TiePolicy.MODERATOR_DECIDES)))));
+        // A null scope behaves as NONE throughout the scope filter, so it is accepted.
+        assertDoesNotThrow(() -> AgentGroupStore.validateVotePhases(voteGroup(votePhase(TurnOrder.PARALLEL, null, null))));
+    }
+
+    @Test
+    void votePhase_sequential_isRejected() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> AgentGroupStore.validateVotePhases(voteGroup(
+                votePhase(TurnOrder.SEQUENTIAL, ContextScope.NONE, null))));
+        assertTrue(ex.getMessage().contains("PARALLEL"), ex.getMessage());
+    }
+
+    @Test
+    void votePhase_contextfulScope_isRejected() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> AgentGroupStore.validateVotePhases(voteGroup(
+                votePhase(TurnOrder.PARALLEL, ContextScope.FULL, null))));
+        assertTrue(ex.getMessage().contains("NONE"), ex.getMessage());
+    }
+
+    @Test
+    void votePhase_explicitWithTooFewOptions_isRejected() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> AgentGroupStore.validateVotePhases(voteGroup(
+                votePhase(TurnOrder.PARALLEL, ContextScope.NONE,
+                        new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT, List.of("only one"), 0.5, Map.of(), false,
+                                TiePolicy.NO_DECISION)))));
+        assertTrue(ex.getMessage().contains("2 options"), ex.getMessage());
+    }
+
+    @Test
+    void votePhase_humanDecides_isRejectedUntilI6() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> AgentGroupStore.validateVotePhases(voteGroup(
+                votePhase(TurnOrder.PARALLEL, ContextScope.NONE,
+                        new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT, List.of("A", "B"), 0.5, Map.of(), false,
+                                TiePolicy.HUMAN_DECIDES)))));
+        assertTrue(ex.getMessage().contains("I6"), ex.getMessage());
+    }
+
+    @Test
+    void votePhase_negativeWeight_isRejected() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> AgentGroupStore.validateVotePhases(voteGroup(
+                votePhase(TurnOrder.PARALLEL, ContextScope.NONE,
+                        new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT, List.of("A", "B"), 0.5,
+                                Map.of("a1", -1.0), false, TiePolicy.NO_DECISION)))));
+        assertTrue(ex.getMessage().contains("weights"), ex.getMessage());
+    }
+
+    @Test
+    void nonVotePhases_areNeverTouchedByVoteValidation() {
+        assertDoesNotThrow(() -> AgentGroupStore.validateVotePhases(config(DiscussionStyle.CUSTOM,
+                List.of(phase("Open", "ALL")), null)));
+        assertDoesNotThrow(() -> AgentGroupStore.validateVotePhases(config(DiscussionStyle.DEBATE, null, null)));
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceExtendedTest.java
@@ -37,6 +37,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -143,6 +144,97 @@ class GroupConversationServiceExtendedTest {
     // =========================================================
     // startAndDiscussAsync
     // =========================================================
+
+    /**
+     * I14 — a VOTE phase end-to-end: blind parallel ballots, weighted tally, the
+     * DecisionRecord on the discussion, and decision_reached finally firing (the §4
+     * gap this item folds in).
+     */
+    @Nested
+    class VotePhases {
+
+        private AgentGroupConfiguration voteConfig(AgentGroupConfiguration.TiePolicy tiePolicy) {
+            var c = new AgentGroupConfiguration();
+            c.setName("Vote Group");
+            c.setStyle(DiscussionStyle.CUSTOM);
+            c.setModeratorAgentId("mod");
+            c.setMembers(List.of(new GroupMember("a1", "Alice", 1, null), new GroupMember("a2", "Bob", 2, null),
+                    new GroupMember("a3", "Carol", 3, null)));
+            c.setPhases(List.of(new AgentGroupConfiguration.DiscussionPhase("Ballot", PhaseType.VOTE, "ALL",
+                    TurnOrder.PARALLEL, ContextScope.NONE, false, null, 1, false, null, false,
+                    new AgentGroupConfiguration.VoteConfig(AgentGroupConfiguration.VoteMethod.MAJORITY,
+                            AgentGroupConfiguration.OptionsSource.EXPLICIT, List.of("Ship it", "Hold it"), 0.5,
+                            Map.of(), false, tiePolicy))));
+            c.setProtocol(new ProtocolConfig(60, ProtocolConfig.MemberFailurePolicy.SKIP, 2,
+                    ProtocolConfig.MemberUnavailablePolicy.SKIP));
+            return c;
+        }
+
+        @Test
+        void votePhase_majorityWins_recordsDecision_andFiresDecisionReached() throws Exception {
+            setupStore(voteConfig(AgentGroupConfiguration.TiePolicy.NO_DECISION));
+            stubAgent("a1", "{\"vote\": \"Ship it\", \"statement\": \"ready\"}");
+            stubAgent("a2", "{\"vote\": \"Ship it\"}");
+            stubAgent("a3", "{\"vote\": \"Hold it\", \"statement\": \"needs QA\"}");
+            var listener = mock(GroupDiscussionEventListener.class);
+
+            GroupConversation gc = service.discuss(GROUP_ID, "Release?", USER_ID, 0, listener);
+
+            assertNotNull(gc.getDecision());
+            assertEquals(GroupConversation.DecisionType.VOTE, gc.getDecision().type());
+            assertEquals("Ship it", gc.getDecision().winner());
+            assertEquals(1, gc.getDecision().dissents().size(), "the losing statement is the minority report");
+
+            var captor = ArgumentCaptor.forClass(GroupConversationEventSink.DecisionReachedEvent.class);
+            verify(listener).onDecisionReached(captor.capture());
+            assertEquals("Ship it", captor.getValue().decision().winner());
+        }
+
+        @Test
+        void votePhase_tie_moderatorDecides_viaOneTiebreakTurn() throws Exception {
+            var config = voteConfig(AgentGroupConfiguration.TiePolicy.MODERATOR_DECIDES);
+            config.setMembers(List.of(new GroupMember("a1", "Alice", 1, null), new GroupMember("a2", "Bob", 2, null)));
+            setupStore(config);
+            stubAgent("a1", "{\"vote\": \"Ship it\"}");
+            stubAgent("a2", "{\"vote\": \"Hold it\"}");
+            stubAgent("mod", "Hold it");
+
+            GroupConversation gc = service.discuss(GROUP_ID, "Release?", USER_ID, 0);
+
+            assertEquals(GroupConversation.DecisionType.VOTE, gc.getDecision().type());
+            assertEquals("Hold it", gc.getDecision().winner());
+            assertEquals("vote+moderator-tiebreak", gc.getDecision().method());
+        }
+
+        @Test
+        void votePhase_tie_noDecisionPolicy_recordsHonestNone_andContinues() throws Exception {
+            var config = voteConfig(AgentGroupConfiguration.TiePolicy.NO_DECISION);
+            config.setMembers(List.of(new GroupMember("a1", "Alice", 1, null), new GroupMember("a2", "Bob", 2, null)));
+            setupStore(config);
+            stubAgent("a1", "{\"vote\": \"Ship it\"}");
+            stubAgent("a2", "{\"vote\": \"Hold it\"}");
+
+            GroupConversation gc = service.discuss(GROUP_ID, "Release?", USER_ID, 0);
+
+            assertEquals(GroupConversation.DecisionType.NONE, gc.getDecision().type());
+            assertNull(gc.getDecision().winner());
+            assertNotEquals(GroupConversation.GroupConversationState.FAILED, gc.getState(),
+                    "an undecided vote is not a failed discussion");
+        }
+
+        @Test
+        void votePhase_ballotsAreVoteEntries_peerHiddenDuringTheirPhase() throws Exception {
+            setupStore(voteConfig(AgentGroupConfiguration.TiePolicy.NO_DECISION));
+            stubAgent("a1", "{\"vote\": \"Ship it\"}");
+            stubAgent("a2", "{\"vote\": \"Ship it\"}");
+            stubAgent("a3", "{\"vote\": \"Hold it\"}");
+
+            GroupConversation gc = service.discuss(GROUP_ID, "Release?", USER_ID, 0);
+
+            long voteEntries = gc.getTranscript().stream().filter(e -> e.type() == TranscriptEntryType.VOTE).count();
+            assertEquals(3, voteEntries, "each ballot is a VOTE transcript entry (F4 hides them until the phase ends)");
+        }
+    }
 
     @Nested
     class AsyncDiscussion {

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
@@ -12,7 +12,11 @@ import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ProtocolConfig;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ProtocolConfig.MemberFailurePolicy;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ProtocolConfig.MemberUnavailablePolicy;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.OptionsSource;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TiePolicy;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TurnOrder;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.VoteConfig;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.VoteMethod;
 import ai.labs.eddi.configs.groups.model.DiscussionStylePresets;
 import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionRecord;
@@ -529,5 +533,64 @@ class PhaseExecutionEngineTest {
                 new AtomicInteger(0), 10);
 
         assertFalse(outcome.isContinue(), "every scheduled turn abstained — the phase must stop");
+    }
+
+    // =================================================================
+    // I14 review round 1 — the moderator tiebreak is budget-gated
+    // =================================================================
+
+    private DiscussionPhase votePhase() {
+        var voteConfig = new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT,
+                List.of("Adopt PostgreSQL", "Stay on MongoDB"), 0.5, java.util.Map.of(), false, TiePolicy.MODERATOR_DECIDES);
+        return new DiscussionPhase("Ballot", PhaseType.VOTE, "ALL", TurnOrder.PARALLEL, ContextScope.NONE,
+                false, null, 1, false, null, false, voteConfig);
+    }
+
+    private TranscriptEntry voteEntry(String agentId, String json) {
+        return new TranscriptEntry(agentId, agentId, json, 0, "Ballot", TranscriptEntryType.VOTE, Instant.now(), null, null);
+    }
+
+    @Test
+    void voteTiebreak_turnBudgetExhausted_keepsNoDecision_andSpendsNothing() throws Exception {
+        var engine = engine();
+        var config = new AgentGroupConfiguration();
+        config.setModeratorAgentId("mod");
+        var ballots = List.of(
+                voteEntry("a", "{\"vote\": \"Adopt PostgreSQL\"}"),
+                voteEntry("b", "{\"vote\": \"Stay on MongoDB\"}"));
+        var turnCounter = new AtomicInteger(5);
+
+        engine.recordVoteDecision(gc(), config, votePhase(), protocol(), 0, ballots,
+                List.of(member("a"), member("b")), null, turnCounter, 5);
+
+        verify(memberTurnExecutor, never()).executeAgentTurn(any(), any(), any(), any(), anyInt(), any(), any(), any(), any(), any());
+        assertEquals(5, turnCounter.get(), "a blocked tiebreak must not consume a turn");
+    }
+
+    @Test
+    void voteTiebreak_withinBudget_countsItsTurn_andCarriesTheLosersDissent() throws Exception {
+        var engine = engine();
+        var config = new AgentGroupConfiguration();
+        config.setModeratorAgentId("mod");
+        when(memberTurnExecutor.executeAgentTurn(any(), any(), any(), any(), anyInt(), any(), any(), any(), any(), any()))
+                .thenReturn(voteEntry("mod", "Adopt PostgreSQL"));
+        var ballots = List.of(
+                voteEntry("a", "{\"vote\": \"Adopt PostgreSQL\", \"statement\": \"pgvector\"}"),
+                voteEntry("b", "{\"vote\": \"Stay on MongoDB\", \"statement\": \"migration risk is real\"}"));
+        var gc = gc();
+        var turnCounter = new AtomicInteger(0);
+
+        engine.recordVoteDecision(gc, config, votePhase(), protocol(), 0, ballots,
+                List.of(member("a"), member("b")), null, turnCounter, 10);
+
+        assertEquals(1, turnCounter.get(), "the tiebreak is a real LLM turn and must be counted");
+        DecisionRecord decision = gc.getDecision();
+        assertEquals(DecisionType.VOTE, decision.type());
+        assertEquals("Adopt PostgreSQL", decision.winner());
+        assertEquals(VoteTallyEngine.METHOD_TIEBREAK, decision.method());
+        // The review defect: reusing the unresolved record's empty dissent list
+        // dropped the minority report for exactly the closest votes.
+        assertEquals(1, decision.dissents().size(), "the losing side's statement must survive the tiebreak");
+        assertEquals("migration risk is real", decision.dissents().get(0).position());
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/VoteTallyEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/VoteTallyEngineTest.java
@@ -224,6 +224,42 @@ class VoteTallyEngineTest {
         assertEquals(2.0, ((Map<?, ?>) outcome.decision().tally().get("totals")).get("Adopt PostgreSQL"));
     }
 
+    @Test
+    @DisplayName("mathematically equal totals that differ in the last floating-point bit are STILL a tie")
+    void tally_floatingPointEqualTotals_isATie() {
+        // 0.1 + 0.2 != 0.3 in doubles. An exact == compare would crown one side
+        // of a genuinely tied vote on representation noise.
+        var config = new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT, OPTIONS, 0.5,
+                Map.of("a1", 0.1, "a2", 0.2, "a3", 0.3), false, TiePolicy.NO_DECISION);
+        var entries = List.of(
+                ballot("a1", "{\"vote\": \"Adopt PostgreSQL\"}"),
+                ballot("a2", "{\"vote\": \"Adopt PostgreSQL\"}"),
+                ballot("a3", "{\"vote\": \"Stay on MongoDB\"}"));
+
+        var outcome = VoteTallyEngine.tally(entries, 3, OPTIONS, config, "Vote");
+
+        assertEquals(DecisionType.NONE, outcome.decision().type(), "0.1+0.2 vs 0.3 is a tie, not a winner");
+        assertEquals(2, outcome.unresolvedOptions().size());
+    }
+
+    @Test
+    @DisplayName("the outcome carries the parsed ballots, so a tie policy's choice still yields dissents")
+    void tally_outcomeCarriesBallots_forTiePolicyDissents() {
+        var entries = List.of(
+                ballot("a1", "{\"vote\": \"Adopt PostgreSQL\", \"statement\": \"pgvector\"}"),
+                ballot("a2", "{\"vote\": \"Stay on MongoDB\", \"statement\": \"migration risk is real\"}"));
+
+        var outcome = VoteTallyEngine.tally(entries, 2, OPTIONS, config(), "Vote");
+
+        assertEquals(DecisionType.NONE, outcome.decision().type(), "an exact tie");
+        assertTrue(outcome.decision().dissents().isEmpty(), "no winner yet, so the record itself has no dissents");
+        assertEquals(2, outcome.ballots().size());
+        // What the moderator tiebreak computes after choosing: the loser's report.
+        var dissents = VoteTallyEngine.losingDissents(outcome.ballots(), "Adopt PostgreSQL");
+        assertEquals(1, dissents.size());
+        assertEquals("migration risk is real", dissents.get(0).position());
+    }
+
     // =================================================================
     // tiebreak choice resolution
     // =================================================================

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/VoteTallyEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/VoteTallyEngineTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.OptionsSource;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TiePolicy;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.VoteConfig;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.VoteMethod;
+import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionType;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * I14 — {@link VoteTallyEngine}: the three-tier ballot parse, option
+ * resolution, weighted tallying, quorum arithmetic (abstentions count against
+ * it), and the losing side's statements becoming dissents. Pure unit tests, no
+ * mocks — the engine is deliberately static and side-effect-free.
+ *
+ * @author tests
+ */
+class VoteTallyEngineTest {
+
+    private static final List<String> OPTIONS = List.of("Adopt PostgreSQL", "Stay on MongoDB");
+
+    private static TranscriptEntry ballot(String agentId, String content) {
+        return new TranscriptEntry(agentId, agentId, content, 0, "Vote", TranscriptEntryType.VOTE, Instant.now(), null, null);
+    }
+
+    private static VoteConfig config() {
+        return new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT, OPTIONS, 0.5, Map.of(), false, TiePolicy.NO_DECISION);
+    }
+
+    // =================================================================
+    // ballot parsing — three tiers
+    // =================================================================
+
+    @Test
+    @DisplayName("tier 1: a strict-JSON ballot parses with confidence and statement")
+    void parse_strictJson() {
+        var b = VoteTallyEngine.parseBallot(
+                ballot("a1", "{\"vote\": \"Adopt PostgreSQL\", \"confidence\": 0.8, \"statement\": \"pgvector matters\"}"),
+                OPTIONS, VoteMethod.MAJORITY);
+
+        assertNotNull(b);
+        assertEquals(List.of("Adopt PostgreSQL"), b.votes());
+        assertEquals(0.8, b.confidence());
+        assertEquals("pgvector matters", b.statement());
+    }
+
+    @Test
+    @DisplayName("tier 1: JSON embedded in prose or a fence still parses")
+    void parse_embeddedJson() {
+        var b = VoteTallyEngine.parseBallot(
+                ballot("a1", "Here is my ballot:\n```json\n{\"vote\": \"Stay on MongoDB\"}\n```"),
+                OPTIONS, VoteMethod.MAJORITY);
+
+        assertNotNull(b);
+        assertEquals(List.of("Stay on MongoDB"), b.votes());
+        assertNull(b.confidence());
+    }
+
+    @Test
+    @DisplayName("APPROVAL ballots may approve several options; duplicates collapse")
+    void parse_approval() {
+        var b = VoteTallyEngine.parseBallot(
+                ballot("a1", "{\"votes\": [\"Adopt PostgreSQL\", \"Stay on MongoDB\", \"Adopt PostgreSQL\"]}"),
+                OPTIONS, VoteMethod.APPROVAL);
+
+        assertNotNull(b);
+        assertEquals(2, b.votes().size());
+    }
+
+    @Test
+    @DisplayName("a ballot may vote by 'Option A' label — resolved positionally")
+    void parse_optionLabel() {
+        var b = VoteTallyEngine.parseBallot(ballot("a1", "{\"vote\": \"Option B\"}"), OPTIONS, VoteMethod.MAJORITY);
+
+        assertNotNull(b);
+        assertEquals(List.of("Stay on MongoDB"), b.votes());
+    }
+
+    @Test
+    @DisplayName("tier 2: exactly one option's text in prose is a ballot; two is ambiguous and is not")
+    void parse_exactScan() {
+        var single = VoteTallyEngine.parseBallot(ballot("a1", "I think we should Adopt PostgreSQL, honestly."), OPTIONS,
+                VoteMethod.MAJORITY);
+        assertNotNull(single);
+        assertEquals(List.of("Adopt PostgreSQL"), single.votes());
+
+        assertNull(VoteTallyEngine.parseBallot(
+                ballot("a1", "Between Adopt PostgreSQL and Stay on MongoDB I really cannot say."), OPTIONS, VoteMethod.MAJORITY),
+                "an ambiguous reply must count against quorum, never be picked by position");
+    }
+
+    @Test
+    @DisplayName("tier 3: out-of-contract votes and empty replies are non-ballots")
+    void parse_nonBallots() {
+        assertNull(VoteTallyEngine.parseBallot(ballot("a1", "{\"vote\": \"Use MySQL\"}"), OPTIONS, VoteMethod.MAJORITY),
+                "a vote outside the contract makes the ballot unreadable, not a write-in");
+        assertNull(VoteTallyEngine.parseBallot(ballot("a1", "   "), OPTIONS, VoteMethod.MAJORITY));
+        assertNull(VoteTallyEngine.parseBallot(null, OPTIONS, VoteMethod.MAJORITY));
+    }
+
+    // =================================================================
+    // option resolution
+    // =================================================================
+
+    @Test
+    @DisplayName("LAST_SYNTHESIS extracts Option lines from the NEWEST synthesis, colon or dash form")
+    void resolveOptions_lastSynthesis() {
+        var older = new TranscriptEntry("mod", "Mod", "Option A: Old first\nOption B: Old second", 0, "S",
+                TranscriptEntryType.SYNTHESIS, Instant.now(), null, null);
+        var newer = new TranscriptEntry("mod", "Mod", "Summary...\nOption A: Adopt PostgreSQL\nOption 2 - Stay on MongoDB\nMore prose.",
+                1, "S", TranscriptEntryType.SYNTHESIS, Instant.now(), null, null);
+        var config = new VoteConfig(VoteMethod.MAJORITY, OptionsSource.LAST_SYNTHESIS, List.of(), 0.5, Map.of(), false,
+                TiePolicy.NO_DECISION);
+
+        List<String> options = VoteTallyEngine.resolveOptions(config, List.of(older, newer));
+
+        assertEquals(List.of("Adopt PostgreSQL", "Stay on MongoDB"), options);
+    }
+
+    @Test
+    @DisplayName("no synthesis on the transcript → no options → the vote cannot run")
+    void resolveOptions_noSynthesis() {
+        var config = new VoteConfig(VoteMethod.MAJORITY, OptionsSource.LAST_SYNTHESIS, List.of(), 0.5, Map.of(), false,
+                TiePolicy.NO_DECISION);
+
+        assertTrue(VoteTallyEngine.resolveOptions(config, List.of()).isEmpty());
+    }
+
+    // =================================================================
+    // tally
+    // =================================================================
+
+    @Test
+    @DisplayName("weighted majority: weights multiply ballots, the heavier side wins")
+    void tally_weightedMajority() {
+        var config = new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT, OPTIONS, 0.5,
+                Map.of("a1", 3.0), false, TiePolicy.NO_DECISION);
+        var entries = List.of(
+                ballot("a1", "{\"vote\": \"Stay on MongoDB\"}"),
+                ballot("a2", "{\"vote\": \"Adopt PostgreSQL\"}"),
+                ballot("a3", "{\"vote\": \"Adopt PostgreSQL\"}"));
+
+        var outcome = VoteTallyEngine.tally(entries, 3, OPTIONS, config, "Vote");
+
+        assertTrue(outcome.unresolvedOptions().isEmpty());
+        assertEquals(DecisionType.VOTE, outcome.decision().type());
+        assertEquals("Stay on MongoDB", outcome.decision().winner(), "3.0 beats 1.0 + 1.0");
+    }
+
+    @Test
+    @DisplayName("an exact tie is unresolved — never a winner by list position")
+    void tally_exactTie() {
+        var entries = List.of(
+                ballot("a1", "{\"vote\": \"Adopt PostgreSQL\"}"),
+                ballot("a2", "{\"vote\": \"Stay on MongoDB\"}"));
+
+        var outcome = VoteTallyEngine.tally(entries, 2, OPTIONS, config(), "Vote");
+
+        assertEquals(DecisionType.NONE, outcome.decision().type());
+        assertEquals(2, outcome.unresolvedOptions().size());
+        assertTrue(outcome.quorumReached());
+    }
+
+    @Test
+    @DisplayName("confidence weighting multiplies only when enabled")
+    void tally_confidenceWeighting() {
+        var entries = List.of(
+                ballot("a1", "{\"vote\": \"Adopt PostgreSQL\", \"confidence\": 0.2}"),
+                ballot("a2", "{\"vote\": \"Stay on MongoDB\", \"confidence\": 0.9}"));
+
+        var unweighted = VoteTallyEngine.tally(entries, 2, OPTIONS, config(), "Vote");
+        assertEquals(DecisionType.NONE, unweighted.decision().type(), "1.0 vs 1.0 without confidence weighting — a tie");
+
+        var weightedConfig = new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT, OPTIONS, 0.5, Map.of(), true,
+                TiePolicy.NO_DECISION);
+        var weighted = VoteTallyEngine.tally(entries, 2, OPTIONS, weightedConfig, "Vote");
+        assertEquals("Stay on MongoDB", weighted.decision().winner(), "0.9 beats 0.2 with confidence weighting on");
+    }
+
+    @Test
+    @DisplayName("quorum counts VALID ballots against everyone asked — abstentions and garbage count against it")
+    void tally_quorum() {
+        // 5 participants, only 2 valid ballots (one garbage reply) → 2/5 < 0.5.
+        var entries = List.of(
+                ballot("a1", "{\"vote\": \"Adopt PostgreSQL\"}"),
+                ballot("a2", "{\"vote\": \"Adopt PostgreSQL\"}"),
+                ballot("a3", "I abstain from voting on this and name no choice at all."));
+
+        var outcome = VoteTallyEngine.tally(entries, 5, OPTIONS, config(), "Vote");
+
+        assertFalse(outcome.quorumReached());
+        assertEquals(DecisionType.NONE, outcome.decision().type());
+        assertTrue(outcome.decision().outcome().contains("2 of 5"), outcome.decision().outcome());
+        assertEquals(OPTIONS.size(), outcome.unresolvedOptions().size(), "a tie policy may still decide among ALL options");
+    }
+
+    @Test
+    @DisplayName("losing-side statements become the decision's dissents; the tally carries the raw ballots")
+    void tally_dissentsAndAudit() {
+        var entries = List.of(
+                ballot("a1", "{\"vote\": \"Adopt PostgreSQL\", \"statement\": \"pgvector\"}"),
+                ballot("a2", "{\"vote\": \"Adopt PostgreSQL\"}"),
+                ballot("a3", "{\"vote\": \"Stay on MongoDB\", \"statement\": \"migration risk is real\"}"));
+
+        var outcome = VoteTallyEngine.tally(entries, 3, OPTIONS, config(), "Vote");
+
+        assertEquals("Adopt PostgreSQL", outcome.decision().winner());
+        assertEquals(1, outcome.decision().dissents().size());
+        assertEquals("migration risk is real", outcome.decision().dissents().get(0).position());
+        assertEquals(3, ((List<?>) outcome.decision().tally().get("ballots")).size(), "every raw ballot is auditable");
+        assertEquals(2.0, ((Map<?, ?>) outcome.decision().tally().get("totals")).get("Adopt PostgreSQL"));
+    }
+
+    // =================================================================
+    // tiebreak choice resolution
+    // =================================================================
+
+    @Test
+    @DisplayName("a tiebreaker's reply resolves by exact text, label, or single-option scan — ambiguity resolves nothing")
+    void resolveChoice() {
+        assertEquals("Adopt PostgreSQL", VoteTallyEngine.resolveChoice("Adopt PostgreSQL", OPTIONS));
+        assertEquals("Stay on MongoDB", VoteTallyEngine.resolveChoice("Option B", OPTIONS));
+        assertEquals("Adopt PostgreSQL", VoteTallyEngine.resolveChoice("I choose Adopt PostgreSQL for pgvector.", OPTIONS));
+        assertNull(VoteTallyEngine.resolveChoice("Both Adopt PostgreSQL and Stay on MongoDB have merit.", OPTIONS));
+        assertNull(VoteTallyEngine.resolveChoice(null, OPTIONS));
+    }
+}

--- a/src/test/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListenerTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListenerTest.java
@@ -493,4 +493,33 @@ class SlackGroupDiscussionListenerTest {
 
         verify(slackApi, times(1)).postMessage(any(), any(), any(), any());
     }
+
+    // ─── Vote tally block (I14) ───
+
+    @Test
+    void onDecisionReached_voteWithTally_postsTheTallyBlock() {
+        listener.onGroupStart(groupStart("ROUND_TABLE", 2));
+        var tally = Map.<String, Object>of(
+                "totals", Map.of("Ship it", 2.0, "Hold it", 1.0),
+                "validBallots", 3, "participants", 3);
+        var decision = new DecisionRecord(DecisionType.VOTE, "\"Ship it\" wins.", "Ship it", tally, List.of(),
+                "vote", "Ballot", null);
+
+        listener.onDecisionReached(new GroupConversationEventSink.DecisionReachedEvent(decision));
+
+        verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), isNull(), contains("Tally:"));
+        verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), isNull(), contains("Ship it — 2.0"));
+        verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), isNull(), contains("Ballots: 3 of 3"));
+    }
+
+    @Test
+    void onDecisionReached_voteWithMalformedTally_stillPostsWithoutThrowing() {
+        listener.onGroupStart(groupStart("ROUND_TABLE", 2));
+        var decision = new DecisionRecord(DecisionType.VOTE, "outcome", "X",
+                Map.of("totals", "not-a-map"), List.of(), "vote", "Ballot", null);
+
+        assertDoesNotThrow(() -> listener.onDecisionReached(new GroupConversationEventSink.DecisionReachedEvent(decision)));
+
+        verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), isNull(), contains("Winner: *X*"));
+    }
 }


### PR DESCRIPTION
Second Wave 2 queue item from `planning/group-collaboration-NEXT.md` §3 (design: plan §I14). A `VOTE` phase collects **explicit ballots**; the deliverable is the auditable process artifact — weighted tally, every raw ballot, losing-side dissents — because LLM ballots are correlated (shared priors, sycophancy) and the plan says so out loud.

## Design

- **Independence is engineered, not advised.** Save-time validation (`AgentGroupStore.validateVotePhases`) HARD-rejects a VOTE phase that is not `PARALLEL` + `contextScope: NONE`. Ballots are cast blind against the pre-fan-out snapshot, and `VOTE` transcript entries stay peer-hidden until their phase completes — F4's commit-reveal visibility matrix covered the new phase type the moment `mapPhaseToEntryType` mapped it (the new `PhaseType.VOTE` enum value flushed every exhaustive switch at compile time).
- **Ballot contract + three-tier parse** (`VoteTallyEngine`, mirroring `DebateVerdictParser`'s discipline incl. `FAIL_ON_TRAILING_TOKENS`): strict JSON → JSON embedded in prose/fence → a reply naming exactly ONE option's text. Out-of-contract votes are non-ballots, never write-ins; non-ballots and abstentions **count against quorum** — a mostly-silent team has not reached quorum, and that is signal. "Option B" label votes resolve positionally.
- **`VoteConfig`:** MAJORITY|APPROVAL, EXPLICIT options (the reliable path) or `LAST_SYNTHESIS` `Option A: …` extraction from the newest synthesis, quorum (default 0.5), per-agent weights, `weightByConfidence` (default off, correlated-self-report caveat in the Javadoc), `tiePolicy`.
- **Ties/quorum failures → tiePolicy:** `MODERATOR_DECIDES` runs one moderator turn under a separate `__vote_tiebreak` conversation key (the I2 judge's rule: contract prompts must not become the moderator's recent history), resolved by the same exact-scan rule as a ballot; `NO_DECISION` records an honest `type: NONE` and the discussion continues. **`HUMAN_DECIDES` is save-time rejected until I6 ships human members** — the queue sequences I14 before I6, and a silently-degrading enum value would be a lie (deviation recorded in the changelog; I6 wires it).
- **`decision_reached` finally fires** — the §4 gap folded in as the plan prescribed: producers for vote decisions AND I3 debate verdicts (fired after the dissent round so the event carries merged dissents). Slack renders a bounded, instanceof-guarded tally block.

## Tests

121 across the touched classes; full `engine.internal` suite green; checkstyle clean.

- Parse tiers: strict/embedded JSON, APPROVAL multi-select with duplicate collapse, label voting, exactly-one-option scan, **ambiguous-two-options refused**, out-of-contract refused.
- Tally: weighted majority; exact tie → unresolved (never a winner by list position); confidence weighting on/off flips a tie; quorum pinned to the "2 of 5" message with garbage counting against it; dissents from losing statements; raw ballots in the tally for audit.
- Save-time validation matrix (PARALLEL, NONE, EXPLICIT <2 options, negative weights, HUMAN_DECIDES).
- Service E2E: majority vote records the decision and fires `decision_reached` with the winner; tie + MODERATOR_DECIDES resolves via one tiebreak turn (`vote+moderator-tiebreak`); tie + NO_DECISION does not fail the discussion; ballots land as VOTE entries.
- Slack: tally block, malformed-tally no-throw.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable `VOTE` discussion phases with majority or approval voting.
  - Supports explicit or synthesis-derived options, quorum requirements, weighted and confidence-based ballots, dissents, and tie policies.
  - Records vote decisions and emits decision-reached events.
  - Displays vote tallies and participation counts in Slack.
- **Bug Fixes**
  - Added validation for unsupported or invalid vote configurations and ballots.
- **Documentation**
  - Documented vote phases, ballot formats, quorum behavior, tie handling, and tally rendering.
- **Tests**
  - Added coverage for voting, validation, tallying, events, and Slack output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->