### PR TITLE
feat(groups): I8 — retro phases harvest team-owned group memory

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 🧠 feat(groups): I8 — retro phases harvest team-owned group memory (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i8-retro-memory`)
+
+Third Wave 2 queue item, and the substrate I13 (Standing Teams) builds on. Discussions stop evaporating: a `RETRO` phase's lessons persist and surface as `{properties.*}` in every member's later discussions.
+
+- **`PhaseType.RETRO`** + built-in template (full-transcript review, JSON lessons contract) + `RetroConfig {maxLessonsPerRun=3, maxStoredLessons=50}`. The template *quotes* the default per-run cap; `RetroEngine` *enforces* the configured one at parse time regardless — the context builder deliberately does not receive the group config.
+- **Storage exactly as the plan resolved (V2):** `IUserMemoryStore.upsert` under the synthetic team owner `"group:"+groupId` with `group` visibility. New `TEAM_OWNER_PREFIX` contract constant; lessons belong to the team, not the human who ran the discussion, and survive that human's GDPR erasure without carrying their identity.
+- **The additive synthetic-team-owner recall branch, on BOTH backends:** Mongo's `buildVisibilityFilter` and Postgres's `buildVisibilityQuery` (+ its bind order) now OR in a narrow team scope — owner ids DERIVED from the supplied group ids (never caller-supplied), `group` visibility, group-id overlap. The user's own scope is untouched, per the plan's "do not widen the existing user-scoped group branch". Both made package-private static so the filter/SQL shapes are directly assertable — and both are pinned side by side so the backends cannot drift.
+- **Idempotency + bounded growth:** key `retro:<sha256(lesson)[0..16]>` with a FIXED `sourceAgentId` ("retro") — the upsert identity for group entries is `(userId, key, sourceAgentId)`, so a real speaker id would have made the same lesson from two speakers two rows. FIFO eviction past `maxStoredLessons` via the newest-first recall (everything past the cap is the oldest); `RetroEngine` is the ONLY reaper — `UserMemoryTool`'s eviction only ever touches the calling agent's `self` entries.
+- **Wiring:** discussion-loop harvest on the RETRO phase's last repeat, before the persist (a crash must not lose lessons a stored document claims were taken); `IUserMemoryStore` reaches the facade by the established null-safe field-injection pattern. New `retro_recorded` event (constant + record + listener default + SSE forward) — fires even at zero lessons stored, which is itself signal.
+
+**Tests (11 new, all green; `engine.internal` + `configs.properties` suites 1572 green; checkstyle clean):** parse tiers (strict/fenced/prose-refused); per-run cap enforced past what the model was told; idempotent team-owned upsert against a REAL in-memory store with the production upsert identity (a mocked idempotency claim would prove nothing); FIFO evicts the oldest and never the newest; `retro_recorded` carries the stored count; null store and failing store never fail the discussion; Mongo filter shape (no-groups → user scope only; with-groups → derived `group:` owners paired with group visibility; no foreign human id reachable); Postgres SQL shape incl. the `??|` escape arithmetic pinning the bind order.
+
+**Files:** `AgentGroupConfiguration` (RETRO + RetroConfig), `DiscussionStylePresets` (TEMPLATE_RETRO), `GroupContextBuilder` (RETRO branch + entry mapping), `RetroEngine` (new), `GroupConversationService` (wiring + store injection), `IUserMemoryStore` (TEAM_OWNER_PREFIX + contract Javadoc), `MongoUserMemoryStore`, `PostgresUserMemoryStore`, `GroupConversationEventSink`/listener/SSE, `docs/group-conversations.md`, 3 test classes.
+
+---
+
 ## 🔀 merge: bring `origin/main` (PR #627 HITL request pinning) into the branch (2026-08-07)
 
 **Repo:** EDDI (`refactor/group-service-split`, PR [#626](https://github.com/labsai/EDDI/pull/626))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 🔎 fix(groups): I8 PR #639 CI round 1 + plan-mandated test extension (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i8-retro-memory`)
+
+Follow-ups on the open PR (commits `8025962c6`, `c2b4b7a79`, `3de3de69e`):
+
+- **CI failures**: `AgentGroupConfigurationTest.phaseType_allValues` pins the enum size (RETRO is this branch's 12th value — same pin fixed for VOTE on the I14 branch), and `PostgresUserMemoryStoreUnitTest.getVisibleEntries_withGroupIds_includesGroupClause` pinned the pre-I8 bind order — now asserts all nine parameters incl. the derived `group:` owners. The third failing check (ClusterFuzzLite) was a transient gcr.io 403 pulling the fuzz image — it passed on the sibling PRs minutes later.
+- **CodeQL**: the four flagged RetroEngine log sinks sanitized (conversation id, phase name, team owner, exception message).
+- **Plan-mandated tests** the first commit missed (`UserMemoryToolScopingTest` extension, named explicitly in the I8 plan item): eviction can never delete a team-owned lesson even with the store wall deliberately breached (the fixed `"retro"` sourceAgentId is a second independent wall), and personal `visibility:self` entries never cross users through a shared group.
+
+---
+
 ## 🧠 feat(groups): I8 — retro phases harvest team-owned group memory (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i8-retro-memory`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 🔎 fix(groups): I8 review round 3 — retro ceilings + creation-ordered FIFO (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i8-retro-memory`)
+
+Two accepted CodeRabbit findings, one rebutted:
+
+1. **RetroConfig ceilings (major)** — the compact ctor accepted any positive int, so `Integer.MAX_VALUE` unbounded the per-run write count and the retained-lesson set. Hard ceilings: `CEILING_MAX_PER_RUN` 20, `CEILING_MAX_STORED` 500 (clamped, not rejected — same normalization style as the rest of the record).
+2. **FIFO vs reharvest (major)** — eviction used the `most_recent` recall order (sorted by `updatedAt`); reharvesting an existing lesson refreshes `updatedAt`, so an old-but-reharvested lesson could shield itself while a later-CREATED lesson got evicted. Eviction now sorts by `createdAt` (which the store `setOnInsert`s — the stable insertion stamp), nulls oldest-first. Regression test reharvests an old lesson before exceeding the cap and asserts the oldest-created is the one evicted.
+3. **Rebutted: RETRO entries lost on mid-repeat HITL resume** — on this branch nothing ever creates a speaker-level `ResumePoint` (producers are I6 human turns and I12 escalations, on other branches), so a RETRO phase cannot resume mid-repeat here. On the integration branch, where producers exist, the I6 `pausedRepeatSliceBase` fix restores the true repeat base at top-of-repeat before `repeatEntries` is sliced — the RETRO harvest reads that same slice, so pre-pause lessons are preserved (pinned by the HumanPauseRepeatSlice tests).
+
+---
+
 ## 🔎 fix(groups): I8 review round 2 — retro cap semantics + event contract (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i8-retro-memory`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 🔎 fix(groups): I8 review round 2 — retro cap semantics + event contract (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i8-retro-memory`)
+
+Four accepted findings from the CodeRabbit round on the stacked PR (#644, which carries this branch):
+
+1. **Template quoted the wrong cap (major)** — the RETRO prompt always rendered `DEFAULT_MAX_PER_RUN` (3), so a group configured above it could never obtain its configured number of lessons. `buildPhaseInput` gained a `RetroConfig` parameter (config-less overloads keep the default); all three agent-turn call sites in `PhaseExecutionEngine` pass `config.getRetroConfig()`. RetroEngine's parse-time enforcement is unchanged and remains the server-side limit.
+2. **Per-entry cap multiplied (major)** — `harvest` applied `maxLessonsPerRun` to each RETRO transcript entry, so a multi-speaker or multi-repeat retro could store `cap × entries`. Now a per-harvest `remaining` allowance shared across entries.
+3. **Missing zero-count event (minor)** — the null-memory-store branch returned before `retro_recorded`; it now fires the event with `lessonsStored = 0`, honoring the contract that a RETRO phase always emits it.
+4. **Fixture didn't cross users (minor)** — `personalEntriesNeverCrossUsers` built its "other user's" entry with the shared helper that stamps USER; it now genuinely belongs to `user-2`.
+
+Tests: RetroEngineTest 8 (+2: per-harvest cap, null-store zero event), GroupContextBuilderTest 41 (+1: configured cap quoted, default fallback), PhaseExecutionEngineTest stub widened to the new arity. All green.
+
+---
+
 ## 🔎 fix(groups): I8 PR #639 CI round 1 + plan-mandated test extension (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i8-retro-memory`)

--- a/docs/group-conversations.md
+++ b/docs/group-conversations.md
@@ -160,6 +160,31 @@ Both caps are enforced independently: `maxPerTurn` bounds a runaway single turn,
 discussion cap counts only agent-filed tasks, so a large planned backlog does not
 exhaust it. A rejected call does not consume the per-turn budget.
 
+## Retro → group memory
+
+A `RETRO` phase stops discussions from evaporating: the group reviews how it
+worked and distills lessons that persist as **team-owned group memory**, then
+surface as `{properties.*}` in every member's later discussions — institutional
+knowledge that compounds run-over-run.
+
+```json
+{ "name": "Retro", "type": "RETRO", "participants": "MODERATOR" },
+"retroConfig": { "maxLessonsPerRun": 3, "maxStoredLessons": 50 }
+```
+
+- The built-in template asks for `{"lessons": [{"lesson": "...", "context":
+  "..."}]}`; parsing is three-tier (strict JSON → embedded JSON → nothing) and
+  the per-run cap is enforced at parse time whatever the model produced.
+- Lessons are stored under the synthetic owner `group:<groupId>` with `group`
+  visibility — they belong to the team, not to whichever human ran the
+  discussion, and survive that human's GDPR erasure without carrying their
+  identity. The idempotency key `retro:<hash(lesson)>` makes re-running the
+  same retro a no-op.
+- **Bounded growth is non-negotiable:** the stored set FIFOs at
+  `maxStoredLessons` — storing past the cap evicts the oldest.
+- Member conversations already load group-visible entries at init, so recall
+  needs no new namespace. The `retro_recorded` SSE event reports each harvest.
+
 ## Nested Groups (Group-of-Groups)
 
 Members can be other groups. The sub-group runs its own discussion and its synthesized answer becomes the member's response.

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -92,6 +92,54 @@ public class AgentGroupConfiguration {
     }
 
     /**
+     * Bounds for RETRO lessons (I8). {@code null} runs a RETRO phase with the
+     * defaults — the caps are non-negotiable either way (bounded growth for an LLM
+     * write surface).
+     */
+    private RetroConfig retroConfig;
+
+    public RetroConfig getRetroConfig() {
+        return retroConfig;
+    }
+
+    public void setRetroConfig(RetroConfig retroConfig) {
+        this.retroConfig = retroConfig;
+    }
+
+    /**
+     * Bounds for the RETRO lesson pipeline (I8).
+     *
+     * @param maxLessonsPerRun
+     *            how many lessons one retro turn may store (default 3) — the
+     *            template quotes this cap to the model, and the parser truncates
+     *            past it regardless
+     * @param maxStoredLessons
+     *            FIFO ceiling on the team's stored lessons (default 50): storing
+     *            the 51st evicts the oldest. Bounded growth is non-negotiable —
+     *            non-positive values fall back to the defaults
+     */
+    public record RetroConfig(int maxLessonsPerRun, int maxStoredLessons) {
+
+        public static final int DEFAULT_MAX_PER_RUN = 3;
+        public static final int DEFAULT_MAX_STORED = 50;
+
+        /** Same normalization choke point as {@link GroupTaskConfig}. */
+        public RetroConfig {
+            if (maxLessonsPerRun <= 0) {
+                maxLessonsPerRun = DEFAULT_MAX_PER_RUN;
+            }
+            if (maxStoredLessons <= 0) {
+                maxStoredLessons = DEFAULT_MAX_STORED;
+            }
+        }
+
+        /** Both caps at their defaults. */
+        public RetroConfig() {
+            this(DEFAULT_MAX_PER_RUN, DEFAULT_MAX_STORED);
+        }
+    }
+
+    /**
      * Governs agent-filed tasks (I5). The task list is otherwise written only by
      * the PLAN phase and by config, so work an agent <em>discovers</em> while
      * executing — a missing migration, an untested edge case — dies in prose. The
@@ -323,7 +371,15 @@ public class AgentGroupConfiguration {
         /** Task execution by assigned agents. */
         EXECUTE,
         /** Verification of task results. */
-        VERIFY
+        VERIFY,
+        /**
+         * Post-discussion retrospective (I8): what worked, what failed, what to do
+         * differently. Parsed lessons land in team-owned group memory (synthetic owner
+         * {@code "group:"+groupId}) so they surface as {@code {properties.*}} in every
+         * member's later discussions — institutional knowledge that compounds
+         * run-over-run.
+         */
+        RETRO
     }
 
     public enum TurnOrder {

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -122,6 +122,15 @@ public class AgentGroupConfiguration {
 
         public static final int DEFAULT_MAX_PER_RUN = 3;
         public static final int DEFAULT_MAX_STORED = 50;
+        /**
+         * Hard ceilings (review finding): the compact constructor accepted any positive
+         * int, so a config carrying {@code Integer.MAX_VALUE} made the per-run write
+         * count and the retained-lesson count effectively unbounded — exactly the
+         * bounded-growth guarantee this record exists to enforce on an LLM-driven write
+         * surface.
+         */
+        public static final int CEILING_MAX_PER_RUN = 20;
+        public static final int CEILING_MAX_STORED = 500;
 
         /** Same normalization choke point as {@link GroupTaskConfig}. */
         public RetroConfig {
@@ -131,6 +140,8 @@ public class AgentGroupConfiguration {
             if (maxStoredLessons <= 0) {
                 maxStoredLessons = DEFAULT_MAX_STORED;
             }
+            maxLessonsPerRun = Math.min(maxLessonsPerRun, CEILING_MAX_PER_RUN);
+            maxStoredLessons = Math.min(maxStoredLessons, CEILING_MAX_STORED);
         }
 
         /** Both caps at their defaults. */

--- a/src/main/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresets.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresets.java
@@ -272,6 +272,28 @@ public final class DiscussionStylePresets {
             ]
             ```""";
 
+    /**
+     * The retrospective prompt (I8). The JSON contract line is what
+     * {@code RetroEngine}'s three-tier parse reads; the cap is quoted to the model
+     * AND enforced by the parser regardless.
+     */
+    public static final String TEMPLATE_RETRO = """
+            The discussion on the question below has concluded:
+            "{question}"
+
+            Full transcript:
+            {#for entry in transcript}
+            [{entry.phaseName}] {entry.speaker}: "{entry.content}"
+            {/for}
+
+            Review how this group worked. What worked, what failed, and what should
+            this group do differently next time? Distill LESSONS the group should
+            remember for future discussions — durable, actionable, not a summary of
+            this question's answer.
+
+            Respond with ONLY this JSON, no other text (max {maxLessonsPerRun} lessons):
+            {"lessons": [{"lesson": "<one sentence the group should remember>", "context": "<when it applies>"}]}""";
+
     // Template lookup by phase type
     private static final Map<PhaseType, String> DEFAULT_TEMPLATES = Map.ofEntries(
             Map.entry(PhaseType.OPINION, TEMPLATE_OPINION_INDEPENDENT),
@@ -284,7 +306,8 @@ public final class DiscussionStylePresets {
             Map.entry(PhaseType.SYNTHESIS, TEMPLATE_SYNTHESIS),
             Map.entry(PhaseType.PLAN, TEMPLATE_PLAN),
             Map.entry(PhaseType.EXECUTE, TEMPLATE_EXECUTE),
-            Map.entry(PhaseType.VERIFY, TEMPLATE_VERIFY));
+            Map.entry(PhaseType.VERIFY, TEMPLATE_VERIFY),
+            Map.entry(PhaseType.RETRO, TEMPLATE_RETRO));
 
     /**
      * Returns the default template for a given phase type.

--- a/src/main/java/ai/labs/eddi/configs/properties/IUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/IUserMemoryStore.java
@@ -116,8 +116,13 @@ public interface IUserMemoryStore {
     // === Queries ===
 
     /**
-     * Returns entries visible to the given agent in the given groups. Combines:
-     * self(agentId) + group(groupIds) + global.
+     * Returns entries visible to the given agent in the given groups. Combines the
+     * user's own scope — self(agentId) + group(groupIds) + global — with,
+     * additively, TEAM-OWNED entries (I8): lessons stored under the synthetic owner
+     * {@link #TEAM_OWNER_PREFIX}{@code +groupId} with {@code group} visibility, for
+     * each supplied group. The team branch never widens the user's own scope — a
+     * personal entry of another human user is unreachable through it, because team
+     * owner ids are derived from the supplied group ids, not caller-supplied.
      *
      * @param recallOrder
      *            "most_recent" (updatedAt DESC) or "most_accessed" (accessCount
@@ -127,6 +132,14 @@ public interface IUserMemoryStore {
      */
     List<UserMemoryEntry> getVisibleEntries(String userId, String agentId, List<String> groupIds, String recallOrder, int maxEntries)
             throws IResourceStore.ResourceStoreException;
+
+    /**
+     * Owner prefix for TEAM-OWNED memory (I8): a group's retro lessons are stored
+     * under the synthetic user {@code "group:"+groupId} so they belong to the team,
+     * not to whichever human happened to run the discussion — and survive that
+     * human's GDPR erasure without carrying their identity.
+     */
+    String TEAM_OWNER_PREFIX = "group:";
 
     /**
      * Text filter across keys and values (v1: regex, v2: semantic search).

--- a/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
@@ -230,9 +230,18 @@ public class MongoUserMemoryStore implements IUserMemoryStore {
     }
 
     /**
-     * Visibility filter for a recall: self(agentId) OR group(groupIds) OR global.
+     * Visibility filter for a recall: the user's own scope — self(agentId) OR
+     * group(groupIds) OR global, always constrained to the user's own entries —
+     * plus, additively, the TEAM-OWNED scope (I8): entries whose owner is the
+     * synthetic {@code "group:"+groupId} user with {@code group} visibility.
+     * Package-private static so the filter's shape is directly assertable.
+     * <p>
+     * The team branch is deliberately narrow: it matches ONLY synthetic team owners
+     * derived from the supplied group ids, with group visibility, with a group-id
+     * overlap — never another human user's entries. The user's own branch is
+     * untouched, so personal recall behaves exactly as before.
      */
-    private Bson buildVisibilityFilter(String userId, String agentId, List<String> groupIds) {
+    static Bson buildVisibilityFilter(String userId, String agentId, List<String> groupIds) {
         List<Bson> visibilityFilters = new ArrayList<>();
 
         // Self: entries created by this agent for this user
@@ -246,7 +255,18 @@ public class MongoUserMemoryStore implements IUserMemoryStore {
         // Global: all global entries for this user
         visibilityFilters.add(eq(FIELD_VISIBILITY, Visibility.global.name()));
 
-        return and(eq(FIELD_USER_ID, userId), or(visibilityFilters));
+        Bson userScope = and(eq(FIELD_USER_ID, userId), or(visibilityFilters));
+        if (groupIds == null || groupIds.isEmpty()) {
+            return userScope;
+        }
+
+        // I8: team-owned lessons. Owner ids are DERIVED from the supplied group
+        // ids, never caller-supplied strings — a caller cannot name an arbitrary
+        // owner this way.
+        List<String> teamOwners = groupIds.stream().map(gid -> IUserMemoryStore.TEAM_OWNER_PREFIX + gid).toList();
+        Bson teamScope = and(in(FIELD_USER_ID, teamOwners), eq(FIELD_VISIBILITY, Visibility.group.name()),
+                in(FIELD_GROUP_IDS, groupIds));
+        return or(userScope, teamScope);
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
@@ -74,7 +74,7 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
      * optional group clause, the closing parenthesis, an ORDER BY and a LIMIT.
      */
     private static final String VISIBILITY_SELECT = """
-            SELECT * FROM usermemories WHERE user_id = ? AND (
+            SELECT * FROM usermemories WHERE ((user_id = ? AND (
                 (visibility = 'self' AND source_agent_id = ?)
                 OR (visibility = 'global')
             """;
@@ -314,22 +314,46 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
     }
 
     /**
-     * Visibility filter for a recall: self(agentId) OR group(groupIds) OR global.
+     * Visibility filter for a recall: the user's own scope — self(agentId) OR
+     * group(groupIds) OR global — plus, additively, the TEAM-OWNED scope (I8):
+     * entries whose owner is the synthetic {@code "group:"+groupId} user with
+     * {@code group} visibility. Mirrors the Mongo store's
+     * {@code buildVisibilityFilter} exactly; the two must not drift.
+     * Package-private static so the SQL shape is directly assertable.
+     * <p>
      * The {@code ??|} is the JDBC escape for PostgreSQL's {@code ?|} JSONB overlap
-     * operator — a single {@code ?} would be parsed as a bind parameter.
+     * operator — a single {@code ?} would be parsed as a bind parameter. Bind order
+     * (see {@code collectInto}): userId, agentId, then — only when groups are
+     * supplied — the group ids (user scope), the derived team owner ids, and the
+     * group ids again (team overlap).
      */
-    private String buildVisibilityQuery(List<String> groupIds) {
+    static String buildVisibilityQuery(List<String> groupIds) {
         StringBuilder sql = new StringBuilder(VISIBILITY_SELECT);
-        if (groupIds != null && !groupIds.isEmpty()) {
+        boolean hasGroups = groupIds != null && !groupIds.isEmpty();
+        if (hasGroups) {
             // `??|` is pgjdbc's escape for the jsonb `?|` overlap operator — a bare `?`
             // would be parsed by the driver as a bind placeholder.
             sql.append(" OR (visibility = 'group' AND group_ids ??| ARRAY[");
-            for (int i = 0; i < groupIds.size(); i++) {
-                sql.append(i > 0 ? ",?" : "?");
-            }
+            appendPlaceholders(sql, groupIds.size());
+            sql.append("])");
+        }
+        sql.append("))");
+        if (hasGroups) {
+            // I8: team-owned lessons. Owner ids are DERIVED from the supplied
+            // group ids at bind time, never caller-supplied strings.
+            sql.append(" OR (visibility = 'group' AND user_id IN (");
+            appendPlaceholders(sql, groupIds.size());
+            sql.append(") AND group_ids ??| ARRAY[");
+            appendPlaceholders(sql, groupIds.size());
             sql.append("])");
         }
         return sql.append(")").toString();
+    }
+
+    private static void appendPlaceholders(StringBuilder sql, int count) {
+        for (int i = 0; i < count; i++) {
+            sql.append(i > 0 ? ",?" : "?");
+        }
     }
 
     /**
@@ -397,7 +421,16 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
             int paramIndex = 1;
             ps.setString(paramIndex++, userId);
             ps.setString(paramIndex++, agentId);
-            if (groupIds != null) {
+            if (groupIds != null && !groupIds.isEmpty()) {
+                // Bind order must mirror buildVisibilityQuery exactly: the user
+                // scope's group overlap, then the derived team owners (I8), then
+                // the team scope's group overlap.
+                for (String gid : groupIds) {
+                    ps.setString(paramIndex++, gid);
+                }
+                for (String gid : groupIds) {
+                    ps.setString(paramIndex++, IUserMemoryStore.TEAM_OWNER_PREFIX + gid);
+                }
                 for (String gid : groupIds) {
                     ps.setString(paramIndex++, gid);
                 }

--- a/src/main/java/ai/labs/eddi/engine/api/IGroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IGroupConversationService.java
@@ -210,6 +210,8 @@ public interface IGroupConversationService {
         }
         default void onConvergenceReached(GroupConversationEventSink.ConvergenceReachedEvent event) {
         }
+        default void onRetroRecorded(GroupConversationEventSink.RetroRecordedEvent event) {
+        }
     }
 
     // --- Exceptions ---

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -37,8 +37,10 @@ import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.internal.groups.DebateVerdictParser;
 import ai.labs.eddi.engine.internal.groups.GroupAttachmentBinder;
+import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.engine.internal.groups.GroupContextBuilder;
 import ai.labs.eddi.engine.internal.groups.GroupHitlCoordinator;
+import ai.labs.eddi.engine.internal.groups.RetroEngine;
 import ai.labs.eddi.engine.internal.groups.LiveDiscussionRegistry;
 import ai.labs.eddi.engine.internal.groups.GroupLifecycleOps;
 import ai.labs.eddi.engine.internal.groups.GroupSigningGuard;
@@ -207,6 +209,14 @@ public class GroupConversationService implements IGroupConversationService {
      */
     @Inject
     LiveDiscussionRegistry liveDiscussionRegistry;
+
+    /**
+     * I8's lesson store. Same field-injection pattern and null-safety as
+     * {@link #attachmentStore} — {@code null} in direct-construction unit tests,
+     * where a RETRO phase runs but persists nothing (warned, never failed).
+     */
+    @Inject
+    IUserMemoryStore userMemoryStore;
 
     // In-node fast-fail guard for concurrent post-discussion operations
     // (follow-up, continue, close) on the same conversation: a second
@@ -848,6 +858,14 @@ public class GroupConversationService implements IGroupConversationService {
                             phaseExecutionEngine.runDissentRound(gc, config, phase, protocol, phaseIdx, speakers, listener,
                                     turnCounter, maxTurns);
                         }
+                    }
+
+                    // I8: a completed RETRO phase harvests its lessons into
+                    // team-owned group memory. Last repeat only — a draft retro is
+                    // not the retrospective — and BEFORE the persist below, so a
+                    // crash cannot lose lessons a stored document claims were taken.
+                    if (phase.type() == PhaseType.RETRO && lastRepeat) {
+                        RetroEngine.harvest(gc, config.getRetroConfig(), repeatEntries, userMemoryStore, phase.name(), listener);
                     }
 
                     gc.setLastModified(Instant.now());

--- a/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
@@ -875,6 +875,12 @@ public class RestGroupConversation implements IRestGroupConversation {
                 // debate verdict before a later synthesis phase).
                 sendEvent(eventSink, sse, GroupConversationEventSink.EVENT_DECISION_REACHED, toJson(event));
             }
+
+            @Override
+            public void onRetroRecorded(GroupConversationEventSink.RetroRecordedEvent event) {
+                // Not terminal — a retro can precede further phases.
+                sendEvent(eventSink, sse, GroupConversationEventSink.EVENT_RETRO_RECORDED, toJson(event));
+            }
         };
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
@@ -64,6 +64,20 @@ public class GroupContextBuilder {
      */
     public String buildPhaseInput(DiscussionPhase phase, GroupMember speaker, String question, List<TranscriptEntry> transcript, int phaseIdx,
                                   GroupMember target, List<GroupMember> allMembers) {
+        return buildPhaseInput(phase, speaker, question, transcript, phaseIdx, target, allMembers, null);
+    }
+
+    /**
+     * @param retroConfig
+     *            the group's RETRO settings; only the {@code RETRO} case reads it
+     *            (the template quotes {@code maxLessonsPerRun} to the model).
+     *            {@code null} falls back to the default cap — review finding: the
+     *            template always quoted the DEFAULT, so a group configured above it
+     *            could never obtain its configured number of lessons.
+     */
+    public String buildPhaseInput(DiscussionPhase phase, GroupMember speaker, String question, List<TranscriptEntry> transcript, int phaseIdx,
+                                  GroupMember target, List<GroupMember> allMembers,
+                                  AgentGroupConfiguration.RetroConfig retroConfig) {
 
         String template = phase.inputTemplate() != null
                 ? phase.inputTemplate()
@@ -201,11 +215,12 @@ public class GroupContextBuilder {
                             return t;
                         }).collect(Collectors.toList());
                 data.put("transcript", fullTranscript);
-                // The template QUOTES the default cap; RetroEngine ENFORCES the
-                // configured one at parse time regardless of what the model was
-                // told. Quoting the default keeps this builder free of the group
-                // config (which it deliberately does not receive).
-                data.put("maxLessonsPerRun", AgentGroupConfiguration.RetroConfig.DEFAULT_MAX_PER_RUN);
+                // The template QUOTES the configured cap so the model is asked for
+                // exactly what the group wants; RetroEngine still ENFORCES it at
+                // parse time regardless of what the model returns.
+                data.put("maxLessonsPerRun", retroConfig != null
+                        ? retroConfig.maxLessonsPerRun()
+                        : AgentGroupConfiguration.RetroConfig.DEFAULT_MAX_PER_RUN);
             }
             default -> {
                 // All PhaseType values handled above; default required by checkstyle

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal.groups;
 
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
@@ -184,6 +185,27 @@ public class GroupContextBuilder {
             }
             case VERIFY -> {
                 // Completed tasks populated by executeTaskPhase
+            }
+            case RETRO -> {
+                // I8: the retro reviews the whole discussion — same full-picture
+                // filter as SYNTHESIS (a retrospective on a windowed excerpt would
+                // draw lessons from an excerpt).
+                List<Map<String, Object>> fullTranscript = transcript.stream()
+                        .filter(e -> e.content() != null && e.type() != TranscriptEntryType.ERROR && e.type() != TranscriptEntryType.SKIPPED
+                                && e.type() != TranscriptEntryType.QUESTION)
+                        .map(e -> {
+                            Map<String, Object> t = new LinkedHashMap<>();
+                            t.put("speaker", e.speakerDisplayName());
+                            t.put("content", e.content());
+                            t.put("phaseName", e.phaseName() != null ? e.phaseName() : "");
+                            return t;
+                        }).collect(Collectors.toList());
+                data.put("transcript", fullTranscript);
+                // The template QUOTES the default cap; RetroEngine ENFORCES the
+                // configured one at parse time regardless of what the model was
+                // told. Quoting the default keeps this builder free of the group
+                // config (which it deliberately does not receive).
+                data.put("maxLessonsPerRun", AgentGroupConfiguration.RetroConfig.DEFAULT_MAX_PER_RUN);
             }
             default -> {
                 // All PhaseType values handled above; default required by checkstyle
@@ -370,6 +392,8 @@ public class GroupContextBuilder {
             case PLAN -> TranscriptEntryType.PLAN;
             case EXECUTE -> TranscriptEntryType.TASK_RESULT;
             case VERIFY -> TranscriptEntryType.VERIFICATION;
+            // I8: retro contributions are public RETRO entries (F4 default).
+            case RETRO -> TranscriptEntryType.RETRO;
         };
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
@@ -511,7 +511,7 @@ public class PhaseExecutionEngine {
                         new GroupConversationEventSink.SpeakerStartEvent(speaker.agentId(), speaker.displayName(), phaseIdx, phase.name()));
             }
             String input = contextBuilder.buildPhaseInput(phase, speaker, question, gc.getTranscript(), phaseIdx, null,
-                    GroupConversationService.rosterWithRecruits(config, gc));
+                    GroupConversationService.rosterWithRecruits(config, gc), config.getRetroConfig());
             TranscriptEntry entry = memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, null, listener);
             gc.getTranscript().add(entry);
             if (listener != null) {
@@ -586,7 +586,7 @@ public class PhaseExecutionEngine {
                 .map(speaker -> CompletableFuture.supplyAsync(callerIdentityContext.withIdentitySupplying(phaseCaller, () -> {
                     try {
                         String input = contextBuilder.buildPhaseInput(phase, speaker, question, snapshotTranscript, phaseIdx, null,
-                                GroupConversationService.rosterWithRecruits(config, gc));
+                                GroupConversationService.rosterWithRecruits(config, gc), config.getRetroConfig());
                         return memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, null, listener, cancellation);
                     } catch (MemberTurnCancelledException e) {
                         // The orchestrator stopped waiting for this batch — surface the
@@ -715,7 +715,7 @@ public class PhaseExecutionEngine {
                             new GroupConversationEventSink.SpeakerStartEvent(speaker.agentId(), speaker.displayName(), phaseIdx, phase.name()));
                 }
                 String input = contextBuilder.buildPhaseInput(phase, speaker, question, gc.getTranscript(), phaseIdx, target,
-                        GroupConversationService.rosterWithRecruits(config, gc));
+                        GroupConversationService.rosterWithRecruits(config, gc), config.getRetroConfig());
                 TranscriptEntry entry = memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, target.agentId(),
                         listener);
                 gc.getTranscript().add(entry);

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.RetroConfig;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import ai.labs.eddi.configs.properties.IUserMemoryStore;
+import ai.labs.eddi.configs.properties.model.Property.Visibility;
+import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
+import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
+import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.jboss.logging.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Turns a RETRO phase's contributions into team-owned group memory (I8).
+ * <p>
+ * Every discussion otherwise evaporates: nothing a group learns about its own
+ * process survives the transcript. Parsed lessons are upserted into
+ * {@link IUserMemoryStore} under the synthetic team owner
+ * ({@code "group:"+groupId}, {@code group} visibility), which member
+ * conversations already load at init — so lessons surface as
+ * {@code {properties.*}} in every later discussion with no new namespace.
+ * <p>
+ * Bounded growth is non-negotiable: per-turn lessons cap at
+ * {@code maxLessonsPerRun} (enforced here, whatever the model was told), the
+ * stored set FIFOs at {@code maxStoredLessons}, and the idempotency key
+ * {@code retro:<hash(lesson)>} with a fixed source agent makes re-running the
+ * same retro a no-op rather than a duplicate.
+ * <p>
+ * Every failure is warn-and-continue — a lesson that fails to store must never
+ * fail the discussion that produced it.
+ *
+ * @author ginccc
+ */
+public final class RetroEngine {
+
+    private static final Logger LOGGER = Logger.getLogger(RetroEngine.class);
+
+    /**
+     * Fixed {@code sourceAgentId} for every lesson. The upsert identity for
+     * group-visible entries is {@code (userId, key, sourceAgentId)} — a real
+     * speaker id there would make the same lesson from two speakers two rows,
+     * defeating the idempotency key.
+     */
+    static final String RETRO_SOURCE = "retro";
+
+    /** Idempotency-key prefix: {@code retro:<sha256(lesson)[0..15]>}. */
+    static final String KEY_PREFIX = "retro:";
+
+    private static final ObjectMapper MAPPER = JsonMapper.builder()
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .build();
+
+    private RetroEngine() {
+    }
+
+    /** One parsed lesson. */
+    public record Lesson(String lesson, String context) {
+    }
+
+    /**
+     * Three-tier parse of one retro contribution: strict JSON → JSON embedded in
+     * prose/fence → give up (empty). Truncated at {@code maxLessonsPerRun}
+     * regardless of what the model produced.
+     */
+    static List<Lesson> parseLessons(String content, int maxLessonsPerRun) {
+        if (content == null || content.isBlank()) {
+            return List.of();
+        }
+        JsonNode node = readJson(content);
+        if (node == null) {
+            node = readJson(embeddedJson(content));
+        }
+        if (node == null || !node.path("lessons").isArray()) {
+            return List.of();
+        }
+        List<Lesson> lessons = new ArrayList<>();
+        for (JsonNode lessonNode : node.path("lessons")) {
+            String lesson = lessonNode.path("lesson").isTextual() ? lessonNode.path("lesson").asText().trim() : null;
+            if (lesson == null || lesson.isBlank()) {
+                continue;
+            }
+            String context = lessonNode.path("context").isTextual() ? lessonNode.path("context").asText().trim() : null;
+            lessons.add(new Lesson(lesson, context != null && !context.isBlank() ? context : null));
+            if (lessons.size() >= maxLessonsPerRun) {
+                break;
+            }
+        }
+        return lessons;
+    }
+
+    /**
+     * Harvests a completed RETRO phase: parses each RETRO entry, upserts the
+     * lessons team-owned, FIFO-evicts past the stored cap, and fires
+     * {@code retro_recorded}.
+     */
+    public static void harvest(GroupConversation gc, RetroConfig retroConfig, List<TranscriptEntry> repeatEntries,
+                               IUserMemoryStore userMemoryStore, String phaseName, GroupDiscussionEventListener listener) {
+        if (userMemoryStore == null) {
+            LOGGER.warnf("Group %s: RETRO phase '%s' ran but no user memory store is available — lessons are not persisted",
+                    gc.getId(), phaseName);
+            return;
+        }
+        RetroConfig config = retroConfig != null ? retroConfig : new RetroConfig();
+        String teamOwner = IUserMemoryStore.TEAM_OWNER_PREFIX + gc.getGroupId();
+
+        int stored = 0;
+        for (TranscriptEntry entry : repeatEntries) {
+            if (entry == null || entry.type() != TranscriptEntryType.RETRO) {
+                continue;
+            }
+            for (Lesson lesson : parseLessons(entry.content(), config.maxLessonsPerRun())) {
+                try {
+                    String value = lesson.context() != null ? lesson.lesson() + " (applies: " + lesson.context() + ")" : lesson.lesson();
+                    userMemoryStore.upsert(new UserMemoryEntry(null, teamOwner, KEY_PREFIX + lessonHash(lesson.lesson()), value,
+                            "context", Visibility.group, RETRO_SOURCE, List.of(gc.getGroupId()), gc.getId(), false, 0,
+                            Instant.now(), Instant.now()));
+                    stored++;
+                } catch (Exception e) {
+                    LOGGER.warnf("Group %s: failed to store a retro lesson: %s", gc.getId(), e.getMessage());
+                }
+            }
+        }
+        if (stored > 0) {
+            evictPastCap(userMemoryStore, teamOwner, gc.getGroupId(), config.maxStoredLessons());
+            LOGGER.infof("Group %s: RETRO phase '%s' stored %d lesson(s) for team %s", gc.getId(), phaseName, stored, teamOwner);
+        }
+        if (listener != null) {
+            listener.onRetroRecorded(new GroupConversationEventSink.RetroRecordedEvent(gc.getGroupId(), phaseName, stored));
+        }
+    }
+
+    /**
+     * FIFO at the stored cap: the recall is newest-first, so everything past the
+     * cap in that ordering is the oldest — evicted so institutional memory stays
+     * bounded. Team-owned entries are untouchable by {@code UserMemoryTool}'s own
+     * eviction (which only ever removes the calling agent's {@code self} entries),
+     * so this is the ONLY reaper.
+     */
+    private static void evictPastCap(IUserMemoryStore store, String teamOwner, String groupId, int maxStoredLessons) {
+        try {
+            List<UserMemoryEntry> entries = store.getVisibleEntries(teamOwner, RETRO_SOURCE, List.of(groupId), "most_recent", -1);
+            for (int i = maxStoredLessons; i < entries.size(); i++) {
+                UserMemoryEntry oldest = entries.get(i);
+                if (oldest.id() != null) {
+                    store.deleteEntry(oldest.id());
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warnf("Failed to FIFO-evict retro lessons for %s: %s", teamOwner, e.getMessage());
+        }
+    }
+
+    /** First 16 hex chars of SHA-256 — collision-safe enough for a 50-entry set. */
+    static String lessonHash(String lesson) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(lesson.toLowerCase().strip().getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash, 0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandatory on every JVM; unreachable.
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static JsonNode readJson(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        try {
+            return MAPPER.readTree(text.trim());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String embeddedJson(String content) {
+        int start = content.indexOf('{');
+        int end = content.lastIndexOf('}');
+        return start >= 0 && end > start ? content.substring(start, end + 1) : null;
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
@@ -25,6 +25,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HexFormat;
 import java.util.List;
 
@@ -164,15 +165,24 @@ public final class RetroEngine {
     }
 
     /**
-     * FIFO at the stored cap: the recall is newest-first, so everything past the
-     * cap in that ordering is the oldest — evicted so institutional memory stays
-     * bounded. Team-owned entries are untouchable by {@code UserMemoryTool}'s own
-     * eviction (which only ever removes the calling agent's {@code self} entries),
-     * so this is the ONLY reaper.
+     * FIFO at the stored cap, ordered by CREATION time. The {@code most_recent}
+     * recall order sorts by {@code updatedAt}, and reharvesting an existing lesson
+     * refreshes that — so eviction keyed on recall order could evict a
+     * later-CREATED lesson while an old-but-reharvested one survived (review
+     * finding). {@code createdAt} is {@code setOnInsert} at the store, so it is the
+     * stable insertion stamp FIFO needs. Team-owned entries are untouchable by
+     * {@code UserMemoryTool}'s own eviction (which only ever removes the calling
+     * agent's {@code self} entries), so this is the ONLY reaper.
      */
     private static void evictPastCap(IUserMemoryStore store, String teamOwner, String groupId, int maxStoredLessons) {
         try {
-            List<UserMemoryEntry> entries = store.getVisibleEntries(teamOwner, RETRO_SOURCE, List.of(groupId), "most_recent", -1);
+            List<UserMemoryEntry> entries = store.getVisibleEntries(teamOwner, RETRO_SOURCE, List.of(groupId), "most_recent", -1)
+                    .stream()
+                    // Newest created first; entries without a createdAt (pre-stamp
+                    // documents) count as oldest and are evicted first.
+                    .sorted(Comparator.comparing(UserMemoryEntry::createdAt,
+                            Comparator.nullsFirst(Comparator.naturalOrder())).reversed())
+                    .toList();
             for (int i = maxStoredLessons; i < entries.size(); i++) {
                 UserMemoryEntry oldest = entries.get(i);
                 if (oldest.id() != null) {

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
@@ -116,23 +116,37 @@ public final class RetroEngine {
         if (userMemoryStore == null) {
             LOGGER.warnf("Group %s: RETRO phase '%s' ran but no user memory store is available — lessons are not persisted",
                     LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phaseName));
+            // The event contract holds even when nothing can be stored: a RETRO
+            // phase always emits retro_recorded (review finding — this path
+            // returned silently, leaving SSE consumers waiting).
+            if (listener != null) {
+                listener.onRetroRecorded(new GroupConversationEventSink.RetroRecordedEvent(gc.getGroupId(), phaseName, 0));
+            }
             return;
         }
         RetroConfig config = retroConfig != null ? retroConfig : new RetroConfig();
         String teamOwner = IUserMemoryStore.TEAM_OWNER_PREFIX + gc.getGroupId();
 
+        // maxLessonsPerRun bounds the whole HARVEST, not each transcript entry —
+        // a multi-participant or multi-repeat RETRO phase produces several RETRO
+        // entries, and a per-entry cap multiplied by entry count (review finding).
+        int remaining = config.maxLessonsPerRun();
         int stored = 0;
         for (TranscriptEntry entry : repeatEntries) {
+            if (remaining <= 0) {
+                break;
+            }
             if (entry == null || entry.type() != TranscriptEntryType.RETRO) {
                 continue;
             }
-            for (Lesson lesson : parseLessons(entry.content(), config.maxLessonsPerRun())) {
+            for (Lesson lesson : parseLessons(entry.content(), remaining)) {
                 try {
                     String value = lesson.context() != null ? lesson.lesson() + " (applies: " + lesson.context() + ")" : lesson.lesson();
                     userMemoryStore.upsert(new UserMemoryEntry(null, teamOwner, KEY_PREFIX + lessonHash(lesson.lesson()), value,
                             "context", Visibility.group, RETRO_SOURCE, List.of(gc.getGroupId()), gc.getId(), false, 0,
                             Instant.now(), Instant.now()));
                     stored++;
+                    remaining--;
                 } catch (Exception e) {
                     LOGGER.warnf("Group %s: failed to store a retro lesson: %s",
                             LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(e.getMessage()));

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.configs.properties.model.Property.Visibility;
 import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
+import ai.labs.eddi.utils.LogSanitizer;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -114,7 +115,7 @@ public final class RetroEngine {
                                IUserMemoryStore userMemoryStore, String phaseName, GroupDiscussionEventListener listener) {
         if (userMemoryStore == null) {
             LOGGER.warnf("Group %s: RETRO phase '%s' ran but no user memory store is available — lessons are not persisted",
-                    gc.getId(), phaseName);
+                    LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phaseName));
             return;
         }
         RetroConfig config = retroConfig != null ? retroConfig : new RetroConfig();
@@ -133,13 +134,15 @@ public final class RetroEngine {
                             Instant.now(), Instant.now()));
                     stored++;
                 } catch (Exception e) {
-                    LOGGER.warnf("Group %s: failed to store a retro lesson: %s", gc.getId(), e.getMessage());
+                    LOGGER.warnf("Group %s: failed to store a retro lesson: %s",
+                            LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(e.getMessage()));
                 }
             }
         }
         if (stored > 0) {
             evictPastCap(userMemoryStore, teamOwner, gc.getGroupId(), config.maxStoredLessons());
-            LOGGER.infof("Group %s: RETRO phase '%s' stored %d lesson(s) for team %s", gc.getId(), phaseName, stored, teamOwner);
+            LOGGER.infof("Group %s: RETRO phase '%s' stored %d lesson(s) for team %s",
+                    LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phaseName), stored, LogSanitizer.sanitize(teamOwner));
         }
         if (listener != null) {
             listener.onRetroRecorded(new GroupConversationEventSink.RetroRecordedEvent(gc.getGroupId(), phaseName, stored));
@@ -163,7 +166,8 @@ public final class RetroEngine {
                 }
             }
         } catch (Exception e) {
-            LOGGER.warnf("Failed to FIFO-evict retro lessons for %s: %s", teamOwner, e.getMessage());
+            LOGGER.warnf("Failed to FIFO-evict retro lessons for %s: %s",
+                    LogSanitizer.sanitize(teamOwner), LogSanitizer.sanitize(e.getMessage()));
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/GroupConversationEventSink.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/GroupConversationEventSink.java
@@ -61,6 +61,12 @@ public final class GroupConversationEventSink {
      * Always preceded by an {@link #EVENT_CONVERGENCE_CHECKED} for the same repeat.
      */
     public static final String EVENT_CONVERGENCE_REACHED = "convergence_reached";
+    /**
+     * A RETRO phase harvested lessons into team-owned group memory (I8). Fires even
+     * with zero lessons stored — "the retro ran and found nothing durable" is
+     * itself signal for an observer.
+     */
+    public static final String EVENT_RETRO_RECORDED = "retro_recorded";
 
     // --- Event payloads ---
 
@@ -158,5 +164,9 @@ public final class GroupConversationEventSink {
      *            run — the concrete saving
      */
     public record ConvergenceReachedEvent(int phaseIndex, String phaseName, int repeat, int repeatsSkipped, String reason) {
+    }
+
+    /** A RETRO phase stored lessons into team-owned group memory (I8). */
+    public record RetroRecordedEvent(String groupId, String phaseName, int lessonsStored) {
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/groups/model/AgentGroupConfigurationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/model/AgentGroupConfigurationTest.java
@@ -136,7 +136,8 @@ class AgentGroupConfigurationTest {
 
     @Test
     void phaseType_allValues() {
-        assertEquals(11, PhaseType.values().length);
+        assertEquals(12, PhaseType.values().length);
+        assertNotNull(PhaseType.valueOf("RETRO"));
         assertNotNull(PhaseType.valueOf("OPINION"));
         assertNotNull(PhaseType.valueOf("CRITIQUE"));
         assertNotNull(PhaseType.valueOf("REVISION"));

--- a/src/test/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStoreVisibilityTest.java
+++ b/src/test/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStoreVisibilityTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.properties.mongo;
+
+import ai.labs.eddi.configs.properties.IUserMemoryStore;
+import com.mongodb.MongoClientSettings;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * I8 — the recall visibility filters on BOTH backends: the user's own scope is
+ * untouched (still constrained to their own {@code userId}), and the additive
+ * team-owned branch reaches ONLY synthetic {@code "group:"+groupId} owners
+ * derived from the supplied group ids. The two backends must not drift, so both
+ * shapes are pinned side by side.
+ *
+ * @author tests
+ */
+class MongoUserMemoryStoreVisibilityTest {
+
+    private static String render(Bson filter) {
+        return filter.toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry()).toJson();
+    }
+
+    // =================================================================
+    // MongoDB
+    // =================================================================
+
+    @Test
+    @DisplayName("Mongo, no groups: the filter is exactly the user's own scope — no team branch at all")
+    void mongo_noGroups_userScopeOnly() {
+        String json = render(MongoUserMemoryStore.buildVisibilityFilter("user-1", "agent-a", List.of()));
+
+        assertTrue(json.contains("user-1"), json);
+        assertFalse(json.contains(IUserMemoryStore.TEAM_OWNER_PREFIX), json);
+    }
+
+    @Test
+    @DisplayName("Mongo, with groups: the team branch matches derived group: owners only, alongside the untouched user scope")
+    void mongo_withGroups_additiveTeamBranch() {
+        String json = render(MongoUserMemoryStore.buildVisibilityFilter("user-1", "agent-a", List.of("g1", "g2")));
+
+        assertTrue(json.contains("\"group:g1\"") && json.contains("\"group:g2\""),
+                "team owners are DERIVED from the supplied group ids: " + json);
+        assertTrue(json.contains("user-1"), "the personal scope keeps its own userId constraint: " + json);
+        // The team branch must pair the synthetic owners with group visibility —
+        // a bare owner match would leak any hypothetical non-group entry.
+        int teamIdx = json.indexOf("group:g1");
+        assertTrue(json.indexOf("group", teamIdx) >= 0, json);
+    }
+
+    @Test
+    @DisplayName("Mongo: another user's id never appears in the filter — the team branch cannot cross humans")
+    void mongo_teamBranch_cannotNameAnotherHuman() {
+        String json = render(MongoUserMemoryStore.buildVisibilityFilter("user-1", "agent-a", List.of("g1")));
+
+        // The only owner ids in the filter are the caller's own and group:g1.
+        assertFalse(json.contains("user-2"), json);
+        assertTrue(json.contains("group:g1"), json);
+    }
+
+}

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
@@ -408,12 +408,19 @@ class PostgresUserMemoryStoreUnitTest {
         sut.getVisibleEntries("user1", "agent1",
                 List.of("group-a", "group-b"), "most_recent", 10);
 
-        // then — params: userId=1, agentId=2, group-a=3, group-b=4, limit=5
+        // then — I8 bind order: userId=1, agentId=2, user-scope group overlap
+        // (group-a=3, group-b=4), derived team owners (group:group-a=5,
+        // group:group-b=6), team-scope group overlap (group-a=7, group-b=8),
+        // limit=9. Mirrors buildVisibilityQuery exactly.
         verify(preparedStatement).setString(1, "user1");
         verify(preparedStatement).setString(2, "agent1");
         verify(preparedStatement).setString(3, "group-a");
         verify(preparedStatement).setString(4, "group-b");
-        verify(preparedStatement).setInt(5, 10);
+        verify(preparedStatement).setString(5, "group:group-a");
+        verify(preparedStatement).setString(6, "group:group-b");
+        verify(preparedStatement).setString(7, "group-a");
+        verify(preparedStatement).setString(8, "group-b");
+        verify(preparedStatement).setInt(9, 10);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreVisibilityTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreVisibilityTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.datastore.postgres;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * I8 — the PostgreSQL twin of {@code MongoUserMemoryStoreVisibilityTest}: the
+ * recall SQL keeps the user's own scope untouched and adds the team-owned
+ * branch only when groups are supplied. The two backends must not drift.
+ *
+ * @author tests
+ */
+class PostgresUserMemoryStoreVisibilityTest {
+
+    @Test
+    @DisplayName("no groups: no team branch, balanced parentheses")
+    void noGroups_userScopeOnly() {
+        String sql = PostgresUserMemoryStore.buildVisibilityQuery(List.of());
+
+        assertFalse(sql.contains("user_id IN"), sql);
+        assertEquals(0, sql.chars().map(c -> c == '(' ? 1 : c == ')' ? -1 : 0).sum(), "unbalanced parens: " + sql);
+    }
+
+    @Test
+    @DisplayName("with groups: the team branch binds one owner and one overlap placeholder per group")
+    void withGroups_additiveTeamBranch() {
+        String sql = PostgresUserMemoryStore.buildVisibilityQuery(List.of("g1", "g2"));
+
+        assertTrue(sql.contains("user_id IN (?,?)"), sql);
+        // user scope overlap + team scope overlap = two ??| ARRAY[?,?] blocks.
+        assertEquals(2, sql.split("\\?\\?\\|", -1).length - 1, sql);
+        assertEquals(0, sql.chars().map(c -> c == '(' ? 1 : c == ')' ? -1 : 0).sum(), "unbalanced parens: " + sql);
+        // Total ordinary binds: userId + agentId + 2 gids (user scope) + 2 owners
+        // + 2 gids (team scope) = 8. Each ??| escape contributes two literal '?'
+        // characters that are NOT bind placeholders — subtract them.
+        assertEquals(8, sql.chars().filter(c -> c == '?').count() - 2L * (sql.split("\\?\\?\\|", -1).length - 1),
+                "bind placeholder count must match collectInto's bind order: " + sql);
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.internal.groups;
 
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.RetroConfig;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
@@ -14,6 +15,7 @@ import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -74,6 +76,26 @@ class GroupContextBuilderTest {
 
         assertEquals("rendered", result);
         verify(templatingEngine).processTemplate(any(), any(), eq(ITemplatingEngine.TemplateMode.TEXT));
+    }
+
+    @Test
+    @DisplayName("the RETRO template quotes the CONFIGURED lesson cap — a group set above the default gets what it asked for")
+    void buildPhaseInput_retro_quotesConfiguredCap() throws Exception {
+        when(templatingEngine.processTemplate(any(), any(), eq(ITemplatingEngine.TemplateMode.TEXT))).thenReturn("rendered");
+
+        builder.buildPhaseInput(phase(PhaseType.RETRO, ContextScope.FULL), member(), "Q?", List.of(), 1, null, null,
+                new RetroConfig(7, 50));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> dataCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(templatingEngine).processTemplate(any(), dataCaptor.capture(), eq(ITemplatingEngine.TemplateMode.TEXT));
+        assertEquals(7, dataCaptor.getValue().get("maxLessonsPerRun"));
+
+        // The config-less overloads still quote the default.
+        clearInvocations(templatingEngine);
+        builder.buildPhaseInput(phase(PhaseType.RETRO, ContextScope.FULL), member(), "Q?", List.of(), 1, null);
+        verify(templatingEngine).processTemplate(any(), dataCaptor.capture(), eq(ITemplatingEngine.TemplateMode.TEXT));
+        assertEquals(RetroConfig.DEFAULT_MAX_PER_RUN, dataCaptor.getValue().get("maxLessonsPerRun"));
     }
 
     // =================================================================

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
@@ -57,7 +57,7 @@ class PhaseExecutionEngineTest {
         // 6-arg one left every turn running with a null input, so a regression that
         // dropped the phase rendering entirely and passed the raw question through
         // would not have failed a single test here.
-        when(contextBuilder.buildPhaseInput(any(), any(), any(), any(), anyInt(), any(), any()))
+        when(contextBuilder.buildPhaseInput(any(), any(), any(), any(), anyInt(), any(), any(), any()))
                 .thenReturn("rendered-input");
         return new PhaseExecutionEngine(memberTurnExecutor, contextBuilder,
                 Executors.newVirtualThreadPerTaskExecutor(), new CallerIdentityContext(null, null));

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
@@ -236,6 +236,33 @@ class RetroEngineTest {
     }
 
     @Test
+    @DisplayName("a null store still fires retro_recorded with zero — the event contract holds when nothing persists")
+    void harvest_nullStore_firesZeroCountEvent() {
+        var listener = Mockito.mock(GroupDiscussionEventListener.class);
+
+        RetroEngine.harvest(gc, new RetroConfig(),
+                List.of(retroEntry("{\"lessons\":[{\"lesson\":\"x\"}]}")), null, "Retro", listener);
+
+        var captor = ArgumentCaptor.forClass(GroupConversationEventSink.RetroRecordedEvent.class);
+        verify(listener).onRetroRecorded(captor.capture());
+        assertEquals(0, captor.getValue().lessonsStored());
+    }
+
+    @Test
+    @DisplayName("maxLessonsPerRun bounds the whole harvest, not each entry — multi-speaker retros cannot multiply it")
+    void harvest_capIsPerHarvest_notPerEntry() throws Exception {
+        var config = new RetroConfig(2, 50);
+
+        RetroEngine.harvest(gc, config, List.of(
+                retroEntry("{\"lessons\":[{\"lesson\":\"one\"},{\"lesson\":\"two\"}]}"),
+                retroEntry("{\"lessons\":[{\"lesson\":\"three\"},{\"lesson\":\"four\"}]}"),
+                retroEntry("{\"lessons\":[{\"lesson\":\"five\"}]}")), store, "Retro", null);
+
+        assertEquals(2, store.countEntries(IUserMemoryStore.TEAM_OWNER_PREFIX + GROUP_ID),
+                "3 RETRO entries × cap 2 used to store up to 6 — the cap is per harvest");
+    }
+
+    @Test
     @DisplayName("a failing store loses that lesson with a warning — never the discussion")
     void harvest_storeFailure_neverThrows() throws IResourceStore.ResourceStoreException {
         var failing = Mockito.mock(IUserMemoryStore.class);

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.RetroConfig;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import ai.labs.eddi.configs.properties.IUserMemoryStore;
+import ai.labs.eddi.configs.properties.model.Properties;
+import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
+import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
+import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
+import ai.labs.eddi.datastore.IResourceStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+
+/**
+ * I8 — {@link RetroEngine}: the three-tier lesson parse, the per-run cap
+ * enforced regardless of what the model was told, idempotent upserts under the
+ * team owner, the FIFO stored-cap eviction, and the retro_recorded event. The
+ * store is a real in-memory fake with the production upsert identity
+ * {@code (userId, key, sourceAgentId)} — idempotency claims scripted into a
+ * mock would prove nothing.
+ *
+ * @author tests
+ */
+class RetroEngineTest {
+
+    private static final String GROUP_ID = "group-1";
+    private static final String TEAM_OWNER = IUserMemoryStore.TEAM_OWNER_PREFIX + GROUP_ID;
+
+    private InMemoryUserMemoryStore store;
+    private GroupConversation gc;
+
+    /** Honest fake: production upsert identity, recency-ordered recall. */
+    static final class InMemoryUserMemoryStore implements IUserMemoryStore {
+        final Map<String, UserMemoryEntry> byId = new LinkedHashMap<>();
+        final AtomicLong seq = new AtomicLong();
+        final AtomicLong clock = new AtomicLong();
+
+        @Override
+        public String upsert(UserMemoryEntry entry) {
+            String identity = entry.userId() + "|" + entry.key() + "|" + entry.sourceAgentId();
+            for (Map.Entry<String, UserMemoryEntry> existing : byId.entrySet()) {
+                UserMemoryEntry e = existing.getValue();
+                if (identity.equals(e.userId() + "|" + e.key() + "|" + e.sourceAgentId())) {
+                    byId.put(existing.getKey(), withId(entry, existing.getKey(), e.createdAt()));
+                    return existing.getKey();
+                }
+            }
+            String id = "m-" + seq.incrementAndGet();
+            byId.put(id, withId(entry, id, Instant.ofEpochMilli(clock.incrementAndGet())));
+            return id;
+        }
+
+        private UserMemoryEntry withId(UserMemoryEntry e, String id, Instant createdAt) {
+            return new UserMemoryEntry(id, e.userId(), e.key(), e.value(), e.category(), e.visibility(), e.sourceAgentId(),
+                    e.groupIds(), e.sourceConversationId(), e.conflicted(), e.accessCount(), createdAt,
+                    Instant.ofEpochMilli(clock.incrementAndGet()));
+        }
+
+        @Override
+        public void deleteEntry(String entryId) {
+            byId.remove(entryId);
+        }
+
+        @Override
+        public List<UserMemoryEntry> getVisibleEntries(String userId, String agentId, List<String> groupIds, String recallOrder,
+                                                       int maxEntries) {
+            List<UserMemoryEntry> visible = new ArrayList<>(byId.values().stream()
+                    .filter(e -> userId.equals(e.userId()))
+                    .sorted(Comparator.comparing(UserMemoryEntry::updatedAt).reversed())
+                    .toList());
+            return maxEntries > 0 && visible.size() > maxEntries ? visible.subList(0, maxEntries) : visible;
+        }
+
+        // Unused surface.
+        @Override
+        public Properties readProperties(String userId) {
+            return null;
+        }
+
+        @Override
+        public void mergeProperties(String userId, Properties properties) {
+        }
+
+        @Override
+        public void deleteProperties(String userId) {
+        }
+
+        @Override
+        public Optional<UserMemoryEntry> findEntryById(String entryId) {
+            return Optional.ofNullable(byId.get(entryId));
+        }
+
+        @Override
+        public List<UserMemoryEntry> filterEntries(String userId, String query) {
+            return List.of();
+        }
+
+        @Override
+        public List<UserMemoryEntry> getEntriesByCategory(String userId, String category) {
+            return List.of();
+        }
+
+        @Override
+        public Optional<UserMemoryEntry> getByKey(String userId, String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<UserMemoryEntry> getAllEntries(String userId) {
+            return List.copyOf(byId.values());
+        }
+
+        @Override
+        public void deleteAllForUser(String userId) {
+        }
+
+        @Override
+        public long countEntries(String userId) {
+            return byId.size();
+        }
+
+        @Override
+        public long deleteOlderThan(int olderThanDays) {
+            return 0;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryUserMemoryStore();
+        gc = new GroupConversation();
+        gc.setId("gc-1");
+        gc.setGroupId(GROUP_ID);
+    }
+
+    private TranscriptEntry retroEntry(String content) {
+        return new TranscriptEntry("mod", "Moderator", content, 0, "Retro", TranscriptEntryType.RETRO, Instant.now(), null, null);
+    }
+
+    // =================================================================
+    // parsing
+    // =================================================================
+
+    @Test
+    @DisplayName("strict JSON and fence-embedded JSON both parse; prose yields nothing")
+    void parse_tiers() {
+        assertEquals(2, RetroEngine.parseLessons(
+                "{\"lessons\":[{\"lesson\":\"Cap debate rounds\",\"context\":\"long debates\"},{\"lesson\":\"Name a moderator\"}]}", 3).size());
+        assertEquals(1, RetroEngine.parseLessons(
+                "Here you go:\n```json\n{\"lessons\":[{\"lesson\":\"Vote earlier\"}]}\n```", 3).size());
+        assertTrue(RetroEngine.parseLessons("We should have voted earlier, honestly.", 3).isEmpty(),
+                "prose is not guessed into a lesson");
+        assertTrue(RetroEngine.parseLessons(null, 3).isEmpty());
+    }
+
+    @Test
+    @DisplayName("the per-run cap is enforced at parse time, whatever the model produced")
+    void parse_capEnforced() {
+        String five = "{\"lessons\":[{\"lesson\":\"a\"},{\"lesson\":\"b\"},{\"lesson\":\"c\"},{\"lesson\":\"d\"},{\"lesson\":\"e\"}]}";
+
+        assertEquals(2, RetroEngine.parseLessons(five, 2).size());
+    }
+
+    // =================================================================
+    // harvest
+    // =================================================================
+
+    @Test
+    @DisplayName("lessons land team-owned with group visibility, and re-running the same retro is a no-op")
+    void harvest_idempotentTeamOwnedUpsert() {
+        var entries = List.of(retroEntry("{\"lessons\":[{\"lesson\":\"Cap debate rounds\",\"context\":\"long debates\"}]}"));
+
+        RetroEngine.harvest(gc, new RetroConfig(), entries, store, "Retro", null);
+        RetroEngine.harvest(gc, new RetroConfig(), entries, store, "Retro", null);
+
+        assertEquals(1, store.byId.size(), "the idempotency key + fixed source agent make a re-run a no-op");
+        UserMemoryEntry lesson = store.byId.values().iterator().next();
+        assertEquals(TEAM_OWNER, lesson.userId(), "owned by the team, not the human who ran the discussion");
+        assertTrue(lesson.key().startsWith(RetroEngine.KEY_PREFIX));
+        assertEquals(List.of(GROUP_ID), lesson.groupIds());
+        assertEquals(RetroEngine.RETRO_SOURCE, lesson.sourceAgentId());
+        assertTrue(lesson.value().toString().contains("Cap debate rounds"));
+        assertTrue(lesson.value().toString().contains("long debates"), "the context rides in the value");
+    }
+
+    @Test
+    @DisplayName("FIFO at maxStoredLessons: storing past the cap evicts the oldest, never the newest")
+    void harvest_fifoEviction() {
+        var config = new RetroConfig(3, 2);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"first oldest\"}]}")), store, "Retro", null);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"second\"}]}")), store, "Retro", null);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"third newest\"}]}")), store, "Retro", null);
+
+        assertEquals(2, store.byId.size(), "the 3rd stored lesson evicts the oldest");
+        List<String> values = store.byId.values().stream().map(e -> e.value().toString()).toList();
+        assertTrue(values.stream().anyMatch(v -> v.contains("third newest")));
+        assertTrue(values.stream().noneMatch(v -> v.contains("first oldest")), "FIFO evicts the OLDEST");
+    }
+
+    @Test
+    @DisplayName("retro_recorded fires with the stored count; a null store warns and never throws")
+    void harvest_eventAndNullStore() {
+        var listener = Mockito.mock(GroupDiscussionEventListener.class);
+
+        RetroEngine.harvest(gc, new RetroConfig(),
+                List.of(retroEntry("{\"lessons\":[{\"lesson\":\"a\"},{\"lesson\":\"b\"}]}")), store, "Retro", listener);
+
+        var captor = ArgumentCaptor.forClass(GroupConversationEventSink.RetroRecordedEvent.class);
+        verify(listener).onRetroRecorded(captor.capture());
+        assertEquals(2, captor.getValue().lessonsStored());
+        assertEquals(GROUP_ID, captor.getValue().groupId());
+
+        assertDoesNotThrow(() -> RetroEngine.harvest(gc, new RetroConfig(),
+                List.of(retroEntry("{\"lessons\":[{\"lesson\":\"x\"}]}")), null, "Retro", null));
+    }
+
+    @Test
+    @DisplayName("a failing store loses that lesson with a warning — never the discussion")
+    void harvest_storeFailure_neverThrows() throws IResourceStore.ResourceStoreException {
+        var failing = Mockito.mock(IUserMemoryStore.class);
+        Mockito.when(failing.upsert(Mockito.any())).thenThrow(new IResourceStore.ResourceStoreException("store down"));
+
+        assertDoesNotThrow(() -> RetroEngine.harvest(gc, new RetroConfig(),
+                List.of(retroEntry("{\"lessons\":[{\"lesson\":\"x\"}]}")), failing, "Retro", null));
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
@@ -219,6 +219,41 @@ class RetroEngineTest {
     }
 
     @Test
+    @DisplayName("FIFO survives a reharvest: eviction orders by CREATION, not by the refreshed updatedAt")
+    void harvest_fifoEviction_reharvestDoesNotShieldOldLessons() throws Exception {
+        var config = new RetroConfig(3, 2);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"alpha oldest\"}]}")), store, "Retro", null);
+        Thread.sleep(5);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"beta middle\"}]}")), store, "Retro", null);
+        Thread.sleep(5);
+        // Reharvest alpha: its updatedAt refreshes, its createdAt does not. The
+        // recall order (most_recent = updatedAt) now lists alpha first — eviction
+        // keyed on recall order would evict beta, keeping the OLDER lesson.
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"alpha oldest\"}]}")), store, "Retro", null);
+        Thread.sleep(5);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"gamma newest\"}]}")), store, "Retro", null);
+
+        assertEquals(2, store.byId.size());
+        List<String> values = store.byId.values().stream().map(e -> e.value().toString()).toList();
+        assertTrue(values.stream().noneMatch(v -> v.contains("alpha oldest")),
+                "FIFO evicts the oldest-CREATED lesson even after a reharvest refreshed it: " + values);
+        assertTrue(values.stream().anyMatch(v -> v.contains("beta middle")), values.toString());
+        assertTrue(values.stream().anyMatch(v -> v.contains("gamma newest")), values.toString());
+    }
+
+    @Test
+    @DisplayName("RetroConfig clamps runaway values to hard ceilings — bounded growth is non-negotiable")
+    void retroConfig_ceilingsClampRunawayValues() {
+        var runaway = new RetroConfig(Integer.MAX_VALUE, Integer.MAX_VALUE);
+        assertEquals(RetroConfig.CEILING_MAX_PER_RUN, runaway.maxLessonsPerRun());
+        assertEquals(RetroConfig.CEILING_MAX_STORED, runaway.maxStoredLessons());
+
+        var sane = new RetroConfig(5, 100);
+        assertEquals(5, sane.maxLessonsPerRun(), "values under the ceiling pass through");
+        assertEquals(100, sane.maxStoredLessons());
+    }
+
+    @Test
     @DisplayName("retro_recorded fires with the stored count; a null store warns and never throws")
     void harvest_eventAndNullStore() {
         var listener = Mockito.mock(GroupDiscussionEventListener.class);

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/UserMemoryToolScopingTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/UserMemoryToolScopingTest.java
@@ -176,10 +176,12 @@ class UserMemoryToolScopingTest {
     void personalEntriesNeverCrossUsers() throws Exception {
         // The tool always queries by ITS user's id — a shared group cannot widen
         // the personal scope. The store is queried for USER only; nothing about
-        // user-2 is ever requested, and a self entry of another AGENT under the
-        // same user stays hidden too (the existing G1 wall).
-        var otherAgentsPrivate = entry("p-1", "salary", Visibility.self, AGENT_A, List.of("g1"), Instant.now());
-        when(store.filterEntries(USER, "salary")).thenReturn(List.of(otherAgentsPrivate));
+        // user-2 is ever requested. The fixture genuinely belongs to user-2
+        // (review finding: the shared helper stamped USER, so the assert passed
+        // because AGENT_A was foreign, not because the entry crossed users).
+        var otherUsersPrivate = new UserMemoryEntry("p-1", "user-2", "salary", "value-of-salary", "fact",
+                Visibility.self, AGENT_A, List.of("g1"), "conv-x", false, 0, Instant.now(), Instant.now());
+        when(store.filterEntries(USER, "salary")).thenReturn(List.of(otherUsersPrivate));
 
         String result = toolFor(AGENT_B, List.of("g1")).searchMemory("salary");
 

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/UserMemoryToolScopingTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/UserMemoryToolScopingTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -141,6 +142,50 @@ class UserMemoryToolScopingTest {
         assertTrue(result.contains("maxEntriesPerUser"), "the error must tell the caller what to do; got: " + result);
         verify(store, never()).deleteEntry(any());
         verify(store, never()).upsert(any());
+    }
+
+    // ==================== I8 — team-owned lessons ====================
+
+    @Test
+    @DisplayName("I8 — eviction can never touch a team-owned retro lesson, even when it is the oldest entry the store returns")
+    void evictOldestNeverTouchesTeamOwnedLessons() throws Exception {
+        config.setMaxEntriesPerUser(2);
+        config.setOnCapReached("evict_oldest");
+
+        // The lesson lives under the synthetic team owner with the fixed "retro"
+        // source. Structurally it can never surface from getAllEntries(USER) —
+        // but even if a store bug returned it, the sourceAgentId filter is a
+        // second independent wall. This test breaches the first wall on purpose.
+        var teamLesson = new UserMemoryEntry("lesson-1", IUserMemoryStore.TEAM_OWNER_PREFIX + "g1", "retro:abc",
+                "Cap debate rounds", "context", Visibility.group, "retro", List.of("g1"), "gc-1", false, 0,
+                Instant.parse("2019-01-01T00:00:00Z"), Instant.parse("2019-01-01T00:00:00Z"));
+        var own = entry("own-1", "mine", Visibility.self, AGENT_B, List.of(), Instant.parse("2024-01-01T00:00:00Z"));
+        when(store.countEntries(USER)).thenReturn(2L);
+        when(store.getAllEntries(USER)).thenReturn(List.of(teamLesson, own));
+        when(store.upsert(any())).thenReturn("new-id");
+
+        String result = toolFor(AGENT_B, List.of("g1")).rememberFact("fresh_fact", "value", "fact", "self");
+
+        assertTrue(result.contains("✅ Remembered"), result);
+        verify(store, never()).deleteEntry("lesson-1");
+        verify(store).deleteEntry("own-1");
+    }
+
+    @Test
+    @DisplayName("I8 — a personal visibility:self entry never surfaces to another user's tool, groups shared or not")
+    void personalEntriesNeverCrossUsers() throws Exception {
+        // The tool always queries by ITS user's id — a shared group cannot widen
+        // the personal scope. The store is queried for USER only; nothing about
+        // user-2 is ever requested, and a self entry of another AGENT under the
+        // same user stays hidden too (the existing G1 wall).
+        var otherAgentsPrivate = entry("p-1", "salary", Visibility.self, AGENT_A, List.of("g1"), Instant.now());
+        when(store.filterEntries(USER, "salary")).thenReturn(List.of(otherAgentsPrivate));
+
+        String result = toolFor(AGENT_B, List.of("g1")).searchMemory("salary");
+
+        assertFalse(result.contains("value-of-salary"), result);
+        verify(store, never()).filterEntries(eq("user-2"), any());
+        verify(store, never()).getAllEntries("user-2");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements **I8 — retro → group memory** from `planning/group-collaboration-improvements-plan.md` (queue position 3 in `planning/group-collaboration-NEXT.md`, after I17 #637 and I14 #638). Discussions stop evaporating: a `RETRO` phase reviews how the group worked and distills lessons that persist as **team-owned group memory**, surfacing as `{properties.*}` in every member's later discussions.

## What's in here

### RETRO phase type + config
- `PhaseType.RETRO` with a built-in template (full-transcript review, JSON `{"lessons": [{"lesson", "context"}]}` contract) and `TEMPLATE_RETRO` preset.
- `RetroConfig { maxLessonsPerRun = 3, maxStoredLessons = 50 }` on `AgentGroupConfiguration`. The template *quotes* the default per-run cap; `RetroEngine` *enforces* the configured one at parse time regardless of what the model produced — the context builder deliberately has no access to the group config.

### Team-owned storage (plan's resolved V2 design)
- Lessons are upserted via `IUserMemoryStore` under the synthetic owner **`group:<groupId>`** with `group` visibility — they belong to the team, not the human who happened to run the discussion, and survive that human's GDPR erasure without carrying their identity. New `TEAM_OWNER_PREFIX` contract constant.
- **Idempotency:** key `retro:<sha256(lesson)[0..16]>` with a FIXED `sourceAgentId` (`"retro"`). The upsert identity for group entries is `(userId, key, sourceAgentId)` — a real speaker id would have made the same lesson from two speakers two rows.
- **Bounded growth:** FIFO eviction past `maxStoredLessons` via the newest-first recall. `RetroEngine` is the only reaper of team-owned entries; `UserMemoryTool`'s own eviction only ever touches the calling agent's `self` entries.

### Recall on BOTH backends
Mongo's `buildVisibilityFilter` and Postgres's `buildVisibilityQuery` (+ bind order) OR in a narrow additive team scope: owner ids **derived from the supplied group ids** (never caller-supplied), `group` visibility, group-id overlap. The user's own scope is untouched, per the plan's "do not widen the existing user-scoped group branch". Both methods are package-private static so the filter/SQL shapes are directly assertable — and both are pinned side by side so the backends cannot drift.

### Wiring + observability
- Discussion loop harvests on the RETRO phase's last repeat, **before** the persist (a crash must not lose lessons a stored document claims were taken). Store failures warn and never fail the discussion.
- New `retro_recorded` event (constant + record + listener default + SSE forward) — fires even at zero lessons stored, which is itself signal.

## Tests (11 new; suites green)

- **RetroEngineTest** (6): parse tiers (strict / fenced / prose-refused / null); per-run cap enforced past what the model was told; idempotent team-owned upsert against a **real in-memory store with the production upsert identity** (a mocked idempotency claim would prove nothing); FIFO evicts the oldest, never the newest; `retro_recorded` carries the stored count; null store and failing store never throw.
- **MongoUserMemoryStoreVisibilityTest** (3): no-groups → user scope only; with-groups → derived `group:` owners paired with group visibility; no foreign human id reachable through the team branch.
- **PostgresUserMemoryStoreVisibilityTest** (2): SQL shape incl. the `??|` escape arithmetic pinning `collectInto`'s bind order; balanced parens.
- Regression: `engine.internal` + `configs.properties` suites — 1572 tests, 0 failures. Checkstyle clean.

## Notes for reviewers

- The visibility-filter change is the security-sensitive part: the team branch can only ever name owners of the form `group:<one of the caller's group ids>` — there is no path from caller input to another human's `userId`.
- `docs/group-conversations.md` gains a "Retro → group memory" section; changelog entry included in the same commit per repo convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable RETRO discussion phases that extract lessons from group conversations.
  - Stored lessons in shared group memory with duplicate prevention and configurable retention limits.
  - Added FIFO cleanup for older lessons and graceful handling of malformed or failed entries.
  - Added `retro_recorded` notifications to streaming conversation updates.

- **Documentation**
  - Documented RETRO configuration, lesson processing, storage, retention, and notification behavior.

- **Tests**
  - Added coverage for lesson extraction, limits, visibility, idempotency, eviction, and event emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->