### PR TITLE
feat(groups): I11 — NEGOTIATION style, the trade form

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 🤝 feat(groups): I11 — NEGOTIATION style, the trade form (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i11-negotiation`)
+
+First Wave 3 queue item. EDDI had win/lose decision forms and no **trade** form; a negotiation's output is a drafted compromise with an explicit **concession ledger** for human sign-off. The typed structure IS the anti-sycophancy mechanism.
+
+- **Phase types `PROPOSAL` + `BARGAIN`; `skipIf="AGREEMENT_REACHED"`** — a single enum condition, deliberately NOT an expression language (a phase is skipped for a reason the engine can PROVE against the typed decision). The arbitration phase is its only user.
+- **`NegotiationState` on `GroupConversation`**: proposals `{id, byAgentId, round, terms (String v1), status OPEN|SUPERSEDED, acceptedBy, acceptanceEntryIndices}` + concessions `{byAgentId, round, gaveUp, inReturnFor, refProposalId}`. Persisted with the document — a pause/resume keeps the table as it stood.
+- **The BARGAIN turn contract** (`{"accept", "proposal": {"terms"}, "concessions": [{"gaveUp","inReturnFor"}]}` + free-text reasoning): three-tier parse mirroring `VoteTallyEngine` (strict → embedded → give up, FAIL_ON_TRAILING_TOKENS); an unparseable turn is prose with NO state effect (WARN, never a guessed acceptance). A concession that names nothing in return is NOT recorded — the rule is the structure, and the baked-in template says so. A new proposal supersedes the mover's own open one; the proposer signs their own terms implicitly.
+- **Ledger accountability:** the open proposals + concession ledger are appended to every PROPOSAL/BARGAIN turn (and to negotiation SYNTHESIS turns — arbitration and final synthesis quote the record). Appended by `NegotiationEngine.appendStateIfRelevant` at the two input-build sites rather than templated, because the state lives on the conversation, which `buildPhaseInput` deliberately does not see.
+- **Agreement**: all non-moderator participants signed the same OPEN proposal → the bargaining phase's repeats end early through the SAME `PhaseOutcome.endRepeats` plumbing convergence uses, and `DecisionRecord{AGREEMENT, method="negotiation"}` carries `tally.signedAcceptances` — each signatory mapped to the transcript index of their (already signed) acceptance entry. The entries ARE the co-signatures; no new crypto. `decision_reached` fires (its F3 event finally has a second producer).
+- **Preset `NEGOTIATION`** (① Positions & Interests, PARALLEL+NONE — interests enable integrative trades ② Opening Proposals ③ Bargaining, repeats=maxRounds ④ Arbitration, MODERATOR + `skipIf` + its own TEMPLATE_ARBITRATION — the default synthesis template asks for a balanced summary, an arbitrator DECIDES ⑤ Synthesis). Arbitration that RUNS records its conclusion as `DecisionRecord{VERDICT, method="arbitration"}` (never overwriting an existing decision).
+- Enum additions are compat-safe; `describe_discussion_styles` (REST) gained the entry via an exhaustive switch the compiler flagged.
+
+**Tests (12 new in `NegotiationEngineTest` + preset shape + 2 enum pins; `engine.internal` + `configs.groups` suites 1694 green; checkstyle clean):** parse tiers incl. the JSON-plus-reasoning form; concession-must-name-return; implicit self-signature with the authoring entry index; supersession; unknown/superseded acceptance + unparseable turn inertness; ledger accumulation with round + refProposal attribution; unanimous acceptance with signed indices asserted exactly; partial acceptance ≠ agreement; arbitration records once and never overwrites; ledger rendering into the turn (and its no-op paths); and the plan's **scripted 3-round bargain converging in round 3** — propose → counter+concede → sign — as living documentation of the protocol.
+
+---
+
 ## 🔀 merge: bring `origin/main` (PR #627 HITL request pinning) into the branch (2026-08-07)
 
 **Repo:** EDDI (`refactor/group-service-split`, PR [#626](https://github.com/labsai/EDDI/pull/626))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,13 @@
 
 ---
 
+## 🔎 fix(groups): I11 final-review finding — negotiation state survives into round 2 (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i11-negotiation`)
+
+Confirmed MAJOR from the final multi-agent review pass: `continueDiscussion` clears every other round-scoped conclusion (`synthesizedAnswer`, `decision`) with an explicit rationale, but not the persisted negotiation table — so round 2 of a NEGOTIATION group ran against round 1's proposals, and one fresh acceptance could reach "unanimous agreement" on signatures cast for a DIFFERENT question, with `tally.signedAcceptances` pointing at round 1's transcript entries. Fixed: `setNegotiation(null)` at round start, mutation-checked (the continuation test seeds a signed round-1 proposal and asserts it does not survive).
+
+
 ## 🔎 fix(groups): I11 PR #641 review round 1 (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i11-negotiation`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 🔎 fix(groups): I11 PR #641 review round 1 (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i11-negotiation`)
+
+All 12 review comments (CodeQL ×4, code-quality ×3, CodeRabbit ×5) triaged; every one accepted and fixed:
+
+- **Stale signatures could reach "unanimity" (the real defect):** `applyMove` never withdrew an agent's earlier signature when they moved. Now: putting new terms on the table (`addProposal`, both the PROPOSAL path and a BARGAIN counter) **withdraws the mover's signatures from every other open proposal** — and, symmetrically, signing someone else's terms **supersedes the signer's own open offer**. A turn carrying BOTH `accept` and `proposal` resolves deterministically for the proposal (the accept is ignored with a WARN — new terms mean the mover is not settling). Mutation-checked: without the withdrawal, the new test's agreement check would pass on a signature its signatory abandoned.
+- **Schema v4 (CodeRabbit Major, accepted):** `negotiationState` is resume-critical — an older deployment re-saving a paused v4 document would drop the table and the agreement check would run empty. `CURRENT_SCHEMA_VERSION` 3→4, identity hop (v3 docs have no negotiation state). Note: the I12 branch bumps to 4 for `runtimePhases` with the same reasoning — on merge the two v4s coalesce into one release-shape v4, which is correct: both features ship together and any pre-release pod must refuse both.
+- **`NegotiationState` encapsulated** (code-quality ×2): getters return unmodifiable views; mutation goes through `addProposal`/`replaceProposal`/`addConcession` — the table cannot be edited behind the state's back.
+- **Unused `phase` parameter dropped** from `applyRepeat` (call sites updated); **moderator filter null-safe** (`filter(Objects::nonNull)` before the id comparison); **CodeQL ×4** log-injection sites sanitized (`LogSanitizer` in `NegotiationEngine` ×3 + the service's skipIf log).
+
+**Tests:** +3 (counter-proposal withdraws the stale signature AND blocks the stale agreement; accept+proposal in one turn → proposal wins; GROUP member's signature not required for unanimity) and 2 extended (superseded-proposal acceptance is inert — the case the DisplayName claimed; the scripted bargain now asserts p2 is SUPERSEDED once its owner signs p3). `NegotiationEngineTest` 15 green; group suites green.
+
+---
+
 ## 🤝 feat(groups): I11 — NEGOTIATION style, the trade form (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i11-negotiation`)

--- a/docs/group-conversations.md
+++ b/docs/group-conversations.md
@@ -16,6 +16,7 @@ Group Conversations enable multiple agents to discuss a question. Each agent par
 | `DELPHI` | Anonymous rounds → convergence → Synthesis | Forecasting, reducing groupthink |
 | `DEBATE` | Pro → Con → Rebuttals → Judge | Trade-off analysis, comparisons |
 | `TASK_FORCE` | Plan → Execute → Verify → Synthesis | Structured task decomposition, parallel execution |
+| `NEGOTIATION` | Positions → Proposals → Bargaining → (Arbitration) → Synthesis | Surfacing trade-offs, drafting compromises |
 | `CUSTOM` | Define your own phases | Any workflow |
 
 ## Quick Start (MCP)
@@ -159,6 +160,37 @@ Both caps are enforced independently: `maxPerTurn` bounds a runaway single turn,
 `maxAgentAddedTasksPerDiscussion` bounds slow drift across a long discussion. The
 discussion cap counts only agent-filed tasks, so a large planned backlog does not
 exhaust it. A rejected call does not consume the per-turn budget.
+
+## Negotiation (I11)
+
+EDDI's other decision forms are win/lose; `NEGOTIATION` is the **trade** form —
+a process for surfacing trade-offs whose output is a drafted compromise with an
+explicit **concession ledger** for human sign-off.
+
+The preset: ① *Positions & Interests* (parallel, context-free — interests
+enable integrative trades) ② *Opening Proposals* ③ *Bargaining* (repeats =
+`maxRounds`, exits early on agreement) ④ *Arbitration* (moderator; **skipped
+entirely** when an agreement was reached — `skipIf: "AGREEMENT_REACHED"`, the
+single deterministic skip condition) ⑤ *Synthesis*.
+
+- A **BARGAIN** turn is a typed move: `{"accept": "<proposalId>"|null,
+  "proposal": {"terms": "..."}|null, "concessions": [{"gaveUp": "...",
+  "inReturnFor": "..."}]}` plus free-text reasoning. Three-tier parse; an
+  unreadable turn is prose with no state effect.
+- The typed structure is the anti-sycophancy mechanism: an acceptance must name
+  a specific proposal id, a concession that names nothing in return is **not
+  recorded**, and the open proposals + ledger are quoted into every turn — the
+  record the outcome will cite.
+- A new proposal supersedes the mover's own open one (one live offer per
+  agent); the proposer signs their own terms implicitly.
+- **Agreement** = every non-moderator participant signed the same open
+  proposal. The bargaining phase ends its repeats early and the conversation
+  carries `decision: {type: "AGREEMENT", method: "negotiation"}` whose
+  `tally.signedAcceptances` maps each signatory to the transcript index of
+  their signed acceptance entry — the (already signed) entries are the
+  co-signatures; no new crypto.
+- No agreement → the arbitration runs and its conclusion becomes
+  `decision: {type: "VERDICT", method: "arbitration"}`.
 
 ## Nested Groups (Group-of-Groups)
 

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -192,6 +192,12 @@ public class AgentGroupConfiguration {
         DEBATE,
         /** Collaborative task accomplishment: plan → execute → verify → synthesis. */
         TASK_FORCE,
+        /**
+         * Trade, not win/lose (I11): positions & interests → opening proposals →
+         * bargaining with a concession ledger → arbitration (skipped once an agreement
+         * is reached) → synthesis.
+         */
+        NEGOTIATION,
         /** User defines phases manually. */
         CUSTOM
     }
@@ -208,7 +214,7 @@ public class AgentGroupConfiguration {
      */
     public record DiscussionPhase(String name, PhaseType type, String participants, TurnOrder turnOrder, ContextScope contextScope,
             boolean targetEachPeer, String inputTemplate, int repeats, boolean requiresApproval, ConvergenceConfig convergence,
-            boolean allowAbstention) {
+            boolean allowAbstention, PhaseSkipCondition skipIf) {
 
         /**
          * Convenience constructor with defaults: participants=ALL,
@@ -217,6 +223,18 @@ public class AgentGroupConfiguration {
          */
         public DiscussionPhase(String name, PhaseType type) {
             this(name, type, "ALL", TurnOrder.SEQUENTIAL, ContextScope.FULL, false, null, 1, false);
+        }
+
+        /**
+         * Backward-compatible constructor without {@code skipIf} (I11) — {@code null}
+         * means the phase always runs, which is the behavior of every phase that
+         * predates I11.
+         */
+        public DiscussionPhase(String name, PhaseType type, String participants, TurnOrder turnOrder, ContextScope contextScope,
+                boolean targetEachPeer, String inputTemplate, int repeats, boolean requiresApproval, ConvergenceConfig convergence,
+                boolean allowAbstention) {
+            this(name, type, participants, turnOrder, contextScope, targetEachPeer, inputTemplate, repeats, requiresApproval, convergence,
+                    allowAbstention, null);
         }
 
         /**
@@ -323,7 +341,31 @@ public class AgentGroupConfiguration {
         /** Task execution by assigned agents. */
         EXECUTE,
         /** Verification of task results. */
-        VERIFY
+        VERIFY,
+        /**
+         * An opening offer in a negotiation (I11) — the whole turn is the proposal's
+         * terms.
+         */
+        PROPOSAL,
+        /**
+         * A bargaining turn (I11): accept an open proposal, counter with a new one,
+         * and/or record concessions — a typed JSON contract, parsed by
+         * {@code NegotiationEngine}.
+         */
+        BARGAIN
+    }
+
+    /**
+     * The one phase-skip condition (I11) — deliberately a single enum, not an
+     * expression language: deterministic governance means a phase is skipped for a
+     * reason the engine can PROVE, not one an expression evaluates to.
+     */
+    public enum PhaseSkipCondition {
+        /**
+         * Skip when the discussion already carries an AGREEMENT decision — the
+         * arbitration phase of a negotiation is only needed when bargaining failed.
+         */
+        AGREEMENT_REACHED
     }
 
     public enum TurnOrder {

--- a/src/main/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresets.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresets.java
@@ -272,6 +272,63 @@ public final class DiscussionStylePresets {
             ]
             ```""";
 
+    /**
+     * The opening offer (I11). The whole reply becomes the proposal's terms —
+     * deliberately prose, not JSON: an opening position is authored, not parsed.
+     */
+    public static final String TEMPLATE_PROPOSAL = """
+            A negotiation is underway on:
+            "{question}"
+
+            {#if previousResponses}
+            Positions and interests stated so far:
+            {#for entry in previousResponses}
+            — {entry.speaker}: "{entry.content}"
+            {/for}
+            {/if}
+
+            As {displayName}, state your OPENING PROPOSAL: concrete terms the \
+            others could accept. Your entire reply is the proposal.""";
+
+    /**
+     * The bargaining contract (I11). The baked-in rules are the anti-sycophancy
+     * mechanism: an acceptance must name a specific proposal id, and a concession
+     * that does not name what was received in return is not recorded. The current
+     * table (open proposals + concession ledger) is appended to this prompt by
+     * {@code NegotiationEngine.appendStateIfRelevant}.
+     */
+    public static final String TEMPLATE_BARGAIN = """
+            A negotiation is underway on:
+            "{question}"
+
+            As {displayName}, make your bargaining move. Reply with JSON in this exact shape \
+            (any field may be null/empty), followed by your free-text reasoning:
+            {"accept": "<proposalId>"|null, "proposal": {"terms": "..."}|null, "concessions": [{"gaveUp": "...", "inReturnFor": "..."}]}
+
+            Rules:
+            - Do not accept any proposal that fails your stated interests.
+            - Every concession must name what you received in return — unreciprocated concessions are not recorded.
+            - The ledger below is the record — it will be quoted in the outcome.""";
+
+    /**
+     * Arbitration (I11): bargaining ended without unanimous acceptance, so the
+     * moderator decides. Only rendered when the phase actually runs — an agreement
+     * skips it entirely ({@code skipIf=AGREEMENT_REACHED}).
+     */
+    public static final String TEMPLATE_ARBITRATION = """
+            You are arbitrating a negotiation on:
+            "{question}"
+
+            The parties bargained but did NOT reach unanimous agreement. The full \
+            transcript is your record:
+            {#for entry in transcript}
+            [{entry.phaseName}] {entry.speaker}: "{entry.content}"
+            {/for}
+
+            As the arbitrator, decide the outcome. Weigh the stated interests, the \
+            open proposals and the concession ledger (appended below); state your \
+            decision and its reasoning plainly.""";
+
     // Template lookup by phase type
     private static final Map<PhaseType, String> DEFAULT_TEMPLATES = Map.ofEntries(
             Map.entry(PhaseType.OPINION, TEMPLATE_OPINION_INDEPENDENT),
@@ -284,7 +341,9 @@ public final class DiscussionStylePresets {
             Map.entry(PhaseType.SYNTHESIS, TEMPLATE_SYNTHESIS),
             Map.entry(PhaseType.PLAN, TEMPLATE_PLAN),
             Map.entry(PhaseType.EXECUTE, TEMPLATE_EXECUTE),
-            Map.entry(PhaseType.VERIFY, TEMPLATE_VERIFY));
+            Map.entry(PhaseType.VERIFY, TEMPLATE_VERIFY),
+            Map.entry(PhaseType.PROPOSAL, TEMPLATE_PROPOSAL),
+            Map.entry(PhaseType.BARGAIN, TEMPLATE_BARGAIN));
 
     /**
      * Returns the default template for a given phase type.
@@ -318,8 +377,35 @@ public final class DiscussionStylePresets {
             case DELPHI -> delphi(rounds);
             case DEBATE -> debate();
             case TASK_FORCE -> taskForce();
+            case NEGOTIATION -> negotiation(rounds);
             case CUSTOM -> List.of();
         };
+    }
+
+    // --- NEGOTIATION (I11) ---
+
+    /**
+     * ① Positions & Interests — PARALLEL and context-free, so parties state genuine
+     * interests before anchoring on each other (interests are what enable
+     * integrative trades). ② Opening Proposals. ③ Bargaining, repeated
+     * {@code rounds} times — the repeat loop exits early on unanimous acceptance. ④
+     * Arbitration — skipped entirely when an agreement was reached. ⑤ Synthesis —
+     * quotes the ledger.
+     */
+    private static List<DiscussionPhase> negotiation(int rounds) {
+        List<DiscussionPhase> phases = new ArrayList<>();
+        phases.add(new DiscussionPhase("Positions & Interests", PhaseType.OPINION, "ALL", TurnOrder.PARALLEL,
+                ContextScope.NONE, false, null, 1));
+        phases.add(new DiscussionPhase("Opening Proposals", PhaseType.PROPOSAL, "ALL", TurnOrder.SEQUENTIAL,
+                ContextScope.FULL, false, null, 1));
+        phases.add(new DiscussionPhase("Bargaining", PhaseType.BARGAIN, "ALL", TurnOrder.SEQUENTIAL,
+                ContextScope.FULL, false, null, rounds));
+        phases.add(new DiscussionPhase("Arbitration", PhaseType.SYNTHESIS, "MODERATOR", TurnOrder.SEQUENTIAL,
+                ContextScope.FULL, false, TEMPLATE_ARBITRATION, 1, false, null, false,
+                AgentGroupConfiguration.PhaseSkipCondition.AGREEMENT_REACHED));
+        phases.add(new DiscussionPhase("Synthesis", PhaseType.SYNTHESIS, "MODERATOR", TurnOrder.SEQUENTIAL,
+                ContextScope.FULL, false, null, 1));
+        return phases;
     }
 
     // --- ROUND_TABLE ---

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
@@ -104,6 +104,12 @@ public class GroupConversation {
      * one of those features ran.
      */
     private DecisionRecord decision;
+    /**
+     * The negotiation's proposals + concession ledger (I11). {@code null} until the
+     * first PROPOSAL/BARGAIN phase produces state; persisted with the document so a
+     * pause/resume keeps the table as it stood.
+     */
+    private NegotiationState negotiation;
     private int depth;
     /** Current discussion round (1-based). Incremented by continueDiscussion(). */
     private int round = 1;
@@ -398,6 +404,76 @@ public class GroupConversation {
     }
 
     /**
+     * The negotiation's working state (I11): open/superseded proposals and the
+     * concession ledger. Persisted with the document — the ledger is the record,
+     * quoted back into every bargaining turn (accountability is the anti-sycophancy
+     * mechanism) and into the outcome.
+     * <p>
+     * Lists are copy-on-write for the same reason the roster lists are: Jackson
+     * walks them unguarded on every persist while a turn may append.
+     */
+    public static class NegotiationState {
+
+        private List<Proposal> proposals = new CopyOnWriteArrayList<>();
+        private List<Concession> concessions = new CopyOnWriteArrayList<>();
+
+        public List<Proposal> getProposals() {
+            return proposals;
+        }
+
+        public void setProposals(List<Proposal> proposals) {
+            this.proposals = proposals != null ? new CopyOnWriteArrayList<>(proposals) : new CopyOnWriteArrayList<>();
+        }
+
+        public List<Concession> getConcessions() {
+            return concessions;
+        }
+
+        public void setConcessions(List<Concession> concessions) {
+            this.concessions = concessions != null ? new CopyOnWriteArrayList<>(concessions) : new CopyOnWriteArrayList<>();
+        }
+    }
+
+    /**
+     * One proposal on the negotiation table (I11).
+     *
+     * @param id
+     *            stable id ("p1", "p2", …) — what a BARGAIN turn's {@code accept}
+     *            names
+     * @param byAgentId
+     *            the proposer (implicitly the first acceptor of their own terms)
+     * @param round
+     *            the phase repeat the proposal was made in
+     * @param terms
+     *            the proposal's terms — a String in v1, deliberately untyped
+     * @param status
+     *            OPEN, SUPERSEDED (the proposer made a newer proposal) or REJECTED
+     * @param acceptedBy
+     *            agent ids that accepted these terms
+     * @param acceptanceEntryIndices
+     *            agentId → absolute transcript index of that agent's accepting
+     *            entry. The signed transcript entries ARE the co-signatures — no
+     *            new crypto; these indices are what the AGREEMENT decision quotes
+     *            in {@code tally.signedAcceptances}
+     */
+    public record Proposal(String id, String byAgentId, int round, String terms, String status,
+            List<String> acceptedBy, Map<String, Integer> acceptanceEntryIndices) {
+    }
+
+    /** Proposal status: still on the table. */
+    public static final String PROPOSAL_OPEN = "OPEN";
+    /** Proposal status: replaced by the proposer's own newer proposal. */
+    public static final String PROPOSAL_SUPERSEDED = "SUPERSEDED";
+
+    /**
+     * One ledger line (I11): what an agent gave up, and what they received in
+     * return — every concession must name its counterpart; that structure is what
+     * stops sycophantic instant-agreement.
+     */
+    public record Concession(String byAgentId, int round, String gaveUp, String inReturnFor, String refProposalId) {
+    }
+
+    /**
      * What kind of conclusion a {@link DecisionRecord} represents (Wave 0, F3).
      */
     public enum DecisionType {
@@ -615,6 +691,23 @@ public class GroupConversation {
 
     public void setDecision(DecisionRecord decision) {
         this.decision = decision;
+    }
+
+    public NegotiationState getNegotiation() {
+        return negotiation;
+    }
+
+    public void setNegotiation(NegotiationState negotiation) {
+        this.negotiation = negotiation;
+    }
+
+    /** The negotiation state, created on first use (I11). */
+    @JsonIgnore
+    public NegotiationState negotiationState() {
+        if (negotiation == null) {
+            negotiation = new NegotiationState();
+        }
+        return negotiation;
     }
 
     public int getDepth() {

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
@@ -30,8 +30,16 @@ public class GroupConversation {
      * Current document shape this code understands (Wave 0, F6). Bump whenever a
      * Wave adds a field resume-time logic depends on, and register that version's
      * migration in {@code GroupConversationSchemaMigrations}.
+     * <p>
+     * Version 4 (I11): {@link #negotiationState} — resume-critical bargaining
+     * state. An older deployment resuming (or merely re-saving) a paused v4
+     * document would silently drop the proposals, signed acceptances and the
+     * concession ledger, and the agreement check would then run against an empty
+     * table — exactly the class of corruption the newer-than-current refusal exists
+     * to prevent. No migration entry: v3 documents have no negotiation state and
+     * the field defaults correctly via Jackson (identity hop).
      */
-    public static final int CURRENT_SCHEMA_VERSION = 3;
+    public static final int CURRENT_SCHEMA_VERSION = 4;
     /**
      * The shape this specific document was last written in. Checked before a
      * resume: newer than {@link #CURRENT_SCHEMA_VERSION} refuses (this deployment
@@ -417,20 +425,42 @@ public class GroupConversation {
         private List<Proposal> proposals = new CopyOnWriteArrayList<>();
         private List<Concession> concessions = new CopyOnWriteArrayList<>();
 
+        /**
+         * Read-only view — all mutation goes through {@link #addProposal},
+         * {@link #replaceProposal} and {@link #addConcession}, so the table cannot be
+         * edited behind the state's back.
+         */
         public List<Proposal> getProposals() {
-            return proposals;
+            return Collections.unmodifiableList(proposals);
         }
 
         public void setProposals(List<Proposal> proposals) {
             this.proposals = proposals != null ? new CopyOnWriteArrayList<>(proposals) : new CopyOnWriteArrayList<>();
         }
 
+        /** Read-only view — see {@link #getProposals}. */
         public List<Concession> getConcessions() {
-            return concessions;
+            return Collections.unmodifiableList(concessions);
         }
 
         public void setConcessions(List<Concession> concessions) {
             this.concessions = concessions != null ? new CopyOnWriteArrayList<>(concessions) : new CopyOnWriteArrayList<>();
+        }
+
+        public void addProposal(Proposal proposal) {
+            proposals.add(proposal);
+        }
+
+        /** In-place status/signature transition; a no-op if {@code oldOne} is gone. */
+        public void replaceProposal(Proposal oldOne, Proposal newOne) {
+            int idx = proposals.indexOf(oldOne);
+            if (idx >= 0) {
+                proposals.set(idx, newOne);
+            }
+        }
+
+        public void addConcession(Concession concession) {
+            concessions.add(concession);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
@@ -80,6 +80,8 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
             case DELPHI -> "Anonymous opinion rounds to reduce groupthink and achieve convergence";
             case DEBATE -> "Structured pro/con argumentation with rebuttal and judge";
             case TASK_FORCE -> "Collaborative task accomplishment: plan, execute in parallel, verify, synthesize";
+            case NEGOTIATION -> "Trade, not win/lose: positions, opening proposals, bargaining with a concession "
+                    + "ledger, arbitration only if no agreement, synthesis";
             case CUSTOM -> "User-defined phases for full control over the discussion flow";
         };
     }

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -26,6 +26,7 @@ import ai.labs.eddi.configs.hitl.HitlGranularity;
 import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
 import ai.labs.eddi.configs.groups.model.DiscussionStylePresets;
 import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionType;
 import ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
@@ -43,6 +44,7 @@ import ai.labs.eddi.engine.internal.groups.LiveDiscussionRegistry;
 import ai.labs.eddi.engine.internal.groups.GroupLifecycleOps;
 import ai.labs.eddi.engine.internal.groups.GroupSigningGuard;
 import ai.labs.eddi.engine.internal.groups.MemberTurnExecutor;
+import ai.labs.eddi.engine.internal.groups.NegotiationEngine;
 import ai.labs.eddi.engine.internal.groups.PhaseExecutionEngine;
 import ai.labs.eddi.engine.internal.groups.PhaseOutcome;
 import ai.labs.eddi.engine.internal.groups.TaskForceEngine;
@@ -672,6 +674,16 @@ public class GroupConversationService implements IGroupConversationService {
                     continue;
                 }
 
+                // I11: the one skip condition — a phase marked skipIf=AGREEMENT_REACHED
+                // (the negotiation's arbitration) is only needed when bargaining
+                // failed; a reached agreement makes it provably redundant. Checked
+                // deterministically against the typed decision, never inferred.
+                if (phase.skipIf() == AgentGroupConfiguration.PhaseSkipCondition.AGREEMENT_REACHED
+                        && gc.getDecision() != null && gc.getDecision().type() == DecisionType.AGREEMENT) {
+                    LOGGER.infof("Group %s: skipping phase '%s' — agreement already reached", gc.getGroupId(), phase.name());
+                    continue;
+                }
+
                 // I2: the previous repeat's contributions, the baseline the
                 // convergence judge compares against. Scoped to this phase — a
                 // comparison across two different phases would be meaningless.
@@ -816,6 +828,23 @@ public class GroupConversationService implements IGroupConversationService {
                                 repeatEntries, previousRepeatEntries, listener, turnCounter, maxTurns);
                     }
 
+                    // I11: fold this repeat's PROPOSAL/BARGAIN turns into the
+                    // negotiation state, then test for unanimous acceptance — which
+                    // ends the phase's repeats early through the same outcome
+                    // plumbing convergence uses. Applied BEFORE the persist below so
+                    // the table and the turns that produced it share one write.
+                    if (phase.type() == PhaseType.PROPOSAL || phase.type() == PhaseType.BARGAIN) {
+                        NegotiationEngine.applyRepeat(gc, phase, repeatEntries, transcriptSizeBeforeRepeat, repeat);
+                        if (phase.type() == PhaseType.BARGAIN
+                                && NegotiationEngine.checkAndRecordAgreement(gc, speakers, config.getModeratorAgentId(), phase.name())) {
+                            outcome = PhaseOutcome.endRepeats("Unanimous acceptance — agreement reached");
+                            if (listener != null) {
+                                listener.onDecisionReached(
+                                        new GroupConversationEventSink.DecisionReachedEvent(gc.getDecision()));
+                            }
+                        }
+                    }
+
                     // I4: the minority report. Placed AFTER the convergence slice above
                     // and BEFORE the persist below — after, so the DISSENT entries do
                     // not land inside repeatEntries where the convergence judge would
@@ -844,6 +873,16 @@ public class GroupConversationService implements IGroupConversationService {
                         // last-repeat reasoning as below — a draft judgment is not the
                         // decision.
                         phaseExecutionEngine.recordDebateVerdict(gc, config, phase, phaseIdx, speakers);
+                        // I11: an arbitration phase (skipIf=AGREEMENT_REACHED) that
+                        // RAN means bargaining failed — its conclusion is the
+                        // discussion's VERDICT. Never overwrites an existing decision.
+                        if (phase.skipIf() == AgentGroupConfiguration.PhaseSkipCondition.AGREEMENT_REACHED) {
+                            NegotiationEngine.recordArbitration(gc, repeatEntries, phase.name());
+                            if (gc.getDecision() != null && listener != null) {
+                                listener.onDecisionReached(
+                                        new GroupConversationEventSink.DecisionReachedEvent(gc.getDecision()));
+                            }
+                        }
                         if (config.isRecordDissents()) {
                             phaseExecutionEngine.runDissentRound(gc, config, phase, protocol, phaseIdx, speakers, listener,
                                     turnCounter, maxTurns);

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -680,7 +680,8 @@ public class GroupConversationService implements IGroupConversationService {
                 // deterministically against the typed decision, never inferred.
                 if (phase.skipIf() == AgentGroupConfiguration.PhaseSkipCondition.AGREEMENT_REACHED
                         && gc.getDecision() != null && gc.getDecision().type() == DecisionType.AGREEMENT) {
-                    LOGGER.infof("Group %s: skipping phase '%s' — agreement already reached", gc.getGroupId(), phase.name());
+                    LOGGER.infof("Group %s: skipping phase '%s' — agreement already reached",
+                            LogSanitizer.sanitize(gc.getGroupId()), LogSanitizer.sanitize(phase.name()));
                     continue;
                 }
 
@@ -834,7 +835,7 @@ public class GroupConversationService implements IGroupConversationService {
                     // plumbing convergence uses. Applied BEFORE the persist below so
                     // the table and the turns that produced it share one write.
                     if (phase.type() == PhaseType.PROPOSAL || phase.type() == PhaseType.BARGAIN) {
-                        NegotiationEngine.applyRepeat(gc, phase, repeatEntries, transcriptSizeBeforeRepeat, repeat);
+                        NegotiationEngine.applyRepeat(gc, repeatEntries, transcriptSizeBeforeRepeat, repeat);
                         if (phase.type() == PhaseType.BARGAIN
                                 && NegotiationEngine.checkAndRecordAgreement(gc, speakers, config.getModeratorAgentId(), phase.name())) {
                             outcome = PhaseOutcome.endRepeats("Unanimous acceptance — agreement reached");

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
@@ -185,6 +185,14 @@ public class GroupContextBuilder {
             case VERIFY -> {
                 // Completed tasks populated by executeTaskPhase
             }
+            case PROPOSAL, BARGAIN -> {
+                // I11: same peer context an OPINION turn gets — the negotiation
+                // TABLE (open proposals + concession ledger) is appended after
+                // rendering by NegotiationEngine.appendStateIfRelevant, because it
+                // lives on the GroupConversation, which this method does not see.
+                List<Map<String, Object>> prev = filterByScope(transcript, phase.contextScope(), phaseIdx, speaker);
+                data.put("previousResponses", prev);
+            }
             default -> {
                 // All PhaseType values handled above; default required by checkstyle
             }
@@ -370,6 +378,8 @@ public class GroupContextBuilder {
             case PLAN -> TranscriptEntryType.PLAN;
             case EXECUTE -> TranscriptEntryType.TASK_RESULT;
             case VERIFY -> TranscriptEntryType.VERIFICATION;
+            case PROPOSAL -> TranscriptEntryType.PROPOSAL;
+            case BARGAIN -> TranscriptEntryType.BARGAIN;
         };
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOps.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOps.java
@@ -364,6 +364,13 @@ public class GroupLifecycleOps {
             // and had this round's dissents merged onto them.
             gc.setSynthesizedAnswer(null);
             gc.setDecision(null);
+            // I11 (final-review finding): the negotiation table is a ROUND-scoped
+            // conclusion like the two fields above. Left in place, round 2 of a
+            // NEGOTIATION group runs against round 1's proposals — a single fresh
+            // acceptance can then reach "unanimous agreement" on signatures cast
+            // for a DIFFERENT question, and the signed-acceptance indices in the
+            // decision would even point at round 1's transcript entries.
+            gc.setNegotiation(null);
             gc.setResumeQuestion(question);
             gc.getTranscript().add(new TranscriptEntry(
                     "user", "User", question, 0, "Question",

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/NegotiationEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/NegotiationEngine.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.MemberType;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.Concession;
+import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionRecord;
+import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionType;
+import ai.labs.eddi.configs.groups.model.GroupConversation.NegotiationState;
+import ai.labs.eddi.configs.groups.model.GroupConversation.Proposal;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The negotiation protocol's state machine (I11): parses PROPOSAL and BARGAIN
+ * turns into {@link NegotiationState} mutations, detects unanimous agreement,
+ * and renders the ledger every bargaining turn is held accountable to.
+ * <p>
+ * EDDI's other decision forms are win/lose; this is the <b>trade</b> form. The
+ * typed structure — every acceptance names a proposal id, every concession
+ * names what was received in return, and the ledger is quoted back into every
+ * turn — is precisely what stops sycophantic instant-agreement: an agent cannot
+ * "agree" without signing a specific set of terms on the record.
+ * <p>
+ * Parse discipline mirrors {@link VoteTallyEngine}: three tiers (strict JSON →
+ * JSON embedded in prose/fence → give up), {@code FAIL_ON_TRAILING_TOKENS}, and
+ * an unreadable turn is prose with NO state effect (WARN) — never a guessed
+ * acceptance.
+ *
+ * @author ginccc
+ */
+public final class NegotiationEngine {
+
+    private static final Logger LOGGER = Logger.getLogger(NegotiationEngine.class);
+
+    /** The mechanism tag on an AGREEMENT reached by unanimous acceptance. */
+    public static final String METHOD_NEGOTIATION = "negotiation";
+    /**
+     * The mechanism tag on a VERDICT the moderator arbitrated after failed
+     * bargaining.
+     */
+    public static final String METHOD_ARBITRATION = "arbitration";
+
+    /**
+     * Terms are quoted into every turn's ledger — bound the quoting, not the entry.
+     */
+    static final int MAX_QUOTED_TERMS_CHARS = 600;
+
+    private static final ObjectMapper MAPPER = JsonMapper.builder()
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .build();
+
+    private NegotiationEngine() {
+    }
+
+    /**
+     * One parsed BARGAIN turn. Any of the parts may be absent; a turn that carries
+     * none of them is a non-move.
+     */
+    record BargainMove(String accept, String proposalTerms, List<ParsedConcession> concessions) {
+    }
+
+    record ParsedConcession(String gaveUp, String inReturnFor) {
+    }
+
+    /**
+     * Applies one completed PROPOSAL/BARGAIN repeat to the negotiation state.
+     * <p>
+     * PROPOSAL entries: the whole turn is the proposal's terms (String v1). BARGAIN
+     * entries: the JSON contract — {@code accept} joins an OPEN proposal's
+     * signatories, {@code proposal} supersedes the mover's own open proposals and
+     * puts new terms on the table, {@code concessions} append to the ledger. An
+     * unparseable BARGAIN turn is prose with no state effect.
+     *
+     * @param transcriptOffset
+     *            absolute transcript index of the repeat's first entry — what turns
+     *            a position in {@code repeatEntries} into the signed entry index an
+     *            acceptance records
+     */
+    public static void applyRepeat(GroupConversation gc, DiscussionPhase phase, List<TranscriptEntry> repeatEntries,
+                                   int transcriptOffset, int round) {
+        if (repeatEntries == null || repeatEntries.isEmpty()) {
+            return;
+        }
+        NegotiationState state = gc.negotiationState();
+        for (int i = 0; i < repeatEntries.size(); i++) {
+            TranscriptEntry entry = repeatEntries.get(i);
+            if (entry == null || entry.content() == null || entry.content().isBlank()) {
+                continue;
+            }
+            int entryIndex = transcriptOffset + i;
+            if (entry.type() == TranscriptEntryType.PROPOSAL) {
+                addProposal(state, entry.speakerAgentId(), entry.content().trim(), round, entryIndex);
+            } else if (entry.type() == TranscriptEntryType.BARGAIN) {
+                BargainMove move = parseBargain(entry.content());
+                if (move == null) {
+                    LOGGER.warnf("Group %s: unparseable BARGAIN turn from '%s' — prose only, no state effect",
+                            gc.getId(), entry.speakerAgentId());
+                    continue;
+                }
+                applyMove(gc, state, entry.speakerAgentId(), move, round, entryIndex);
+            }
+        }
+    }
+
+    /**
+     * Three-tier BARGAIN parse. {@code null} = not a readable move.
+     */
+    static BargainMove parseBargain(String content) {
+        JsonNode node = readJson(content);
+        if (node == null) {
+            node = readJson(embeddedJson(content));
+        }
+        if (node == null || !node.isObject()) {
+            return null;
+        }
+        String accept = node.path("accept").isTextual() && !node.path("accept").asText().isBlank()
+                ? node.path("accept").asText().trim()
+                : null;
+        String proposalTerms = null;
+        JsonNode proposal = node.path("proposal");
+        if (proposal.isObject() && proposal.path("terms").isTextual() && !proposal.path("terms").asText().isBlank()) {
+            proposalTerms = proposal.path("terms").asText().trim();
+        }
+        List<ParsedConcession> concessions = new ArrayList<>();
+        if (node.path("concessions").isArray()) {
+            for (JsonNode c : node.path("concessions")) {
+                String gaveUp = c.path("gaveUp").isTextual() ? c.path("gaveUp").asText().trim() : null;
+                String inReturnFor = c.path("inReturnFor").isTextual() ? c.path("inReturnFor").asText().trim() : null;
+                // The rule IS the structure: a concession that does not name what
+                // was received in return is not recorded.
+                if (gaveUp != null && !gaveUp.isBlank() && inReturnFor != null && !inReturnFor.isBlank()) {
+                    concessions.add(new ParsedConcession(gaveUp, inReturnFor));
+                }
+            }
+        }
+        if (accept == null && proposalTerms == null && concessions.isEmpty()) {
+            return null;
+        }
+        return new BargainMove(accept, proposalTerms, concessions);
+    }
+
+    private static void applyMove(GroupConversation gc, NegotiationState state, String agentId, BargainMove move,
+                                  int round, int entryIndex) {
+        if (move.accept() != null) {
+            Proposal target = findById(state, move.accept());
+            if (target == null || !GroupConversation.PROPOSAL_OPEN.equals(target.status())) {
+                LOGGER.warnf("Group %s: '%s' accepted %s proposal '%s' — ignored",
+                        gc.getId(), agentId, target == null ? "unknown" : "non-open", move.accept());
+            } else if (!target.acceptedBy().contains(agentId)) {
+                List<String> acceptedBy = new ArrayList<>(target.acceptedBy());
+                acceptedBy.add(agentId);
+                Map<String, Integer> indices = new LinkedHashMap<>(target.acceptanceEntryIndices());
+                indices.put(agentId, entryIndex);
+                replace(state, target, new Proposal(target.id(), target.byAgentId(), target.round(), target.terms(),
+                        target.status(), List.copyOf(acceptedBy), Map.copyOf(indices)));
+            }
+        }
+        Proposal added = null;
+        if (move.proposalTerms() != null) {
+            added = addProposal(state, agentId, move.proposalTerms(), round, entryIndex);
+        }
+        for (ParsedConcession c : move.concessions()) {
+            state.getConcessions().add(new Concession(agentId, round, c.gaveUp(), c.inReturnFor(),
+                    added != null ? added.id() : null));
+        }
+    }
+
+    /**
+     * Puts new terms on the table. The proposer's own OPEN proposals are SUPERSEDED
+     * — one live offer per agent — and the proposer signs their own terms
+     * implicitly (their authoring entry is the signature).
+     */
+    private static Proposal addProposal(NegotiationState state, String agentId, String terms, int round, int entryIndex) {
+        for (Proposal p : state.getProposals()) {
+            if (GroupConversation.PROPOSAL_OPEN.equals(p.status()) && p.byAgentId().equals(agentId)) {
+                replace(state, p, new Proposal(p.id(), p.byAgentId(), p.round(), p.terms(),
+                        GroupConversation.PROPOSAL_SUPERSEDED, p.acceptedBy(), p.acceptanceEntryIndices()));
+            }
+        }
+        Proposal proposal = new Proposal("p" + (state.getProposals().size() + 1), agentId, round, terms,
+                GroupConversation.PROPOSAL_OPEN, List.of(agentId), Map.of(agentId, entryIndex));
+        state.getProposals().add(proposal);
+        return proposal;
+    }
+
+    private static Proposal findById(NegotiationState state, String id) {
+        return state.getProposals().stream().filter(p -> p.id().equals(id)).findFirst().orElse(null);
+    }
+
+    private static void replace(NegotiationState state, Proposal oldOne, Proposal newOne) {
+        int idx = state.getProposals().indexOf(oldOne);
+        if (idx >= 0) {
+            state.getProposals().set(idx, newOne);
+        }
+    }
+
+    /**
+     * Unanimous agreement: every non-moderator AGENT participant has signed the
+     * SAME open proposal. Records the AGREEMENT decision — the signed acceptance
+     * entries ARE the co-signatures; their transcript indices ride
+     * {@code tally.signedAcceptances}, no new crypto — and returns {@code true} so
+     * the caller can end the phase's repeats early (the I2 plumbing).
+     */
+    public static boolean checkAndRecordAgreement(GroupConversation gc, List<GroupMember> participants,
+                                                  String moderatorAgentId, String phaseName) {
+        NegotiationState state = gc.getNegotiation();
+        if (state == null || state.getProposals().isEmpty() || participants == null || participants.isEmpty()) {
+            return false;
+        }
+        List<String> required = participants.stream()
+                .filter(Objects::nonNull)
+                .filter(m -> m.memberType() != MemberType.GROUP)
+                .map(GroupMember::agentId)
+                .filter(id -> !id.equals(moderatorAgentId))
+                .distinct()
+                .toList();
+        if (required.isEmpty()) {
+            return false;
+        }
+        for (Proposal p : state.getProposals()) {
+            if (!GroupConversation.PROPOSAL_OPEN.equals(p.status())) {
+                continue;
+            }
+            if (p.acceptedBy().containsAll(required)) {
+                Map<String, Object> tally = new LinkedHashMap<>();
+                tally.put("proposalId", p.id());
+                tally.put("proposedBy", p.byAgentId());
+                tally.put("terms", p.terms());
+                tally.put("signedAcceptances", p.acceptanceEntryIndices());
+                tally.put("concessions", state.getConcessions().stream().map(c -> {
+                    Map<String, Object> line = new LinkedHashMap<>();
+                    line.put("by", c.byAgentId());
+                    line.put("gaveUp", c.gaveUp());
+                    line.put("inReturnFor", c.inReturnFor());
+                    return line;
+                }).toList());
+                String outcome = "Agreement on proposal %s (by %s), signed by all %d participants: %s%s".formatted(
+                        p.id(), p.byAgentId(), required.size(), truncate(p.terms()),
+                        state.getConcessions().isEmpty()
+                                ? ""
+                                : " — " + state.getConcessions().size() + " concession(s) on the ledger.");
+                gc.setDecision(new DecisionRecord(DecisionType.AGREEMENT, outcome, p.id(), tally, List.of(),
+                        METHOD_NEGOTIATION, phaseName, null));
+                LOGGER.infof("Group %s: negotiation reached agreement on proposal %s", gc.getId(), p.id());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Records the moderator's arbitration as the discussion's VERDICT (I11) — the
+     * bargaining failed, so the last arbitration entry's prose is the decision.
+     * Never overwrites an existing decision.
+     */
+    public static void recordArbitration(GroupConversation gc, List<TranscriptEntry> repeatEntries, String phaseName) {
+        if (gc.getDecision() != null || repeatEntries == null) {
+            return;
+        }
+        repeatEntries.stream()
+                .filter(e -> e != null && e.type() == TranscriptEntryType.SYNTHESIS && e.content() != null
+                        && !e.content().isBlank())
+                .reduce((first, second) -> second)
+                .ifPresent(e -> gc.setDecision(new DecisionRecord(DecisionType.VERDICT, e.content(), null, null,
+                        List.of(), METHOD_ARBITRATION, phaseName, null)));
+    }
+
+    /**
+     * Renders the negotiation state into a turn's input: open proposals (with ids,
+     * so an acceptance can name one) and the concession ledger. Appended to
+     * PROPOSAL/BARGAIN turns and to negotiation SYNTHESIS turns (arbitration and
+     * final synthesis quote the ledger); a no-op for every other phase or when
+     * there is no state yet.
+     */
+    public static String appendStateIfRelevant(String input, GroupConversation gc, DiscussionPhase phase) {
+        NegotiationState state = gc.getNegotiation();
+        if (state == null || (state.getProposals().isEmpty() && state.getConcessions().isEmpty())) {
+            return input;
+        }
+        if (phase.type() != PhaseType.PROPOSAL && phase.type() != PhaseType.BARGAIN
+                && phase.type() != PhaseType.SYNTHESIS) {
+            return input;
+        }
+        var sb = new StringBuilder(input);
+        sb.append("\n\nNEGOTIATION TABLE (the record — it will be quoted in the outcome):\n");
+        sb.append("Open proposals:\n");
+        boolean anyOpen = false;
+        for (Proposal p : state.getProposals()) {
+            if (GroupConversation.PROPOSAL_OPEN.equals(p.status())) {
+                anyOpen = true;
+                sb.append("- [").append(p.id()).append("] by ").append(p.byAgentId())
+                        .append(" (accepted by: ").append(String.join(", ", p.acceptedBy())).append("): ")
+                        .append(truncate(p.terms())).append('\n');
+            }
+        }
+        if (!anyOpen) {
+            sb.append("- (none)\n");
+        }
+        sb.append("Concession ledger:\n");
+        if (state.getConcessions().isEmpty()) {
+            sb.append("- (empty)\n");
+        } else {
+            for (Concession c : state.getConcessions()) {
+                sb.append("- ").append(c.byAgentId()).append(" gave up \"").append(truncate(c.gaveUp()))
+                        .append("\" in return for \"").append(truncate(c.inReturnFor())).append("\"\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static String truncate(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.length() <= MAX_QUOTED_TERMS_CHARS ? value : value.substring(0, MAX_QUOTED_TERMS_CHARS) + "…";
+    }
+
+    private static JsonNode readJson(String content) {
+        if (content == null || content.isBlank()) {
+            return null;
+        }
+        try {
+            return MAPPER.readTree(content.trim());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** JSON embedded in prose or a code fence — first balanced object. */
+    private static String embeddedJson(String content) {
+        if (content == null) {
+            return null;
+        }
+        int start = content.indexOf('{');
+        if (start < 0) {
+            return null;
+        }
+        int depth = 0;
+        boolean inString = false;
+        boolean escaped = false;
+        for (int i = start; i < content.length(); i++) {
+            char c = content.charAt(i);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                inString = !inString;
+            } else if (!inString) {
+                if (c == '{') {
+                    depth++;
+                } else if (c == '}') {
+                    depth--;
+                    if (depth == 0) {
+                        return content.substring(start, i + 1);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/NegotiationEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/NegotiationEngine.java
@@ -16,6 +16,7 @@ import ai.labs.eddi.configs.groups.model.GroupConversation.NegotiationState;
 import ai.labs.eddi.configs.groups.model.GroupConversation.Proposal;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import ai.labs.eddi.utils.LogSanitizer;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -85,16 +86,20 @@ public final class NegotiationEngine {
      * <p>
      * PROPOSAL entries: the whole turn is the proposal's terms (String v1). BARGAIN
      * entries: the JSON contract — {@code accept} joins an OPEN proposal's
-     * signatories, {@code proposal} supersedes the mover's own open proposals and
-     * puts new terms on the table, {@code concessions} append to the ledger. An
-     * unparseable BARGAIN turn is prose with no state effect.
+     * signatories (and abandons the signer's own open offer), {@code proposal}
+     * supersedes the mover's own open proposals, withdraws their signatures from
+     * everyone else's, and puts new terms on the table; {@code concessions} append
+     * to the ledger. A turn carrying BOTH {@code accept} and {@code proposal} is
+     * resolved for the proposal — the accept is ignored with a WARN, because new
+     * terms mean the mover is not settling on existing ones. An unparseable BARGAIN
+     * turn is prose with no state effect.
      *
      * @param transcriptOffset
      *            absolute transcript index of the repeat's first entry — what turns
      *            a position in {@code repeatEntries} into the signed entry index an
      *            acceptance records
      */
-    public static void applyRepeat(GroupConversation gc, DiscussionPhase phase, List<TranscriptEntry> repeatEntries,
+    public static void applyRepeat(GroupConversation gc, List<TranscriptEntry> repeatEntries,
                                    int transcriptOffset, int round) {
         if (repeatEntries == null || repeatEntries.isEmpty()) {
             return;
@@ -112,7 +117,7 @@ public final class NegotiationEngine {
                 BargainMove move = parseBargain(entry.content());
                 if (move == null) {
                     LOGGER.warnf("Group %s: unparseable BARGAIN turn from '%s' — prose only, no state effect",
-                            gc.getId(), entry.speakerAgentId());
+                            LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(entry.speakerAgentId()));
                     continue;
                 }
                 applyMove(gc, state, entry.speakerAgentId(), move, round, entryIndex);
@@ -159,57 +164,84 @@ public final class NegotiationEngine {
 
     private static void applyMove(GroupConversation gc, NegotiationState state, String agentId, BargainMove move,
                                   int round, int entryIndex) {
-        if (move.accept() != null) {
+        boolean counterProposal = move.proposalTerms() != null;
+        if (move.accept() != null && counterProposal) {
+            // Contradictory intent, resolved deterministically: new terms mean the
+            // mover is NOT settling on existing ones. Honoring the accept would
+            // record a signature the same turn walks away from.
+            LOGGER.warnf("Group %s: '%s' sent accept AND a counter-proposal in one turn — the counter-proposal wins, "
+                    + "the accept is ignored", LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(agentId));
+        } else if (move.accept() != null) {
             Proposal target = findById(state, move.accept());
             if (target == null || !GroupConversation.PROPOSAL_OPEN.equals(target.status())) {
                 LOGGER.warnf("Group %s: '%s' accepted %s proposal '%s' — ignored",
-                        gc.getId(), agentId, target == null ? "unknown" : "non-open", move.accept());
+                        LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(agentId),
+                        target == null ? "unknown" : "non-open", LogSanitizer.sanitize(move.accept()));
             } else if (!target.acceptedBy().contains(agentId)) {
                 List<String> acceptedBy = new ArrayList<>(target.acceptedBy());
                 acceptedBy.add(agentId);
                 Map<String, Integer> indices = new LinkedHashMap<>(target.acceptanceEntryIndices());
                 indices.put(agentId, entryIndex);
-                replace(state, target, new Proposal(target.id(), target.byAgentId(), target.round(), target.terms(),
-                        target.status(), List.copyOf(acceptedBy), Map.copyOf(indices)));
+                state.replaceProposal(target, new Proposal(target.id(), target.byAgentId(), target.round(),
+                        target.terms(), target.status(), List.copyOf(acceptedBy), Map.copyOf(indices)));
+                // Signing someone else's terms abandons the signer's own live
+                // offer — the symmetric half of addProposal's withdrawal rule: any
+                // move that puts an agent's name on new terms removes their
+                // competing one from the table.
+                for (Proposal own : state.getProposals()) {
+                    if (GroupConversation.PROPOSAL_OPEN.equals(own.status())
+                            && own.byAgentId().equals(agentId) && !own.id().equals(target.id())) {
+                        state.replaceProposal(own, new Proposal(own.id(), own.byAgentId(), own.round(), own.terms(),
+                                GroupConversation.PROPOSAL_SUPERSEDED, own.acceptedBy(), own.acceptanceEntryIndices()));
+                    }
+                }
             }
         }
         Proposal added = null;
-        if (move.proposalTerms() != null) {
+        if (counterProposal) {
             added = addProposal(state, agentId, move.proposalTerms(), round, entryIndex);
         }
         for (ParsedConcession c : move.concessions()) {
-            state.getConcessions().add(new Concession(agentId, round, c.gaveUp(), c.inReturnFor(),
+            state.addConcession(new Concession(agentId, round, c.gaveUp(), c.inReturnFor(),
                     added != null ? added.id() : null));
         }
     }
 
     /**
-     * Puts new terms on the table. The proposer's own OPEN proposals are SUPERSEDED
-     * — one live offer per agent — and the proposer signs their own terms
-     * implicitly (their authoring entry is the signature).
+     * Puts new terms on the table. Because a new offer means the mover has moved,
+     * it does two withdrawals first: the proposer's own OPEN proposals are
+     * SUPERSEDED (one live offer per agent), and the proposer's <b>signatures on
+     * every other open proposal are withdrawn</b> — otherwise a proposal could
+     * reach "unanimity" on a signature its signatory abandoned turns ago, which is
+     * exactly the stale-agreement failure the typed ledger exists to prevent. The
+     * proposer then signs their own terms implicitly (the authoring entry is the
+     * signature).
      */
     private static Proposal addProposal(NegotiationState state, String agentId, String terms, int round, int entryIndex) {
         for (Proposal p : state.getProposals()) {
-            if (GroupConversation.PROPOSAL_OPEN.equals(p.status()) && p.byAgentId().equals(agentId)) {
-                replace(state, p, new Proposal(p.id(), p.byAgentId(), p.round(), p.terms(),
+            if (!GroupConversation.PROPOSAL_OPEN.equals(p.status())) {
+                continue;
+            }
+            if (p.byAgentId().equals(agentId)) {
+                state.replaceProposal(p, new Proposal(p.id(), p.byAgentId(), p.round(), p.terms(),
                         GroupConversation.PROPOSAL_SUPERSEDED, p.acceptedBy(), p.acceptanceEntryIndices()));
+            } else if (p.acceptedBy().contains(agentId)) {
+                List<String> acceptedBy = new ArrayList<>(p.acceptedBy());
+                acceptedBy.remove(agentId);
+                Map<String, Integer> indices = new LinkedHashMap<>(p.acceptanceEntryIndices());
+                indices.remove(agentId);
+                state.replaceProposal(p, new Proposal(p.id(), p.byAgentId(), p.round(), p.terms(),
+                        p.status(), List.copyOf(acceptedBy), Map.copyOf(indices)));
             }
         }
         Proposal proposal = new Proposal("p" + (state.getProposals().size() + 1), agentId, round, terms,
                 GroupConversation.PROPOSAL_OPEN, List.of(agentId), Map.of(agentId, entryIndex));
-        state.getProposals().add(proposal);
+        state.addProposal(proposal);
         return proposal;
     }
 
     private static Proposal findById(NegotiationState state, String id) {
         return state.getProposals().stream().filter(p -> p.id().equals(id)).findFirst().orElse(null);
-    }
-
-    private static void replace(NegotiationState state, Proposal oldOne, Proposal newOne) {
-        int idx = state.getProposals().indexOf(oldOne);
-        if (idx >= 0) {
-            state.getProposals().set(idx, newOne);
-        }
     }
 
     /**
@@ -229,6 +261,7 @@ public final class NegotiationEngine {
                 .filter(Objects::nonNull)
                 .filter(m -> m.memberType() != MemberType.GROUP)
                 .map(GroupMember::agentId)
+                .filter(Objects::nonNull)
                 .filter(id -> !id.equals(moderatorAgentId))
                 .distinct()
                 .toList();
@@ -259,7 +292,8 @@ public final class NegotiationEngine {
                                 : " — " + state.getConcessions().size() + " concession(s) on the ledger.");
                 gc.setDecision(new DecisionRecord(DecisionType.AGREEMENT, outcome, p.id(), tally, List.of(),
                         METHOD_NEGOTIATION, phaseName, null));
-                LOGGER.infof("Group %s: negotiation reached agreement on proposal %s", gc.getId(), p.id());
+                LOGGER.infof("Group %s: negotiation reached agreement on proposal %s",
+                        LogSanitizer.sanitize(gc.getId()), p.id());
                 return true;
             }
         }

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
@@ -512,6 +512,9 @@ public class PhaseExecutionEngine {
             }
             String input = contextBuilder.buildPhaseInput(phase, speaker, question, gc.getTranscript(), phaseIdx, null,
                     GroupConversationService.rosterWithRecruits(config, gc));
+            // I11: the negotiation table lives on gc, which buildPhaseInput does
+            // not see — appended here (no-op for non-negotiation phases).
+            input = NegotiationEngine.appendStateIfRelevant(input, gc, phase);
             TranscriptEntry entry = memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, null, listener);
             gc.getTranscript().add(entry);
             if (listener != null) {
@@ -587,6 +590,8 @@ public class PhaseExecutionEngine {
                     try {
                         String input = contextBuilder.buildPhaseInput(phase, speaker, question, snapshotTranscript, phaseIdx, null,
                                 GroupConversationService.rosterWithRecruits(config, gc));
+                        // I11: see the sequential loop — appended, not templated.
+                        input = NegotiationEngine.appendStateIfRelevant(input, gc, phase);
                         return memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, null, listener, cancellation);
                     } catch (MemberTurnCancelledException e) {
                         // The orchestrator stopped waiting for this batch — surface the

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListener.java
@@ -41,7 +41,7 @@ public class SlackGroupDiscussionListener implements GroupDiscussionEventListene
      * mode (single thread) is too hard to follow with multiple agents.
      */
     private static final Set<String> EXPANDED_STYLES = Set.of(
-            "ROUND_TABLE", "PEER_REVIEW", "DEVIL_ADVOCATE", "DEBATE", "DELPHI", "TASK_FORCE");
+            "ROUND_TABLE", "PEER_REVIEW", "DEVIL_ADVOCATE", "DEBATE", "DELPHI", "TASK_FORCE", "NEGOTIATION");
 
     private final SlackWebApiClient slackApi;
     private final String authToken;

--- a/src/test/java/ai/labs/eddi/configs/groups/model/AgentGroupConfigurationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/model/AgentGroupConfigurationTest.java
@@ -47,13 +47,14 @@ class AgentGroupConfigurationTest {
 
     @Test
     void style_allValues() {
-        assertEquals(7, DiscussionStyle.values().length);
+        assertEquals(8, DiscussionStyle.values().length);
         assertNotNull(DiscussionStyle.valueOf("ROUND_TABLE"));
         assertNotNull(DiscussionStyle.valueOf("PEER_REVIEW"));
         assertNotNull(DiscussionStyle.valueOf("DEVIL_ADVOCATE"));
         assertNotNull(DiscussionStyle.valueOf("DELPHI"));
         assertNotNull(DiscussionStyle.valueOf("DEBATE"));
         assertNotNull(DiscussionStyle.valueOf("TASK_FORCE"));
+        assertNotNull(DiscussionStyle.valueOf("NEGOTIATION"));
         assertNotNull(DiscussionStyle.valueOf("CUSTOM"));
     }
 
@@ -136,7 +137,9 @@ class AgentGroupConfigurationTest {
 
     @Test
     void phaseType_allValues() {
-        assertEquals(11, PhaseType.values().length);
+        assertEquals(13, PhaseType.values().length);
+        assertNotNull(PhaseType.valueOf("PROPOSAL"));
+        assertNotNull(PhaseType.valueOf("BARGAIN"));
         assertNotNull(PhaseType.valueOf("OPINION"));
         assertNotNull(PhaseType.valueOf("CRITIQUE"));
         assertNotNull(PhaseType.valueOf("REVISION"));

--- a/src/test/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresetsTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresetsTest.java
@@ -267,6 +267,48 @@ class DiscussionStylePresetsTest {
         assertEquals(PhaseType.SYNTHESIS, phases.get(3).type());
     }
 
+    // --- NEGOTIATION (I11) ---
+
+    @Test
+    void negotiation_produces5Phases_withTheProtocolShape() {
+        List<DiscussionPhase> phases = DiscussionStylePresets.expand(DiscussionStyle.NEGOTIATION, 3);
+
+        assertEquals(5, phases.size());
+
+        // ① Positions & Interests — PARALLEL and context-free: parties state
+        // genuine interests before anchoring on each other.
+        var positions = phases.get(0);
+        assertEquals(PhaseType.OPINION, positions.type());
+        assertEquals(TurnOrder.PARALLEL, positions.turnOrder());
+        assertEquals(ContextScope.NONE, positions.contextScope());
+
+        // ② Opening Proposals
+        var proposals = phases.get(1);
+        assertEquals(PhaseType.PROPOSAL, proposals.type());
+        assertEquals("ALL", proposals.participants());
+
+        // ③ Bargaining — repeats = maxRounds; the loop exits early on agreement.
+        var bargaining = phases.get(2);
+        assertEquals(PhaseType.BARGAIN, bargaining.type());
+        assertEquals(3, bargaining.repeats());
+        assertEquals(TurnOrder.SEQUENTIAL, bargaining.turnOrder());
+
+        // ④ Arbitration — MODERATOR, skipped entirely when agreement was reached,
+        // with its own template (the default SYNTHESIS asks for a balanced
+        // summary; an arbitrator DECIDES).
+        var arbitration = phases.get(3);
+        assertEquals(PhaseType.SYNTHESIS, arbitration.type());
+        assertEquals("MODERATOR", arbitration.participants());
+        assertEquals(AgentGroupConfiguration.PhaseSkipCondition.AGREEMENT_REACHED, arbitration.skipIf());
+        assertEquals(DiscussionStylePresets.TEMPLATE_ARBITRATION, arbitration.inputTemplate());
+
+        // ⑤ Synthesis
+        var synthesis = phases.get(4);
+        assertEquals(PhaseType.SYNTHESIS, synthesis.type());
+        assertEquals("MODERATOR", synthesis.participants());
+        assertNull(synthesis.skipIf(), "only the arbitration is conditional");
+    }
+
     @Test
     void taskForce_turnOrders() {
         List<DiscussionPhase> phases = DiscussionStylePresets.expand(DiscussionStyle.TASK_FORCE, 1);

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTest.java
@@ -982,6 +982,12 @@ class GroupConversationServiceTest {
             inProgress.setGroupId("group-1");
             inProgress.setState(GroupConversationState.IN_PROGRESS);
             inProgress.setRound(1);
+            // Final-review finding: the negotiation table is a round-scoped
+            // conclusion. Seed round 1's table with a signed proposal — round 2
+            // must NOT be able to reach "unanimous agreement" on it.
+            inProgress.negotiationState().addProposal(new GroupConversation.Proposal(
+                    "p1", "a1", 0, "round 1 terms", GroupConversation.PROPOSAL_OPEN,
+                    java.util.List.of("a1"), java.util.Map.of("a1", 3)));
             when(conversationStore.read("gc-1")).thenReturn(gc, inProgress);
             when(conversationStore.compareAndSetState("gc-1",
                     GroupConversationState.COMPLETED, GroupConversationState.IN_PROGRESS)).thenReturn(true);
@@ -992,6 +998,8 @@ class GroupConversationServiceTest {
                     () -> service.continueDiscussion("gc-1", "round two question", null));
 
             assertEquals(2, inProgress.getRound());
+            assertNull(inProgress.getNegotiation(),
+                    "round 1's proposals and signatures must not survive into round 2's bargaining");
             var transcript = inProgress.getTranscript();
             assertFalse(transcript.isEmpty());
             var last = transcript.get(transcript.size() - 1);

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/NegotiationEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/NegotiationEngineTest.java
@@ -100,7 +100,7 @@ class NegotiationEngineTest {
     void apply_proposalTurn() {
         var gc = gc();
 
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "We split revenue 50/50.")), 10, 0);
+        NegotiationEngine.applyRepeat(gc, List.of(proposal("a1", "We split revenue 50/50.")), 10, 0);
 
         var proposals = gc.getNegotiation().getProposals();
         assertEquals(1, proposals.size());
@@ -116,9 +116,9 @@ class NegotiationEngineTest {
     @DisplayName("a new proposal by the same agent SUPERSEDES their open one — one live offer per agent")
     void apply_supersession() {
         var gc = gc();
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "50/50")), 0, 0);
+        NegotiationEngine.applyRepeat(gc, List.of(proposal("a1", "50/50")), 0, 0);
 
-        NegotiationEngine.applyRepeat(gc, bargainPhase(),
+        NegotiationEngine.applyRepeat(gc,
                 List.of(bargain("a1", "{\"proposal\": {\"terms\": \"55/45 with support included\"}}")), 1, 1);
 
         var proposals = gc.getNegotiation().getProposals();
@@ -132,26 +132,69 @@ class NegotiationEngineTest {
     @DisplayName("accepting an unknown or superseded proposal is ignored; an unparseable turn is inert")
     void apply_badMovesAreInert() {
         var gc = gc();
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "50/50")), 0, 0);
+        NegotiationEngine.applyRepeat(gc, List.of(proposal("a1", "50/50")), 0, 0);
         var before = List.copyOf(gc.getNegotiation().getProposals());
 
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+        NegotiationEngine.applyRepeat(gc, List.of(
                 bargain("a2", "{\"accept\": \"p99\"}"),
                 bargain("a2", "Honestly I just want to talk it through some more.")), 1, 1);
 
         assertEquals(before, gc.getNegotiation().getProposals(), "no guessed acceptances, no state drift");
         assertTrue(gc.getNegotiation().getConcessions().isEmpty());
+
+        // p1 is superseded by a1's counter; a2 may no longer sign it.
+        NegotiationEngine.applyRepeat(gc, List.of(bargain("a1", "{\"proposal\": {\"terms\": \"55/45\"}}")), 3, 1);
+        NegotiationEngine.applyRepeat(gc, List.of(bargain("a2", "{\"accept\": \"p1\"}")), 4, 1);
+        assertEquals(List.of("a1"), gc.getNegotiation().getProposals().get(0).acceptedBy(),
+                "a superseded proposal cannot gain new signatures");
+    }
+
+    @Test
+    @DisplayName("a counter-proposal withdraws the mover's signature from every other open proposal")
+    void apply_counterProposalWithdrawsStaleSignatures() {
+        var gc = gc();
+        NegotiationEngine.applyRepeat(gc, List.of(proposal("a1", "50/50")), 0, 0);
+        NegotiationEngine.applyRepeat(gc, List.of(bargain("a2", "{\"accept\": \"p1\"}")), 1, 1);
+        assertEquals(List.of("a1", "a2"), gc.getNegotiation().getProposals().get(0).acceptedBy());
+
+        // a2 moves away — new terms on the table.
+        NegotiationEngine.applyRepeat(gc, List.of(bargain("a2", "{\"proposal\": {\"terms\": \"45/55\"}}")), 2, 2);
+
+        Proposal p1 = gc.getNegotiation().getProposals().get(0);
+        assertEquals(List.of("a1"), p1.acceptedBy(), "the abandoned signature is withdrawn");
+        assertFalse(p1.acceptanceEntryIndices().containsKey("a2"), "and its signed entry index with it");
+        // Mutation-check for the agreement path: without the withdrawal, p1 would
+        // now "reach unanimity" on a signature a2 walked away from.
+        assertFalse(NegotiationEngine.checkAndRecordAgreement(gc, List.of(ALICE, BOB, MOD), "mod", "Bargaining"),
+                "no agreement on a stale signature");
+    }
+
+    @Test
+    @DisplayName("a turn carrying both accept and proposal resolves for the proposal — the accept is ignored")
+    void apply_acceptPlusProposal_proposalWins() {
+        var gc = gc();
+        NegotiationEngine.applyRepeat(gc, List.of(proposal("a1", "50/50")), 0, 0);
+
+        NegotiationEngine.applyRepeat(gc, List.of(
+                bargain("a2", "{\"accept\": \"p1\", \"proposal\": {\"terms\": \"45/55\"}}")), 1, 1);
+
+        var proposals = gc.getNegotiation().getProposals();
+        assertEquals(List.of("a1"), proposals.get(0).acceptedBy(),
+                "the accept is ignored — new terms mean the mover is not settling");
+        assertEquals(2, proposals.size());
+        assertEquals("a2", proposals.get(1).byAgentId());
+        assertEquals(GroupConversation.PROPOSAL_OPEN, proposals.get(1).status());
     }
 
     @Test
     @DisplayName("the ledger accumulates across rounds, each line referencing the round it was made in")
     void apply_ledgerAccumulation() {
         var gc = gc();
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+        NegotiationEngine.applyRepeat(gc, List.of(
                 bargain("a1", "{\"proposal\": {\"terms\": \"50/50\"}, "
                         + "\"concessions\": [{\"gaveUp\": \"exclusivity\", \"inReturnFor\": \"faster payout\"}]}")),
                 0, 0);
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+        NegotiationEngine.applyRepeat(gc, List.of(
                 bargain("a2", "{\"concessions\": [{\"gaveUp\": \"launch veto\", \"inReturnFor\": \"quarterly review\"}]}")), 1, 1);
 
         var ledger = gc.getNegotiation().getConcessions();
@@ -170,8 +213,8 @@ class NegotiationEngineTest {
     @DisplayName("unanimous acceptance records the AGREEMENT with the signed entry indices — the co-signatures")
     void agreement_unanimousAcceptance() {
         var gc = gc();
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "We split revenue 50/50.")), 5, 0);
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(bargain("a2", "{\"accept\": \"p1\"}")), 7, 1);
+        NegotiationEngine.applyRepeat(gc, List.of(proposal("a1", "We split revenue 50/50.")), 5, 0);
+        NegotiationEngine.applyRepeat(gc, List.of(bargain("a2", "{\"accept\": \"p1\"}")), 7, 1);
 
         assertTrue(NegotiationEngine.checkAndRecordAgreement(gc, List.of(ALICE, BOB, MOD), "mod", "Bargaining"));
 
@@ -189,7 +232,7 @@ class NegotiationEngineTest {
     @DisplayName("partial acceptance is no agreement; the moderator's signature is not required")
     void agreement_partialIsNone() {
         var gc = gc();
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+        NegotiationEngine.applyRepeat(gc, List.of(
                 proposal("a1", "50/50"),
                 proposal("a2", "60/40")), 0, 0);
 
@@ -229,7 +272,7 @@ class NegotiationEngineTest {
     @DisplayName("the table renders open proposals (with ids and signatories) and the ledger into a BARGAIN turn")
     void render_tableIntoBargainTurn() {
         var gc = gc();
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+        NegotiationEngine.applyRepeat(gc, List.of(
                 bargain("a1", "{\"proposal\": {\"terms\": \"50/50 split\"}, "
                         + "\"concessions\": [{\"gaveUp\": \"exclusivity\", \"inReturnFor\": \"faster payout\"}]}")),
                 0, 0);
@@ -248,7 +291,7 @@ class NegotiationEngineTest {
         var gc = gc();
         assertEquals("PROMPT", NegotiationEngine.appendStateIfRelevant("PROMPT", gc, bargainPhase()));
 
-        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "50/50")), 0, 0);
+        NegotiationEngine.applyRepeat(gc, List.of(proposal("a1", "50/50")), 0, 0);
         var opinionPhase = new DiscussionPhase("Open", PhaseType.OPINION, "ALL", TurnOrder.SEQUENTIAL,
                 ContextScope.FULL, false, null, 1, false);
         assertEquals("PROMPT", NegotiationEngine.appendStateIfRelevant("PROMPT", gc, opinionPhase));
@@ -266,29 +309,47 @@ class NegotiationEngineTest {
         var participants = List.of(ALICE, BOB, MOD);
 
         // Round 1 — both parties put opening terms on the table. No agreement.
-        NegotiationEngine.applyRepeat(gc, phase, List.of(
+        NegotiationEngine.applyRepeat(gc, List.of(
                 bargain("a1", "{\"proposal\": {\"terms\": \"Alice leads, 60/40 revenue\"}}"),
                 bargain("a2", "{\"proposal\": {\"terms\": \"Shared lead, 50/50 revenue\"}}")), 0, 0);
         assertFalse(NegotiationEngine.checkAndRecordAgreement(gc, participants, "mod", phase.name()));
 
         // Round 2 — Alice counters toward Bob, naming her concession's return.
         // Her first proposal is superseded; still no unanimous signature.
-        NegotiationEngine.applyRepeat(gc, phase, List.of(
+        NegotiationEngine.applyRepeat(gc, List.of(
                 bargain("a1", "{\"proposal\": {\"terms\": \"Shared lead, 55/45 revenue\"}, "
                         + "\"concessions\": [{\"gaveUp\": \"sole lead\", \"inReturnFor\": \"the larger revenue share\"}]}"),
                 bargain("a2", "{\"concessions\": [{\"gaveUp\": \"strict 50/50\", \"inReturnFor\": \"shared lead confirmed\"}]}")), 2, 1);
         assertFalse(NegotiationEngine.checkAndRecordAgreement(gc, participants, "mod", phase.name()));
 
         // Round 3 — Bob signs Alice's open counter. Unanimous; repeats would end here.
-        NegotiationEngine.applyRepeat(gc, phase, List.of(
+        NegotiationEngine.applyRepeat(gc, List.of(
                 bargain("a2", "{\"accept\": \"p3\"}")), 4, 2);
         assertTrue(NegotiationEngine.checkAndRecordAgreement(gc, participants, "mod", phase.name()),
                 "round 3 converges");
+
+        // Signing Alice's terms abandoned Bob's own competing offer — p2 does not
+        // linger OPEN behind the agreement.
+        assertEquals(GroupConversation.PROPOSAL_SUPERSEDED, gc.getNegotiation().getProposals().get(1).status(),
+                "the signer's own open offer is superseded by their acceptance");
 
         var decision = gc.getDecision();
         assertEquals(DecisionType.AGREEMENT, decision.type());
         assertEquals("p3", decision.winner());
         assertTrue(decision.outcome().contains("2 concession"), decision.outcome());
         assertEquals(2, gc.getNegotiation().getConcessions().size());
+    }
+
+    @Test
+    @DisplayName("a GROUP member's signature is not required for unanimity — nested groups cannot sign")
+    void agreement_groupMemberNotRequired() {
+        var gc = gc();
+        var nestedGroup = new GroupMember("g1", "Sub Team", 3, null,
+                ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.MemberType.GROUP);
+        NegotiationEngine.applyRepeat(gc, List.of(proposal("a1", "50/50")), 0, 0);
+        NegotiationEngine.applyRepeat(gc, List.of(bargain("a2", "{\"accept\": \"p1\"}")), 1, 1);
+
+        assertTrue(NegotiationEngine.checkAndRecordAgreement(gc, List.of(ALICE, BOB, MOD, nestedGroup), "mod",
+                "Bargaining"), "both AGENT participants signed — the GROUP member is not on the required list");
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/NegotiationEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/NegotiationEngineTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TurnOrder;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionType;
+import ai.labs.eddi.configs.groups.model.GroupConversation.Proposal;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * I11 — {@link NegotiationEngine}: the three-tier bargain parse, the proposal
+ * table (creation, implicit self-signature, supersession), the concession
+ * ledger's must-name-a-return rule, unanimous-acceptance detection with signed
+ * entry indices, arbitration recording, and the ledger rendering every turn is
+ * held accountable to. Pure unit tests, no mocks — the engine is deliberately
+ * static and side-effect-free beyond the conversation it is handed.
+ *
+ * @author tests
+ */
+class NegotiationEngineTest {
+
+    private static final GroupMember ALICE = new GroupMember("a1", "Alice", 1, null);
+    private static final GroupMember BOB = new GroupMember("a2", "Bob", 2, null);
+    private static final GroupMember MOD = new GroupMember("mod", "Moderator", 0, "MODERATOR");
+
+    private GroupConversation gc() {
+        var gc = new GroupConversation();
+        gc.setId("gc-1");
+        gc.setGroupId("group-1");
+        return gc;
+    }
+
+    private DiscussionPhase bargainPhase() {
+        return new DiscussionPhase("Bargaining", PhaseType.BARGAIN, "ALL", TurnOrder.SEQUENTIAL, ContextScope.FULL,
+                false, null, 3, false);
+    }
+
+    private TranscriptEntry proposal(String agentId, String terms) {
+        return new TranscriptEntry(agentId, agentId, terms, 1, "Opening Proposals", TranscriptEntryType.PROPOSAL,
+                Instant.now(), null, null);
+    }
+
+    private TranscriptEntry bargain(String agentId, String json) {
+        return new TranscriptEntry(agentId, agentId, json, 2, "Bargaining", TranscriptEntryType.BARGAIN,
+                Instant.now(), null, null);
+    }
+
+    // =================================================================
+    // parsing — three tiers
+    // =================================================================
+
+    @Test
+    @DisplayName("strict JSON, fenced JSON, and JSON-with-reasoning all parse; pure prose is a non-move")
+    void parse_tiers() {
+        assertNotNull(NegotiationEngine.parseBargain("{\"accept\": \"p1\"}"));
+        assertNotNull(NegotiationEngine.parseBargain("My move:\n```json\n{\"proposal\": {\"terms\": \"50/50 split\"}}\n```"));
+        assertNotNull(NegotiationEngine.parseBargain(
+                "{\"accept\": null, \"proposal\": {\"terms\": \"60/40\"}, \"concessions\": []} I offer this because…"));
+        assertNull(NegotiationEngine.parseBargain("I think we should probably find some middle ground."),
+                "prose is never guessed into a move");
+        assertNull(NegotiationEngine.parseBargain("{\"accept\": null, \"proposal\": null, \"concessions\": []}"),
+                "a JSON turn carrying no move is a non-move");
+        assertNull(NegotiationEngine.parseBargain(null));
+    }
+
+    @Test
+    @DisplayName("a concession that names nothing in return is NOT recorded — the rule IS the structure")
+    void parse_concessionRequiresReturn() {
+        var move = NegotiationEngine.parseBargain(
+                "{\"concessions\": [{\"gaveUp\": \"weekend support\", \"inReturnFor\": \"\"}, "
+                        + "{\"gaveUp\": \"launch date\", \"inReturnFor\": \"extra QA week\"}]}");
+
+        assertNotNull(move);
+        assertEquals(1, move.concessions().size());
+        assertEquals("launch date", move.concessions().get(0).gaveUp());
+    }
+
+    // =================================================================
+    // proposal table
+    // =================================================================
+
+    @Test
+    @DisplayName("a PROPOSAL turn puts terms on the table, signed implicitly by its author")
+    void apply_proposalTurn() {
+        var gc = gc();
+
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "We split revenue 50/50.")), 10, 0);
+
+        var proposals = gc.getNegotiation().getProposals();
+        assertEquals(1, proposals.size());
+        Proposal p = proposals.get(0);
+        assertEquals("p1", p.id());
+        assertEquals("a1", p.byAgentId());
+        assertEquals(GroupConversation.PROPOSAL_OPEN, p.status());
+        assertEquals(List.of("a1"), p.acceptedBy(), "the proposer signs their own terms");
+        assertEquals(Map.of("a1", 10), p.acceptanceEntryIndices(), "the authoring entry IS the signature");
+    }
+
+    @Test
+    @DisplayName("a new proposal by the same agent SUPERSEDES their open one — one live offer per agent")
+    void apply_supersession() {
+        var gc = gc();
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "50/50")), 0, 0);
+
+        NegotiationEngine.applyRepeat(gc, bargainPhase(),
+                List.of(bargain("a1", "{\"proposal\": {\"terms\": \"55/45 with support included\"}}")), 1, 1);
+
+        var proposals = gc.getNegotiation().getProposals();
+        assertEquals(2, proposals.size());
+        assertEquals(GroupConversation.PROPOSAL_SUPERSEDED, proposals.get(0).status());
+        assertEquals(GroupConversation.PROPOSAL_OPEN, proposals.get(1).status());
+        assertEquals("p2", proposals.get(1).id());
+    }
+
+    @Test
+    @DisplayName("accepting an unknown or superseded proposal is ignored; an unparseable turn is inert")
+    void apply_badMovesAreInert() {
+        var gc = gc();
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "50/50")), 0, 0);
+        var before = List.copyOf(gc.getNegotiation().getProposals());
+
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+                bargain("a2", "{\"accept\": \"p99\"}"),
+                bargain("a2", "Honestly I just want to talk it through some more.")), 1, 1);
+
+        assertEquals(before, gc.getNegotiation().getProposals(), "no guessed acceptances, no state drift");
+        assertTrue(gc.getNegotiation().getConcessions().isEmpty());
+    }
+
+    @Test
+    @DisplayName("the ledger accumulates across rounds, each line referencing the round it was made in")
+    void apply_ledgerAccumulation() {
+        var gc = gc();
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+                bargain("a1", "{\"proposal\": {\"terms\": \"50/50\"}, "
+                        + "\"concessions\": [{\"gaveUp\": \"exclusivity\", \"inReturnFor\": \"faster payout\"}]}")),
+                0, 0);
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+                bargain("a2", "{\"concessions\": [{\"gaveUp\": \"launch veto\", \"inReturnFor\": \"quarterly review\"}]}")), 1, 1);
+
+        var ledger = gc.getNegotiation().getConcessions();
+        assertEquals(2, ledger.size());
+        assertEquals(0, ledger.get(0).round());
+        assertEquals("p1", ledger.get(0).refProposalId(), "a concession made WITH a proposal references it");
+        assertEquals(1, ledger.get(1).round());
+        assertNull(ledger.get(1).refProposalId());
+    }
+
+    // =================================================================
+    // agreement
+    // =================================================================
+
+    @Test
+    @DisplayName("unanimous acceptance records the AGREEMENT with the signed entry indices — the co-signatures")
+    void agreement_unanimousAcceptance() {
+        var gc = gc();
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "We split revenue 50/50.")), 5, 0);
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(bargain("a2", "{\"accept\": \"p1\"}")), 7, 1);
+
+        assertTrue(NegotiationEngine.checkAndRecordAgreement(gc, List.of(ALICE, BOB, MOD), "mod", "Bargaining"));
+
+        var decision = gc.getDecision();
+        assertEquals(DecisionType.AGREEMENT, decision.type());
+        assertEquals(NegotiationEngine.METHOD_NEGOTIATION, decision.method());
+        assertEquals("p1", decision.winner());
+        @SuppressWarnings("unchecked")
+        Map<String, Integer> signed = (Map<String, Integer>) decision.tally().get("signedAcceptances");
+        assertEquals(Map.of("a1", 5, "a2", 7), signed,
+                "the signed transcript entries ARE the co-signatures — their indices are the record");
+    }
+
+    @Test
+    @DisplayName("partial acceptance is no agreement; the moderator's signature is not required")
+    void agreement_partialIsNone() {
+        var gc = gc();
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+                proposal("a1", "50/50"),
+                proposal("a2", "60/40")), 0, 0);
+
+        assertFalse(NegotiationEngine.checkAndRecordAgreement(gc, List.of(ALICE, BOB, MOD), "mod", "Bargaining"),
+                "two open proposals, each signed only by its author");
+        assertNull(gc.getDecision());
+    }
+
+    // =================================================================
+    // arbitration
+    // =================================================================
+
+    @Test
+    @DisplayName("arbitration records the moderator's conclusion as the VERDICT — and never overwrites a decision")
+    void arbitration_recordsVerdictOnce() {
+        var gc = gc();
+        var arbitrationEntry = new TranscriptEntry("mod", "Moderator", "Split 55/45; support shared.", 3,
+                "Arbitration", TranscriptEntryType.SYNTHESIS, Instant.now(), null, null);
+
+        NegotiationEngine.recordArbitration(gc, List.of(arbitrationEntry), "Arbitration");
+
+        assertEquals(DecisionType.VERDICT, gc.getDecision().type());
+        assertEquals(NegotiationEngine.METHOD_ARBITRATION, gc.getDecision().method());
+        assertEquals("Split 55/45; support shared.", gc.getDecision().outcome());
+
+        var existing = gc.getDecision();
+        NegotiationEngine.recordArbitration(gc, List.of(new TranscriptEntry("mod", "Moderator", "Other.", 3,
+                "Arbitration", TranscriptEntryType.SYNTHESIS, Instant.now(), null, null)), "Arbitration");
+        assertSame(existing, gc.getDecision(), "an existing decision is never overwritten");
+    }
+
+    // =================================================================
+    // ledger rendering — the accountability mechanism
+    // =================================================================
+
+    @Test
+    @DisplayName("the table renders open proposals (with ids and signatories) and the ledger into a BARGAIN turn")
+    void render_tableIntoBargainTurn() {
+        var gc = gc();
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(
+                bargain("a1", "{\"proposal\": {\"terms\": \"50/50 split\"}, "
+                        + "\"concessions\": [{\"gaveUp\": \"exclusivity\", \"inReturnFor\": \"faster payout\"}]}")),
+                0, 0);
+
+        String rendered = NegotiationEngine.appendStateIfRelevant("PROMPT", gc, bargainPhase());
+
+        assertTrue(rendered.startsWith("PROMPT"));
+        assertTrue(rendered.contains("[p1] by a1"), rendered);
+        assertTrue(rendered.contains("50/50 split"), rendered);
+        assertTrue(rendered.contains("gave up \"exclusivity\" in return for \"faster payout\""), rendered);
+    }
+
+    @Test
+    @DisplayName("no negotiation state, or a non-negotiation phase, appends nothing")
+    void render_noOpOtherwise() {
+        var gc = gc();
+        assertEquals("PROMPT", NegotiationEngine.appendStateIfRelevant("PROMPT", gc, bargainPhase()));
+
+        NegotiationEngine.applyRepeat(gc, bargainPhase(), List.of(proposal("a1", "50/50")), 0, 0);
+        var opinionPhase = new DiscussionPhase("Open", PhaseType.OPINION, "ALL", TurnOrder.SEQUENTIAL,
+                ContextScope.FULL, false, null, 1, false);
+        assertEquals("PROMPT", NegotiationEngine.appendStateIfRelevant("PROMPT", gc, opinionPhase));
+    }
+
+    // =================================================================
+    // the scripted three-round bargain — living documentation of the protocol
+    // =================================================================
+
+    @Test
+    @DisplayName("a scripted 3-round bargain converges in round 3: propose → counter+concede → sign")
+    void scripted_threeRoundBargain() {
+        var gc = gc();
+        var phase = bargainPhase();
+        var participants = List.of(ALICE, BOB, MOD);
+
+        // Round 1 — both parties put opening terms on the table. No agreement.
+        NegotiationEngine.applyRepeat(gc, phase, List.of(
+                bargain("a1", "{\"proposal\": {\"terms\": \"Alice leads, 60/40 revenue\"}}"),
+                bargain("a2", "{\"proposal\": {\"terms\": \"Shared lead, 50/50 revenue\"}}")), 0, 0);
+        assertFalse(NegotiationEngine.checkAndRecordAgreement(gc, participants, "mod", phase.name()));
+
+        // Round 2 — Alice counters toward Bob, naming her concession's return.
+        // Her first proposal is superseded; still no unanimous signature.
+        NegotiationEngine.applyRepeat(gc, phase, List.of(
+                bargain("a1", "{\"proposal\": {\"terms\": \"Shared lead, 55/45 revenue\"}, "
+                        + "\"concessions\": [{\"gaveUp\": \"sole lead\", \"inReturnFor\": \"the larger revenue share\"}]}"),
+                bargain("a2", "{\"concessions\": [{\"gaveUp\": \"strict 50/50\", \"inReturnFor\": \"shared lead confirmed\"}]}")), 2, 1);
+        assertFalse(NegotiationEngine.checkAndRecordAgreement(gc, participants, "mod", phase.name()));
+
+        // Round 3 — Bob signs Alice's open counter. Unanimous; repeats would end here.
+        NegotiationEngine.applyRepeat(gc, phase, List.of(
+                bargain("a2", "{\"accept\": \"p3\"}")), 4, 2);
+        assertTrue(NegotiationEngine.checkAndRecordAgreement(gc, participants, "mod", phase.name()),
+                "round 3 converges");
+
+        var decision = gc.getDecision();
+        assertEquals(DecisionType.AGREEMENT, decision.type());
+        assertEquals("p3", decision.winner());
+        assertTrue(decision.outcome().contains("2 concession"), decision.outcome());
+        assertEquals(2, gc.getNegotiation().getConcessions().size());
+    }
+}


### PR DESCRIPTION
## Summary

Implements **I11 — NEGOTIATION style** from `planning/group-collaboration-improvements-plan.md` (first Wave 3 item in the `planning/group-collaboration-NEXT.md` queue, after I17 #637, I14 #638, I8 #639, I6 #640). EDDI had win/lose decision forms (verdicts, votes) and no **trade** form: a negotiation is a process for surfacing trade-offs, and its output is a drafted compromise with an explicit **concession ledger** for human sign-off. The typed structure is precisely what stops sycophantic instant-agreement.

## Design (per the plan, decisions honored)

- **Phase types `PROPOSAL` + `BARGAIN`; `skipIf: "AGREEMENT_REACHED"`** — a single enum condition, deliberately NOT an expression language: a phase is skipped for a reason the engine can *prove* against the typed decision. The arbitration phase is its only user.
- **`NegotiationState` on `GroupConversation`**: proposals `{id, byAgentId, round, terms (String v1), status OPEN|SUPERSEDED, acceptedBy, acceptanceEntryIndices}` + concessions `{byAgentId, round, gaveUp, inReturnFor, refProposalId}`. Persisted with the document, so a pause/resume keeps the table as it stood.
- **The BARGAIN turn contract**: `{"accept": "<proposalId>"|null, "proposal": {"terms": "..."}|null, "concessions": [{"gaveUp": "...", "inReturnFor": "..."}]}` + free-text reasoning. Three-tier parse mirroring `VoteTallyEngine`'s discipline (strict JSON → embedded → give up, `FAIL_ON_TRAILING_TOKENS`); an unparseable turn is prose with **no state effect** (WARN) — never a guessed acceptance. A concession that names nothing in return is **not recorded** — the rule is the structure, and the baked-in template says so (*"Every concession must name what you received in return. The ledger below is the record — it will be quoted in the outcome."*). A new proposal supersedes the mover's own open one (one live offer per agent); the proposer signs their own terms implicitly.
- **Ledger accountability**: the open proposals (with ids and signatories) + concession ledger are appended to every PROPOSAL/BARGAIN turn and to negotiation SYNTHESIS turns (arbitration and final synthesis quote the record). Appended by `NegotiationEngine.appendStateIfRelevant` at the two input-build sites rather than templated — the state lives on the conversation, which `buildPhaseInput` deliberately does not see.
- **Agreement**: all non-moderator participants signed the same OPEN proposal → the bargaining phase ends its repeats early through the **same `PhaseOutcome.endRepeats` plumbing convergence uses**, and `DecisionRecord{AGREEMENT, method="negotiation"}` carries `tally.signedAcceptances` — each signatory mapped to the transcript index of their (already signed) acceptance entry. **The signed entries ARE the co-signatures; no new crypto.** `decision_reached` fires.
- **Preset `NEGOTIATION`**: ① Positions & Interests (ALL, PARALLEL, NONE — interests enable integrative trades) ② Opening Proposals (SEQUENTIAL, FULL) ③ Bargaining (SEQUENTIAL, FULL, repeats=maxRounds) ④ Arbitration (MODERATOR, `skipIf=AGREEMENT_REACHED`, its own `TEMPLATE_ARBITRATION` — the default synthesis template asks for a balanced summary; an arbitrator *decides*) ⑤ Synthesis. An arbitration that runs records its conclusion as `DecisionRecord{VERDICT, method="arbitration"}`, never overwriting an existing decision.
- Enum additions are compat-safe (`TranscriptEntryType.PROPOSAL/BARGAIN` already existed from Wave 0's F4 peer-visibility matrix — peer-visible, as open bargaining must be).

## Tests (12 new in `NegotiationEngineTest` + preset shape + enum pins; 1694 tests green across `engine.internal` + `configs.groups`; checkstyle clean)

Parse tiers incl. JSON-followed-by-reasoning; concession-must-name-return; implicit self-signature with the authoring entry index asserted; supersession; unknown/superseded acceptances and unparseable turns are inert (state compared before/after); ledger accumulation with round + refProposal attribution; **unanimous acceptance with the signed entry indices asserted exactly**; partial acceptance ≠ agreement (and the moderator's signature is not required); arbitration records once and never overwrites; ledger rendering into the turn + its no-op paths; preset shape (5 phases, PARALLEL+NONE positions, repeats=maxRounds bargaining, conditional arbitration with its own template); and the plan's **scripted 3-round bargain converging in round 3** (propose → counter+concede → sign) as living documentation of the protocol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `NEGOTIATION` discussion style with structured proposals, bargaining, concessions, agreement detection, arbitration, and final synthesis.
  * Added configurable proposal and bargaining phases, including conditional arbitration when no agreement is reached.
  * Added negotiation support to Slack discussions and REST style descriptions.
  * Negotiation progress and decisions are preserved across conversations.

* **Documentation**
  * Documented negotiation phases, behavior, and configuration options.

* **Tests**
  * Added coverage for negotiation flows, parsing, agreements, arbitration, and preset configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->