### PR TITLE
feat(groups): standing teams — workspace, backlog, cadences (I13)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,22 @@
 
 ---
 
+## 🏭 feat(groups): I13 — standing teams (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i13-standing-teams` — stacked on the I8 branch: retro lessons flow through I8 unchanged)
+
+Ninth queue item, the Wave 3 flagship. A group conversation is an episode; the **`GroupWorkspace`** is what persists — backlog, cadences, metrics. Deliberately thin glue over existing machinery: the backlog IS a `SharedTaskList`, scheduling IS `SchedulePollerService`, the run ceiling IS I1's inherited-ceiling slot.
+
+- **Model + store:** `GroupWorkspace` (own collection, one doc per group id): `backlog` (SharedTaskList reused whole so pulled tasks flow straight into the task-force machinery), `metrics {discussions, tasksVerified, totalCost, lastRunAt, perMemberStats}` (per-member stats are reliability RECORDING only — the research-adopted substrate; no routing/weighting in v1), `cadences [{cadenceId, scheduleRef, inputTemplate (Qute), maxBacklogTasksPerRun=5, maxCostPerRun, createdBy}]`, `runningDiscussionId` + `pulledTaskIds`. `IGroupWorkspaceStore`/`GroupWorkspaceStore` follow the GroupConversationStore single-version pattern; `casRunningDiscussion` is a conditional store write (`storeIfFieldEquals`) — cluster-safe, no in-JVM locks, idle sentinel `""` because the CAS compares a concrete stored value.
+- **`TeamCadenceService`** (the DreamService pattern, exactly): metadata contract `teamCadenceType="team_cadence"` + a dedicated `ScheduleFireExecutor.fireTeamCadence` branch, so cluster claim/lease/retry/dead-letter/fire-logs come free. The fire protocol is crash-proof by construction: **reconcile** (a finished previous run is written back FIRST; one still running — possibly paused at an HITL gate for days — skips the fire) → **pull** (top-N executable by priority; empty pull skips, logged) → **claim** (CAS; a lost race cancels the just-started discussion and stands down) → **run**. Deliberate skips are COMPLETED fires with the reason logged; real failures are FAILED so they retry and dead-letter.
+- **Task injection without config writes:** new `GroupConversationService.startCadenceDiscussionAsync` — the pulled tasks replace `config.tasks` on the call's own fresh read (a runtime copy; the stored config is never written) and `maxCostPerRun` rides `inheritedCostCeiling`, so `effectiveCostCeiling` takes the tighter of it and the group's own ceiling (dollar-primary, the Dream precedent). The discussion runs under the cadence **creator's** identity (`createdBy`), not a synthetic scheduler user.
+- **Writeback** at the next fire or on workspace read (read-repair in the REST layer) — never from the discussion thread, so a crash loses nothing: VERIFIED stays VERIFIED on the backlog + credits the assignee's stats; anything else returns to PENDING with the reviewer feedback appended to the description (the cross-run retry loop); FAILED/CANCELLED returns every pulled task untouched; a vanished discussion releases the claim instead of stalling every future fire.
+- **Surfaces:** REST `/groupstore/groups/{groupId}/workspace` (GET workspace/backlog with read-repair; POST backlog — cap 200 with an actionable 409; POST/DELETE cadences — the cron is validated at creation by computing the first fire, and the schedule carries the dispatch metadata); MCP `add_team_task` + `list_team_backlog` (whitelisted; filter pins green). **Teardown:** a permanent group deletion cascades to the workspace; a soft delete keeps it (the group can come back).
+
+**Tests (+14 TeamCadenceServiceTest, +9 RestGroupWorkspaceTest, +2 fire-executor dispatch, +4 MCP, +2 cascade):** fire pulls top-priority tasks and the captured `startCadenceDiscussionAsync` call carries them, the creator identity and the dollar ceiling; every skip (empty backlog, still-running, lost claim → cancel); reconcile-then-run; writeback matrix (VERIFIED credited / failed-with-feedback returns as the retry loop / FAILED returns untouched / vanished releases) — the feedback-appended and VERIFIED assertions are the mutation-check; backlog cap actionable on both surfaces; cadence schedule metadata + invalid-cron-fails-at-creation; permanent-delete cascade vs soft-delete keep.
+
+---
+
 ## 🔎 fix(groups): I8 PR #639 CI round 1 + plan-mandated test extension (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i8-retro-memory`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,25 @@
 
 ---
 
+## 🔎 fix(groups): I13 + HITL fixes from the final cross-branch review (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i13-standing-teams`)
+
+Fixes from the 23-agent final review (5 dimensions, every non-minor finding adversarially double-verified; 9 confirmed across all branches — the four below are the ones on this branch's surface):
+
+1. **Settle race (major/concurrency)** — `TeamCadenceService.settle()` released the claim with an **unconditional** `update()`, so a writeback racing a concurrent reconcile (schedule fire on another pod, or the REST read-repair) could clobber a *newer* claim, orphaning that discussion's outcomes. Now conditional: `settle(workspace, gc, settledDiscussionId)` releases via `casRunningDiscussion(workspace, settledDiscussionId)`; both writebacks capture the id before clearing and return the verdict; a lost race drops the caller's mutations (`writeback_lostSettleRace_dropsMutations` pins it). Reconcile propagates the verdict so a losing caller treats the workspace as busy.
+2. **Cost ceiling lost on HITL resume (major/cost-bounds)** — `GroupConversation.inheritedCostCeiling` was `@JsonIgnore transient`, so a cadence run that paused for approval resumed with **no ceiling**. Now a persisted field (documented as a review finding in the Javadoc).
+3. **Backlog write caps bypassed (major/security)** — REST `addBacklogTask` and MCP `add_team_task` skipped the caps the agent tool surface enforces: subject ≤ `MAX_AGENT_TASK_SUBJECT_LENGTH` (200), description ≤ `MAX_AGENT_TASK_DESCRIPTION_LENGTH` (4000), and duplicate subjects (case-insensitive) now 409/error — writeback matches outcomes **by subject**, so duplicates made outcome attribution ambiguous. Plus two bound minors: cadence count capped at 20/workspace, `inputTemplate` ≤ 4000 chars.
+4. **Unbounded failure-feedback growth (major/cost-bounds)** — the COMPLETED writeback appended each failed run's **entire agent output** to the persisted task description every run. New `appendFeedbackBounded`: 500-char per-run slice, total trimmed from the front (oldest first) to the shared 4000-char description cap.
+
+Also on this branch's surface: the **claim-CAS exception path** now cancels the just-started discussion before rethrowing (previously it leaked an unclaimed discussion running to completion with outcomes no writeback collects), the template-failure log sanitizes the exception message, and `GroupHitlCoordinator`'s executor-saturated resume rollback uses remove-and-recheck (`removeTokenAndConvertIfSignalled`) like every sibling rollback path — a cancel signalled between token registration and the rollback was silently dropped, leaving a "cancelled" discussion stuck AWAITING_APPROVAL (regression test added, mutation-verified: reverting the fix fails it).
+
+**Rebutted (deliberate, not fixed):** MCP `list_team_backlog` requiring `eddi-viewer` while REST listing requires editor — consistent with the read_group/list_groups viewer convention across all MCP group read tools.
+
+**Tests:** TeamCadenceServiceTest 17 (+3), RestGroupWorkspaceTest 12 (+3), McpGroupToolsTest 52 (+2), GroupHitlCoordinatorTest 16 (+1). All green.
+
+---
+
 ## 🔎 fix(groups): I13 PR #644 review round 1 (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i13-standing-teams`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 🧠 feat(groups): I8 — retro phases harvest team-owned group memory (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i8-retro-memory`)
+
+Third Wave 2 queue item, and the substrate I13 (Standing Teams) builds on. Discussions stop evaporating: a `RETRO` phase's lessons persist and surface as `{properties.*}` in every member's later discussions.
+
+- **`PhaseType.RETRO`** + built-in template (full-transcript review, JSON lessons contract) + `RetroConfig {maxLessonsPerRun=3, maxStoredLessons=50}`. The template *quotes* the default per-run cap; `RetroEngine` *enforces* the configured one at parse time regardless — the context builder deliberately does not receive the group config.
+- **Storage exactly as the plan resolved (V2):** `IUserMemoryStore.upsert` under the synthetic team owner `"group:"+groupId` with `group` visibility. New `TEAM_OWNER_PREFIX` contract constant; lessons belong to the team, not the human who ran the discussion, and survive that human's GDPR erasure without carrying their identity.
+- **The additive synthetic-team-owner recall branch, on BOTH backends:** Mongo's `buildVisibilityFilter` and Postgres's `buildVisibilityQuery` (+ its bind order) now OR in a narrow team scope — owner ids DERIVED from the supplied group ids (never caller-supplied), `group` visibility, group-id overlap. The user's own scope is untouched, per the plan's "do not widen the existing user-scoped group branch". Both made package-private static so the filter/SQL shapes are directly assertable — and both are pinned side by side so the backends cannot drift.
+- **Idempotency + bounded growth:** key `retro:<sha256(lesson)[0..16]>` with a FIXED `sourceAgentId` ("retro") — the upsert identity for group entries is `(userId, key, sourceAgentId)`, so a real speaker id would have made the same lesson from two speakers two rows. FIFO eviction past `maxStoredLessons` via the newest-first recall (everything past the cap is the oldest); `RetroEngine` is the ONLY reaper — `UserMemoryTool`'s eviction only ever touches the calling agent's `self` entries.
+- **Wiring:** discussion-loop harvest on the RETRO phase's last repeat, before the persist (a crash must not lose lessons a stored document claims were taken); `IUserMemoryStore` reaches the facade by the established null-safe field-injection pattern. New `retro_recorded` event (constant + record + listener default + SSE forward) — fires even at zero lessons stored, which is itself signal.
+
+**Tests (11 new, all green; `engine.internal` + `configs.properties` suites 1572 green; checkstyle clean):** parse tiers (strict/fenced/prose-refused); per-run cap enforced past what the model was told; idempotent team-owned upsert against a REAL in-memory store with the production upsert identity (a mocked idempotency claim would prove nothing); FIFO evicts the oldest and never the newest; `retro_recorded` carries the stored count; null store and failing store never fail the discussion; Mongo filter shape (no-groups → user scope only; with-groups → derived `group:` owners paired with group visibility; no foreign human id reachable); Postgres SQL shape incl. the `??|` escape arithmetic pinning the bind order.
+
+**Files:** `AgentGroupConfiguration` (RETRO + RetroConfig), `DiscussionStylePresets` (TEMPLATE_RETRO), `GroupContextBuilder` (RETRO branch + entry mapping), `RetroEngine` (new), `GroupConversationService` (wiring + store injection), `IUserMemoryStore` (TEAM_OWNER_PREFIX + contract Javadoc), `MongoUserMemoryStore`, `PostgresUserMemoryStore`, `GroupConversationEventSink`/listener/SSE, `docs/group-conversations.md`, 3 test classes.
+
+---
+
 ## 🔀 merge: bring `origin/main` (PR #627 HITL request pinning) into the branch (2026-08-07)
 
 **Repo:** EDDI (`refactor/group-service-split`, PR [#626](https://github.com/labsai/EDDI/pull/626))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 🔎 fix(groups): I8 PR #639 CI round 1 + plan-mandated test extension (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i8-retro-memory`)
+
+Follow-ups on the open PR (commits `8025962c6`, `c2b4b7a79`, `3de3de69e`):
+
+- **CI failures**: `AgentGroupConfigurationTest.phaseType_allValues` pins the enum size (RETRO is this branch's 12th value — same pin fixed for VOTE on the I14 branch), and `PostgresUserMemoryStoreUnitTest.getVisibleEntries_withGroupIds_includesGroupClause` pinned the pre-I8 bind order — now asserts all nine parameters incl. the derived `group:` owners. The third failing check (ClusterFuzzLite) was a transient gcr.io 403 pulling the fuzz image — it passed on the sibling PRs minutes later.
+- **CodeQL**: the four flagged RetroEngine log sinks sanitized (conversation id, phase name, team owner, exception message).
+- **Plan-mandated tests** the first commit missed (`UserMemoryToolScopingTest` extension, named explicitly in the I8 plan item): eviction can never delete a team-owned lesson even with the store wall deliberately breached (the fixed `"retro"` sourceAgentId is a second independent wall), and personal `visibility:self` entries never cross users through a shared group.
+
+---
+
 ## 🧠 feat(groups): I8 — retro phases harvest team-owned group memory (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i8-retro-memory`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,14 @@
 
 ---
 
+## 🔎 fix(groups): I13 PR #644 review round 1 (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i13-standing-teams`)
+
+All 3 findings (CodeQL ×2, code-quality ×1) accepted and fixed: the workspace-deletion and cadence-deletion logs sanitize their caller-influenced values; `GroupWorkspace.getCadences` returns an unmodifiable view with mutation through new `addCadence`/`removeCadence` (the NegotiationState treatment) — REST layer and tests rewired. Suites (73) green.
+
+---
+
 ## 🏭 feat(groups): I13 — standing teams (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i13-standing-teams` — stacked on the I8 branch: retro lessons flow through I8 unchanged)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,22 @@
 
 ---
 
+## 🔎 fix(groups): I13 review round 2 — workspace concurrency + schedule lifecycle (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i13-standing-teams`)
+
+Five accepted findings from the CodeRabbit/CodeQL round on PR #644:
+
+1. **Atomic backlog adds (major)** — both backlog-add surfaces (REST `addBacklogTask`, MCP `add_team_task`) validated the cap/duplicate rules against their own snapshot and then issued a whole-document `update`, so two concurrent adds could both pass under the cap and the later write dropped the earlier task. New optimistic-concurrency primitive: `GroupWorkspace.revision` (string stamp) + `IGroupWorkspaceStore.casRevision` (revision-conditional store via `storeIfFieldEquals`, bump-in-write, loser restores its stamp). Both surfaces run a 3-attempt read-validate-mutate-CAS loop; exhaustion is an honest 409/error telling the caller to retry. Pre-revision documents get stamped by one plain write, then CAS'd forever after.
+2. **Duplicate workspace documents (major)** — `readOrCreate` read-then-inserted with no unique constraint (the storage abstraction has none), so concurrent creators could each insert a document and split subsequent writes. Now: after inserting, re-query; every racer that does not hold the deterministic survivor (lexicographically smallest id = earliest ObjectId) deletes its own insert and adopts the survivor. `find()` picks the same survivor when duplicates linger, so readers and racers always agree.
+3. **Orphaned schedule on failed cadence write (major)** — `addCadence` created the `ScheduleConfiguration` before the workspace write; a failed write left an enabled schedule no cadence names, firing "cadence no longer exists" forever with no delete path. The failed write now compensates by deleting the schedule.
+4. **Group deletion left cadence schedules behind (major)** — permanent group deletion removed only the workspace; enabled schedules kept firing "No workspace exists". `RestAgentGroupStore` now retires every cadence's schedule BEFORE deleting the workspace (crash between the two leaves the recoverable order).
+5. **Log sanitization (minor + CodeQL 478/480)** — the run-claim disappearance warning sanitizes `groupId`; the same treatment in the new casRevision path.
+
+Tests: GroupWorkspaceStoreTest (new, 5: CAS bump/restore/legacy-stamp, duplicate convergence in readOrCreate and find), RestGroupWorkspaceTest 14 (+2: lost-CAS retry/exhaustion, schedule cleanup on failed write), McpGroupToolsTest 53 (+1 retry/exhaustion), RestAgentGroupStoreTest (+1 schedule retirement). All green.
+
+---
+
 ## 🔎 fix(groups): I8 review round 2 — retro cap semantics + event contract (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i8-retro-memory`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,21 @@ Two accepted CodeRabbit findings, one rebutted:
 1. **RetroConfig ceilings (major)** — the compact ctor accepted any positive int, so `Integer.MAX_VALUE` unbounded the per-run write count and the retained-lesson set. Hard ceilings: `CEILING_MAX_PER_RUN` 20, `CEILING_MAX_STORED` 500 (clamped, not rejected — same normalization style as the rest of the record).
 2. **FIFO vs reharvest (major)** — eviction used the `most_recent` recall order (sorted by `updatedAt`); reharvesting an existing lesson refreshes `updatedAt`, so an old-but-reharvested lesson could shield itself while a later-CREATED lesson got evicted. Eviction now sorts by `createdAt` (which the store `setOnInsert`s — the stable insertion stamp), nulls oldest-first. Regression test reharvests an old lesson before exceeding the cap and asserts the oldest-created is the one evicted.
 3. **Rebutted: RETRO entries lost on mid-repeat HITL resume** — on this branch nothing ever creates a speaker-level `ResumePoint` (producers are I6 human turns and I12 escalations, on other branches), so a RETRO phase cannot resume mid-repeat here. On the integration branch, where producers exist, the I6 `pausedRepeatSliceBase` fix restores the true repeat base at top-of-repeat before `repeatEntries` is sliced — the RETRO harvest reads that same slice, so pre-pause lessons are preserved (pinned by the HumanPauseRepeatSlice tests).
+## 🔎 fix(groups): I13 review round 3 — revision parse guard, convergence limit, test pins (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i13-standing-teams`)
+
+Six findings from the CodeRabbit/CodeQL round on the round-2 push, all accepted:
+
+1. **NumberFormatException in casRevision (CodeQL, both #644 and #645)** — `Long.parseLong` on a persisted value; a corrupt revision surfaced as an uncaught runtime exception (bare 500 at REST). Guarded: non-numeric revision throws the method's declared `ResourceStoreException` with the value named; the instance keeps the corrupt value for diagnosis.
+2. **Convergence limit (major)** — `findWorkspaceIds` fetched at most 2 ids; with 3+ concurrent creators, different racers could see different subsets and compute different survivors, never converging. Limit raised to 50 so every realistic racer set fits one query.
+3. **Javadoc detachment (minor)** — `casRevision` was inserted between `casRunningDiscussion`'s Javadoc and its declaration, silently detaching it. Reordered; the claim Javadoc is re-attached.
+4. **Legacy null-revision window (minor)** — documented on `IGroupWorkspaceStore.casRevision`: one unconditional stamp per pre-revision document, CAS'd forever after.
+5. **Deletion-order pin (minor)** — the schedule-retirement test now uses `InOrder`, protecting the crash-recoverable order (schedules before workspace), not just the calls.
+6. **Write-path pins (minor)** — the backlog rejection tests assert `never().casRevision(any())` (the actual write path) alongside the legacy `update` pin; the lost-settle test uses `verifyNoMoreInteractions` so the failed conditional release is provably the ONLY store interaction.
+
+---
+
 ## 🔎 fix(groups): I13 review round 2 — workspace concurrency + schedule lifecycle (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i13-standing-teams`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 🔎 fix(groups): I8 review round 3 — retro ceilings + creation-ordered FIFO (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i8-retro-memory`)
+
+Two accepted CodeRabbit findings, one rebutted:
+
+1. **RetroConfig ceilings (major)** — the compact ctor accepted any positive int, so `Integer.MAX_VALUE` unbounded the per-run write count and the retained-lesson set. Hard ceilings: `CEILING_MAX_PER_RUN` 20, `CEILING_MAX_STORED` 500 (clamped, not rejected — same normalization style as the rest of the record).
+2. **FIFO vs reharvest (major)** — eviction used the `most_recent` recall order (sorted by `updatedAt`); reharvesting an existing lesson refreshes `updatedAt`, so an old-but-reharvested lesson could shield itself while a later-CREATED lesson got evicted. Eviction now sorts by `createdAt` (which the store `setOnInsert`s — the stable insertion stamp), nulls oldest-first. Regression test reharvests an old lesson before exceeding the cap and asserts the oldest-created is the one evicted.
+3. **Rebutted: RETRO entries lost on mid-repeat HITL resume** — on this branch nothing ever creates a speaker-level `ResumePoint` (producers are I6 human turns and I12 escalations, on other branches), so a RETRO phase cannot resume mid-repeat here. On the integration branch, where producers exist, the I6 `pausedRepeatSliceBase` fix restores the true repeat base at top-of-repeat before `repeatEntries` is sliced — the RETRO harvest reads that same slice, so pre-pause lessons are preserved (pinned by the HumanPauseRepeatSlice tests).
+
+---
+
 ## 🔎 fix(groups): I8 review round 2 — retro cap semantics + event contract (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i8-retro-memory`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 🔎 fix(groups): I8 review round 2 — retro cap semantics + event contract (2026-08-08)
+
+**Repo:** EDDI (`feat/group-i8-retro-memory`)
+
+Four accepted findings from the CodeRabbit round on the stacked PR (#644, which carries this branch):
+
+1. **Template quoted the wrong cap (major)** — the RETRO prompt always rendered `DEFAULT_MAX_PER_RUN` (3), so a group configured above it could never obtain its configured number of lessons. `buildPhaseInput` gained a `RetroConfig` parameter (config-less overloads keep the default); all three agent-turn call sites in `PhaseExecutionEngine` pass `config.getRetroConfig()`. RetroEngine's parse-time enforcement is unchanged and remains the server-side limit.
+2. **Per-entry cap multiplied (major)** — `harvest` applied `maxLessonsPerRun` to each RETRO transcript entry, so a multi-speaker or multi-repeat retro could store `cap × entries`. Now a per-harvest `remaining` allowance shared across entries.
+3. **Missing zero-count event (minor)** — the null-memory-store branch returned before `retro_recorded`; it now fires the event with `lessonsStored = 0`, honoring the contract that a RETRO phase always emits it.
+4. **Fixture didn't cross users (minor)** — `personalEntriesNeverCrossUsers` built its "other user's" entry with the shared helper that stamps USER; it now genuinely belongs to `user-2`.
+
+Tests: RetroEngineTest 8 (+2: per-harvest cap, null-store zero event), GroupContextBuilderTest 41 (+1: configured cap quoted, default fallback), PhaseExecutionEngineTest stub widened to the new arity. All green.
+
+---
+
 ## 🔎 fix(groups): I8 PR #639 CI round 1 + plan-mandated test extension (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i8-retro-memory`)

--- a/docs/group-conversations.md
+++ b/docs/group-conversations.md
@@ -185,6 +185,52 @@ knowledge that compounds run-over-run.
 - Member conversations already load group-visible entries at init, so recall
   needs no new namespace. The `retro_recorded` SSE event reports each harvest.
 
+## Standing Teams (I13)
+
+A group *conversation* is an episode; a **team** persists. The `GroupWorkspace`
+(one document per group, own collection) holds what survives between episodes:
+a **backlog** (a `SharedTaskList`, so pulled tasks flow straight into the
+task-force machinery), **cadences** that pull from it on a schedule, and the
+team's running **metrics** — deliberately thin glue over the existing
+schedulers, I1's cost ledger and I8's retro memory.
+
+```
+POST /groupstore/groups/{groupId}/workspace/backlog   {"subject": "...", "description": "...", "priority": 5}
+POST /groupstore/groups/{groupId}/workspace/cadences  {"cronExpression": "0 9 * * 1", "maxBacklogTasksPerRun": 5, "maxCostPerRun": 2.50}
+GET  /groupstore/groups/{groupId}/workspace
+```
+
+MCP: `add_team_task`, `list_team_backlog`. The backlog caps at 200 with an
+actionable error — it is a working set, not an archive.
+
+**Cadence fires ride the schedule machinery whole** (`SchedulePollerService`
+claim/lease/retry/dead-letter; the executor branches on
+`teamCadenceType: "team_cadence"` exactly like Dream consolidation). Each fire:
+
+1. **Reconcile** — a finished previous run is written back first; one still in
+   flight (or paused at an HITL gate for days) skips the fire.
+2. **Pull** — top-N *executable* backlog tasks by priority; an empty pull
+   skips, logged.
+3. **Claim** — a conditional store write on `runningDiscussionId`; two pods
+   firing concurrently cannot both start, without any in-JVM lock.
+4. **Run** — pulled tasks are injected as a runtime copy of `config.tasks`
+   (the stored config is never written) and the cadence's `maxCostPerRun`
+   rides the inherited-ceiling slot: dollar-primary, per the Dream precedent.
+   The discussion runs under the cadence *creator's* identity.
+
+**Writeback** happens at the next fire (or on a workspace read — read-repair),
+never from inside the discussion thread, so a pod crash mid-discussion loses
+nothing. VERIFIED outcomes stay VERIFIED on the backlog and credit the
+assignee's `perMemberStats`; anything else returns to PENDING with the
+reviewer's feedback appended to the description — **the cross-run retry
+loop**. A FAILED/CANCELLED discussion returns every pulled task untouched.
+Retro lessons flow through I8 unchanged (no duplication).
+
+Per-member stats are reliability **recording only** — nothing routes or
+weights on them in v1. A *permanent* group deletion cascades to the workspace;
+a soft (versioned) delete keeps it, because the group can come back. Not in
+v1: cross-team handoff, Manager UI, reputation weighting.
+
 ## Nested Groups (Group-of-Groups)
 
 Members can be other groups. The sub-group runs its own discussion and its synthesized answer becomes the member's response.

--- a/docs/group-conversations.md
+++ b/docs/group-conversations.md
@@ -160,6 +160,31 @@ Both caps are enforced independently: `maxPerTurn` bounds a runaway single turn,
 discussion cap counts only agent-filed tasks, so a large planned backlog does not
 exhaust it. A rejected call does not consume the per-turn budget.
 
+## Retro → group memory
+
+A `RETRO` phase stops discussions from evaporating: the group reviews how it
+worked and distills lessons that persist as **team-owned group memory**, then
+surface as `{properties.*}` in every member's later discussions — institutional
+knowledge that compounds run-over-run.
+
+```json
+{ "name": "Retro", "type": "RETRO", "participants": "MODERATOR" },
+"retroConfig": { "maxLessonsPerRun": 3, "maxStoredLessons": 50 }
+```
+
+- The built-in template asks for `{"lessons": [{"lesson": "...", "context":
+  "..."}]}`; parsing is three-tier (strict JSON → embedded JSON → nothing) and
+  the per-run cap is enforced at parse time whatever the model produced.
+- Lessons are stored under the synthetic owner `group:<groupId>` with `group`
+  visibility — they belong to the team, not to whichever human ran the
+  discussion, and survive that human's GDPR erasure without carrying their
+  identity. The idempotency key `retro:<hash(lesson)>` makes re-running the
+  same retro a no-op.
+- **Bounded growth is non-negotiable:** the stored set FIFOs at
+  `maxStoredLessons` — storing past the cap evicts the oldest.
+- Member conversations already load group-visible entries at init, so recall
+  needs no new namespace. The `retro_recorded` SSE event reports each harvest.
+
 ## Nested Groups (Group-of-Groups)
 
 Members can be other groups. The sub-group runs its own discussion and its synthesized answer becomes the member's response.

--- a/src/main/java/ai/labs/eddi/configs/groups/IGroupWorkspaceStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/IGroupWorkspaceStore.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups;
+
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.datastore.IResourceStore;
+
+/**
+ * Store for {@link GroupWorkspace} documents (I13) — one per group config id,
+ * own collection.
+ *
+ * @author ginccc
+ */
+public interface IGroupWorkspaceStore {
+
+    /**
+     * The group's workspace, or {@code null} if none exists yet. Never creates.
+     */
+    GroupWorkspace find(String groupId) throws IResourceStore.ResourceStoreException;
+
+    /**
+     * The group's workspace, created empty on first access. Creation races are
+     * benign for an empty document: if two callers create concurrently, the later
+     * writer's empty workspace wins and neither loses data it had.
+     */
+    GroupWorkspace readOrCreate(String groupId) throws IResourceStore.ResourceStoreException;
+
+    void update(GroupWorkspace workspace) throws IResourceStore.ResourceStoreException;
+
+    /** Deletes the group's workspace, if any. Idempotent. */
+    void deleteByGroupId(String groupId) throws IResourceStore.ResourceStoreException;
+
+    /**
+     * Atomically claims the workspace for one cadence discussion: writes
+     * {@code workspace} (which must already carry the new
+     * {@code runningDiscussionId} and pulled-task state) only if the PERSISTED
+     * {@code runningDiscussionId} still equals {@code expectedRunning}. Returns
+     * {@code false} when another pod won the claim (or released it) in between —
+     * the caller skips its run.
+     */
+    boolean casRunningDiscussion(GroupWorkspace workspace, String expectedRunning)
+            throws IResourceStore.ResourceStoreException;
+}

--- a/src/main/java/ai/labs/eddi/configs/groups/IGroupWorkspaceStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/IGroupWorkspaceStore.java
@@ -40,6 +40,18 @@ public interface IGroupWorkspaceStore {
      * {@code false} when another pod won the claim (or released it) in between —
      * the caller skips its run.
      */
+    /**
+     * Optimistic-concurrency write: persists {@code workspace} only if its
+     * {@code revision} still matches what this caller read, bumping it in the same
+     * write. Use for every read-modify-write surface (backlog adds) so two
+     * concurrent editors cannot silently drop each other's changes — the loser
+     * re-reads and retries.
+     *
+     * @return {@code true} if the write landed; {@code false} if a concurrent
+     *         writer changed the workspace first (re-read before retrying)
+     */
+    boolean casRevision(GroupWorkspace workspace) throws IResourceStore.ResourceStoreException;
+
     boolean casRunningDiscussion(GroupWorkspace workspace, String expectedRunning)
             throws IResourceStore.ResourceStoreException;
 }

--- a/src/main/java/ai/labs/eddi/configs/groups/IGroupWorkspaceStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/IGroupWorkspaceStore.java
@@ -40,18 +40,24 @@ public interface IGroupWorkspaceStore {
      * {@code false} when another pod won the claim (or released it) in between —
      * the caller skips its run.
      */
+    boolean casRunningDiscussion(GroupWorkspace workspace, String expectedRunning)
+            throws IResourceStore.ResourceStoreException;
+
     /**
      * Optimistic-concurrency write: persists {@code workspace} only if its
      * {@code revision} still matches what this caller read, bumping it in the same
      * write. Use for every read-modify-write surface (backlog adds) so two
      * concurrent editors cannot silently drop each other's changes — the loser
      * re-reads and retries.
+     * <p>
+     * Known bound: a document created before the {@code revision} field existed
+     * carries {@code null} — the first write on such a document is a plain
+     * (unconditional) stamp, so two callers that BOTH read the pre-revision shape
+     * can still race that one write. The window is one write per legacy document;
+     * every write after the stamp is CAS'd.
      *
      * @return {@code true} if the write landed; {@code false} if a concurrent
      *         writer changed the workspace first (re-read before retrying)
      */
     boolean casRevision(GroupWorkspace workspace) throws IResourceStore.ResourceStoreException;
-
-    boolean casRunningDiscussion(GroupWorkspace workspace, String expectedRunning)
-            throws IResourceStore.ResourceStoreException;
 }

--- a/src/main/java/ai/labs/eddi/configs/groups/IRestGroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/IRestGroupWorkspace.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+/**
+ * REST surface for a group's standing workspace (I13): the backlog human PMs
+ * feed, the cadences that pull from it, and the team's running metrics.
+ *
+ * @author ginccc
+ */
+@Path("/groupstore/groups/{groupId}/workspace")
+@Tag(name = "13. Agent Groups", description = "Standing team workspace — backlog, cadences, metrics")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@RolesAllowed({"eddi-admin", "eddi-editor"})
+public interface IRestGroupWorkspace {
+
+    /**
+     * A backlog task as a human PM files it.
+     *
+     * @param priority
+     *            higher runs earlier when a cadence pulls
+     */
+    record BacklogTaskRequest(String subject, String description, int priority) {
+    }
+
+    /**
+     * A cadence definition. {@code cronExpression} is the standard 5-field form the
+     * schedule store already speaks.
+     */
+    record CadenceRequest(String cronExpression, String timeZone, String inputTemplate,
+            int maxBacklogTasksPerRun, Double maxCostPerRun) {
+    }
+
+    @GET
+    @Operation(description = "Read the group's workspace (backlog, cadences, metrics). "
+            + "Settles a finished cadence discussion on read, so metrics are current.")
+    Response readWorkspace(@PathParam("groupId") String groupId);
+
+    @GET
+    @Path("/backlog")
+    @Operation(description = "List the backlog tasks.")
+    Response readBacklog(@PathParam("groupId") String groupId);
+
+    @POST
+    @Path("/backlog")
+    @Operation(description = "Add a task to the backlog (cap: 200 — the backlog is a working set, not an archive).")
+    Response addBacklogTask(@PathParam("groupId") String groupId, BacklogTaskRequest request);
+
+    @POST
+    @Path("/cadences")
+    @Operation(description = "Add a cadence: a cron-scheduled pull of executable backlog tasks into a group discussion.")
+    Response addCadence(@PathParam("groupId") String groupId, CadenceRequest request);
+
+    @DELETE
+    @Path("/cadences/{cadenceId}")
+    @Operation(description = "Remove a cadence and its schedule.")
+    Response deleteCadence(@PathParam("groupId") String groupId, @PathParam("cadenceId") String cadenceId);
+}

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -92,6 +92,54 @@ public class AgentGroupConfiguration {
     }
 
     /**
+     * Bounds for RETRO lessons (I8). {@code null} runs a RETRO phase with the
+     * defaults — the caps are non-negotiable either way (bounded growth for an LLM
+     * write surface).
+     */
+    private RetroConfig retroConfig;
+
+    public RetroConfig getRetroConfig() {
+        return retroConfig;
+    }
+
+    public void setRetroConfig(RetroConfig retroConfig) {
+        this.retroConfig = retroConfig;
+    }
+
+    /**
+     * Bounds for the RETRO lesson pipeline (I8).
+     *
+     * @param maxLessonsPerRun
+     *            how many lessons one retro turn may store (default 3) — the
+     *            template quotes this cap to the model, and the parser truncates
+     *            past it regardless
+     * @param maxStoredLessons
+     *            FIFO ceiling on the team's stored lessons (default 50): storing
+     *            the 51st evicts the oldest. Bounded growth is non-negotiable —
+     *            non-positive values fall back to the defaults
+     */
+    public record RetroConfig(int maxLessonsPerRun, int maxStoredLessons) {
+
+        public static final int DEFAULT_MAX_PER_RUN = 3;
+        public static final int DEFAULT_MAX_STORED = 50;
+
+        /** Same normalization choke point as {@link GroupTaskConfig}. */
+        public RetroConfig {
+            if (maxLessonsPerRun <= 0) {
+                maxLessonsPerRun = DEFAULT_MAX_PER_RUN;
+            }
+            if (maxStoredLessons <= 0) {
+                maxStoredLessons = DEFAULT_MAX_STORED;
+            }
+        }
+
+        /** Both caps at their defaults. */
+        public RetroConfig() {
+            this(DEFAULT_MAX_PER_RUN, DEFAULT_MAX_STORED);
+        }
+    }
+
+    /**
      * Governs agent-filed tasks (I5). The task list is otherwise written only by
      * the PLAN phase and by config, so work an agent <em>discovers</em> while
      * executing — a missing migration, an untested edge case — dies in prose. The
@@ -323,7 +371,15 @@ public class AgentGroupConfiguration {
         /** Task execution by assigned agents. */
         EXECUTE,
         /** Verification of task results. */
-        VERIFY
+        VERIFY,
+        /**
+         * Post-discussion retrospective (I8): what worked, what failed, what to do
+         * differently. Parsed lessons land in team-owned group memory (synthetic owner
+         * {@code "group:"+groupId}) so they surface as {@code {properties.*}} in every
+         * member's later discussions — institutional knowledge that compounds
+         * run-over-run.
+         */
+        RETRO
     }
 
     public enum TurnOrder {

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -122,6 +122,15 @@ public class AgentGroupConfiguration {
 
         public static final int DEFAULT_MAX_PER_RUN = 3;
         public static final int DEFAULT_MAX_STORED = 50;
+        /**
+         * Hard ceilings (review finding): the compact constructor accepted any positive
+         * int, so a config carrying {@code Integer.MAX_VALUE} made the per-run write
+         * count and the retained-lesson count effectively unbounded — exactly the
+         * bounded-growth guarantee this record exists to enforce on an LLM-driven write
+         * surface.
+         */
+        public static final int CEILING_MAX_PER_RUN = 20;
+        public static final int CEILING_MAX_STORED = 500;
 
         /** Same normalization choke point as {@link GroupTaskConfig}. */
         public RetroConfig {
@@ -131,6 +140,8 @@ public class AgentGroupConfiguration {
             if (maxStoredLessons <= 0) {
                 maxStoredLessons = DEFAULT_MAX_STORED;
             }
+            maxLessonsPerRun = Math.min(maxLessonsPerRun, CEILING_MAX_PER_RUN);
+            maxStoredLessons = Math.min(maxStoredLessons, CEILING_MAX_STORED);
         }
 
         /** Both caps at their defaults. */

--- a/src/main/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresets.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/DiscussionStylePresets.java
@@ -272,6 +272,28 @@ public final class DiscussionStylePresets {
             ]
             ```""";
 
+    /**
+     * The retrospective prompt (I8). The JSON contract line is what
+     * {@code RetroEngine}'s three-tier parse reads; the cap is quoted to the model
+     * AND enforced by the parser regardless.
+     */
+    public static final String TEMPLATE_RETRO = """
+            The discussion on the question below has concluded:
+            "{question}"
+
+            Full transcript:
+            {#for entry in transcript}
+            [{entry.phaseName}] {entry.speaker}: "{entry.content}"
+            {/for}
+
+            Review how this group worked. What worked, what failed, and what should
+            this group do differently next time? Distill LESSONS the group should
+            remember for future discussions — durable, actionable, not a summary of
+            this question's answer.
+
+            Respond with ONLY this JSON, no other text (max {maxLessonsPerRun} lessons):
+            {"lessons": [{"lesson": "<one sentence the group should remember>", "context": "<when it applies>"}]}""";
+
     // Template lookup by phase type
     private static final Map<PhaseType, String> DEFAULT_TEMPLATES = Map.ofEntries(
             Map.entry(PhaseType.OPINION, TEMPLATE_OPINION_INDEPENDENT),
@@ -284,7 +306,8 @@ public final class DiscussionStylePresets {
             Map.entry(PhaseType.SYNTHESIS, TEMPLATE_SYNTHESIS),
             Map.entry(PhaseType.PLAN, TEMPLATE_PLAN),
             Map.entry(PhaseType.EXECUTE, TEMPLATE_EXECUTE),
-            Map.entry(PhaseType.VERIFY, TEMPLATE_VERIFY));
+            Map.entry(PhaseType.VERIFY, TEMPLATE_VERIFY),
+            Map.entry(PhaseType.RETRO, TEMPLATE_RETRO));
 
     /**
      * Returns the default template for a given phase type.

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupConversation.java
@@ -227,14 +227,18 @@ public class GroupConversation {
 
     /**
      * A parent discussion's remaining cost budget at the moment it dispatched this
-     * nested one (I1), or {@code null} for a top-level discussion (and for a parent
-     * that has no ceiling of its own). The discussion runs under
-     * {@code min(own configured ceiling, this)} — see
-     * {@code GroupConversationService.effectiveCostCeiling}. Transient: it is a
-     * property of one dispatch, not of the stored discussion.
+     * nested one (I1), or a cadence run's {@code maxCostPerRun} (I13), or
+     * {@code null} for an unconstrained top-level discussion. The discussion runs
+     * under {@code min(own configured ceiling, this)} — see
+     * {@code GroupConversationService.effectiveCostCeiling}.
+     * <p>
+     * PERSISTED (final-review finding): this was transient, so every HITL
+     * pause/resume re-read the document and silently DROPPED the ceiling — a
+     * cadence discussion whose group config had no ceiling of its own resumed with
+     * unlimited spend after one human approval. The ceiling is a property of the
+     * RUN, and the run survives pauses.
      */
-    @JsonIgnore
-    private transient Double inheritedCostCeiling;
+    private Double inheritedCostCeiling;
 
     /**
      * A single entry in the discussion transcript. Each entry records one agent's

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupWorkspace.java
@@ -82,6 +82,15 @@ public class GroupWorkspace {
     private List<String> pulledTaskIds = new CopyOnWriteArrayList<>();
     private Instant created;
     private Instant lastModified;
+    /**
+     * Optimistic-concurrency stamp for read-modify-write surfaces (review finding:
+     * two concurrent backlog adds could both pass the cap/duplicate checks against
+     * their own snapshots and the later whole-document write dropped the earlier
+     * task). Bumped by {@code IGroupWorkspaceStore.casRevision}; stored as a string
+     * because the conditional-store primitive compares string field equality.
+     * {@code null} on documents created before this field existed.
+     */
+    private String revision = "0";
 
     /**
      * One scheduled pull from the backlog.
@@ -292,5 +301,13 @@ public class GroupWorkspace {
 
     public void setLastModified(Instant lastModified) {
         this.lastModified = lastModified;
+    }
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public void setRevision(String revision) {
+        this.revision = revision;
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupWorkspace.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.groups.model;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -237,8 +238,24 @@ public class GroupWorkspace {
         this.metrics = metrics != null ? metrics : new WorkspaceMetrics();
     }
 
+    /**
+     * Read-only view — mutation goes through {@link #addCadence} and
+     * {@link #removeCadence}, so the schedule references cannot be edited behind
+     * the workspace's back.
+     */
     public List<Cadence> getCadences() {
-        return cadences;
+        return Collections.unmodifiableList(cadences);
+    }
+
+    public void addCadence(Cadence cadence) {
+        if (cadence != null) {
+            cadences.add(cadence);
+        }
+    }
+
+    /** @return {@code true} if a cadence with that id existed and was removed */
+    public boolean removeCadence(String cadenceId) {
+        return cadences.removeIf(c -> c.cadenceId().equals(cadenceId));
     }
 
     public void setCadences(List<Cadence> cadences) {

--- a/src/main/java/ai/labs/eddi/configs/groups/model/GroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/GroupWorkspace.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * A group's standing workspace (I13): the persistent half of a team. A group
+ * <em>conversation</em> is an episode; the workspace is what survives between
+ * episodes — the backlog, the cadences that pull work from it, and the team's
+ * running metrics.
+ * <p>
+ * One document per group config id, in its own collection — deliberately NOT
+ * embedded in the versioned {@link AgentGroupConfiguration}: the workspace
+ * mutates on every cadence run and backlog write, and versioning it alongside
+ * the config would turn each of those into a config revision.
+ * <p>
+ * <b>Concurrency.</b> Cadence fires are cluster-wide (any pod's poller may
+ * claim one), so "is a cadence discussion already running?" is decided by a
+ * conditional store write on {@link #runningDiscussionId} — see
+ * {@code IGroupWorkspaceStore#claimRun} — never by in-JVM locks. The idle value
+ * is the empty string, not {@code null}, because the conditional write compares
+ * a stored field against a concrete value.
+ * <p>
+ * <b>Per-member stats are reliability RECORDING only</b> (research-adopted
+ * substrate): nothing routes or weights on them in v1, and that is a deliberate
+ * scope cut, not an oversight.
+ *
+ * @author ginccc
+ */
+public class GroupWorkspace {
+
+    /**
+     * Document shape version for THIS collection (independent of
+     * {@code GroupConversation}'s). Version 1 is the first that ever existed.
+     */
+    public static final int CURRENT_SCHEMA_VERSION = 1;
+
+    /**
+     * Backlog ceiling. A backlog is a working set, not an archive — past this size,
+     * adding tasks fails with an actionable error instead of growing unboundedly
+     * (an LLM or a runaway integration can call add in a loop).
+     */
+    public static final int MAX_BACKLOG_SIZE = 200;
+
+    /** Default number of backlog tasks one cadence run pulls. */
+    public static final int DEFAULT_MAX_BACKLOG_TASKS_PER_RUN = 5;
+
+    /** {@link #runningDiscussionId}'s idle value — see the class Javadoc. */
+    public static final String NO_RUNNING_DISCUSSION = "";
+
+    private String id;
+    private int schemaVersion = CURRENT_SCHEMA_VERSION;
+    private String groupId;
+    /**
+     * The team's persistent backlog. Reuses {@link SharedTaskList} whole —
+     * statuses, dependency plumbing, caps — so a cadence run can hand pulled tasks
+     * straight to the task-force machinery without a parallel task model.
+     */
+    private SharedTaskList backlog = new SharedTaskList();
+    private WorkspaceMetrics metrics = new WorkspaceMetrics();
+    private List<Cadence> cadences = new CopyOnWriteArrayList<>();
+    /**
+     * The cadence discussion currently in flight, or
+     * {@link #NO_RUNNING_DISCUSSION}. Claimed by conditional write before a cadence
+     * run starts; cleared by writeback once that discussion reaches a terminal
+     * state.
+     */
+    private String runningDiscussionId = NO_RUNNING_DISCUSSION;
+    /**
+     * Backlog task ids the running discussion pulled — what writeback returns to
+     * PENDING if the discussion fails, and matches outcomes against when it
+     * completes.
+     */
+    private List<String> pulledTaskIds = new CopyOnWriteArrayList<>();
+    private Instant created;
+    private Instant lastModified;
+
+    /**
+     * One scheduled pull from the backlog.
+     *
+     * @param cadenceId
+     *            stable id within this workspace
+     * @param scheduleRef
+     *            id of the {@code ScheduleConfiguration} driving this cadence —
+     *            cadence execution rides {@code SchedulePollerService}'s
+     *            cluster-aware claim/lease/retry machinery whole; the workspace
+     *            never runs its own timer
+     * @param inputTemplate
+     *            optional Qute template rendered over the backlog summary to
+     *            produce the discussion question; {@code null} uses a plain default
+     * @param maxBacklogTasksPerRun
+     *            how many executable tasks one fire pulls (default
+     *            {@value #DEFAULT_MAX_BACKLOG_TASKS_PER_RUN})
+     * @param maxCostPerRun
+     *            dollar ceiling for one cadence discussion — dollar-primary per the
+     *            Dream precedent; {@code null} falls back to the group's own
+     *            {@code maxCostPerDiscussion}
+     * @param createdBy
+     *            principal that created the cadence — the identity its discussions
+     *            run under (a cadence run must be attributable to whoever set it
+     *            up, not to a synthetic scheduler user)
+     */
+    public record Cadence(String cadenceId, String scheduleRef, String inputTemplate, int maxBacklogTasksPerRun,
+            Double maxCostPerRun, String createdBy) {
+
+        public Cadence {
+            if (maxBacklogTasksPerRun <= 0) {
+                maxBacklogTasksPerRun = DEFAULT_MAX_BACKLOG_TASKS_PER_RUN;
+            }
+        }
+    }
+
+    /**
+     * The team's running totals. A plain mutable POJO — writeback is the only
+     * writer, and it runs under the workspace's single-writer claim.
+     */
+    public static class WorkspaceMetrics {
+
+        private int discussions;
+        private int tasksVerified;
+        private double totalCost;
+        private Instant lastRunAt;
+        private Map<String, MemberStats> perMemberStats = new ConcurrentHashMap<>();
+
+        public int getDiscussions() {
+            return discussions;
+        }
+
+        public void setDiscussions(int discussions) {
+            this.discussions = discussions;
+        }
+
+        public int getTasksVerified() {
+            return tasksVerified;
+        }
+
+        public void setTasksVerified(int tasksVerified) {
+            this.tasksVerified = tasksVerified;
+        }
+
+        public double getTotalCost() {
+            return totalCost;
+        }
+
+        public void setTotalCost(double totalCost) {
+            this.totalCost = totalCost;
+        }
+
+        public Instant getLastRunAt() {
+            return lastRunAt;
+        }
+
+        public void setLastRunAt(Instant lastRunAt) {
+            this.lastRunAt = lastRunAt;
+        }
+
+        public Map<String, MemberStats> getPerMemberStats() {
+            return perMemberStats;
+        }
+
+        public void setPerMemberStats(Map<String, MemberStats> perMemberStats) {
+            this.perMemberStats = perMemberStats != null
+                    ? new ConcurrentHashMap<>(perMemberStats)
+                    : new ConcurrentHashMap<>();
+        }
+    }
+
+    /**
+     * Reliability recording for one member — see the class Javadoc's scope note.
+     */
+    public static class MemberStats {
+
+        private int tasksVerified;
+        private int tasksFailed;
+
+        public int getTasksVerified() {
+            return tasksVerified;
+        }
+
+        public void setTasksVerified(int tasksVerified) {
+            this.tasksVerified = tasksVerified;
+        }
+
+        public int getTasksFailed() {
+            return tasksFailed;
+        }
+
+        public void setTasksFailed(int tasksFailed) {
+            this.tasksFailed = tasksFailed;
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public int getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(int schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public SharedTaskList getBacklog() {
+        return backlog;
+    }
+
+    public void setBacklog(SharedTaskList backlog) {
+        this.backlog = backlog != null ? backlog : new SharedTaskList();
+    }
+
+    public WorkspaceMetrics getMetrics() {
+        return metrics;
+    }
+
+    public void setMetrics(WorkspaceMetrics metrics) {
+        this.metrics = metrics != null ? metrics : new WorkspaceMetrics();
+    }
+
+    public List<Cadence> getCadences() {
+        return cadences;
+    }
+
+    public void setCadences(List<Cadence> cadences) {
+        this.cadences = cadences != null ? new CopyOnWriteArrayList<>(cadences) : new CopyOnWriteArrayList<>();
+    }
+
+    public String getRunningDiscussionId() {
+        return runningDiscussionId;
+    }
+
+    public void setRunningDiscussionId(String runningDiscussionId) {
+        this.runningDiscussionId = runningDiscussionId != null ? runningDiscussionId : NO_RUNNING_DISCUSSION;
+    }
+
+    public List<String> getPulledTaskIds() {
+        return pulledTaskIds;
+    }
+
+    public void setPulledTaskIds(List<String> pulledTaskIds) {
+        this.pulledTaskIds = pulledTaskIds != null ? new CopyOnWriteArrayList<>(pulledTaskIds) : new CopyOnWriteArrayList<>();
+    }
+
+    public Instant getCreated() {
+        return created;
+    }
+
+    public void setCreated(Instant created) {
+        this.created = created;
+    }
+
+    public Instant getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(Instant lastModified) {
+        this.lastModified = lastModified;
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStore.java
@@ -115,8 +115,12 @@ public class GroupWorkspaceStore implements IGroupWorkspaceStore {
     private List<IResourceStore.IResourceId> findWorkspaceIds(String groupId) {
         var filter = new IResourceFilter.QueryFilters(
                 List.of(new IResourceFilter.QueryFilter("groupId", "^" + groupId + "$")));
+        // High enough that EVERY realistic racer set fits in one query — with a
+        // small limit, three-plus concurrent creators could each see a different
+        // subset and compute different survivors, and the documents would never
+        // converge (review finding).
         List<IResourceStore.IResourceId> ids = storage.findResources(
-                new IResourceFilter.QueryFilters[]{filter}, "lastModified", 0, 2);
+                new IResourceFilter.QueryFilters[]{filter}, "lastModified", 0, 50);
         return ids != null ? ids : List.of();
     }
 
@@ -152,7 +156,23 @@ public class GroupWorkspaceStore implements IGroupWorkspaceStore {
     @Override
     public boolean casRevision(GroupWorkspace workspace) throws IResourceStore.ResourceStoreException {
         String expected = workspace.getRevision();
-        workspace.setRevision(expected == null ? "1" : String.valueOf(Long.parseLong(expected) + 1));
+        String bumped;
+        if (expected == null) {
+            bumped = "1";
+        } else {
+            try {
+                bumped = String.valueOf(Long.parseLong(expected) + 1);
+            } catch (NumberFormatException e) {
+                // A corrupt revision must surface through the method's declared
+                // error model, not as an uncaught runtime exception the REST
+                // layer's generic handler turns into a bare 500 (CodeQL).
+                throw new IResourceStore.ResourceStoreException(
+                        "Workspace revision for group " + workspace.getGroupId() + " is not numeric: '"
+                                + expected + "'",
+                        e);
+            }
+        }
+        workspace.setRevision(bumped);
         workspace.setLastModified(Instant.now());
         if (expected == null) {
             // Pre-revision document: no field to compare against. One plain write

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStore.java
@@ -51,19 +51,22 @@ public class GroupWorkspaceStore implements IGroupWorkspaceStore {
             return null;
         }
         try {
-            var filter = new IResourceFilter.QueryFilters(
-                    List.of(new IResourceFilter.QueryFilter("groupId", "^" + groupId + "$")));
-            List<IResourceStore.IResourceId> ids = storage.findResources(
-                    new IResourceFilter.QueryFilters[]{filter}, "lastModified", 0, 1);
-            if (ids == null || ids.isEmpty()) {
+            List<IResourceStore.IResourceId> ids = findWorkspaceIds(groupId);
+            if (ids.isEmpty()) {
                 return null;
             }
-            IResourceStorage.IResource<GroupWorkspace> resource = storage.read(ids.get(0).getId(), SINGLE_VERSION);
+            String survivorId = survivorId(ids);
+            if (ids.size() > 1) {
+                LOGGER.warnf("Group %s has %d workspace documents — a concurrent readOrCreate raced its "
+                        + "duplicate guard; reading the deterministic survivor %s",
+                        LogSanitizer.sanitize(groupId), ids.size(), survivorId);
+            }
+            IResourceStorage.IResource<GroupWorkspace> resource = storage.read(survivorId, SINGLE_VERSION);
             if (resource == null) {
                 return null;
             }
             GroupWorkspace workspace = resource.getData();
-            workspace.setId(ids.get(0).getId());
+            workspace.setId(survivorId);
             return workspace;
         } catch (IOException e) {
             throw new IResourceStore.ResourceStoreException("Failed to read group workspace: " + e.getMessage(), e);
@@ -84,10 +87,46 @@ public class GroupWorkspaceStore implements IGroupWorkspaceStore {
             IResourceStorage.IResource<GroupWorkspace> resource = storage.newResource(workspace);
             storage.store(resource);
             workspace.setId(resource.getId());
-            return workspace;
         } catch (IOException e) {
             throw new IResourceStore.ResourceStoreException("Failed to create group workspace: " + e.getMessage(), e);
         }
+        // Duplicate-insert guard (review finding): the storage abstraction has no
+        // unique constraint on groupId, so two concurrent creators can both miss
+        // find() above and insert. Re-query: every racer that does NOT hold the
+        // deterministic survivor removes ITS OWN insert and adopts the survivor —
+        // all callers converge on one document. find() picks the same survivor,
+        // so even a racer that crashes before this guard cannot split writes.
+        List<IResourceStore.IResourceId> ids = findWorkspaceIds(groupId);
+        if (ids.size() > 1) {
+            String survivorId = survivorId(ids);
+            if (!survivorId.equals(workspace.getId())) {
+                LOGGER.infof("readOrCreate raced for group %s — removing this caller's duplicate %s, adopting %s",
+                        LogSanitizer.sanitize(groupId), workspace.getId(), survivorId);
+                storage.removeAllPermanently(workspace.getId());
+                GroupWorkspace survivor = find(groupId);
+                if (survivor != null) {
+                    return survivor;
+                }
+            }
+        }
+        return workspace;
+    }
+
+    private List<IResourceStore.IResourceId> findWorkspaceIds(String groupId) {
+        var filter = new IResourceFilter.QueryFilters(
+                List.of(new IResourceFilter.QueryFilter("groupId", "^" + groupId + "$")));
+        List<IResourceStore.IResourceId> ids = storage.findResources(
+                new IResourceFilter.QueryFilters[]{filter}, "lastModified", 0, 2);
+        return ids != null ? ids : List.of();
+    }
+
+    /**
+     * The lexicographically smallest id — for ObjectIds that is the EARLIEST
+     * insert, and every caller (both racers and later readers) derives the same
+     * answer with no coordination.
+     */
+    private static String survivorId(List<IResourceStore.IResourceId> ids) {
+        return ids.stream().map(IResourceStore.IResourceId::getId).sorted().findFirst().orElseThrow();
     }
 
     @Override
@@ -111,6 +150,33 @@ public class GroupWorkspaceStore implements IGroupWorkspaceStore {
     }
 
     @Override
+    public boolean casRevision(GroupWorkspace workspace) throws IResourceStore.ResourceStoreException {
+        String expected = workspace.getRevision();
+        workspace.setRevision(expected == null ? "1" : String.valueOf(Long.parseLong(expected) + 1));
+        workspace.setLastModified(Instant.now());
+        if (expected == null) {
+            // Pre-revision document: no field to compare against. One plain write
+            // stamps the revision; every later write on this document is CAS'd.
+            update(workspace);
+            return true;
+        }
+        try {
+            IResourceStorage.IResource<GroupWorkspace> resource = storage.newResource(workspace.getId(), SINGLE_VERSION, workspace);
+            storage.storeIfFieldEquals(resource, "revision", expected);
+            return true;
+        } catch (IResourceStore.ResourceModifiedException e) {
+            workspace.setRevision(expected);
+            return false;
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            LOGGER.warnf("Workspace %s disappeared during a revision-checked write", LogSanitizer.sanitize(workspace.getGroupId()));
+            workspace.setRevision(expected);
+            return false;
+        } catch (IOException e) {
+            throw new IResourceStore.ResourceStoreException("Failed revision-checked workspace update: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
     public boolean casRunningDiscussion(GroupWorkspace workspace, String expectedRunning)
             throws IResourceStore.ResourceStoreException {
         try {
@@ -127,7 +193,7 @@ public class GroupWorkspaceStore implements IGroupWorkspaceStore {
         } catch (IResourceStore.ResourceNotFoundException e) {
             // Workspace deleted (group teardown) while a claim was in flight —
             // treat as a lost claim rather than an error; the run must not start.
-            LOGGER.warnf("Workspace %s disappeared during a run claim", workspace.getGroupId());
+            LOGGER.warnf("Workspace %s disappeared during a run claim", LogSanitizer.sanitize(workspace.getGroupId()));
             return false;
         } catch (IOException e) {
             throw new IResourceStore.ResourceStoreException("Failed conditional workspace update: " + e.getMessage(), e);

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStore.java
@@ -11,6 +11,7 @@ import ai.labs.eddi.datastore.IResourceStorage;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStorageFactory;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
+import ai.labs.eddi.utils.LogSanitizer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -105,7 +106,7 @@ public class GroupWorkspaceStore implements IGroupWorkspaceStore {
         GroupWorkspace workspace = find(groupId);
         if (workspace != null && workspace.getId() != null) {
             storage.removeAllPermanently(workspace.getId());
-            LOGGER.infof("Deleted workspace for group %s", groupId);
+            LOGGER.infof("Deleted workspace for group %s", LogSanitizer.sanitize(groupId));
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStore.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups.mongo;
+
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.datastore.IResourceFilter;
+import ai.labs.eddi.datastore.IResourceStorage;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.IResourceStorageFactory;
+import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * DB-agnostic store for {@link GroupWorkspace} documents (I13). Follows
+ * {@link GroupConversationStore}'s single-version pattern; workspaces are keyed
+ * logically by {@code groupId} (one document per group), physically by the
+ * storage id.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class GroupWorkspaceStore implements IGroupWorkspaceStore {
+
+    private static final Logger LOGGER = Logger.getLogger(GroupWorkspaceStore.class);
+    private static final int SINGLE_VERSION = 1;
+
+    /** Same reasoning as {@link GroupConversationStore}'s SAFE_ID. */
+    private static final Pattern SAFE_ID = Pattern.compile("[A-Za-z0-9-]+");
+
+    private final IResourceStorage<GroupWorkspace> storage;
+
+    @Inject
+    public GroupWorkspaceStore(IResourceStorageFactory storageFactory, IDocumentBuilder documentBuilder) {
+        this.storage = storageFactory.create("groupworkspaces", documentBuilder, GroupWorkspace.class, "groupId");
+    }
+
+    @Override
+    public GroupWorkspace find(String groupId) throws IResourceStore.ResourceStoreException {
+        if (groupId == null || groupId.isBlank() || !SAFE_ID.matcher(groupId).matches()) {
+            return null;
+        }
+        try {
+            var filter = new IResourceFilter.QueryFilters(
+                    List.of(new IResourceFilter.QueryFilter("groupId", "^" + groupId + "$")));
+            List<IResourceStore.IResourceId> ids = storage.findResources(
+                    new IResourceFilter.QueryFilters[]{filter}, "lastModified", 0, 1);
+            if (ids == null || ids.isEmpty()) {
+                return null;
+            }
+            IResourceStorage.IResource<GroupWorkspace> resource = storage.read(ids.get(0).getId(), SINGLE_VERSION);
+            if (resource == null) {
+                return null;
+            }
+            GroupWorkspace workspace = resource.getData();
+            workspace.setId(ids.get(0).getId());
+            return workspace;
+        } catch (IOException e) {
+            throw new IResourceStore.ResourceStoreException("Failed to read group workspace: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public GroupWorkspace readOrCreate(String groupId) throws IResourceStore.ResourceStoreException {
+        GroupWorkspace existing = find(groupId);
+        if (existing != null) {
+            return existing;
+        }
+        var workspace = new GroupWorkspace();
+        workspace.setGroupId(groupId);
+        workspace.setCreated(Instant.now());
+        workspace.setLastModified(Instant.now());
+        try {
+            IResourceStorage.IResource<GroupWorkspace> resource = storage.newResource(workspace);
+            storage.store(resource);
+            workspace.setId(resource.getId());
+            return workspace;
+        } catch (IOException e) {
+            throw new IResourceStore.ResourceStoreException("Failed to create group workspace: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void update(GroupWorkspace workspace) throws IResourceStore.ResourceStoreException {
+        try {
+            workspace.setLastModified(Instant.now());
+            IResourceStorage.IResource<GroupWorkspace> resource = storage.newResource(workspace.getId(), SINGLE_VERSION, workspace);
+            storage.store(resource);
+        } catch (IOException e) {
+            throw new IResourceStore.ResourceStoreException("Failed to update group workspace: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void deleteByGroupId(String groupId) throws IResourceStore.ResourceStoreException {
+        GroupWorkspace workspace = find(groupId);
+        if (workspace != null && workspace.getId() != null) {
+            storage.removeAllPermanently(workspace.getId());
+            LOGGER.infof("Deleted workspace for group %s", groupId);
+        }
+    }
+
+    @Override
+    public boolean casRunningDiscussion(GroupWorkspace workspace, String expectedRunning)
+            throws IResourceStore.ResourceStoreException {
+        try {
+            workspace.setLastModified(Instant.now());
+            IResourceStorage.IResource<GroupWorkspace> resource = storage.newResource(workspace.getId(), SINGLE_VERSION, workspace);
+            // Conditional on the PERSISTED value — same cross-process atomicity as
+            // GroupConversationStore.updateIfState. An in-JVM check would only
+            // serialize one pod's cadence fires against itself.
+            storage.storeIfFieldEquals(resource, "runningDiscussionId",
+                    expectedRunning != null ? expectedRunning : GroupWorkspace.NO_RUNNING_DISCUSSION);
+            return true;
+        } catch (IResourceStore.ResourceModifiedException e) {
+            return false;
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            // Workspace deleted (group teardown) while a claim was in flight —
+            // treat as a lost claim rather than an error; the run must not start.
+            LOGGER.warnf("Workspace %s disappeared during a run claim", workspace.getGroupId());
+            return false;
+        } catch (IOException e) {
+            throw new IResourceStore.ResourceStoreException("Failed conditional workspace update: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.groups.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionStyle;
@@ -43,14 +44,17 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
     private final IAgentGroupStore groupStore;
     private final IDocumentDescriptorStore documentDescriptorStore;
     private final IJsonSchemaCreator jsonSchemaCreator;
+    private final IGroupWorkspaceStore workspaceStore;
     private final RestVersionInfo<AgentGroupConfiguration> restVersionInfo;
 
     @Inject
-    public RestAgentGroupStore(IAgentGroupStore groupStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator) {
+    public RestAgentGroupStore(IAgentGroupStore groupStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
+            IGroupWorkspaceStore workspaceStore) {
         restVersionInfo = new RestVersionInfo<>(resourceURI, groupStore, documentDescriptorStore);
         this.groupStore = groupStore;
         this.documentDescriptorStore = documentDescriptorStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
+        this.workspaceStore = workspaceStore;
     }
 
     @Override
@@ -137,7 +141,19 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
 
     @Override
     public Response deleteGroup(String id, Integer version, Boolean permanent) {
-        return restVersionInfo.delete(id, version, permanent);
+        Response response = restVersionInfo.delete(id, version, permanent);
+        // I13: a permanently deleted group takes its standing workspace with it —
+        // backlog, cadences and metrics are meaningless without the config they
+        // belong to, and an orphaned cadence would keep firing into errors. A
+        // soft (versioned) delete keeps the workspace: the group can come back.
+        if (Boolean.TRUE.equals(permanent) && response.getStatus() < 300) {
+            try {
+                workspaceStore.deleteByGroupId(id);
+            } catch (Exception e) {
+                LOG.errorf(e, "Failed to cascade workspace deletion for group %s", sanitize(id));
+            }
+        }
+        return response;
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
@@ -9,10 +9,12 @@ import ai.labs.eddi.configs.groups.IAgentGroupStore;
 import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionStyle;
 import ai.labs.eddi.configs.groups.model.DiscussionStylePresets;
 import ai.labs.eddi.configs.rest.RestVersionInfo;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
@@ -45,16 +47,18 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
     private final IDocumentDescriptorStore documentDescriptorStore;
     private final IJsonSchemaCreator jsonSchemaCreator;
     private final IGroupWorkspaceStore workspaceStore;
+    private final IScheduleStore scheduleStore;
     private final RestVersionInfo<AgentGroupConfiguration> restVersionInfo;
 
     @Inject
     public RestAgentGroupStore(IAgentGroupStore groupStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
-            IGroupWorkspaceStore workspaceStore) {
+            IGroupWorkspaceStore workspaceStore, IScheduleStore scheduleStore) {
         restVersionInfo = new RestVersionInfo<>(resourceURI, groupStore, documentDescriptorStore);
         this.groupStore = groupStore;
         this.documentDescriptorStore = documentDescriptorStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
         this.workspaceStore = workspaceStore;
+        this.scheduleStore = scheduleStore;
     }
 
     @Override
@@ -148,6 +152,23 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
         // soft (versioned) delete keeps the workspace: the group can come back.
         if (Boolean.TRUE.equals(permanent) && response.getStatus() < 300) {
             try {
+                // Review finding: cadence ScheduleConfigurations outlive the
+                // workspace — enabled and due, the fire executor keeps selecting
+                // them and every fire errors with "No workspace exists". Retire
+                // the schedules BEFORE the workspace so a crash between the two
+                // leaves the recoverable order (schedules gone, workspace still
+                // deletable), never the orphaned one.
+                GroupWorkspace workspace = workspaceStore.find(id);
+                if (workspace != null) {
+                    for (GroupWorkspace.Cadence cadence : workspace.getCadences()) {
+                        try {
+                            scheduleStore.deleteSchedule(cadence.scheduleRef());
+                        } catch (Exception e) {
+                            LOG.warnf("Could not delete schedule %s of cadence %s while deleting group %s: %s",
+                                    cadence.scheduleRef(), cadence.cadenceId(), sanitize(id), e.getMessage());
+                        }
+                    }
+                }
                 workspaceStore.deleteByGroupId(id);
             } catch (Exception e) {
                 LOG.errorf(e, "Failed to cascade workspace deletion for group %s", sanitize(id));

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
@@ -23,7 +23,6 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.UUID;
 
@@ -160,7 +159,7 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
 
             var cadence = new Cadence(cadenceId, scheduleId, request.inputTemplate(),
                     request.maxBacklogTasksPerRun(), request.maxCostPerRun(), principal);
-            workspace.getCadences().add(cadence);
+            workspace.addCadence(cadence);
             workspaceStore.update(workspace);
             LOG.infof("Cadence %s created for group %s (schedule %s, cron '%s')", cadenceId, sanitize(groupId),
                     scheduleId, sanitize(request.cronExpression()));
@@ -197,12 +196,10 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
             try {
                 scheduleStore.deleteSchedule(cadence.scheduleRef());
             } catch (Exception e) {
-                LOG.warnf("Could not delete schedule %s for cadence %s: %s", cadence.scheduleRef(), cadenceId,
-                        e.getMessage());
+                LOG.warnf("Could not delete schedule %s for cadence %s: %s", cadence.scheduleRef(),
+                        sanitize(cadenceId), sanitize(e.getMessage()));
             }
-            var remaining = new ArrayList<>(workspace.getCadences());
-            remaining.removeIf(c -> cadenceId.equals(c.cadenceId()));
-            workspace.setCadences(remaining);
+            workspace.removeCadence(cadenceId);
             workspaceStore.update(workspace);
             return Response.noContent().build();
         } catch (IResourceStore.ResourceNotFoundException e) {

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestGroupWorkspace;
 import ai.labs.eddi.configs.groups.model.GroupWorkspace;
 import ai.labs.eddi.configs.groups.model.GroupWorkspace.Cadence;
+import ai.labs.eddi.configs.groups.model.SharedTaskList;
 import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.internal.CronParser;
@@ -42,6 +43,11 @@ import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 public class RestGroupWorkspace implements IRestGroupWorkspace {
 
     private static final Logger LOG = Logger.getLogger(RestGroupWorkspace.class);
+
+    /** A workspace is a team's schedule, not a cron farm. */
+    static final int MAX_CADENCES_PER_WORKSPACE = 20;
+    /** The template renders into a discussion question — bound the prose. */
+    static final int MAX_INPUT_TEMPLATE_LENGTH = 4000;
 
     private final IGroupWorkspaceStore workspaceStore;
     private final IAgentGroupStore groupStore;
@@ -95,6 +101,23 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(Map.of("error", "subject is required")).build();
         }
+        // Final-review finding: the agent tool surface enforces these; a human
+        // surface bypassing them let one request grow the persisted document
+        // arbitrarily and made duplicate subjects ambiguous for the writeback's
+        // subject-based outcome matching.
+        if (request.subject().trim().length() > SharedTaskList.MAX_AGENT_TASK_SUBJECT_LENGTH) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "subject exceeds " + SharedTaskList.MAX_AGENT_TASK_SUBJECT_LENGTH
+                            + " characters"))
+                    .build();
+        }
+        if (request.description() != null
+                && request.description().length() > SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "description exceeds " + SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH
+                            + " characters"))
+                    .build();
+        }
         try {
             requireGroupExists(groupId);
             GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
@@ -105,8 +128,15 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
                                 + " tasks — complete or delete existing tasks before adding more"))
                         .build();
             }
+            String subject = request.subject().trim();
+            if (workspace.getBacklog().getTasks().stream().anyMatch(t -> subject.equalsIgnoreCase(t.subject()))) {
+                return Response.status(Response.Status.CONFLICT)
+                        .entity(Map.of("error", "A backlog task with that subject already exists — "
+                                + "writeback matches outcomes by subject, so subjects must be unique"))
+                        .build();
+            }
             TaskItem task = workspace.getBacklog().addTask(new TaskItem(
-                    request.subject().trim(),
+                    subject,
                     request.description() != null ? request.description() : "",
                     request.priority()));
             workspaceStore.update(workspace);
@@ -135,6 +165,17 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
             Instant firstFire = CronParser.computeNextFire(request.cronExpression().trim(), Instant.now(), zone);
 
             GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
+            if (workspace.getCadences().size() >= MAX_CADENCES_PER_WORKSPACE) {
+                return Response.status(Response.Status.CONFLICT)
+                        .entity(Map.of("error", "This workspace already has " + MAX_CADENCES_PER_WORKSPACE
+                                + " cadences — delete one before adding more"))
+                        .build();
+            }
+            if (request.inputTemplate() != null && request.inputTemplate().length() > MAX_INPUT_TEMPLATE_LENGTH) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(Map.of("error", "inputTemplate exceeds " + MAX_INPUT_TEMPLATE_LENGTH + " characters"))
+                        .build();
+            }
             String cadenceId = UUID.randomUUID().toString();
             String principal = identity != null && identity.getPrincipal() != null
                     && identity.getPrincipal().getName() != null && !identity.getPrincipal().getName().isBlank()

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups.rest;
+
+import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
+import ai.labs.eddi.configs.groups.IRestGroupWorkspace;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace.Cadence;
+import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.runtime.internal.CronParser;
+import ai.labs.eddi.engine.runtime.internal.TeamCadenceService;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
+
+/**
+ * REST implementation for {@link IRestGroupWorkspace} (I13).
+ * <p>
+ * Reads run {@link TeamCadenceService#reconcile} first (read-repair): a cadence
+ * discussion that finished since the last fire is settled before the workspace
+ * is rendered, so a human never reads hour-old "running" state or stale
+ * metrics.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class RestGroupWorkspace implements IRestGroupWorkspace {
+
+    private static final Logger LOG = Logger.getLogger(RestGroupWorkspace.class);
+
+    private final IGroupWorkspaceStore workspaceStore;
+    private final IAgentGroupStore groupStore;
+    private final IScheduleStore scheduleStore;
+    private final TeamCadenceService teamCadenceService;
+    private final SecurityIdentity identity;
+
+    @Inject
+    public RestGroupWorkspace(IGroupWorkspaceStore workspaceStore, IAgentGroupStore groupStore,
+            IScheduleStore scheduleStore, TeamCadenceService teamCadenceService, SecurityIdentity identity) {
+        this.workspaceStore = workspaceStore;
+        this.groupStore = groupStore;
+        this.scheduleStore = scheduleStore;
+        this.teamCadenceService = teamCadenceService;
+        this.identity = identity;
+    }
+
+    @Override
+    public Response readWorkspace(String groupId) {
+        try {
+            requireGroupExists(groupId);
+            GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
+            teamCadenceService.reconcile(workspace);
+            return Response.ok(workspace).build();
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", e.getMessage())).build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to read workspace for group %s", sanitize(groupId));
+            return Response.serverError().build();
+        }
+    }
+
+    @Override
+    public Response readBacklog(String groupId) {
+        try {
+            requireGroupExists(groupId);
+            GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
+            teamCadenceService.reconcile(workspace);
+            return Response.ok(workspace.getBacklog().getTasks()).build();
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", e.getMessage())).build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to read backlog for group %s", sanitize(groupId));
+            return Response.serverError().build();
+        }
+    }
+
+    @Override
+    public Response addBacklogTask(String groupId, BacklogTaskRequest request) {
+        if (request == null || request.subject() == null || request.subject().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "subject is required")).build();
+        }
+        try {
+            requireGroupExists(groupId);
+            GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
+            if (workspace.getBacklog().size() >= GroupWorkspace.MAX_BACKLOG_SIZE) {
+                // Actionable, not silent: say WHAT is full and what to do about it.
+                return Response.status(Response.Status.CONFLICT)
+                        .entity(Map.of("error", "The backlog already holds " + GroupWorkspace.MAX_BACKLOG_SIZE
+                                + " tasks — complete or delete existing tasks before adding more"))
+                        .build();
+            }
+            TaskItem task = workspace.getBacklog().addTask(new TaskItem(
+                    request.subject().trim(),
+                    request.description() != null ? request.description() : "",
+                    request.priority()));
+            workspaceStore.update(workspace);
+            return Response.status(Response.Status.CREATED).entity(task).build();
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", e.getMessage())).build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to add backlog task for group %s", sanitize(groupId));
+            return Response.serverError().build();
+        }
+    }
+
+    @Override
+    public Response addCadence(String groupId, CadenceRequest request) {
+        if (request == null || request.cronExpression() == null || request.cronExpression().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "cronExpression is required")).build();
+        }
+        try {
+            requireGroupExists(groupId);
+            ZoneId zone = request.timeZone() != null && !request.timeZone().isBlank()
+                    ? ZoneId.of(request.timeZone())
+                    : ZoneId.of("UTC");
+            // Validate the cron by computing the first fire — an unparseable
+            // expression must fail HERE, not silently never fire.
+            Instant firstFire = CronParser.computeNextFire(request.cronExpression().trim(), Instant.now(), zone);
+
+            GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
+            String cadenceId = UUID.randomUUID().toString();
+            String principal = identity != null && identity.getPrincipal() != null
+                    && identity.getPrincipal().getName() != null && !identity.getPrincipal().getName().isBlank()
+                            ? identity.getPrincipal().getName()
+                            : TeamCadenceService.FALLBACK_USER_ID;
+
+            var schedule = new ScheduleConfiguration();
+            schedule.setName("team-cadence-" + groupId + "-" + cadenceId);
+            schedule.setTriggerType(ScheduleConfiguration.TriggerType.CRON);
+            schedule.setCronExpression(request.cronExpression().trim());
+            schedule.setTimeZone(zone.getId());
+            schedule.setEnabled(true);
+            schedule.setUserId(principal);
+            schedule.setCreatedBy(principal);
+            schedule.setNextFire(firstFire);
+            schedule.setCreatedAt(Instant.now());
+            schedule.setMetadata(Map.of(
+                    TeamCadenceService.METADATA_TYPE_KEY, TeamCadenceService.METADATA_TYPE_CADENCE,
+                    TeamCadenceService.METADATA_GROUP_ID_KEY, groupId,
+                    TeamCadenceService.METADATA_CADENCE_ID_KEY, cadenceId));
+            String scheduleId = scheduleStore.createSchedule(schedule);
+
+            var cadence = new Cadence(cadenceId, scheduleId, request.inputTemplate(),
+                    request.maxBacklogTasksPerRun(), request.maxCostPerRun(), principal);
+            workspace.getCadences().add(cadence);
+            workspaceStore.update(workspace);
+            LOG.infof("Cadence %s created for group %s (schedule %s, cron '%s')", cadenceId, sanitize(groupId),
+                    scheduleId, sanitize(request.cronExpression()));
+            return Response.status(Response.Status.CREATED).entity(cadence).build();
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", e.getMessage())).build();
+        } catch (IllegalArgumentException | java.time.DateTimeException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "Invalid cadence definition: " + e.getMessage())).build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to add cadence for group %s", sanitize(groupId));
+            return Response.serverError().build();
+        }
+    }
+
+    @Override
+    public Response deleteCadence(String groupId, String cadenceId) {
+        try {
+            requireGroupExists(groupId);
+            GroupWorkspace workspace = workspaceStore.find(groupId);
+            if (workspace == null) {
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(Map.of("error", "No workspace exists for this group")).build();
+            }
+            Cadence cadence = workspace.getCadences().stream()
+                    .filter(c -> cadenceId.equals(c.cadenceId()))
+                    .findFirst().orElse(null);
+            if (cadence == null) {
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(Map.of("error", "No such cadence")).build();
+            }
+            // Schedule first: a cadence whose schedule outlives it would keep
+            // firing into "cadence no longer exists" errors forever.
+            try {
+                scheduleStore.deleteSchedule(cadence.scheduleRef());
+            } catch (Exception e) {
+                LOG.warnf("Could not delete schedule %s for cadence %s: %s", cadence.scheduleRef(), cadenceId,
+                        e.getMessage());
+            }
+            var remaining = new ArrayList<>(workspace.getCadences());
+            remaining.removeIf(c -> cadenceId.equals(c.cadenceId()));
+            workspace.setCadences(remaining);
+            workspaceStore.update(workspace);
+            return Response.noContent().build();
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", e.getMessage())).build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to delete cadence %s for group %s", sanitize(cadenceId), sanitize(groupId));
+            return Response.serverError().build();
+        }
+    }
+
+    /** 404 for a workspace under a group id that names no stored group config. */
+    private void requireGroupExists(String groupId) throws IResourceStore.ResourceNotFoundException,
+            IResourceStore.ResourceStoreException {
+        if (groupStore.getCurrentResourceId(groupId) == null) {
+            throw new IResourceStore.ResourceNotFoundException("Group not found.");
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
@@ -48,6 +48,8 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
     static final int MAX_CADENCES_PER_WORKSPACE = 20;
     /** The template renders into a discussion question — bound the prose. */
     static final int MAX_INPUT_TEMPLATE_LENGTH = 4000;
+    /** Lost-CAS retries before telling the caller to try again. */
+    public static final int MAX_CAS_ATTEMPTS = 3;
 
     private final IGroupWorkspaceStore workspaceStore;
     private final IAgentGroupStore groupStore;
@@ -120,27 +122,37 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
         }
         try {
             requireGroupExists(groupId);
-            GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
-            if (workspace.getBacklog().size() >= GroupWorkspace.MAX_BACKLOG_SIZE) {
-                // Actionable, not silent: say WHAT is full and what to do about it.
-                return Response.status(Response.Status.CONFLICT)
-                        .entity(Map.of("error", "The backlog already holds " + GroupWorkspace.MAX_BACKLOG_SIZE
-                                + " tasks — complete or delete existing tasks before adding more"))
-                        .build();
-            }
             String subject = request.subject().trim();
-            if (workspace.getBacklog().getTasks().stream().anyMatch(t -> subject.equalsIgnoreCase(t.subject()))) {
-                return Response.status(Response.Status.CONFLICT)
-                        .entity(Map.of("error", "A backlog task with that subject already exists — "
-                                + "writeback matches outcomes by subject, so subjects must be unique"))
-                        .build();
+            // Optimistic-concurrency retry (review finding): the cap and duplicate
+            // checks run against THIS caller's snapshot; a plain whole-document
+            // update let two concurrent adds both pass under the cap and the later
+            // write drop the earlier task. A lost CAS re-reads and re-validates.
+            for (int attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+                GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
+                if (workspace.getBacklog().size() >= GroupWorkspace.MAX_BACKLOG_SIZE) {
+                    // Actionable, not silent: say WHAT is full and what to do about it.
+                    return Response.status(Response.Status.CONFLICT)
+                            .entity(Map.of("error", "The backlog already holds " + GroupWorkspace.MAX_BACKLOG_SIZE
+                                    + " tasks — complete or delete existing tasks before adding more"))
+                            .build();
+                }
+                if (workspace.getBacklog().getTasks().stream().anyMatch(t -> subject.equalsIgnoreCase(t.subject()))) {
+                    return Response.status(Response.Status.CONFLICT)
+                            .entity(Map.of("error", "A backlog task with that subject already exists — "
+                                    + "writeback matches outcomes by subject, so subjects must be unique"))
+                            .build();
+                }
+                TaskItem task = workspace.getBacklog().addTask(new TaskItem(
+                        subject,
+                        request.description() != null ? request.description() : "",
+                        request.priority()));
+                if (workspaceStore.casRevision(workspace)) {
+                    return Response.status(Response.Status.CREATED).entity(task).build();
+                }
             }
-            TaskItem task = workspace.getBacklog().addTask(new TaskItem(
-                    subject,
-                    request.description() != null ? request.description() : "",
-                    request.priority()));
-            workspaceStore.update(workspace);
-            return Response.status(Response.Status.CREATED).entity(task).build();
+            return Response.status(Response.Status.CONFLICT)
+                    .entity(Map.of("error", "The workspace is being modified concurrently — retry the request"))
+                    .build();
         } catch (IResourceStore.ResourceNotFoundException e) {
             return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", e.getMessage())).build();
         } catch (Exception e) {
@@ -201,7 +213,20 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
             var cadence = new Cadence(cadenceId, scheduleId, request.inputTemplate(),
                     request.maxBacklogTasksPerRun(), request.maxCostPerRun(), principal);
             workspace.addCadence(cadence);
-            workspaceStore.update(workspace);
+            try {
+                workspaceStore.update(workspace);
+            } catch (Exception e) {
+                // Compensate (review finding): the schedule exists but no cadence
+                // names its scheduleRef — it would fire into "cadence no longer
+                // exists" forever and deleteCadence could never reach it.
+                try {
+                    scheduleStore.deleteSchedule(scheduleId);
+                } catch (Exception cleanupFailure) {
+                    LOG.errorf(cleanupFailure, "Orphaned schedule %s for group %s after a failed workspace write",
+                            scheduleId, sanitize(groupId));
+                }
+                throw e;
+            }
             LOG.infof("Cadence %s created for group %s (schedule %s, cron '%s')", cadenceId, sanitize(groupId),
                     scheduleId, sanitize(request.cronExpression()));
             return Response.status(Response.Status.CREATED).entity(cadence).build();

--- a/src/main/java/ai/labs/eddi/configs/properties/IUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/IUserMemoryStore.java
@@ -116,8 +116,13 @@ public interface IUserMemoryStore {
     // === Queries ===
 
     /**
-     * Returns entries visible to the given agent in the given groups. Combines:
-     * self(agentId) + group(groupIds) + global.
+     * Returns entries visible to the given agent in the given groups. Combines the
+     * user's own scope — self(agentId) + group(groupIds) + global — with,
+     * additively, TEAM-OWNED entries (I8): lessons stored under the synthetic owner
+     * {@link #TEAM_OWNER_PREFIX}{@code +groupId} with {@code group} visibility, for
+     * each supplied group. The team branch never widens the user's own scope — a
+     * personal entry of another human user is unreachable through it, because team
+     * owner ids are derived from the supplied group ids, not caller-supplied.
      *
      * @param recallOrder
      *            "most_recent" (updatedAt DESC) or "most_accessed" (accessCount
@@ -127,6 +132,14 @@ public interface IUserMemoryStore {
      */
     List<UserMemoryEntry> getVisibleEntries(String userId, String agentId, List<String> groupIds, String recallOrder, int maxEntries)
             throws IResourceStore.ResourceStoreException;
+
+    /**
+     * Owner prefix for TEAM-OWNED memory (I8): a group's retro lessons are stored
+     * under the synthetic user {@code "group:"+groupId} so they belong to the team,
+     * not to whichever human happened to run the discussion — and survive that
+     * human's GDPR erasure without carrying their identity.
+     */
+    String TEAM_OWNER_PREFIX = "group:";
 
     /**
      * Text filter across keys and values (v1: regex, v2: semantic search).

--- a/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
@@ -230,9 +230,18 @@ public class MongoUserMemoryStore implements IUserMemoryStore {
     }
 
     /**
-     * Visibility filter for a recall: self(agentId) OR group(groupIds) OR global.
+     * Visibility filter for a recall: the user's own scope — self(agentId) OR
+     * group(groupIds) OR global, always constrained to the user's own entries —
+     * plus, additively, the TEAM-OWNED scope (I8): entries whose owner is the
+     * synthetic {@code "group:"+groupId} user with {@code group} visibility.
+     * Package-private static so the filter's shape is directly assertable.
+     * <p>
+     * The team branch is deliberately narrow: it matches ONLY synthetic team owners
+     * derived from the supplied group ids, with group visibility, with a group-id
+     * overlap — never another human user's entries. The user's own branch is
+     * untouched, so personal recall behaves exactly as before.
      */
-    private Bson buildVisibilityFilter(String userId, String agentId, List<String> groupIds) {
+    static Bson buildVisibilityFilter(String userId, String agentId, List<String> groupIds) {
         List<Bson> visibilityFilters = new ArrayList<>();
 
         // Self: entries created by this agent for this user
@@ -246,7 +255,18 @@ public class MongoUserMemoryStore implements IUserMemoryStore {
         // Global: all global entries for this user
         visibilityFilters.add(eq(FIELD_VISIBILITY, Visibility.global.name()));
 
-        return and(eq(FIELD_USER_ID, userId), or(visibilityFilters));
+        Bson userScope = and(eq(FIELD_USER_ID, userId), or(visibilityFilters));
+        if (groupIds == null || groupIds.isEmpty()) {
+            return userScope;
+        }
+
+        // I8: team-owned lessons. Owner ids are DERIVED from the supplied group
+        // ids, never caller-supplied strings — a caller cannot name an arbitrary
+        // owner this way.
+        List<String> teamOwners = groupIds.stream().map(gid -> IUserMemoryStore.TEAM_OWNER_PREFIX + gid).toList();
+        Bson teamScope = and(in(FIELD_USER_ID, teamOwners), eq(FIELD_VISIBILITY, Visibility.group.name()),
+                in(FIELD_GROUP_IDS, groupIds));
+        return or(userScope, teamScope);
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
@@ -74,7 +74,7 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
      * optional group clause, the closing parenthesis, an ORDER BY and a LIMIT.
      */
     private static final String VISIBILITY_SELECT = """
-            SELECT * FROM usermemories WHERE user_id = ? AND (
+            SELECT * FROM usermemories WHERE ((user_id = ? AND (
                 (visibility = 'self' AND source_agent_id = ?)
                 OR (visibility = 'global')
             """;
@@ -314,22 +314,46 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
     }
 
     /**
-     * Visibility filter for a recall: self(agentId) OR group(groupIds) OR global.
+     * Visibility filter for a recall: the user's own scope — self(agentId) OR
+     * group(groupIds) OR global — plus, additively, the TEAM-OWNED scope (I8):
+     * entries whose owner is the synthetic {@code "group:"+groupId} user with
+     * {@code group} visibility. Mirrors the Mongo store's
+     * {@code buildVisibilityFilter} exactly; the two must not drift.
+     * Package-private static so the SQL shape is directly assertable.
+     * <p>
      * The {@code ??|} is the JDBC escape for PostgreSQL's {@code ?|} JSONB overlap
-     * operator — a single {@code ?} would be parsed as a bind parameter.
+     * operator — a single {@code ?} would be parsed as a bind parameter. Bind order
+     * (see {@code collectInto}): userId, agentId, then — only when groups are
+     * supplied — the group ids (user scope), the derived team owner ids, and the
+     * group ids again (team overlap).
      */
-    private String buildVisibilityQuery(List<String> groupIds) {
+    static String buildVisibilityQuery(List<String> groupIds) {
         StringBuilder sql = new StringBuilder(VISIBILITY_SELECT);
-        if (groupIds != null && !groupIds.isEmpty()) {
+        boolean hasGroups = groupIds != null && !groupIds.isEmpty();
+        if (hasGroups) {
             // `??|` is pgjdbc's escape for the jsonb `?|` overlap operator — a bare `?`
             // would be parsed by the driver as a bind placeholder.
             sql.append(" OR (visibility = 'group' AND group_ids ??| ARRAY[");
-            for (int i = 0; i < groupIds.size(); i++) {
-                sql.append(i > 0 ? ",?" : "?");
-            }
+            appendPlaceholders(sql, groupIds.size());
+            sql.append("])");
+        }
+        sql.append("))");
+        if (hasGroups) {
+            // I8: team-owned lessons. Owner ids are DERIVED from the supplied
+            // group ids at bind time, never caller-supplied strings.
+            sql.append(" OR (visibility = 'group' AND user_id IN (");
+            appendPlaceholders(sql, groupIds.size());
+            sql.append(") AND group_ids ??| ARRAY[");
+            appendPlaceholders(sql, groupIds.size());
             sql.append("])");
         }
         return sql.append(")").toString();
+    }
+
+    private static void appendPlaceholders(StringBuilder sql, int count) {
+        for (int i = 0; i < count; i++) {
+            sql.append(i > 0 ? ",?" : "?");
+        }
     }
 
     /**
@@ -397,7 +421,16 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
             int paramIndex = 1;
             ps.setString(paramIndex++, userId);
             ps.setString(paramIndex++, agentId);
-            if (groupIds != null) {
+            if (groupIds != null && !groupIds.isEmpty()) {
+                // Bind order must mirror buildVisibilityQuery exactly: the user
+                // scope's group overlap, then the derived team owners (I8), then
+                // the team scope's group overlap.
+                for (String gid : groupIds) {
+                    ps.setString(paramIndex++, gid);
+                }
+                for (String gid : groupIds) {
+                    ps.setString(paramIndex++, IUserMemoryStore.TEAM_OWNER_PREFIX + gid);
+                }
                 for (String gid : groupIds) {
                     ps.setString(paramIndex++, gid);
                 }

--- a/src/main/java/ai/labs/eddi/engine/api/IGroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IGroupConversationService.java
@@ -210,6 +210,8 @@ public interface IGroupConversationService {
         }
         default void onConvergenceReached(GroupConversationEventSink.ConvergenceReachedEvent event) {
         }
+        default void onRetroRecorded(GroupConversationEventSink.RetroRecordedEvent event) {
+        }
     }
 
     // --- Exceptions ---

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -506,6 +506,63 @@ public class GroupConversationService implements IGroupConversationService {
     }
 
     /**
+     * Starts a cadence-driven discussion (I13): {@code startAndDiscussAsync} with
+     * two overrides a scheduled backlog run needs — the pulled backlog tasks
+     * replace the config's pre-configured task list (a runtime copy; the stored
+     * config is never written), and the cadence's dollar ceiling rides the
+     * inherited-ceiling slot so {@code effectiveCostCeiling} takes the tighter of
+     * it and the group's own {@code maxCostPerDiscussion}.
+     * <p>
+     * The config instance mutated here is this call's own fresh read from the store
+     * — deserialized per read, shared with nothing.
+     */
+    public GroupConversation startCadenceDiscussionAsync(String groupId, String question, String userId,
+                                                         List<AgentGroupConfiguration.TaskDefinition> injectedTasks,
+                                                         Double maxCostPerRun, GroupDiscussionEventListener listener)
+            throws GroupDiscussionException, IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+        if (groupId == null) {
+            throw new IllegalArgumentException("groupId must not be null");
+        }
+        rejectIfShuttingDown();
+
+        IResourceStore.IResourceId currentGroupId = groupStore.getCurrentResourceId(groupId);
+        if (currentGroupId == null) {
+            throw new IResourceStore.ResourceNotFoundException("Group not found.");
+        }
+        AgentGroupConfiguration config = groupStore.read(groupId, currentGroupId.getVersion());
+        if (config == null) {
+            throw new IResourceStore.ResourceNotFoundException("Group configuration not found.");
+        }
+        if (injectedTasks != null && !injectedTasks.isEmpty()) {
+            config.setTasks(List.copyOf(injectedTasks));
+        }
+
+        List<DiscussionPhase> phases = resolvePhases(config);
+        if (phases.isEmpty()) {
+            throw new GroupDiscussionException("No discussion phases are defined for this group.");
+        }
+
+        GroupConversation gc = createGroupConversation(groupId, question, userId, 0);
+        gc.setInheritedCostCeiling(maxCostPerRun);
+        activeTokens.put(gc.getId(), new DiscussionControlToken());
+        final var discussionCaller = callerIdentityContext.captureOrCurrent();
+        try {
+            executorService.submit(callerIdentityContext.withIdentity(discussionCaller, () -> {
+                try {
+                    executeDiscussion(gc, config, phases, question, listener, 0);
+                } catch (Exception e) {
+                    LOGGER.errorf("Cadence group discussion failed for %s: %s", LogSanitizer.sanitize(groupId), e.getMessage());
+                }
+            }));
+        } catch (RuntimeException e) {
+            activeTokens.remove(gc.getId());
+            failConversation(gc);
+            throw new GroupDiscussionException("Failed to start cadence discussion: " + e.getMessage(), e);
+        }
+        return gc;
+    }
+
+    /**
      * Materialize discussion attachments and bind them to the group conversation.
      * Delegates to {@link GroupAttachmentBinder}; see its Javadoc for behavior.
      * Constructed per call (not cached) since {@link #attachmentStore} is a

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -37,8 +37,10 @@ import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.internal.groups.DebateVerdictParser;
 import ai.labs.eddi.engine.internal.groups.GroupAttachmentBinder;
+import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.engine.internal.groups.GroupContextBuilder;
 import ai.labs.eddi.engine.internal.groups.GroupHitlCoordinator;
+import ai.labs.eddi.engine.internal.groups.RetroEngine;
 import ai.labs.eddi.engine.internal.groups.LiveDiscussionRegistry;
 import ai.labs.eddi.engine.internal.groups.GroupLifecycleOps;
 import ai.labs.eddi.engine.internal.groups.GroupSigningGuard;
@@ -207,6 +209,14 @@ public class GroupConversationService implements IGroupConversationService {
      */
     @Inject
     LiveDiscussionRegistry liveDiscussionRegistry;
+
+    /**
+     * I8's lesson store. Same field-injection pattern and null-safety as
+     * {@link #attachmentStore} — {@code null} in direct-construction unit tests,
+     * where a RETRO phase runs but persists nothing (warned, never failed).
+     */
+    @Inject
+    IUserMemoryStore userMemoryStore;
 
     // In-node fast-fail guard for concurrent post-discussion operations
     // (follow-up, continue, close) on the same conversation: a second
@@ -848,6 +858,14 @@ public class GroupConversationService implements IGroupConversationService {
                             phaseExecutionEngine.runDissentRound(gc, config, phase, protocol, phaseIdx, speakers, listener,
                                     turnCounter, maxTurns);
                         }
+                    }
+
+                    // I8: a completed RETRO phase harvests its lessons into
+                    // team-owned group memory. Last repeat only — a draft retro is
+                    // not the retrospective — and BEFORE the persist below, so a
+                    // crash cannot lose lessons a stored document claims were taken.
+                    if (phase.type() == PhaseType.RETRO && lastRepeat) {
+                        RetroEngine.harvest(gc, config.getRetroConfig(), repeatEntries, userMemoryStore, phase.name(), listener);
                     }
 
                     gc.setLastModified(Instant.now());

--- a/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
@@ -875,6 +875,12 @@ public class RestGroupConversation implements IRestGroupConversation {
                 // debate verdict before a later synthesis phase).
                 sendEvent(eventSink, sse, GroupConversationEventSink.EVENT_DECISION_REACHED, toJson(event));
             }
+
+            @Override
+            public void onRetroRecorded(GroupConversationEventSink.RetroRecordedEvent event) {
+                // Not terminal — a retro can precede further phases.
+                sendEvent(eventSink, sse, GroupConversationEventSink.EVENT_RETRO_RECORDED, toJson(event));
+            }
         };
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
@@ -64,6 +64,20 @@ public class GroupContextBuilder {
      */
     public String buildPhaseInput(DiscussionPhase phase, GroupMember speaker, String question, List<TranscriptEntry> transcript, int phaseIdx,
                                   GroupMember target, List<GroupMember> allMembers) {
+        return buildPhaseInput(phase, speaker, question, transcript, phaseIdx, target, allMembers, null);
+    }
+
+    /**
+     * @param retroConfig
+     *            the group's RETRO settings; only the {@code RETRO} case reads it
+     *            (the template quotes {@code maxLessonsPerRun} to the model).
+     *            {@code null} falls back to the default cap — review finding: the
+     *            template always quoted the DEFAULT, so a group configured above it
+     *            could never obtain its configured number of lessons.
+     */
+    public String buildPhaseInput(DiscussionPhase phase, GroupMember speaker, String question, List<TranscriptEntry> transcript, int phaseIdx,
+                                  GroupMember target, List<GroupMember> allMembers,
+                                  AgentGroupConfiguration.RetroConfig retroConfig) {
 
         String template = phase.inputTemplate() != null
                 ? phase.inputTemplate()
@@ -201,11 +215,12 @@ public class GroupContextBuilder {
                             return t;
                         }).collect(Collectors.toList());
                 data.put("transcript", fullTranscript);
-                // The template QUOTES the default cap; RetroEngine ENFORCES the
-                // configured one at parse time regardless of what the model was
-                // told. Quoting the default keeps this builder free of the group
-                // config (which it deliberately does not receive).
-                data.put("maxLessonsPerRun", AgentGroupConfiguration.RetroConfig.DEFAULT_MAX_PER_RUN);
+                // The template QUOTES the configured cap so the model is asked for
+                // exactly what the group wants; RetroEngine still ENFORCES it at
+                // parse time regardless of what the model returns.
+                data.put("maxLessonsPerRun", retroConfig != null
+                        ? retroConfig.maxLessonsPerRun()
+                        : AgentGroupConfiguration.RetroConfig.DEFAULT_MAX_PER_RUN);
             }
             default -> {
                 // All PhaseType values handled above; default required by checkstyle

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilder.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal.groups;
 
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
@@ -184,6 +185,27 @@ public class GroupContextBuilder {
             }
             case VERIFY -> {
                 // Completed tasks populated by executeTaskPhase
+            }
+            case RETRO -> {
+                // I8: the retro reviews the whole discussion — same full-picture
+                // filter as SYNTHESIS (a retrospective on a windowed excerpt would
+                // draw lessons from an excerpt).
+                List<Map<String, Object>> fullTranscript = transcript.stream()
+                        .filter(e -> e.content() != null && e.type() != TranscriptEntryType.ERROR && e.type() != TranscriptEntryType.SKIPPED
+                                && e.type() != TranscriptEntryType.QUESTION)
+                        .map(e -> {
+                            Map<String, Object> t = new LinkedHashMap<>();
+                            t.put("speaker", e.speakerDisplayName());
+                            t.put("content", e.content());
+                            t.put("phaseName", e.phaseName() != null ? e.phaseName() : "");
+                            return t;
+                        }).collect(Collectors.toList());
+                data.put("transcript", fullTranscript);
+                // The template QUOTES the default cap; RetroEngine ENFORCES the
+                // configured one at parse time regardless of what the model was
+                // told. Quoting the default keeps this builder free of the group
+                // config (which it deliberately does not receive).
+                data.put("maxLessonsPerRun", AgentGroupConfiguration.RetroConfig.DEFAULT_MAX_PER_RUN);
             }
             default -> {
                 // All PhaseType values handled above; default required by checkstyle
@@ -370,6 +392,8 @@ public class GroupContextBuilder {
             case PLAN -> TranscriptEntryType.PLAN;
             case EXECUTE -> TranscriptEntryType.TASK_RESULT;
             case VERIFY -> TranscriptEntryType.VERIFICATION;
+            // I8: retro contributions are public RETRO entries (F4 default).
+            case RETRO -> TranscriptEntryType.RETRO;
         };
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupHitlCoordinator.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupHitlCoordinator.java
@@ -828,9 +828,12 @@ public class GroupHitlCoordinator {
             // Executor saturated/shut down — no thread will run the resume. The CAS
             // above already consumed the pause; restore it so the approval remains
             // actionable instead of leaving an IN_PROGRESS zombie.
-            activeTokens.remove(gc.getId());
             restoreGroupPause(gc, savedPhaseIndex, savedPhaseName, savedPauseType, savedPausedAt, null,
                     savedTimeoutPolicy, savedApprovalTimeout);
+            // Remove-and-recheck like every other rollback path — a plain remove
+            // here dropped a cancel signalled between token registration and this
+            // rollback, leaving a "cancelled" discussion stuck AWAITING_APPROVAL.
+            removeTokenAndConvertIfSignalled(gc, listener);
             throw new IResourceStore.ResourceStoreException(
                     "Failed to submit resumed group discussion: " + e.getMessage(), e);
         }

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
@@ -511,7 +511,7 @@ public class PhaseExecutionEngine {
                         new GroupConversationEventSink.SpeakerStartEvent(speaker.agentId(), speaker.displayName(), phaseIdx, phase.name()));
             }
             String input = contextBuilder.buildPhaseInput(phase, speaker, question, gc.getTranscript(), phaseIdx, null,
-                    GroupConversationService.rosterWithRecruits(config, gc));
+                    GroupConversationService.rosterWithRecruits(config, gc), config.getRetroConfig());
             TranscriptEntry entry = memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, null, listener);
             gc.getTranscript().add(entry);
             if (listener != null) {
@@ -586,7 +586,7 @@ public class PhaseExecutionEngine {
                 .map(speaker -> CompletableFuture.supplyAsync(callerIdentityContext.withIdentitySupplying(phaseCaller, () -> {
                     try {
                         String input = contextBuilder.buildPhaseInput(phase, speaker, question, snapshotTranscript, phaseIdx, null,
-                                GroupConversationService.rosterWithRecruits(config, gc));
+                                GroupConversationService.rosterWithRecruits(config, gc), config.getRetroConfig());
                         return memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, null, listener, cancellation);
                     } catch (MemberTurnCancelledException e) {
                         // The orchestrator stopped waiting for this batch — surface the
@@ -715,7 +715,7 @@ public class PhaseExecutionEngine {
                             new GroupConversationEventSink.SpeakerStartEvent(speaker.agentId(), speaker.displayName(), phaseIdx, phase.name()));
                 }
                 String input = contextBuilder.buildPhaseInput(phase, speaker, question, gc.getTranscript(), phaseIdx, target,
-                        GroupConversationService.rosterWithRecruits(config, gc));
+                        GroupConversationService.rosterWithRecruits(config, gc), config.getRetroConfig());
                 TranscriptEntry entry = memberTurnExecutor.executeAgentTurn(speaker, gc, input, protocol, phaseIdx, phase, target.agentId(),
                         listener);
                 gc.getTranscript().add(entry);

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.RetroConfig;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import ai.labs.eddi.configs.properties.IUserMemoryStore;
+import ai.labs.eddi.configs.properties.model.Property.Visibility;
+import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
+import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
+import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.jboss.logging.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Turns a RETRO phase's contributions into team-owned group memory (I8).
+ * <p>
+ * Every discussion otherwise evaporates: nothing a group learns about its own
+ * process survives the transcript. Parsed lessons are upserted into
+ * {@link IUserMemoryStore} under the synthetic team owner
+ * ({@code "group:"+groupId}, {@code group} visibility), which member
+ * conversations already load at init — so lessons surface as
+ * {@code {properties.*}} in every later discussion with no new namespace.
+ * <p>
+ * Bounded growth is non-negotiable: per-turn lessons cap at
+ * {@code maxLessonsPerRun} (enforced here, whatever the model was told), the
+ * stored set FIFOs at {@code maxStoredLessons}, and the idempotency key
+ * {@code retro:<hash(lesson)>} with a fixed source agent makes re-running the
+ * same retro a no-op rather than a duplicate.
+ * <p>
+ * Every failure is warn-and-continue — a lesson that fails to store must never
+ * fail the discussion that produced it.
+ *
+ * @author ginccc
+ */
+public final class RetroEngine {
+
+    private static final Logger LOGGER = Logger.getLogger(RetroEngine.class);
+
+    /**
+     * Fixed {@code sourceAgentId} for every lesson. The upsert identity for
+     * group-visible entries is {@code (userId, key, sourceAgentId)} — a real
+     * speaker id there would make the same lesson from two speakers two rows,
+     * defeating the idempotency key.
+     */
+    static final String RETRO_SOURCE = "retro";
+
+    /** Idempotency-key prefix: {@code retro:<sha256(lesson)[0..15]>}. */
+    static final String KEY_PREFIX = "retro:";
+
+    private static final ObjectMapper MAPPER = JsonMapper.builder()
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+            .build();
+
+    private RetroEngine() {
+    }
+
+    /** One parsed lesson. */
+    public record Lesson(String lesson, String context) {
+    }
+
+    /**
+     * Three-tier parse of one retro contribution: strict JSON → JSON embedded in
+     * prose/fence → give up (empty). Truncated at {@code maxLessonsPerRun}
+     * regardless of what the model produced.
+     */
+    static List<Lesson> parseLessons(String content, int maxLessonsPerRun) {
+        if (content == null || content.isBlank()) {
+            return List.of();
+        }
+        JsonNode node = readJson(content);
+        if (node == null) {
+            node = readJson(embeddedJson(content));
+        }
+        if (node == null || !node.path("lessons").isArray()) {
+            return List.of();
+        }
+        List<Lesson> lessons = new ArrayList<>();
+        for (JsonNode lessonNode : node.path("lessons")) {
+            String lesson = lessonNode.path("lesson").isTextual() ? lessonNode.path("lesson").asText().trim() : null;
+            if (lesson == null || lesson.isBlank()) {
+                continue;
+            }
+            String context = lessonNode.path("context").isTextual() ? lessonNode.path("context").asText().trim() : null;
+            lessons.add(new Lesson(lesson, context != null && !context.isBlank() ? context : null));
+            if (lessons.size() >= maxLessonsPerRun) {
+                break;
+            }
+        }
+        return lessons;
+    }
+
+    /**
+     * Harvests a completed RETRO phase: parses each RETRO entry, upserts the
+     * lessons team-owned, FIFO-evicts past the stored cap, and fires
+     * {@code retro_recorded}.
+     */
+    public static void harvest(GroupConversation gc, RetroConfig retroConfig, List<TranscriptEntry> repeatEntries,
+                               IUserMemoryStore userMemoryStore, String phaseName, GroupDiscussionEventListener listener) {
+        if (userMemoryStore == null) {
+            LOGGER.warnf("Group %s: RETRO phase '%s' ran but no user memory store is available — lessons are not persisted",
+                    gc.getId(), phaseName);
+            return;
+        }
+        RetroConfig config = retroConfig != null ? retroConfig : new RetroConfig();
+        String teamOwner = IUserMemoryStore.TEAM_OWNER_PREFIX + gc.getGroupId();
+
+        int stored = 0;
+        for (TranscriptEntry entry : repeatEntries) {
+            if (entry == null || entry.type() != TranscriptEntryType.RETRO) {
+                continue;
+            }
+            for (Lesson lesson : parseLessons(entry.content(), config.maxLessonsPerRun())) {
+                try {
+                    String value = lesson.context() != null ? lesson.lesson() + " (applies: " + lesson.context() + ")" : lesson.lesson();
+                    userMemoryStore.upsert(new UserMemoryEntry(null, teamOwner, KEY_PREFIX + lessonHash(lesson.lesson()), value,
+                            "context", Visibility.group, RETRO_SOURCE, List.of(gc.getGroupId()), gc.getId(), false, 0,
+                            Instant.now(), Instant.now()));
+                    stored++;
+                } catch (Exception e) {
+                    LOGGER.warnf("Group %s: failed to store a retro lesson: %s", gc.getId(), e.getMessage());
+                }
+            }
+        }
+        if (stored > 0) {
+            evictPastCap(userMemoryStore, teamOwner, gc.getGroupId(), config.maxStoredLessons());
+            LOGGER.infof("Group %s: RETRO phase '%s' stored %d lesson(s) for team %s", gc.getId(), phaseName, stored, teamOwner);
+        }
+        if (listener != null) {
+            listener.onRetroRecorded(new GroupConversationEventSink.RetroRecordedEvent(gc.getGroupId(), phaseName, stored));
+        }
+    }
+
+    /**
+     * FIFO at the stored cap: the recall is newest-first, so everything past the
+     * cap in that ordering is the oldest — evicted so institutional memory stays
+     * bounded. Team-owned entries are untouchable by {@code UserMemoryTool}'s own
+     * eviction (which only ever removes the calling agent's {@code self} entries),
+     * so this is the ONLY reaper.
+     */
+    private static void evictPastCap(IUserMemoryStore store, String teamOwner, String groupId, int maxStoredLessons) {
+        try {
+            List<UserMemoryEntry> entries = store.getVisibleEntries(teamOwner, RETRO_SOURCE, List.of(groupId), "most_recent", -1);
+            for (int i = maxStoredLessons; i < entries.size(); i++) {
+                UserMemoryEntry oldest = entries.get(i);
+                if (oldest.id() != null) {
+                    store.deleteEntry(oldest.id());
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warnf("Failed to FIFO-evict retro lessons for %s: %s", teamOwner, e.getMessage());
+        }
+    }
+
+    /** First 16 hex chars of SHA-256 — collision-safe enough for a 50-entry set. */
+    static String lessonHash(String lesson) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(lesson.toLowerCase().strip().getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash, 0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandatory on every JVM; unreachable.
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static JsonNode readJson(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        try {
+            return MAPPER.readTree(text.trim());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String embeddedJson(String content) {
+        int start = content.indexOf('{');
+        int end = content.lastIndexOf('}');
+        return start >= 0 && end > start ? content.substring(start, end + 1) : null;
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
@@ -25,6 +25,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HexFormat;
 import java.util.List;
 
@@ -164,15 +165,24 @@ public final class RetroEngine {
     }
 
     /**
-     * FIFO at the stored cap: the recall is newest-first, so everything past the
-     * cap in that ordering is the oldest — evicted so institutional memory stays
-     * bounded. Team-owned entries are untouchable by {@code UserMemoryTool}'s own
-     * eviction (which only ever removes the calling agent's {@code self} entries),
-     * so this is the ONLY reaper.
+     * FIFO at the stored cap, ordered by CREATION time. The {@code most_recent}
+     * recall order sorts by {@code updatedAt}, and reharvesting an existing lesson
+     * refreshes that — so eviction keyed on recall order could evict a
+     * later-CREATED lesson while an old-but-reharvested one survived (review
+     * finding). {@code createdAt} is {@code setOnInsert} at the store, so it is the
+     * stable insertion stamp FIFO needs. Team-owned entries are untouchable by
+     * {@code UserMemoryTool}'s own eviction (which only ever removes the calling
+     * agent's {@code self} entries), so this is the ONLY reaper.
      */
     private static void evictPastCap(IUserMemoryStore store, String teamOwner, String groupId, int maxStoredLessons) {
         try {
-            List<UserMemoryEntry> entries = store.getVisibleEntries(teamOwner, RETRO_SOURCE, List.of(groupId), "most_recent", -1);
+            List<UserMemoryEntry> entries = store.getVisibleEntries(teamOwner, RETRO_SOURCE, List.of(groupId), "most_recent", -1)
+                    .stream()
+                    // Newest created first; entries without a createdAt (pre-stamp
+                    // documents) count as oldest and are evicted first.
+                    .sorted(Comparator.comparing(UserMemoryEntry::createdAt,
+                            Comparator.nullsFirst(Comparator.naturalOrder())).reversed())
+                    .toList();
             for (int i = maxStoredLessons; i < entries.size(); i++) {
                 UserMemoryEntry oldest = entries.get(i);
                 if (oldest.id() != null) {

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
@@ -116,23 +116,37 @@ public final class RetroEngine {
         if (userMemoryStore == null) {
             LOGGER.warnf("Group %s: RETRO phase '%s' ran but no user memory store is available — lessons are not persisted",
                     LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phaseName));
+            // The event contract holds even when nothing can be stored: a RETRO
+            // phase always emits retro_recorded (review finding — this path
+            // returned silently, leaving SSE consumers waiting).
+            if (listener != null) {
+                listener.onRetroRecorded(new GroupConversationEventSink.RetroRecordedEvent(gc.getGroupId(), phaseName, 0));
+            }
             return;
         }
         RetroConfig config = retroConfig != null ? retroConfig : new RetroConfig();
         String teamOwner = IUserMemoryStore.TEAM_OWNER_PREFIX + gc.getGroupId();
 
+        // maxLessonsPerRun bounds the whole HARVEST, not each transcript entry —
+        // a multi-participant or multi-repeat RETRO phase produces several RETRO
+        // entries, and a per-entry cap multiplied by entry count (review finding).
+        int remaining = config.maxLessonsPerRun();
         int stored = 0;
         for (TranscriptEntry entry : repeatEntries) {
+            if (remaining <= 0) {
+                break;
+            }
             if (entry == null || entry.type() != TranscriptEntryType.RETRO) {
                 continue;
             }
-            for (Lesson lesson : parseLessons(entry.content(), config.maxLessonsPerRun())) {
+            for (Lesson lesson : parseLessons(entry.content(), remaining)) {
                 try {
                     String value = lesson.context() != null ? lesson.lesson() + " (applies: " + lesson.context() + ")" : lesson.lesson();
                     userMemoryStore.upsert(new UserMemoryEntry(null, teamOwner, KEY_PREFIX + lessonHash(lesson.lesson()), value,
                             "context", Visibility.group, RETRO_SOURCE, List.of(gc.getGroupId()), gc.getId(), false, 0,
                             Instant.now(), Instant.now()));
                     stored++;
+                    remaining--;
                 } catch (Exception e) {
                     LOGGER.warnf("Group %s: failed to store a retro lesson: %s",
                             LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(e.getMessage()));

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/RetroEngine.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.configs.properties.model.Property.Visibility;
 import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
+import ai.labs.eddi.utils.LogSanitizer;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -114,7 +115,7 @@ public final class RetroEngine {
                                IUserMemoryStore userMemoryStore, String phaseName, GroupDiscussionEventListener listener) {
         if (userMemoryStore == null) {
             LOGGER.warnf("Group %s: RETRO phase '%s' ran but no user memory store is available — lessons are not persisted",
-                    gc.getId(), phaseName);
+                    LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phaseName));
             return;
         }
         RetroConfig config = retroConfig != null ? retroConfig : new RetroConfig();
@@ -133,13 +134,15 @@ public final class RetroEngine {
                             Instant.now(), Instant.now()));
                     stored++;
                 } catch (Exception e) {
-                    LOGGER.warnf("Group %s: failed to store a retro lesson: %s", gc.getId(), e.getMessage());
+                    LOGGER.warnf("Group %s: failed to store a retro lesson: %s",
+                            LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(e.getMessage()));
                 }
             }
         }
         if (stored > 0) {
             evictPastCap(userMemoryStore, teamOwner, gc.getGroupId(), config.maxStoredLessons());
-            LOGGER.infof("Group %s: RETRO phase '%s' stored %d lesson(s) for team %s", gc.getId(), phaseName, stored, teamOwner);
+            LOGGER.infof("Group %s: RETRO phase '%s' stored %d lesson(s) for team %s",
+                    LogSanitizer.sanitize(gc.getId()), LogSanitizer.sanitize(phaseName), stored, LogSanitizer.sanitize(teamOwner));
         }
         if (listener != null) {
             listener.onRetroRecorded(new GroupConversationEventSink.RetroRecordedEvent(gc.getGroupId(), phaseName, stored));
@@ -163,7 +166,8 @@ public final class RetroEngine {
                 }
             }
         } catch (Exception e) {
-            LOGGER.warnf("Failed to FIFO-evict retro lessons for %s: %s", teamOwner, e.getMessage());
+            LOGGER.warnf("Failed to FIFO-evict retro lessons for %s: %s",
+                    LogSanitizer.sanitize(teamOwner), LogSanitizer.sanitize(e.getMessage()));
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/GroupConversationEventSink.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/GroupConversationEventSink.java
@@ -61,6 +61,12 @@ public final class GroupConversationEventSink {
      * Always preceded by an {@link #EVENT_CONVERGENCE_CHECKED} for the same repeat.
      */
     public static final String EVENT_CONVERGENCE_REACHED = "convergence_reached";
+    /**
+     * A RETRO phase harvested lessons into team-owned group memory (I8). Fires even
+     * with zero lessons stored — "the retro ran and found nothing durable" is
+     * itself signal for an observer.
+     */
+    public static final String EVENT_RETRO_RECORDED = "retro_recorded";
 
     // --- Event payloads ---
 
@@ -158,5 +164,9 @@ public final class GroupConversationEventSink {
      *            run — the concrete saving
      */
     public record ConvergenceReachedEvent(int phaseIndex, String phaseName, int repeat, int repeatsSkipped, String reason) {
+    }
+
+    /** A RETRO phase stored lessons into team-owned group memory (I8). */
+    public record RetroRecordedEvent(String groupId, String phaseName, int lessonsStored) {
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.GroupWorkspace;
 import ai.labs.eddi.configs.groups.model.SharedTaskList;
+import ai.labs.eddi.configs.groups.rest.RestGroupWorkspace;
 import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TaskDefinition;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionStyle;
@@ -551,20 +552,27 @@ public class McpGroupTools {
             if (groupStore.getCurrentResourceId(groupId) == null) {
                 return errorJson("Group not found: " + groupId);
             }
-            var workspace = workspaceStore.readOrCreate(groupId);
-            if (workspace.getBacklog().size() >= GroupWorkspace.MAX_BACKLOG_SIZE) {
-                return errorJson("The backlog already holds " + GroupWorkspace.MAX_BACKLOG_SIZE
-                        + " tasks — complete or delete existing tasks before adding more");
-            }
             String trimmedSubject = subject.trim();
-            if (workspace.getBacklog().getTasks().stream().anyMatch(t -> trimmedSubject.equalsIgnoreCase(t.subject()))) {
-                return errorJson("A backlog task with that subject already exists — writeback matches outcomes "
-                        + "by subject, so subjects must be unique");
+            // Optimistic-concurrency retry — same reasoning as the REST surface: a
+            // lost CAS re-reads and re-validates so concurrent adds cannot drop
+            // each other or slip past the cap.
+            for (int attempt = 0; attempt < RestGroupWorkspace.MAX_CAS_ATTEMPTS; attempt++) {
+                var workspace = workspaceStore.readOrCreate(groupId);
+                if (workspace.getBacklog().size() >= GroupWorkspace.MAX_BACKLOG_SIZE) {
+                    return errorJson("The backlog already holds " + GroupWorkspace.MAX_BACKLOG_SIZE
+                            + " tasks — complete or delete existing tasks before adding more");
+                }
+                if (workspace.getBacklog().getTasks().stream().anyMatch(t -> trimmedSubject.equalsIgnoreCase(t.subject()))) {
+                    return errorJson("A backlog task with that subject already exists — writeback matches outcomes "
+                            + "by subject, so subjects must be unique");
+                }
+                var task = workspace.getBacklog().addTask(new TaskItem(
+                        trimmedSubject, description != null ? description : "", parseIntOrDefault(priority, 0)));
+                if (workspaceStore.casRevision(workspace)) {
+                    return jsonSerialization.serialize(task);
+                }
             }
-            var task = workspace.getBacklog().addTask(new TaskItem(
-                    trimmedSubject, description != null ? description : "", parseIntOrDefault(priority, 0)));
-            workspaceStore.update(workspace);
-            return jsonSerialization.serialize(task);
+            return errorJson("The workspace is being modified concurrently — retry the request");
         } catch (Exception e) {
             LOGGER.errorf("add_team_task failed: %s", e.getMessage());
             return errorJson(e.getMessage());

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
@@ -4,8 +4,11 @@
  */
 package ai.labs.eddi.engine.mcp;
 
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TaskDefinition;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionStyle;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
@@ -52,17 +55,19 @@ public class McpGroupTools {
     private final IJsonSerialization jsonSerialization;
     private final SecurityIdentity identity;
     private final OwnershipValidator ownershipValidator;
+    private final IGroupWorkspaceStore workspaceStore;
     private final boolean authEnabled;
 
     @Inject
     public McpGroupTools(IRestAgentGroupStore groupStore, IGroupConversationService groupConversationService, IJsonSerialization jsonSerialization,
-            SecurityIdentity identity, OwnershipValidator ownershipValidator,
+            SecurityIdentity identity, OwnershipValidator ownershipValidator, IGroupWorkspaceStore workspaceStore,
             @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authEnabled) {
         this.groupStore = groupStore;
         this.groupConversationService = groupConversationService;
         this.jsonSerialization = jsonSerialization;
         this.identity = identity;
         this.ownershipValidator = ownershipValidator;
+        this.workspaceStore = workspaceStore;
         this.authEnabled = authEnabled;
     }
 
@@ -516,6 +521,59 @@ public class McpGroupTools {
         } catch (Exception e) {
             LOGGER.error("close_group_conversation failed", e);
             return errorJson("Failed to close group conversation", "INTERNAL", null);
+        }
+    }
+
+    // =================================================================
+    // I13 — standing-team workspace (backlog for human PMs)
+    // =================================================================
+
+    @Tool(description = "Add a task to a standing team's backlog (I13). The backlog persists across "
+            + "discussions; scheduled cadences pull executable tasks from it into task-force runs. "
+            + "Higher priority runs earlier. Returns the created task.")
+    @Blocking
+    public String add_team_task(@ToolArg(description = "Group configuration ID") String groupId,
+                                @ToolArg(description = "Task subject (short, unique within the backlog)") String subject,
+                                @ToolArg(description = "Task description (optional)") String description,
+                                @ToolArg(description = "Priority, higher runs earlier (default 0)") String priority) {
+        requireRole(identity, authEnabled, "eddi-editor");
+        try {
+            if (subject == null || subject.isBlank()) {
+                return errorJson("subject is required");
+            }
+            if (groupStore.getCurrentResourceId(groupId) == null) {
+                return errorJson("Group not found: " + groupId);
+            }
+            var workspace = workspaceStore.readOrCreate(groupId);
+            if (workspace.getBacklog().size() >= GroupWorkspace.MAX_BACKLOG_SIZE) {
+                return errorJson("The backlog already holds " + GroupWorkspace.MAX_BACKLOG_SIZE
+                        + " tasks — complete or delete existing tasks before adding more");
+            }
+            var task = workspace.getBacklog().addTask(new TaskItem(
+                    subject.trim(), description != null ? description : "", parseIntOrDefault(priority, 0)));
+            workspaceStore.update(workspace);
+            return jsonSerialization.serialize(task);
+        } catch (Exception e) {
+            LOGGER.errorf("add_team_task failed: %s", e.getMessage());
+            return errorJson(e.getMessage());
+        }
+    }
+
+    @Tool(description = "List a standing team's backlog (I13): every task with its status, priority, "
+            + "assignee and verification outcome.")
+    @Blocking
+    public String list_team_backlog(@ToolArg(description = "Group configuration ID") String groupId) {
+        requireRole(identity, authEnabled, "eddi-viewer");
+        try {
+            if (groupStore.getCurrentResourceId(groupId) == null) {
+                return errorJson("Group not found: " + groupId);
+            }
+            var workspace = workspaceStore.find(groupId);
+            return jsonSerialization.serialize(
+                    workspace != null ? workspace.getBacklog().getTasks() : List.of());
+        } catch (Exception e) {
+            LOGGER.errorf("list_team_backlog failed: %s", e.getMessage());
+            return errorJson(e.getMessage());
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.configs.groups.model.SharedTaskList;
 import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TaskDefinition;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionStyle;
@@ -541,6 +542,12 @@ public class McpGroupTools {
             if (subject == null || subject.isBlank()) {
                 return errorJson("subject is required");
             }
+            if (subject.trim().length() > SharedTaskList.MAX_AGENT_TASK_SUBJECT_LENGTH) {
+                return errorJson("subject exceeds " + SharedTaskList.MAX_AGENT_TASK_SUBJECT_LENGTH + " characters");
+            }
+            if (description != null && description.length() > SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH) {
+                return errorJson("description exceeds " + SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH + " characters");
+            }
             if (groupStore.getCurrentResourceId(groupId) == null) {
                 return errorJson("Group not found: " + groupId);
             }
@@ -549,8 +556,13 @@ public class McpGroupTools {
                 return errorJson("The backlog already holds " + GroupWorkspace.MAX_BACKLOG_SIZE
                         + " tasks — complete or delete existing tasks before adding more");
             }
+            String trimmedSubject = subject.trim();
+            if (workspace.getBacklog().getTasks().stream().anyMatch(t -> trimmedSubject.equalsIgnoreCase(t.subject()))) {
+                return errorJson("A backlog task with that subject already exists — writeback matches outcomes "
+                        + "by subject, so subjects must be unique");
+            }
             var task = workspace.getBacklog().addTask(new TaskItem(
-                    subject.trim(), description != null ? description : "", parseIntOrDefault(priority, 0)));
+                    trimmedSubject, description != null ? description : "", parseIntOrDefault(priority, 0)));
             workspaceStore.update(workspace);
             return jsonSerialization.serialize(task);
         } catch (Exception e) {

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpToolFilter.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpToolFilter.java
@@ -49,6 +49,7 @@ public class McpToolFilter implements ToolFilter {
             "list_agent_triggers", "create_agent_trigger", "update_agent_trigger", "delete_agent_trigger",
             // Group Conversations (Phase 10)
             "describe_discussion_styles", "list_groups", "read_group", "create_group", "update_group", "delete_group", "discuss_with_group",
+            "add_team_task", "list_team_backlog",
             "read_group_conversation", "list_group_conversations", "start_group_discussion", "delete_group_conversation",
             // Group Conversation Follow-Ups
             "followup_with_member", "continue_group_discussion", "close_group_conversation",

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/ScheduleFireExecutor.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/ScheduleFireExecutor.java
@@ -63,6 +63,9 @@ public class ScheduleFireExecutor {
     @Inject
     DreamService dreamService;
 
+    @Inject
+    TeamCadenceService teamCadenceService;
+
     /**
      * Execute a schedule fire. Returns the fire log entry.
      *
@@ -110,6 +113,13 @@ public class ScheduleFireExecutor {
             // (cluster-wide CAS claim, lease, retry/backoff, dead-lettering, fire
             // log) applies unchanged.
             return fireDreamConsolidation(schedule, instanceId, attemptNumber);
+        }
+
+        if (TeamCadenceService.isTeamCadenceSchedule(md)) {
+            // Team cadence fast-path (I13) — a backlog pull into a group
+            // discussion, not a conversation turn. Same reasoning and machinery
+            // as the Dream fast-path above.
+            return fireTeamCadence(schedule, instanceId, attemptNumber);
         }
 
         Instant startedAt = Instant.now();
@@ -248,6 +258,61 @@ public class ScheduleFireExecutor {
             scheduleStore.logFire(fireLog);
         } catch (Exception e) {
             LOGGER.errorf(e, "[SCHEDULE] Failed to log dream fire for schedule %s", schedule.getId());
+        } finally {
+            restoreInterrupt(interrupted);
+        }
+        return fireLog;
+    }
+
+    /**
+     * Run one team-cadence pull (I13) and record the fire. Mirrors
+     * {@link #fireDreamConsolidation}: a deliberate skip (backlog empty, previous
+     * discussion still running, lost claim) is COMPLETED with the reason in the
+     * log; a real failure is FAILED so it retries with backoff and eventually
+     * dead-letters instead of appearing to run while doing nothing.
+     */
+    private ScheduleFireLog fireTeamCadence(ScheduleConfiguration schedule, String instanceId, int attemptNumber) {
+        Instant startedAt = Instant.now();
+        String status;
+        String errorMessage = null;
+        String conversationId = null;
+        boolean interrupted = false;
+
+        try {
+            TeamCadenceService.CadenceResult result = teamCadenceService.processScheduledFire(schedule.getMetadata());
+            conversationId = result.discussionId();
+            if (result.isSuccess()) {
+                status = ScheduleConfiguration.FireStatus.COMPLETED.name();
+                if (result.skippedReason() != null) {
+                    LOGGER.infof("[SCHEDULE] Team cadence '%s' (id=%s) skipped: %s", schedule.getName(), schedule.getId(),
+                            result.skippedReason());
+                } else {
+                    LOGGER.infof("[SCHEDULE] Team cadence '%s' (id=%s) started discussion %s with %d task(s)",
+                            schedule.getName(), schedule.getId(), result.discussionId(), result.tasksPulled());
+                }
+            } else {
+                status = ScheduleConfiguration.FireStatus.FAILED.name();
+                errorMessage = result.error();
+                LOGGER.errorf("[SCHEDULE] Team cadence failed for schedule '%s' (id=%s): %s", schedule.getName(),
+                        schedule.getId(), errorMessage);
+            }
+        } catch (Exception e) {
+            // Same B2 interrupt reasoning — and the same ordering — as fire() above.
+            if (e instanceof InterruptedException) {
+                interrupted = true;
+            }
+            status = ScheduleConfiguration.FireStatus.FAILED.name();
+            errorMessage = e.getClass().getSimpleName() + ": " + e.getMessage();
+            LOGGER.errorf(e, "[SCHEDULE] Team cadence threw for schedule '%s' (id=%s)", schedule.getName(), schedule.getId());
+        }
+
+        var fireLog = new ScheduleFireLog(UUID.randomUUID().toString(), schedule.getId(), schedule.getFireId(),
+                schedule.getNextFire(), startedAt, Instant.now(), status, instanceId, conversationId, errorMessage,
+                attemptNumber, 0.0);
+        try {
+            scheduleStore.logFire(fireLog);
+        } catch (Exception e) {
+            LOGGER.errorf(e, "[SCHEDULE] Failed to log team-cadence fire for schedule %s", schedule.getId());
         } finally {
             restoreInterrupt(interrupted);
         }

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceService.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceService.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.runtime.internal;
+
+import ai.labs.eddi.configs.groups.IGroupConversationStore;
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TaskDefinition;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace.Cadence;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace.MemberStats;
+import ai.labs.eddi.configs.groups.model.SharedTaskList;
+import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
+import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskStatus;
+import ai.labs.eddi.engine.internal.GroupConversationService;
+import ai.labs.eddi.modules.templating.ITemplatingEngine;
+import ai.labs.eddi.utils.LogSanitizer;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Executes team cadences (I13): scheduled pulls from a {@link GroupWorkspace}'s
+ * backlog into a group discussion, and the writeback of that discussion's
+ * outcomes. The scheduling itself rides {@code SchedulePollerService} whole —
+ * cluster-wide claim, lease, retry/backoff, dead-lettering and fire logs come
+ * free, exactly the DreamService precedent; this class is only the fire
+ * handler.
+ * <p>
+ * <b>The run protocol is crash-proof by construction:</b>
+ * <ol>
+ * <li><b>Reconcile:</b> if the workspace records a running discussion, read it.
+ * Terminal → write its outcomes back and release the claim. Still running (or
+ * paused at an HITL gate) → skip this fire; a discussion may legitimately wait
+ * on a human for days.</li>
+ * <li><b>Pull:</b> top-N executable backlog tasks by priority. Empty → skip
+ * (logged) — a cadence with no work must not burn a discussion.</li>
+ * <li><b>Claim:</b> conditional store write on {@code runningDiscussionId} —
+ * two pods firing concurrently cannot both start (no in-JVM locks).</li>
+ * <li><b>Run:</b> the pulled tasks are injected as a runtime copy of
+ * {@code config.tasks}; the cadence's dollar ceiling rides the
+ * inherited-ceiling slot (dollar-primary, per the Dream precedent).</li>
+ * </ol>
+ * Writeback therefore happens on the fire AFTER the discussion ends (or on a
+ * workspace read — see the REST layer's read-repair), never from inside the
+ * discussion thread: a pod crash mid-discussion loses nothing, because the next
+ * fire finds the terminal state and reconciles it.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class TeamCadenceService {
+
+    private static final Logger LOGGER = Logger.getLogger(TeamCadenceService.class);
+
+    /**
+     * Metadata key marking a schedule as cadence-managed — the contract between
+     * schedule authors (the workspace REST layer) and the dispatcher
+     * ({@code ScheduleFireExecutor}), mirroring {@code DreamService}'s.
+     */
+    public static final String METADATA_TYPE_KEY = "teamCadenceType";
+    /** Metadata value for team-cadence schedules. */
+    public static final String METADATA_TYPE_CADENCE = "team_cadence";
+    public static final String METADATA_GROUP_ID_KEY = "groupId";
+    public static final String METADATA_CADENCE_ID_KEY = "cadenceId";
+
+    /** Fallback identity when a cadence predates {@code createdBy}. */
+    public static final String FALLBACK_USER_ID = "system:team-cadence";
+
+    private final IGroupWorkspaceStore workspaceStore;
+    private final IGroupConversationStore conversationStore;
+    private final GroupConversationService groupConversationService;
+    private final ITemplatingEngine templatingEngine;
+    private final MeterRegistry meterRegistry;
+
+    private Counter cadenceRunsStarted;
+    private Counter cadenceRunsSkipped;
+    private Counter cadenceWritebacks;
+
+    @Inject
+    public TeamCadenceService(IGroupWorkspaceStore workspaceStore, IGroupConversationStore conversationStore,
+            GroupConversationService groupConversationService, ITemplatingEngine templatingEngine,
+            MeterRegistry meterRegistry) {
+        this.workspaceStore = workspaceStore;
+        this.conversationStore = conversationStore;
+        this.groupConversationService = groupConversationService;
+        this.templatingEngine = templatingEngine;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    void initMetrics() {
+        cadenceRunsStarted = meterRegistry.counter("eddi_team_cadence_runs_started_total");
+        cadenceRunsSkipped = meterRegistry.counter("eddi_team_cadence_runs_skipped_total");
+        cadenceWritebacks = meterRegistry.counter("eddi_team_cadence_writebacks_total");
+    }
+
+    /** True if the given schedule metadata marks a team-cadence schedule. */
+    public static boolean isTeamCadenceSchedule(Map<String, Object> metadata) {
+        return metadata != null && METADATA_TYPE_CADENCE.equals(metadata.get(METADATA_TYPE_KEY));
+    }
+
+    /**
+     * One fire's outcome. {@code error == null} means the fire itself succeeded —
+     * including the deliberate skips, which carry a {@code skippedReason} so the
+     * fire log says WHY nothing ran.
+     */
+    public record CadenceResult(String groupId, String cadenceId, String discussionId, int tasksPulled,
+            String skippedReason, String error) {
+
+        public boolean isSuccess() {
+            return error == null;
+        }
+
+        static CadenceResult skipped(String groupId, String cadenceId, String reason) {
+            return new CadenceResult(groupId, cadenceId, null, 0, reason, null);
+        }
+
+        static CadenceResult failed(String groupId, String cadenceId, String error) {
+            return new CadenceResult(groupId, cadenceId, null, 0, null, error);
+        }
+    }
+
+    /**
+     * Handles one schedule fire. Never throws — every failure lands in the result's
+     * {@code error}, so the fire log records it and the schedule's retry/backoff
+     * machinery decides what happens next.
+     */
+    public CadenceResult processScheduledFire(Map<String, Object> metadata) {
+        String groupId = metadata != null ? String.valueOf(metadata.get(METADATA_GROUP_ID_KEY)) : null;
+        String cadenceId = metadata != null ? String.valueOf(metadata.get(METADATA_CADENCE_ID_KEY)) : null;
+        if (groupId == null || "null".equals(groupId) || cadenceId == null || "null".equals(cadenceId)) {
+            return CadenceResult.failed(groupId, cadenceId, "Schedule metadata names no groupId/cadenceId");
+        }
+        try {
+            GroupWorkspace workspace = workspaceStore.find(groupId);
+            if (workspace == null) {
+                return CadenceResult.failed(groupId, cadenceId, "No workspace exists for group " + groupId);
+            }
+
+            // 1. Reconcile a previous run before anything else.
+            if (!reconcile(workspace)) {
+                cadenceRunsSkipped.increment();
+                return CadenceResult.skipped(groupId, cadenceId,
+                        "Previous cadence discussion " + workspace.getRunningDiscussionId() + " is still running");
+            }
+
+            Cadence cadence = workspace.getCadences().stream()
+                    .filter(c -> cadenceId.equals(c.cadenceId()))
+                    .findFirst().orElse(null);
+            if (cadence == null) {
+                return CadenceResult.failed(groupId, cadenceId,
+                        "Cadence " + cadenceId + " no longer exists on the workspace — delete its schedule");
+            }
+
+            // 2. Pull: top-N executable backlog tasks, highest priority first.
+            List<TaskItem> pulled = workspace.getBacklog().findExecutableTasks().stream()
+                    .sorted(Comparator.comparingInt(TaskItem::priority).reversed())
+                    .limit(cadence.maxBacklogTasksPerRun())
+                    .toList();
+            if (pulled.isEmpty()) {
+                cadenceRunsSkipped.increment();
+                LOGGER.infof("Cadence %s for group %s: no executable backlog tasks — skipping this fire",
+                        LogSanitizer.sanitize(cadenceId), LogSanitizer.sanitize(groupId));
+                return CadenceResult.skipped(groupId, cadenceId, "No executable backlog tasks");
+            }
+
+            // 3. Run — started BEFORE the claim so the claim can carry the real
+            // discussion id, then claimed BEFORE any task turns can complete.
+            // startCadenceDiscussionAsync creates the conversation synchronously
+            // and only then submits the discussion to the executor, so the id
+            // exists here while no work has run yet; if the claim then loses,
+            // the just-started discussion is cancelled before its first turn.
+            String question = renderQuestion(cadence, workspace, pulled);
+            String userId = cadence.createdBy() != null && !cadence.createdBy().isBlank()
+                    ? cadence.createdBy()
+                    : FALLBACK_USER_ID;
+            GroupConversation gc = groupConversationService.startCadenceDiscussionAsync(
+                    groupId, question, userId, toTaskDefinitions(pulled), cadence.maxCostPerRun(), null);
+
+            // 4. Claim: conditional on the persisted idle marker.
+            String before = workspace.getRunningDiscussionId();
+            workspace.setRunningDiscussionId(gc.getId());
+            workspace.setPulledTaskIds(pulled.stream().map(TaskItem::id).toList());
+            for (TaskItem task : pulled) {
+                workspace.getBacklog().updateTask(withStatus(task, TaskStatus.IN_PROGRESS));
+            }
+            if (!workspaceStore.casRunningDiscussion(workspace, before)) {
+                // Another pod claimed between our read and our write — cancel the
+                // discussion this fire started and stand down.
+                LOGGER.infof("Cadence %s for group %s lost the run claim — cancelling its just-started discussion %s",
+                        LogSanitizer.sanitize(cadenceId), LogSanitizer.sanitize(groupId), gc.getId());
+                cancelQuietly(gc.getId());
+                cadenceRunsSkipped.increment();
+                return CadenceResult.skipped(groupId, cadenceId, "Lost the run claim to a concurrent fire");
+            }
+
+            cadenceRunsStarted.increment();
+            LOGGER.infof("Cadence %s for group %s started discussion %s with %d backlog task(s)",
+                    LogSanitizer.sanitize(cadenceId), LogSanitizer.sanitize(groupId), gc.getId(), pulled.size());
+            return new CadenceResult(groupId, cadenceId, gc.getId(), pulled.size(), null, null);
+        } catch (Exception e) {
+            LOGGER.errorf(e, "Cadence fire failed for group %s / cadence %s",
+                    LogSanitizer.sanitize(groupId), LogSanitizer.sanitize(cadenceId));
+            return CadenceResult.failed(groupId, cadenceId, e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Settles a previous cadence run, if any. Returns {@code true} when the
+     * workspace is idle (possibly after writing back a finished discussion),
+     * {@code false} when a previous discussion is genuinely still in flight.
+     * <p>
+     * Public beyond the fire path: the REST layer runs this as read-repair so a
+     * human looking at the workspace sees settled metrics, not "running" state for
+     * a discussion that ended an hour ago.
+     */
+    public boolean reconcile(GroupWorkspace workspace) {
+        String runningId = workspace.getRunningDiscussionId();
+        if (runningId == null || runningId.isEmpty()) {
+            return true;
+        }
+        GroupConversation gc;
+        try {
+            gc = conversationStore.read(runningId);
+        } catch (Exception e) {
+            // Deleted or unreadable — release the claim and return the pulled
+            // tasks; holding the workspace hostage to a vanished discussion would
+            // stall every future fire.
+            LOGGER.warnf("Cadence discussion %s for group %s is gone (%s) — releasing the claim",
+                    runningId, LogSanitizer.sanitize(workspace.getGroupId()), e.getClass().getSimpleName());
+            writebackFailure(workspace, null);
+            return true;
+        }
+        return switch (gc.getState()) {
+            case COMPLETED -> {
+                writebackCompleted(workspace, gc);
+                yield true;
+            }
+            case FAILED, CANCELLED -> {
+                writebackFailure(workspace, gc);
+                yield true;
+            }
+            default -> false; // IN_PROGRESS, SYNTHESIZING, AWAITING_* — still running
+        };
+    }
+
+    /**
+     * Writeback for a COMPLETED cadence discussion: match every pulled backlog task
+     * against the discussion's task list by subject — VERIFIED outcomes stay
+     * VERIFIED on the backlog (and credit the assignee's stats); anything else
+     * returns to PENDING with the reviewer feedback appended to the description,
+     * which is the cross-run retry loop.
+     */
+    void writebackCompleted(GroupWorkspace workspace, GroupConversation gc) {
+        SharedTaskList discussionTasks = gc.getTaskList();
+        for (String pulledId : workspace.getPulledTaskIds()) {
+            TaskItem backlogTask = workspace.getBacklog().findById(pulledId);
+            if (backlogTask == null) {
+                continue;
+            }
+            TaskItem outcome = discussionTasks == null
+                    ? null
+                    : discussionTasks.getTasks().stream()
+                            .filter(t -> backlogTask.subject().equals(t.subject()))
+                            .findFirst().orElse(null);
+            if (outcome != null && outcome.verified()) {
+                workspace.getBacklog().updateTask(new TaskItem(backlogTask.id(), backlogTask.subject(),
+                        backlogTask.description(), TaskStatus.VERIFIED, outcome.assignedAgentId(),
+                        outcome.assignedDisplayName(), backlogTask.dependsOnIds(), outcome.result(),
+                        outcome.verificationNote(), true, backlogTask.priority(), backlogTask.createdAt(),
+                        Instant.now()));
+                workspace.getMetrics().setTasksVerified(workspace.getMetrics().getTasksVerified() + 1);
+                if (outcome.assignedAgentId() != null) {
+                    memberStats(workspace, outcome.assignedAgentId()).setTasksVerified(
+                            memberStats(workspace, outcome.assignedAgentId()).getTasksVerified() + 1);
+                }
+            } else {
+                String feedback = outcome != null && outcome.verificationNote() != null
+                        ? outcome.verificationNote()
+                        : (outcome != null && outcome.result() != null ? outcome.result() : "not completed this run");
+                workspace.getBacklog().updateTask(new TaskItem(backlogTask.id(), backlogTask.subject(),
+                        backlogTask.description() + "\n[Cadence run " + gc.getId() + "] " + feedback,
+                        TaskStatus.PENDING, null, null, backlogTask.dependsOnIds(), null, null, false,
+                        backlogTask.priority(), backlogTask.createdAt(), null));
+                if (outcome != null && outcome.assignedAgentId() != null) {
+                    memberStats(workspace, outcome.assignedAgentId()).setTasksFailed(
+                            memberStats(workspace, outcome.assignedAgentId()).getTasksFailed() + 1);
+                }
+            }
+        }
+        settle(workspace, gc);
+    }
+
+    /**
+     * Writeback for a FAILED/CANCELLED (or vanished) discussion: every pulled task
+     * returns to PENDING untouched — the work simply did not happen.
+     */
+    void writebackFailure(GroupWorkspace workspace, GroupConversation gc) {
+        for (String pulledId : workspace.getPulledTaskIds()) {
+            TaskItem backlogTask = workspace.getBacklog().findById(pulledId);
+            if (backlogTask != null && backlogTask.status() != TaskStatus.VERIFIED) {
+                workspace.getBacklog().updateTask(withStatus(backlogTask, TaskStatus.PENDING));
+            }
+        }
+        settle(workspace, gc);
+    }
+
+    private void settle(GroupWorkspace workspace, GroupConversation gc) {
+        var metrics = workspace.getMetrics();
+        metrics.setDiscussions(metrics.getDiscussions() + 1);
+        metrics.setLastRunAt(Instant.now());
+        if (gc != null) {
+            metrics.setTotalCost(metrics.getTotalCost() + gc.getTotalCost());
+        }
+        workspace.setRunningDiscussionId(GroupWorkspace.NO_RUNNING_DISCUSSION);
+        workspace.setPulledTaskIds(List.of());
+        try {
+            workspaceStore.update(workspace);
+            cadenceWritebacks.increment();
+        } catch (Exception e) {
+            LOGGER.errorf(e, "Failed to persist cadence writeback for group %s",
+                    LogSanitizer.sanitize(workspace.getGroupId()));
+        }
+    }
+
+    private MemberStats memberStats(GroupWorkspace workspace, String agentId) {
+        return workspace.getMetrics().getPerMemberStats().computeIfAbsent(agentId, k -> new MemberStats());
+    }
+
+    private static TaskItem withStatus(TaskItem task, TaskStatus status) {
+        return new TaskItem(task.id(), task.subject(), task.description(), status, task.assignedAgentId(),
+                task.assignedDisplayName(), task.dependsOnIds(), task.result(), task.verificationNote(),
+                task.verified(), task.priority(), task.createdAt(), task.completedAt());
+    }
+
+    /**
+     * Pulled backlog items as a runtime task plan. Dependencies are dropped on
+     * purpose: {@code findExecutableTasks} already guaranteed every pulled task's
+     * dependencies are met, and backlog ids mean nothing inside the discussion.
+     */
+    private static List<TaskDefinition> toTaskDefinitions(List<TaskItem> pulled) {
+        List<TaskDefinition> defs = new ArrayList<>(pulled.size());
+        for (TaskItem task : pulled) {
+            defs.add(new TaskDefinition(task.subject(), task.description(), "ALL", List.of(), task.priority()));
+        }
+        return defs;
+    }
+
+    /**
+     * The discussion question: the cadence's Qute template rendered over a compact
+     * backlog summary, or a plain default. A template failure degrades to the
+     * default — a cadence must not stop pulling work because its prose template
+     * broke.
+     */
+    private String renderQuestion(Cadence cadence, GroupWorkspace workspace, List<TaskItem> pulled) {
+        StringBuilder summary = new StringBuilder("Work the following backlog tasks:\n");
+        for (TaskItem task : pulled) {
+            summary.append("- ").append(task.subject());
+            if (task.description() != null && !task.description().isBlank()) {
+                summary.append(": ").append(task.description());
+            }
+            summary.append('\n');
+        }
+        if (cadence.inputTemplate() == null || cadence.inputTemplate().isBlank()) {
+            return summary.toString();
+        }
+        try {
+            return templatingEngine.processTemplate(cadence.inputTemplate(), Map.of(
+                    "backlogSummary", summary.toString(),
+                    "groupId", workspace.getGroupId(),
+                    "taskCount", pulled.size()));
+        } catch (Exception e) {
+            LOGGER.warnf("Cadence %s input template failed to render (%s) — using the plain backlog summary",
+                    LogSanitizer.sanitize(cadence.cadenceId()), e.getMessage());
+            return summary.toString();
+        }
+    }
+
+    private void cancelQuietly(String discussionId) {
+        try {
+            groupConversationService.cancelDiscussion(discussionId, null);
+        } catch (Exception e) {
+            LOGGER.warnf("Could not cancel discussion %s after a lost cadence claim: %s", discussionId, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceService.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceService.java
@@ -197,7 +197,17 @@ public class TeamCadenceService {
             for (TaskItem task : pulled) {
                 workspace.getBacklog().updateTask(withStatus(task, TaskStatus.IN_PROGRESS));
             }
-            if (!workspaceStore.casRunningDiscussion(workspace, before)) {
+            boolean claimed;
+            try {
+                claimed = workspaceStore.casRunningDiscussion(workspace, before);
+            } catch (Exception e) {
+                // A store failure during the claim leaves a discussion nobody
+                // references — cancel it before failing, or it runs unclaimed to
+                // completion with outcomes no writeback will ever collect.
+                cancelQuietly(gc.getId());
+                throw e;
+            }
+            if (!claimed) {
                 // Another pod claimed between our read and our write — cancel the
                 // discussion this fire started and stand down.
                 LOGGER.infof("Cadence %s for group %s lost the run claim — cancelling its just-started discussion %s",
@@ -241,18 +251,14 @@ public class TeamCadenceService {
             // stall every future fire.
             LOGGER.warnf("Cadence discussion %s for group %s is gone (%s) — releasing the claim",
                     runningId, LogSanitizer.sanitize(workspace.getGroupId()), e.getClass().getSimpleName());
-            writebackFailure(workspace, null);
-            return true;
+            return writebackFailure(workspace, null);
         }
         return switch (gc.getState()) {
-            case COMPLETED -> {
-                writebackCompleted(workspace, gc);
-                yield true;
-            }
-            case FAILED, CANCELLED -> {
-                writebackFailure(workspace, gc);
-                yield true;
-            }
+            // A lost settle race means another reconciler (or a fresh claim) got
+            // there first — this caller must treat the workspace as busy and let
+            // the next fire read fresh state.
+            case COMPLETED -> writebackCompleted(workspace, gc);
+            case FAILED, CANCELLED -> writebackFailure(workspace, gc);
             default -> false; // IN_PROGRESS, SYNTHESIZING, AWAITING_* — still running
         };
     }
@@ -264,7 +270,8 @@ public class TeamCadenceService {
      * returns to PENDING with the reviewer feedback appended to the description,
      * which is the cross-run retry loop.
      */
-    void writebackCompleted(GroupWorkspace workspace, GroupConversation gc) {
+    boolean writebackCompleted(GroupWorkspace workspace, GroupConversation gc) {
+        String settledDiscussionId = workspace.getRunningDiscussionId();
         SharedTaskList discussionTasks = gc.getTaskList();
         for (String pulledId : workspace.getPulledTaskIds()) {
             TaskItem backlogTask = workspace.getBacklog().findById(pulledId);
@@ -292,7 +299,7 @@ public class TeamCadenceService {
                         ? outcome.verificationNote()
                         : (outcome != null && outcome.result() != null ? outcome.result() : "not completed this run");
                 workspace.getBacklog().updateTask(new TaskItem(backlogTask.id(), backlogTask.subject(),
-                        backlogTask.description() + "\n[Cadence run " + gc.getId() + "] " + feedback,
+                        appendFeedbackBounded(backlogTask.description(), gc.getId(), feedback),
                         TaskStatus.PENDING, null, null, backlogTask.dependsOnIds(), null, null, false,
                         backlogTask.priority(), backlogTask.createdAt(), null));
                 if (outcome != null && outcome.assignedAgentId() != null) {
@@ -301,24 +308,34 @@ public class TeamCadenceService {
                 }
             }
         }
-        settle(workspace, gc);
+        return settle(workspace, gc, settledDiscussionId);
     }
 
     /**
      * Writeback for a FAILED/CANCELLED (or vanished) discussion: every pulled task
      * returns to PENDING untouched — the work simply did not happen.
      */
-    void writebackFailure(GroupWorkspace workspace, GroupConversation gc) {
+    boolean writebackFailure(GroupWorkspace workspace, GroupConversation gc) {
+        String settledDiscussionId = workspace.getRunningDiscussionId();
         for (String pulledId : workspace.getPulledTaskIds()) {
             TaskItem backlogTask = workspace.getBacklog().findById(pulledId);
             if (backlogTask != null && backlogTask.status() != TaskStatus.VERIFIED) {
                 workspace.getBacklog().updateTask(withStatus(backlogTask, TaskStatus.PENDING));
             }
         }
-        settle(workspace, gc);
+        return settle(workspace, gc, settledDiscussionId);
     }
 
-    private void settle(GroupWorkspace workspace, GroupConversation gc) {
+    /**
+     * @return {@code true} if THIS caller's writeback won — the persisted claim
+     *         still named the discussion being settled. {@code false} means a
+     *         concurrent reconcile (schedule fire on another pod, or the REST
+     *         read-repair) settled it first, or a new run already claimed the
+     *         workspace; either way this caller's mutations are stale and MUST die
+     *         unwritten — an unconditional write here clobbered a live claim,
+     *         orphaning its discussion's outcomes (final-review finding).
+     */
+    private boolean settle(GroupWorkspace workspace, GroupConversation gc, String settledDiscussionId) {
         var metrics = workspace.getMetrics();
         metrics.setDiscussions(metrics.getDiscussions() + 1);
         metrics.setLastRunAt(Instant.now());
@@ -328,16 +345,43 @@ public class TeamCadenceService {
         workspace.setRunningDiscussionId(GroupWorkspace.NO_RUNNING_DISCUSSION);
         workspace.setPulledTaskIds(List.of());
         try {
-            workspaceStore.update(workspace);
+            if (!workspaceStore.casRunningDiscussion(workspace, settledDiscussionId)) {
+                LOGGER.infof("Cadence writeback for group %s lost the settle race on discussion %s — another "
+                        + "reconciler settled it (or a new run claimed the workspace); dropping stale mutations",
+                        LogSanitizer.sanitize(workspace.getGroupId()), settledDiscussionId);
+                return false;
+            }
             cadenceWritebacks.increment();
+            return true;
         } catch (Exception e) {
             LOGGER.errorf(e, "Failed to persist cadence writeback for group %s",
                     LogSanitizer.sanitize(workspace.getGroupId()));
+            return false;
         }
     }
 
     private MemberStats memberStats(GroupWorkspace workspace, String agentId) {
         return workspace.getMetrics().getPerMemberStats().computeIfAbsent(agentId, k -> new MemberStats());
+    }
+
+    /** One failed run's feedback slice — enough context, never a whole turn. */
+    static final int MAX_FEEDBACK_CHARS = 500;
+
+    /**
+     * Bounded feedback append (final-review finding): {@code outcome.result()} is
+     * the agent's ENTIRE turn output, and a task failing every run appended it to a
+     * PERSISTED description each time — unbounded document growth that also rode
+     * into the next run's PLAN/bid prompts. The feedback is capped per run and the
+     * accumulated description trimmed from the FRONT (oldest feedback first) to the
+     * shared task-description ceiling.
+     */
+    static String appendFeedbackBounded(String description, String runId, String feedback) {
+        String slice = feedback.length() <= MAX_FEEDBACK_CHARS
+                ? feedback
+                : feedback.substring(0, MAX_FEEDBACK_CHARS) + "…";
+        String combined = (description != null ? description : "") + "\n[Cadence run " + runId + "] " + slice;
+        int cap = SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH;
+        return combined.length() <= cap ? combined : "…" + combined.substring(combined.length() - cap + 1);
     }
 
     private static TaskItem withStatus(TaskItem task, TaskStatus status) {
@@ -384,7 +428,7 @@ public class TeamCadenceService {
                     "taskCount", pulled.size()));
         } catch (Exception e) {
             LOGGER.warnf("Cadence %s input template failed to render (%s) — using the plain backlog summary",
-                    LogSanitizer.sanitize(cadence.cadenceId()), e.getMessage());
+                    LogSanitizer.sanitize(cadence.cadenceId()), LogSanitizer.sanitize(e.getMessage()));
             return summary.toString();
         }
     }

--- a/src/test/java/ai/labs/eddi/configs/groups/model/AgentGroupConfigurationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/model/AgentGroupConfigurationTest.java
@@ -136,7 +136,8 @@ class AgentGroupConfigurationTest {
 
     @Test
     void phaseType_allValues() {
-        assertEquals(11, PhaseType.values().length);
+        assertEquals(12, PhaseType.values().length);
+        assertNotNull(PhaseType.valueOf("RETRO"));
         assertNotNull(PhaseType.valueOf("OPINION"));
         assertNotNull(PhaseType.valueOf("CRITIQUE"));
         assertNotNull(PhaseType.valueOf("REVISION"));

--- a/src/test/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStoreTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups.mongo;
+
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.datastore.IResourceStorage;
+import ai.labs.eddi.datastore.IResourceStorageFactory;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * I13 review round 2 — {@link GroupWorkspaceStore}: the revision-checked write
+ * and the duplicate-insert convergence guard (no unique constraint exists in
+ * the storage abstraction, so the store must converge racers itself).
+ */
+class GroupWorkspaceStoreTest {
+
+    private static final String GROUP_ID = "group-1";
+
+    private IResourceStorage<GroupWorkspace> storage;
+    private GroupWorkspaceStore store;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        storage = mock(IResourceStorage.class);
+        var factory = mock(IResourceStorageFactory.class);
+        when(factory.create(anyString(), any(), eq(GroupWorkspace.class), any())).thenReturn(storage);
+        store = new GroupWorkspaceStore(factory, mock(IDocumentBuilder.class));
+    }
+
+    private IResourceStore.IResourceId resourceId(String id) {
+        var resourceId = mock(IResourceStore.IResourceId.class);
+        lenient().when(resourceId.getId()).thenReturn(id);
+        lenient().when(resourceId.getVersion()).thenReturn(1);
+        return resourceId;
+    }
+
+    @SuppressWarnings("unchecked")
+    private IResourceStorage.IResource<GroupWorkspace> resource(GroupWorkspace workspace, String id) throws Exception {
+        IResourceStorage.IResource<GroupWorkspace> resource = mock(IResourceStorage.IResource.class);
+        lenient().when(resource.getData()).thenReturn(workspace);
+        lenient().when(resource.getId()).thenReturn(id);
+        return resource;
+    }
+
+    // =================================================================
+    // casRevision
+    // =================================================================
+
+    @Test
+    @DisplayName("a matching revision writes conditionally and bumps the stamp")
+    void casRevision_match_bumpsAndStoresConditionally() throws Exception {
+        var workspace = new GroupWorkspace();
+        workspace.setId("ws-1");
+        workspace.setGroupId(GROUP_ID);
+        workspace.setRevision("4");
+        var res = resource(workspace, "ws-1");
+        when(storage.newResource(eq("ws-1"), anyInt(), eq(workspace))).thenReturn(res);
+
+        assertTrue(store.casRevision(workspace));
+
+        assertEquals("5", workspace.getRevision());
+        verify(storage).storeIfFieldEquals(res, "revision", "4");
+        verify(storage, never()).store(any(IResourceStorage.IResource.class));
+    }
+
+    @Test
+    @DisplayName("a lost revision race returns false and restores the caller's stamp for the re-read")
+    void casRevision_mismatch_returnsFalseAndRestores() throws Exception {
+        var workspace = new GroupWorkspace();
+        workspace.setId("ws-1");
+        workspace.setGroupId(GROUP_ID);
+        workspace.setRevision("4");
+        var res = resource(workspace, "ws-1");
+        when(storage.newResource(eq("ws-1"), anyInt(), eq(workspace))).thenReturn(res);
+        doThrow(new IResourceStore.ResourceModifiedException("raced"))
+                .when(storage).storeIfFieldEquals(any(), eq("revision"), eq("4"));
+
+        assertFalse(store.casRevision(workspace));
+
+        assertEquals("4", workspace.getRevision(), "a failed CAS must not leave a phantom bump on the instance");
+    }
+
+    @Test
+    @DisplayName("a pre-revision document is stamped with one plain write, then CAS'd forever after")
+    void casRevision_legacyNullRevision_stampsWithPlainWrite() throws Exception {
+        var workspace = new GroupWorkspace();
+        workspace.setId("ws-1");
+        workspace.setGroupId(GROUP_ID);
+        workspace.setRevision(null);
+        var res = resource(workspace, "ws-1");
+        when(storage.newResource(eq("ws-1"), anyInt(), eq(workspace))).thenReturn(res);
+
+        assertTrue(store.casRevision(workspace));
+
+        assertEquals("1", workspace.getRevision());
+        verify(storage).store(any(IResourceStorage.IResource.class));
+        verify(storage, never()).storeIfFieldEquals(any(), anyString(), anyString());
+    }
+
+    // =================================================================
+    // readOrCreate duplicate convergence
+    // =================================================================
+
+    @Test
+    @DisplayName("a raced readOrCreate deletes its own duplicate and adopts the deterministic survivor")
+    void readOrCreate_race_convergesOnSurvivor() throws Exception {
+        // First find(): nothing yet (both racers miss). After OUR insert (id
+        // "bbb"), the re-query sees TWO documents; the survivor is "aaa".
+        var idBbb = resourceId("bbb");
+        var idAaa = resourceId("aaa");
+        var inserted = resource(new GroupWorkspace(), "bbb");
+        var survivor = new GroupWorkspace();
+        survivor.setGroupId(GROUP_ID);
+        var survivorResource = resource(survivor, "aaa");
+        when(storage.findResources(any(), eq("lastModified"), eq(0), eq(2)))
+                .thenReturn(List.of())
+                .thenReturn(List.of(idBbb, idAaa))
+                .thenReturn(List.of(idAaa));
+        when(storage.newResource(any(GroupWorkspace.class))).thenReturn(inserted);
+        when(storage.read("aaa", 1)).thenReturn(survivorResource);
+
+        GroupWorkspace result = store.readOrCreate(GROUP_ID);
+
+        verify(storage).removeAllPermanently("bbb");
+        assertEquals("aaa", result.getId(), "the loser adopts the earlier insert");
+    }
+
+    @Test
+    @DisplayName("find() with lingering duplicates always reads the same survivor")
+    void find_duplicates_readsDeterministicSurvivor() throws Exception {
+        var idBbb = resourceId("bbb");
+        var idAaa = resourceId("aaa");
+        var survivor = new GroupWorkspace();
+        survivor.setGroupId(GROUP_ID);
+        var survivorResource = resource(survivor, "aaa");
+        when(storage.findResources(any(), eq("lastModified"), eq(0), eq(2)))
+                .thenReturn(List.of(idBbb, idAaa));
+        when(storage.read("aaa", 1)).thenReturn(survivorResource);
+
+        GroupWorkspace result = store.find(GROUP_ID);
+
+        assertEquals("aaa", result.getId(),
+                "sorting by id, not lastModified — every reader and both racers must agree");
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/mongo/GroupWorkspaceStoreTest.java
@@ -120,6 +120,21 @@ class GroupWorkspaceStoreTest {
         verify(storage, never()).storeIfFieldEquals(any(), anyString(), anyString());
     }
 
+    @Test
+    @DisplayName("a corrupt (non-numeric) revision surfaces as the declared store exception, not a raw NumberFormatException")
+    void casRevision_corruptRevision_throwsDeclaredException() {
+        var workspace = new GroupWorkspace();
+        workspace.setId("ws-1");
+        workspace.setGroupId(GROUP_ID);
+        workspace.setRevision("not-a-number");
+
+        var thrown = org.junit.jupiter.api.Assertions.assertThrows(
+                IResourceStore.ResourceStoreException.class, () -> store.casRevision(workspace));
+
+        assertTrue(thrown.getMessage().contains("not-a-number"), thrown.getMessage());
+        assertEquals("not-a-number", workspace.getRevision(), "the corrupt value is left for diagnosis, never bumped");
+    }
+
     // =================================================================
     // readOrCreate duplicate convergence
     // =================================================================
@@ -135,7 +150,7 @@ class GroupWorkspaceStoreTest {
         var survivor = new GroupWorkspace();
         survivor.setGroupId(GROUP_ID);
         var survivorResource = resource(survivor, "aaa");
-        when(storage.findResources(any(), eq("lastModified"), eq(0), eq(2)))
+        when(storage.findResources(any(), eq("lastModified"), eq(0), eq(50)))
                 .thenReturn(List.of())
                 .thenReturn(List.of(idBbb, idAaa))
                 .thenReturn(List.of(idAaa));
@@ -156,7 +171,7 @@ class GroupWorkspaceStoreTest {
         var survivor = new GroupWorkspace();
         survivor.setGroupId(GROUP_ID);
         var survivorResource = resource(survivor, "aaa");
-        when(storage.findResources(any(), eq("lastModified"), eq(0), eq(2)))
+        when(storage.findResources(any(), eq("lastModified"), eq(0), eq(50)))
                 .thenReturn(List.of(idBbb, idAaa));
         when(storage.read("aaa", 1)).thenReturn(survivorResource);
 

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreExtendedTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.configs.groups.rest;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
 import ai.labs.eddi.datastore.IResourceStore;
@@ -42,7 +43,8 @@ class RestAgentGroupStoreExtendedTest {
         groupStore = mock(IAgentGroupStore.class);
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
-        restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator);
+        restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator,
+                mock(IGroupWorkspaceStore.class));
     }
 
     // ==================== updateGroup ====================

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreExtendedTest.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
 import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
 import ai.labs.eddi.datastore.IResourceStore;
@@ -44,7 +45,7 @@ class RestAgentGroupStoreExtendedTest {
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
         restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator,
-                mock(IGroupWorkspaceStore.class));
+                mock(IGroupWorkspaceStore.class), mock(IScheduleStore.class));
     }
 
     // ==================== updateGroup ====================

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
@@ -163,10 +163,13 @@ class RestAgentGroupStoreTest {
             restStore.deleteGroup("group-1", 1, true);
 
             // Review finding: enabled ScheduleConfigurations outlived the deleted
-            // workspace and fired "No workspace exists" forever.
-            verify(scheduleStore).deleteSchedule("sched-1");
-            verify(scheduleStore).deleteSchedule("sched-2");
-            verify(workspaceStore).deleteByGroupId("group-1");
+            // workspace and fired "No workspace exists" forever. InOrder pins the
+            // crash-recoverable ORDER, not just the calls — deleting the workspace
+            // first would leave unreachable schedules on a crash in between.
+            var inOrder = inOrder(scheduleStore, workspaceStore);
+            inOrder.verify(scheduleStore).deleteSchedule("sched-1");
+            inOrder.verify(scheduleStore).deleteSchedule("sched-2");
+            inOrder.verify(workspaceStore).deleteByGroupId("group-1");
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
@@ -7,6 +7,8 @@ package ai.labs.eddi.configs.groups.rest;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
 import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionStyle;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
@@ -32,6 +34,7 @@ class RestAgentGroupStoreTest {
     private IDocumentDescriptorStore documentDescriptorStore;
     private IJsonSchemaCreator jsonSchemaCreator;
     private IGroupWorkspaceStore workspaceStore;
+    private IScheduleStore scheduleStore;
     private RestAgentGroupStore restStore;
 
     @BeforeEach
@@ -40,7 +43,8 @@ class RestAgentGroupStoreTest {
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
         workspaceStore = mock(IGroupWorkspaceStore.class);
-        restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator, workspaceStore);
+        scheduleStore = mock(IScheduleStore.class);
+        restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator, workspaceStore, scheduleStore);
     }
 
     @Nested
@@ -140,6 +144,28 @@ class RestAgentGroupStoreTest {
             restStore.deleteGroup("group-1", 1, true);
 
             verify(groupStore).deleteAllPermanently("group-1");
+            verify(workspaceStore).deleteByGroupId("group-1");
+        }
+
+        @Test
+        @DisplayName("a PERMANENT delete retires the cadence schedules BEFORE the workspace — no orphan fires")
+        void permanentDelete_retiresCadenceSchedulesFirst() throws Exception {
+            when(groupStore.getCurrentResourceId("group-1"))
+                    .thenReturn(createResourceId("group-1", 1));
+            var workspace = new GroupWorkspace();
+            workspace.setGroupId("group-1");
+            workspace.addCadence(new GroupWorkspace.Cadence(
+                    "c-1", "sched-1", null, 5, null, "pm"));
+            workspace.addCadence(new GroupWorkspace.Cadence(
+                    "c-2", "sched-2", null, 5, null, "pm"));
+            when(workspaceStore.find("group-1")).thenReturn(workspace);
+
+            restStore.deleteGroup("group-1", 1, true);
+
+            // Review finding: enabled ScheduleConfigurations outlived the deleted
+            // workspace and fired "No workspace exists" forever.
+            verify(scheduleStore).deleteSchedule("sched-1");
+            verify(scheduleStore).deleteSchedule("sched-2");
             verify(workspaceStore).deleteByGroupId("group-1");
         }
 

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.groups.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionStyle;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
@@ -30,6 +31,7 @@ class RestAgentGroupStoreTest {
     private IAgentGroupStore groupStore;
     private IDocumentDescriptorStore documentDescriptorStore;
     private IJsonSchemaCreator jsonSchemaCreator;
+    private IGroupWorkspaceStore workspaceStore;
     private RestAgentGroupStore restStore;
 
     @BeforeEach
@@ -37,7 +39,8 @@ class RestAgentGroupStoreTest {
         groupStore = mock(IAgentGroupStore.class);
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
-        restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator);
+        workspaceStore = mock(IGroupWorkspaceStore.class);
+        restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator, workspaceStore);
     }
 
     @Nested
@@ -126,6 +129,29 @@ class RestAgentGroupStoreTest {
             restStore.deleteGroup("group-1", 1, false);
 
             verify(groupStore).delete("group-1", 1);
+        }
+
+        @Test
+        @DisplayName("I13: a PERMANENT delete cascades to the standing workspace")
+        void permanentDelete_cascadesToWorkspace() throws Exception {
+            when(groupStore.getCurrentResourceId("group-1"))
+                    .thenReturn(createResourceId("group-1", 1));
+
+            restStore.deleteGroup("group-1", 1, true);
+
+            verify(groupStore).deleteAllPermanently("group-1");
+            verify(workspaceStore).deleteByGroupId("group-1");
+        }
+
+        @Test
+        @DisplayName("I13: a soft (versioned) delete keeps the workspace — the group can come back")
+        void softDelete_keepsWorkspace() throws Exception {
+            when(groupStore.getCurrentResourceId("group-1"))
+                    .thenReturn(createResourceId("group-1", 1));
+
+            restStore.deleteGroup("group-1", 1, false);
+
+            verify(workspaceStore, never()).deleteByGroupId(anyString());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
@@ -170,7 +170,7 @@ class RestGroupWorkspaceTest {
     @Test
     void deleteCadence_removesScheduleAndCadence() throws Exception {
         var workspace = workspace();
-        workspace.getCadences().add(new Cadence("c-1", "sched-9", null, 5, null, "pm"));
+        workspace.addCadence(new Cadence("c-1", "sched-9", null, 5, null, "pm"));
 
         var response = rest.deleteCadence(GROUP_ID, "c-1");
 

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
@@ -126,6 +126,7 @@ class RestGroupWorkspaceTest {
         assertTrue(String.valueOf(response.getEntity()).contains("complete or delete"),
                 "the error says what to do about it: " + response.getEntity());
         verify(workspaceStore, never()).update(any());
+        verify(workspaceStore, never()).casRevision(any());
     }
 
     @Test
@@ -146,6 +147,7 @@ class RestGroupWorkspaceTest {
         assertEquals(400, rest.addBacklogTask(GROUP_ID, new BacklogTaskRequest("Ok", longDescription, 0)).getStatus());
 
         verify(workspaceStore, never()).update(any());
+        verify(workspaceStore, never()).casRevision(any());
     }
 
     @Test
@@ -160,6 +162,7 @@ class RestGroupWorkspaceTest {
         assertTrue(String.valueOf(response.getEntity()).contains("subject"), String.valueOf(response.getEntity()));
         assertEquals(1, workspace.getBacklog().size());
         verify(workspaceStore, never()).update(any());
+        verify(workspaceStore, never()).casRevision(any());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.groups.rest;
+
+import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
+import ai.labs.eddi.configs.groups.IRestGroupWorkspace.BacklogTaskRequest;
+import ai.labs.eddi.configs.groups.IRestGroupWorkspace.CadenceRequest;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace.Cadence;
+import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.runtime.internal.TeamCadenceService;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * I13 — {@link RestGroupWorkspace}: backlog writes with the actionable cap,
+ * cadence lifecycle (schedule created with the fire-dispatch metadata, deleted
+ * with the cadence), and the group-existence gate.
+ */
+class RestGroupWorkspaceTest {
+
+    private static final String GROUP_ID = "group-1";
+
+    private IGroupWorkspaceStore workspaceStore;
+    private IAgentGroupStore groupStore;
+    private IScheduleStore scheduleStore;
+    private TeamCadenceService teamCadenceService;
+    private RestGroupWorkspace rest;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        workspaceStore = mock(IGroupWorkspaceStore.class);
+        groupStore = mock(IAgentGroupStore.class);
+        scheduleStore = mock(IScheduleStore.class);
+        teamCadenceService = mock(TeamCadenceService.class);
+        var identity = mock(SecurityIdentity.class);
+        var principal = mock(Principal.class);
+        lenient().when(principal.getName()).thenReturn("pm@example.com");
+        lenient().when(identity.getPrincipal()).thenReturn(principal);
+        rest = new RestGroupWorkspace(workspaceStore, groupStore, scheduleStore, teamCadenceService, identity);
+
+        var resourceId = mock(IResourceStore.IResourceId.class);
+        lenient().when(resourceId.getVersion()).thenReturn(1);
+        lenient().when(groupStore.getCurrentResourceId(GROUP_ID)).thenReturn(resourceId);
+    }
+
+    private GroupWorkspace workspace() throws Exception {
+        var workspace = new GroupWorkspace();
+        workspace.setId("ws-1");
+        workspace.setGroupId(GROUP_ID);
+        lenient().when(workspaceStore.readOrCreate(GROUP_ID)).thenReturn(workspace);
+        lenient().when(workspaceStore.find(GROUP_ID)).thenReturn(workspace);
+        return workspace;
+    }
+
+    @Test
+    @DisplayName("reading the workspace runs read-repair reconcile first")
+    void readWorkspace_readRepairs() throws Exception {
+        var workspace = workspace();
+
+        var response = rest.readWorkspace(GROUP_ID);
+
+        assertEquals(200, response.getStatus());
+        verify(teamCadenceService).reconcile(workspace);
+    }
+
+    @Test
+    void readWorkspace_unknownGroup_404() throws Exception {
+        when(groupStore.getCurrentResourceId("missing")).thenReturn(null);
+
+        assertEquals(404, rest.readWorkspace("missing").getStatus());
+        verify(workspaceStore, never()).readOrCreate(any());
+    }
+
+    @Test
+    void addBacklogTask_persistsTheTask() throws Exception {
+        var workspace = workspace();
+
+        var response = rest.addBacklogTask(GROUP_ID, new BacklogTaskRequest("Ship it", "the feature", 3));
+
+        assertEquals(201, response.getStatus());
+        assertEquals(1, workspace.getBacklog().size());
+        TaskItem task = workspace.getBacklog().getTasks().get(0);
+        assertEquals("Ship it", task.subject());
+        assertEquals(3, task.priority());
+        verify(workspaceStore).update(workspace);
+    }
+
+    @Test
+    @DisplayName("the backlog cap fails with an ACTIONABLE error, not a silent drop")
+    void addBacklogTask_capIsActionable() throws Exception {
+        var workspace = workspace();
+        for (int i = 0; i < GroupWorkspace.MAX_BACKLOG_SIZE; i++) {
+            workspace.getBacklog().addTask(new TaskItem("Task " + i, "", 0));
+        }
+
+        var response = rest.addBacklogTask(GROUP_ID, new BacklogTaskRequest("One more", "", 0));
+
+        assertEquals(409, response.getStatus());
+        assertTrue(String.valueOf(response.getEntity()).contains("complete or delete"),
+                "the error says what to do about it: " + response.getEntity());
+        verify(workspaceStore, never()).update(any());
+    }
+
+    @Test
+    void addBacklogTask_blankSubject_400() {
+        assertEquals(400, rest.addBacklogTask(GROUP_ID, new BacklogTaskRequest("  ", "", 0)).getStatus());
+        assertEquals(400, rest.addBacklogTask(GROUP_ID, null).getStatus());
+    }
+
+    @Test
+    @DisplayName("adding a cadence creates the schedule carrying the fire-dispatch metadata")
+    void addCadence_createsScheduleWithMetadata() throws Exception {
+        var workspace = workspace();
+        when(scheduleStore.createSchedule(any())).thenReturn("sched-9");
+
+        var response = rest.addCadence(GROUP_ID, new CadenceRequest("0 9 * * 1", "UTC", null, 3, 2.50));
+
+        assertEquals(201, response.getStatus());
+        ArgumentCaptor<ScheduleConfiguration> captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
+        verify(scheduleStore).createSchedule(captor.capture());
+        var schedule = captor.getValue();
+        assertEquals(TeamCadenceService.METADATA_TYPE_CADENCE,
+                schedule.getMetadata().get(TeamCadenceService.METADATA_TYPE_KEY));
+        assertEquals(GROUP_ID, schedule.getMetadata().get(TeamCadenceService.METADATA_GROUP_ID_KEY));
+        assertEquals("0 9 * * 1", schedule.getCronExpression());
+        assertEquals("pm@example.com", schedule.getCreatedBy());
+
+        assertEquals(1, workspace.getCadences().size());
+        Cadence cadence = workspace.getCadences().get(0);
+        assertEquals("sched-9", cadence.scheduleRef());
+        assertEquals(3, cadence.maxBacklogTasksPerRun());
+        assertEquals(2.50, cadence.maxCostPerRun());
+        assertEquals("pm@example.com", cadence.createdBy(), "cadence runs are attributable to their creator");
+        verify(workspaceStore).update(workspace);
+    }
+
+    @Test
+    @DisplayName("an unparseable cron fails at creation, not silently at fire time")
+    void addCadence_invalidCron_400() throws Exception {
+        workspace();
+
+        var response = rest.addCadence(GROUP_ID, new CadenceRequest("not a cron", null, null, 0, null));
+
+        assertEquals(400, response.getStatus());
+        verify(scheduleStore, never()).createSchedule(any());
+    }
+
+    @Test
+    void deleteCadence_removesScheduleAndCadence() throws Exception {
+        var workspace = workspace();
+        workspace.getCadences().add(new Cadence("c-1", "sched-9", null, 5, null, "pm"));
+
+        var response = rest.deleteCadence(GROUP_ID, "c-1");
+
+        assertEquals(204, response.getStatus());
+        verify(scheduleStore).deleteSchedule("sched-9");
+        assertTrue(workspace.getCadences().isEmpty());
+        verify(workspaceStore).update(workspace);
+    }
+
+    @Test
+    void deleteCadence_unknownCadence_404() throws Exception {
+        workspace();
+
+        assertEquals(404, rest.deleteCadence(GROUP_ID, "no-such").getStatus());
+        verify(scheduleStore, never()).deleteSchedule(anyString());
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
@@ -28,9 +28,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,6 +74,7 @@ class RestGroupWorkspaceTest {
         workspace.setGroupId(GROUP_ID);
         lenient().when(workspaceStore.readOrCreate(GROUP_ID)).thenReturn(workspace);
         lenient().when(workspaceStore.find(GROUP_ID)).thenReturn(workspace);
+        lenient().when(workspaceStore.casRevision(workspace)).thenReturn(true);
         return workspace;
     }
 
@@ -105,7 +108,8 @@ class RestGroupWorkspaceTest {
         TaskItem task = workspace.getBacklog().getTasks().get(0);
         assertEquals("Ship it", task.subject());
         assertEquals(3, task.priority());
-        verify(workspaceStore).update(workspace);
+        verify(workspaceStore).casRevision(workspace);
+        verify(workspaceStore, never()).update(any());
     }
 
     @Test
@@ -156,6 +160,42 @@ class RestGroupWorkspaceTest {
         assertTrue(String.valueOf(response.getEntity()).contains("subject"), String.valueOf(response.getEntity()));
         assertEquals(1, workspace.getBacklog().size());
         verify(workspaceStore, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("a lost revision race re-reads and retries; exhaustion is an honest 409")
+    void addBacklogTask_lostCas_retriesThenGivesUp() throws Exception {
+        // Each read returns a FRESH document — in production a re-read reflects
+        // the concurrent writer's state, never this caller's failed mutation.
+        when(workspaceStore.readOrCreate(GROUP_ID)).thenAnswer(inv -> {
+            var w = new GroupWorkspace();
+            w.setId("ws-1");
+            w.setGroupId(GROUP_ID);
+            return w;
+        });
+        when(workspaceStore.casRevision(any())).thenReturn(false, true);
+
+        assertEquals(201, rest.addBacklogTask(GROUP_ID, new BacklogTaskRequest("Ship it", "", 0)).getStatus());
+        verify(workspaceStore, times(2).description("one re-read per attempt")).readOrCreate(GROUP_ID);
+
+        when(workspaceStore.casRevision(any())).thenReturn(false);
+        var response = rest.addBacklogTask(GROUP_ID, new BacklogTaskRequest("Another", "", 0));
+        assertEquals(409, response.getStatus());
+        assertTrue(String.valueOf(response.getEntity()).contains("concurrently"),
+                "exhausted retries tell the caller to retry: " + response.getEntity());
+    }
+
+    @Test
+    @DisplayName("a failed workspace write deletes the just-created schedule — no orphan fires forever")
+    void addCadence_workspaceWriteFails_deletesSchedule() throws Exception {
+        var workspace = workspace();
+        when(scheduleStore.createSchedule(any())).thenReturn("sched-9");
+        doThrow(new IResourceStore.ResourceStoreException("store down")).when(workspaceStore).update(workspace);
+
+        var response = rest.addCadence(GROUP_ID, new CadenceRequest("0 9 * * 1", null, null, 0, null));
+
+        assertEquals(500, response.getStatus());
+        verify(scheduleStore).deleteSchedule("sched-9");
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.groups.IRestGroupWorkspace.BacklogTaskRequest;
 import ai.labs.eddi.configs.groups.IRestGroupWorkspace.CadenceRequest;
 import ai.labs.eddi.configs.groups.model.GroupWorkspace;
 import ai.labs.eddi.configs.groups.model.GroupWorkspace.Cadence;
+import ai.labs.eddi.configs.groups.model.SharedTaskList;
 import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.internal.TeamCadenceService;
@@ -130,6 +131,34 @@ class RestGroupWorkspaceTest {
     }
 
     @Test
+    @DisplayName("REST enforces the same subject/description bounds as the agent tool surface")
+    void addBacklogTask_oversizedFields_400() throws Exception {
+        workspace();
+
+        String longSubject = "s".repeat(SharedTaskList.MAX_AGENT_TASK_SUBJECT_LENGTH + 1);
+        assertEquals(400, rest.addBacklogTask(GROUP_ID, new BacklogTaskRequest(longSubject, "", 0)).getStatus());
+
+        String longDescription = "d".repeat(SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH + 1);
+        assertEquals(400, rest.addBacklogTask(GROUP_ID, new BacklogTaskRequest("Ok", longDescription, 0)).getStatus());
+
+        verify(workspaceStore, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("duplicate subjects are rejected — writeback matches outcomes by subject")
+    void addBacklogTask_duplicateSubject_409() throws Exception {
+        var workspace = workspace();
+        workspace.getBacklog().addTask(new TaskItem("Ship it", "", 0));
+
+        var response = rest.addBacklogTask(GROUP_ID, new BacklogTaskRequest("ship IT", "", 0));
+
+        assertEquals(409, response.getStatus());
+        assertTrue(String.valueOf(response.getEntity()).contains("subject"), String.valueOf(response.getEntity()));
+        assertEquals(1, workspace.getBacklog().size());
+        verify(workspaceStore, never()).update(any());
+    }
+
+    @Test
     @DisplayName("adding a cadence creates the schedule carrying the fire-dispatch metadata")
     void addCadence_createsScheduleWithMetadata() throws Exception {
         var workspace = workspace();
@@ -164,6 +193,23 @@ class RestGroupWorkspaceTest {
         var response = rest.addCadence(GROUP_ID, new CadenceRequest("not a cron", null, null, 0, null));
 
         assertEquals(400, response.getStatus());
+        verify(scheduleStore, never()).createSchedule(any());
+    }
+
+    @Test
+    @DisplayName("a workspace is a team's schedule, not a cron farm — the cadence count is capped")
+    void addCadence_countCap_409_andTemplateBound_400() throws Exception {
+        var workspace = workspace();
+        for (int i = 0; i < RestGroupWorkspace.MAX_CADENCES_PER_WORKSPACE; i++) {
+            workspace.addCadence(new Cadence("c-" + i, "sched-" + i, null, 5, null, "pm"));
+        }
+        assertEquals(409, rest.addCadence(GROUP_ID, new CadenceRequest("0 9 * * 1", null, null, 0, null)).getStatus());
+
+        var fresh = workspace();
+        String hugeTemplate = "t".repeat(RestGroupWorkspace.MAX_INPUT_TEMPLATE_LENGTH + 1);
+        assertEquals(400,
+                rest.addCadence(GROUP_ID, new CadenceRequest("0 9 * * 1", null, hugeTemplate, 0, null)).getStatus());
+        assertTrue(fresh.getCadences().isEmpty());
         verify(scheduleStore, never()).createSchedule(any());
     }
 

--- a/src/test/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStoreVisibilityTest.java
+++ b/src/test/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStoreVisibilityTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.properties.mongo;
+
+import ai.labs.eddi.configs.properties.IUserMemoryStore;
+import com.mongodb.MongoClientSettings;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * I8 — the recall visibility filters on BOTH backends: the user's own scope is
+ * untouched (still constrained to their own {@code userId}), and the additive
+ * team-owned branch reaches ONLY synthetic {@code "group:"+groupId} owners
+ * derived from the supplied group ids. The two backends must not drift, so both
+ * shapes are pinned side by side.
+ *
+ * @author tests
+ */
+class MongoUserMemoryStoreVisibilityTest {
+
+    private static String render(Bson filter) {
+        return filter.toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry()).toJson();
+    }
+
+    // =================================================================
+    // MongoDB
+    // =================================================================
+
+    @Test
+    @DisplayName("Mongo, no groups: the filter is exactly the user's own scope — no team branch at all")
+    void mongo_noGroups_userScopeOnly() {
+        String json = render(MongoUserMemoryStore.buildVisibilityFilter("user-1", "agent-a", List.of()));
+
+        assertTrue(json.contains("user-1"), json);
+        assertFalse(json.contains(IUserMemoryStore.TEAM_OWNER_PREFIX), json);
+    }
+
+    @Test
+    @DisplayName("Mongo, with groups: the team branch matches derived group: owners only, alongside the untouched user scope")
+    void mongo_withGroups_additiveTeamBranch() {
+        String json = render(MongoUserMemoryStore.buildVisibilityFilter("user-1", "agent-a", List.of("g1", "g2")));
+
+        assertTrue(json.contains("\"group:g1\"") && json.contains("\"group:g2\""),
+                "team owners are DERIVED from the supplied group ids: " + json);
+        assertTrue(json.contains("user-1"), "the personal scope keeps its own userId constraint: " + json);
+        // The team branch must pair the synthetic owners with group visibility —
+        // a bare owner match would leak any hypothetical non-group entry.
+        int teamIdx = json.indexOf("group:g1");
+        assertTrue(json.indexOf("group", teamIdx) >= 0, json);
+    }
+
+    @Test
+    @DisplayName("Mongo: another user's id never appears in the filter — the team branch cannot cross humans")
+    void mongo_teamBranch_cannotNameAnotherHuman() {
+        String json = render(MongoUserMemoryStore.buildVisibilityFilter("user-1", "agent-a", List.of("g1")));
+
+        // The only owner ids in the filter are the caller's own and group:g1.
+        assertFalse(json.contains("user-2"), json);
+        assertTrue(json.contains("group:g1"), json);
+    }
+
+}

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
@@ -408,12 +408,19 @@ class PostgresUserMemoryStoreUnitTest {
         sut.getVisibleEntries("user1", "agent1",
                 List.of("group-a", "group-b"), "most_recent", 10);
 
-        // then — params: userId=1, agentId=2, group-a=3, group-b=4, limit=5
+        // then — I8 bind order: userId=1, agentId=2, user-scope group overlap
+        // (group-a=3, group-b=4), derived team owners (group:group-a=5,
+        // group:group-b=6), team-scope group overlap (group-a=7, group-b=8),
+        // limit=9. Mirrors buildVisibilityQuery exactly.
         verify(preparedStatement).setString(1, "user1");
         verify(preparedStatement).setString(2, "agent1");
         verify(preparedStatement).setString(3, "group-a");
         verify(preparedStatement).setString(4, "group-b");
-        verify(preparedStatement).setInt(5, 10);
+        verify(preparedStatement).setString(5, "group:group-a");
+        verify(preparedStatement).setString(6, "group:group-b");
+        verify(preparedStatement).setString(7, "group-a");
+        verify(preparedStatement).setString(8, "group-b");
+        verify(preparedStatement).setInt(9, 10);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreVisibilityTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreVisibilityTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.datastore.postgres;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * I8 — the PostgreSQL twin of {@code MongoUserMemoryStoreVisibilityTest}: the
+ * recall SQL keeps the user's own scope untouched and adds the team-owned
+ * branch only when groups are supplied. The two backends must not drift.
+ *
+ * @author tests
+ */
+class PostgresUserMemoryStoreVisibilityTest {
+
+    @Test
+    @DisplayName("no groups: no team branch, balanced parentheses")
+    void noGroups_userScopeOnly() {
+        String sql = PostgresUserMemoryStore.buildVisibilityQuery(List.of());
+
+        assertFalse(sql.contains("user_id IN"), sql);
+        assertEquals(0, sql.chars().map(c -> c == '(' ? 1 : c == ')' ? -1 : 0).sum(), "unbalanced parens: " + sql);
+    }
+
+    @Test
+    @DisplayName("with groups: the team branch binds one owner and one overlap placeholder per group")
+    void withGroups_additiveTeamBranch() {
+        String sql = PostgresUserMemoryStore.buildVisibilityQuery(List.of("g1", "g2"));
+
+        assertTrue(sql.contains("user_id IN (?,?)"), sql);
+        // user scope overlap + team scope overlap = two ??| ARRAY[?,?] blocks.
+        assertEquals(2, sql.split("\\?\\?\\|", -1).length - 1, sql);
+        assertEquals(0, sql.chars().map(c -> c == '(' ? 1 : c == ')' ? -1 : 0).sum(), "unbalanced parens: " + sql);
+        // Total ordinary binds: userId + agentId + 2 gids (user scope) + 2 owners
+        // + 2 gids (team scope) = 8. Each ??| escape contributes two literal '?'
+        // characters that are NOT bind placeholders — subtract them.
+        assertEquals(8, sql.chars().filter(c -> c == '?').count() - 2L * (sql.split("\\?\\?\\|", -1).length - 1),
+                "bind placeholder count must match collectInto's bind order: " + sql);
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.internal.groups;
 
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.RetroConfig;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
@@ -14,6 +15,7 @@ import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -74,6 +76,26 @@ class GroupContextBuilderTest {
 
         assertEquals("rendered", result);
         verify(templatingEngine).processTemplate(any(), any(), eq(ITemplatingEngine.TemplateMode.TEXT));
+    }
+
+    @Test
+    @DisplayName("the RETRO template quotes the CONFIGURED lesson cap — a group set above the default gets what it asked for")
+    void buildPhaseInput_retro_quotesConfiguredCap() throws Exception {
+        when(templatingEngine.processTemplate(any(), any(), eq(ITemplatingEngine.TemplateMode.TEXT))).thenReturn("rendered");
+
+        builder.buildPhaseInput(phase(PhaseType.RETRO, ContextScope.FULL), member(), "Q?", List.of(), 1, null, null,
+                new RetroConfig(7, 50));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> dataCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(templatingEngine).processTemplate(any(), dataCaptor.capture(), eq(ITemplatingEngine.TemplateMode.TEXT));
+        assertEquals(7, dataCaptor.getValue().get("maxLessonsPerRun"));
+
+        // The config-less overloads still quote the default.
+        clearInvocations(templatingEngine);
+        builder.buildPhaseInput(phase(PhaseType.RETRO, ContextScope.FULL), member(), "Q?", List.of(), 1, null);
+        verify(templatingEngine).processTemplate(any(), dataCaptor.capture(), eq(ITemplatingEngine.TemplateMode.TEXT));
+        assertEquals(RetroConfig.DEFAULT_MAX_PER_RUN, dataCaptor.getValue().get("maxLessonsPerRun"));
     }
 
     // =================================================================

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupHitlCoordinatorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupHitlCoordinatorTest.java
@@ -280,4 +280,52 @@ class GroupHitlCoordinatorTest {
     void constructedWithMockedCollaborators_doesNotThrow() {
         assertDoesNotThrow(this::coordinator);
     }
+
+    /**
+     * Final-review minor: the executor-saturated rollback used a PLAIN token remove
+     * while every sibling rollback path uses remove-and-recheck. A cancel signalled
+     * between the token registration (right after the resume CAS) and the rollback
+     * was silently dropped with the discarded token — the operator was told
+     * "cancelled", yet the discussion sat restored to AWAITING_APPROVAL forever.
+     */
+    @Test
+    void resumeRollback_onSaturatedExecutor_convertsASignalledCancel() throws Exception {
+        var activeTokens = new ConcurrentHashMap<String, DiscussionControlToken>();
+        var executorService = mock(ExecutorService.class);
+        conversationStore = mock(IGroupConversationStore.class);
+        groupStore = mock(IAgentGroupStore.class);
+        scheduleStore = mock(IScheduleStore.class);
+        var coordinator = new GroupHitlCoordinator(groupStore, conversationStore, scheduleStore,
+                mock(AuditLedgerService.class), new GroupSigningGuard(null, null, null, "default"),
+                activeTokens, executorService, new CallerIdentityContext(null, null),
+                Mockito.mock(GroupConversationService.class),
+                new SimpleMeterRegistry().counter("test.hitl.pause"),
+                new SimpleMeterRegistry().counter("test.hitl.resume"),
+                new SimpleMeterRegistry().counter("test.group.failure"));
+
+        var gc = gc(GroupConversationState.AWAITING_APPROVAL);
+        gc.setSchemaVersion(GroupConversation.CURRENT_SCHEMA_VERSION);
+        gc.setPausedAtPhaseIndex(0);
+        gc.setPausedPhaseName("Phase 1");
+        gc.setHitlPauseType(GroupConversation.HitlPauseType.PHASE);
+        gc.setPausedAt(java.time.Instant.now());
+        when(conversationStore.read(GC_ID)).thenReturn(gc);
+        when(executorService.submit(any(Runnable.class))).thenAnswer(invocation -> {
+            // The racing cancel: lands after the fresh token was registered but
+            // before the rollback runs — exactly the dropped window.
+            activeTokens.get(GC_ID).setSignal(ControlSignal.CANCEL_GRACEFUL);
+            throw new java.util.concurrent.RejectedExecutionException("saturated");
+        });
+        var decision = new ai.labs.eddi.engine.lifecycle.model.HitlDecision();
+        decision.setVerdict(ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict.APPROVED);
+        var request = new ai.labs.eddi.engine.internal.GroupApprovalRequest();
+        request.setDecision(decision);
+
+        assertThrows(IResourceStore.ResourceStoreException.class,
+                () -> coordinator.resumeDiscussion(GC_ID, request, null));
+
+        assertTrue(activeTokens.isEmpty(), "the rollback must not leak the control token");
+        assertEquals(GroupConversationState.CANCELLED, gc.getState(),
+                "a cancel signalled during the rollback window converts the restored pause instead of vanishing");
+    }
 }

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
@@ -57,7 +57,7 @@ class PhaseExecutionEngineTest {
         // 6-arg one left every turn running with a null input, so a regression that
         // dropped the phase rendering entirely and passed the raw question through
         // would not have failed a single test here.
-        when(contextBuilder.buildPhaseInput(any(), any(), any(), any(), anyInt(), any(), any()))
+        when(contextBuilder.buildPhaseInput(any(), any(), any(), any(), anyInt(), any(), any(), any()))
                 .thenReturn("rendered-input");
         return new PhaseExecutionEngine(memberTurnExecutor, contextBuilder,
                 Executors.newVirtualThreadPerTaskExecutor(), new CallerIdentityContext(null, null));

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
@@ -236,6 +236,33 @@ class RetroEngineTest {
     }
 
     @Test
+    @DisplayName("a null store still fires retro_recorded with zero — the event contract holds when nothing persists")
+    void harvest_nullStore_firesZeroCountEvent() {
+        var listener = Mockito.mock(GroupDiscussionEventListener.class);
+
+        RetroEngine.harvest(gc, new RetroConfig(),
+                List.of(retroEntry("{\"lessons\":[{\"lesson\":\"x\"}]}")), null, "Retro", listener);
+
+        var captor = ArgumentCaptor.forClass(GroupConversationEventSink.RetroRecordedEvent.class);
+        verify(listener).onRetroRecorded(captor.capture());
+        assertEquals(0, captor.getValue().lessonsStored());
+    }
+
+    @Test
+    @DisplayName("maxLessonsPerRun bounds the whole harvest, not each entry — multi-speaker retros cannot multiply it")
+    void harvest_capIsPerHarvest_notPerEntry() throws Exception {
+        var config = new RetroConfig(2, 50);
+
+        RetroEngine.harvest(gc, config, List.of(
+                retroEntry("{\"lessons\":[{\"lesson\":\"one\"},{\"lesson\":\"two\"}]}"),
+                retroEntry("{\"lessons\":[{\"lesson\":\"three\"},{\"lesson\":\"four\"}]}"),
+                retroEntry("{\"lessons\":[{\"lesson\":\"five\"}]}")), store, "Retro", null);
+
+        assertEquals(2, store.countEntries(IUserMemoryStore.TEAM_OWNER_PREFIX + GROUP_ID),
+                "3 RETRO entries × cap 2 used to store up to 6 — the cap is per harvest");
+    }
+
+    @Test
     @DisplayName("a failing store loses that lesson with a warning — never the discussion")
     void harvest_storeFailure_neverThrows() throws IResourceStore.ResourceStoreException {
         var failing = Mockito.mock(IUserMemoryStore.class);

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal.groups;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.RetroConfig;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntry;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import ai.labs.eddi.configs.properties.IUserMemoryStore;
+import ai.labs.eddi.configs.properties.model.Properties;
+import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
+import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
+import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
+import ai.labs.eddi.datastore.IResourceStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+
+/**
+ * I8 — {@link RetroEngine}: the three-tier lesson parse, the per-run cap
+ * enforced regardless of what the model was told, idempotent upserts under the
+ * team owner, the FIFO stored-cap eviction, and the retro_recorded event. The
+ * store is a real in-memory fake with the production upsert identity
+ * {@code (userId, key, sourceAgentId)} — idempotency claims scripted into a
+ * mock would prove nothing.
+ *
+ * @author tests
+ */
+class RetroEngineTest {
+
+    private static final String GROUP_ID = "group-1";
+    private static final String TEAM_OWNER = IUserMemoryStore.TEAM_OWNER_PREFIX + GROUP_ID;
+
+    private InMemoryUserMemoryStore store;
+    private GroupConversation gc;
+
+    /** Honest fake: production upsert identity, recency-ordered recall. */
+    static final class InMemoryUserMemoryStore implements IUserMemoryStore {
+        final Map<String, UserMemoryEntry> byId = new LinkedHashMap<>();
+        final AtomicLong seq = new AtomicLong();
+        final AtomicLong clock = new AtomicLong();
+
+        @Override
+        public String upsert(UserMemoryEntry entry) {
+            String identity = entry.userId() + "|" + entry.key() + "|" + entry.sourceAgentId();
+            for (Map.Entry<String, UserMemoryEntry> existing : byId.entrySet()) {
+                UserMemoryEntry e = existing.getValue();
+                if (identity.equals(e.userId() + "|" + e.key() + "|" + e.sourceAgentId())) {
+                    byId.put(existing.getKey(), withId(entry, existing.getKey(), e.createdAt()));
+                    return existing.getKey();
+                }
+            }
+            String id = "m-" + seq.incrementAndGet();
+            byId.put(id, withId(entry, id, Instant.ofEpochMilli(clock.incrementAndGet())));
+            return id;
+        }
+
+        private UserMemoryEntry withId(UserMemoryEntry e, String id, Instant createdAt) {
+            return new UserMemoryEntry(id, e.userId(), e.key(), e.value(), e.category(), e.visibility(), e.sourceAgentId(),
+                    e.groupIds(), e.sourceConversationId(), e.conflicted(), e.accessCount(), createdAt,
+                    Instant.ofEpochMilli(clock.incrementAndGet()));
+        }
+
+        @Override
+        public void deleteEntry(String entryId) {
+            byId.remove(entryId);
+        }
+
+        @Override
+        public List<UserMemoryEntry> getVisibleEntries(String userId, String agentId, List<String> groupIds, String recallOrder,
+                                                       int maxEntries) {
+            List<UserMemoryEntry> visible = new ArrayList<>(byId.values().stream()
+                    .filter(e -> userId.equals(e.userId()))
+                    .sorted(Comparator.comparing(UserMemoryEntry::updatedAt).reversed())
+                    .toList());
+            return maxEntries > 0 && visible.size() > maxEntries ? visible.subList(0, maxEntries) : visible;
+        }
+
+        // Unused surface.
+        @Override
+        public Properties readProperties(String userId) {
+            return null;
+        }
+
+        @Override
+        public void mergeProperties(String userId, Properties properties) {
+        }
+
+        @Override
+        public void deleteProperties(String userId) {
+        }
+
+        @Override
+        public Optional<UserMemoryEntry> findEntryById(String entryId) {
+            return Optional.ofNullable(byId.get(entryId));
+        }
+
+        @Override
+        public List<UserMemoryEntry> filterEntries(String userId, String query) {
+            return List.of();
+        }
+
+        @Override
+        public List<UserMemoryEntry> getEntriesByCategory(String userId, String category) {
+            return List.of();
+        }
+
+        @Override
+        public Optional<UserMemoryEntry> getByKey(String userId, String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<UserMemoryEntry> getAllEntries(String userId) {
+            return List.copyOf(byId.values());
+        }
+
+        @Override
+        public void deleteAllForUser(String userId) {
+        }
+
+        @Override
+        public long countEntries(String userId) {
+            return byId.size();
+        }
+
+        @Override
+        public long deleteOlderThan(int olderThanDays) {
+            return 0;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryUserMemoryStore();
+        gc = new GroupConversation();
+        gc.setId("gc-1");
+        gc.setGroupId(GROUP_ID);
+    }
+
+    private TranscriptEntry retroEntry(String content) {
+        return new TranscriptEntry("mod", "Moderator", content, 0, "Retro", TranscriptEntryType.RETRO, Instant.now(), null, null);
+    }
+
+    // =================================================================
+    // parsing
+    // =================================================================
+
+    @Test
+    @DisplayName("strict JSON and fence-embedded JSON both parse; prose yields nothing")
+    void parse_tiers() {
+        assertEquals(2, RetroEngine.parseLessons(
+                "{\"lessons\":[{\"lesson\":\"Cap debate rounds\",\"context\":\"long debates\"},{\"lesson\":\"Name a moderator\"}]}", 3).size());
+        assertEquals(1, RetroEngine.parseLessons(
+                "Here you go:\n```json\n{\"lessons\":[{\"lesson\":\"Vote earlier\"}]}\n```", 3).size());
+        assertTrue(RetroEngine.parseLessons("We should have voted earlier, honestly.", 3).isEmpty(),
+                "prose is not guessed into a lesson");
+        assertTrue(RetroEngine.parseLessons(null, 3).isEmpty());
+    }
+
+    @Test
+    @DisplayName("the per-run cap is enforced at parse time, whatever the model produced")
+    void parse_capEnforced() {
+        String five = "{\"lessons\":[{\"lesson\":\"a\"},{\"lesson\":\"b\"},{\"lesson\":\"c\"},{\"lesson\":\"d\"},{\"lesson\":\"e\"}]}";
+
+        assertEquals(2, RetroEngine.parseLessons(five, 2).size());
+    }
+
+    // =================================================================
+    // harvest
+    // =================================================================
+
+    @Test
+    @DisplayName("lessons land team-owned with group visibility, and re-running the same retro is a no-op")
+    void harvest_idempotentTeamOwnedUpsert() {
+        var entries = List.of(retroEntry("{\"lessons\":[{\"lesson\":\"Cap debate rounds\",\"context\":\"long debates\"}]}"));
+
+        RetroEngine.harvest(gc, new RetroConfig(), entries, store, "Retro", null);
+        RetroEngine.harvest(gc, new RetroConfig(), entries, store, "Retro", null);
+
+        assertEquals(1, store.byId.size(), "the idempotency key + fixed source agent make a re-run a no-op");
+        UserMemoryEntry lesson = store.byId.values().iterator().next();
+        assertEquals(TEAM_OWNER, lesson.userId(), "owned by the team, not the human who ran the discussion");
+        assertTrue(lesson.key().startsWith(RetroEngine.KEY_PREFIX));
+        assertEquals(List.of(GROUP_ID), lesson.groupIds());
+        assertEquals(RetroEngine.RETRO_SOURCE, lesson.sourceAgentId());
+        assertTrue(lesson.value().toString().contains("Cap debate rounds"));
+        assertTrue(lesson.value().toString().contains("long debates"), "the context rides in the value");
+    }
+
+    @Test
+    @DisplayName("FIFO at maxStoredLessons: storing past the cap evicts the oldest, never the newest")
+    void harvest_fifoEviction() {
+        var config = new RetroConfig(3, 2);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"first oldest\"}]}")), store, "Retro", null);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"second\"}]}")), store, "Retro", null);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"third newest\"}]}")), store, "Retro", null);
+
+        assertEquals(2, store.byId.size(), "the 3rd stored lesson evicts the oldest");
+        List<String> values = store.byId.values().stream().map(e -> e.value().toString()).toList();
+        assertTrue(values.stream().anyMatch(v -> v.contains("third newest")));
+        assertTrue(values.stream().noneMatch(v -> v.contains("first oldest")), "FIFO evicts the OLDEST");
+    }
+
+    @Test
+    @DisplayName("retro_recorded fires with the stored count; a null store warns and never throws")
+    void harvest_eventAndNullStore() {
+        var listener = Mockito.mock(GroupDiscussionEventListener.class);
+
+        RetroEngine.harvest(gc, new RetroConfig(),
+                List.of(retroEntry("{\"lessons\":[{\"lesson\":\"a\"},{\"lesson\":\"b\"}]}")), store, "Retro", listener);
+
+        var captor = ArgumentCaptor.forClass(GroupConversationEventSink.RetroRecordedEvent.class);
+        verify(listener).onRetroRecorded(captor.capture());
+        assertEquals(2, captor.getValue().lessonsStored());
+        assertEquals(GROUP_ID, captor.getValue().groupId());
+
+        assertDoesNotThrow(() -> RetroEngine.harvest(gc, new RetroConfig(),
+                List.of(retroEntry("{\"lessons\":[{\"lesson\":\"x\"}]}")), null, "Retro", null));
+    }
+
+    @Test
+    @DisplayName("a failing store loses that lesson with a warning — never the discussion")
+    void harvest_storeFailure_neverThrows() throws IResourceStore.ResourceStoreException {
+        var failing = Mockito.mock(IUserMemoryStore.class);
+        Mockito.when(failing.upsert(Mockito.any())).thenThrow(new IResourceStore.ResourceStoreException("store down"));
+
+        assertDoesNotThrow(() -> RetroEngine.harvest(gc, new RetroConfig(),
+                List.of(retroEntry("{\"lessons\":[{\"lesson\":\"x\"}]}")), failing, "Retro", null));
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/RetroEngineTest.java
@@ -219,6 +219,41 @@ class RetroEngineTest {
     }
 
     @Test
+    @DisplayName("FIFO survives a reharvest: eviction orders by CREATION, not by the refreshed updatedAt")
+    void harvest_fifoEviction_reharvestDoesNotShieldOldLessons() throws Exception {
+        var config = new RetroConfig(3, 2);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"alpha oldest\"}]}")), store, "Retro", null);
+        Thread.sleep(5);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"beta middle\"}]}")), store, "Retro", null);
+        Thread.sleep(5);
+        // Reharvest alpha: its updatedAt refreshes, its createdAt does not. The
+        // recall order (most_recent = updatedAt) now lists alpha first — eviction
+        // keyed on recall order would evict beta, keeping the OLDER lesson.
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"alpha oldest\"}]}")), store, "Retro", null);
+        Thread.sleep(5);
+        RetroEngine.harvest(gc, config, List.of(retroEntry("{\"lessons\":[{\"lesson\":\"gamma newest\"}]}")), store, "Retro", null);
+
+        assertEquals(2, store.byId.size());
+        List<String> values = store.byId.values().stream().map(e -> e.value().toString()).toList();
+        assertTrue(values.stream().noneMatch(v -> v.contains("alpha oldest")),
+                "FIFO evicts the oldest-CREATED lesson even after a reharvest refreshed it: " + values);
+        assertTrue(values.stream().anyMatch(v -> v.contains("beta middle")), values.toString());
+        assertTrue(values.stream().anyMatch(v -> v.contains("gamma newest")), values.toString());
+    }
+
+    @Test
+    @DisplayName("RetroConfig clamps runaway values to hard ceilings — bounded growth is non-negotiable")
+    void retroConfig_ceilingsClampRunawayValues() {
+        var runaway = new RetroConfig(Integer.MAX_VALUE, Integer.MAX_VALUE);
+        assertEquals(RetroConfig.CEILING_MAX_PER_RUN, runaway.maxLessonsPerRun());
+        assertEquals(RetroConfig.CEILING_MAX_STORED, runaway.maxStoredLessons());
+
+        var sane = new RetroConfig(5, 100);
+        assertEquals(5, sane.maxLessonsPerRun(), "values under the ceiling pass through");
+        assertEquals(100, sane.maxStoredLessons());
+    }
+
+    @Test
     @DisplayName("retro_recorded fires with the stored count; a null store warns and never throws")
     void harvest_eventAndNullStore() {
         var listener = Mockito.mock(GroupDiscussionEventListener.class);

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
@@ -734,6 +734,7 @@ class McpGroupToolsTest {
 
         assertTrue(result.contains("complete or delete"), "the cap error says what to do about it: " + result);
         verify(workspaceStore, never()).update(any());
+        verify(workspaceStore, never()).casRevision(any());
     }
 
     @Test
@@ -770,6 +771,7 @@ class McpGroupToolsTest {
         String longDescription = "d".repeat(SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH + 1);
         assertTrue(tools.add_team_task("g1", "Ok", longDescription, null).contains("error"));
         verify(workspaceStore, never()).update(any());
+        verify(workspaceStore, never()).casRevision(any());
     }
 
     @Test
@@ -783,6 +785,7 @@ class McpGroupToolsTest {
         assertTrue(result.contains("subject"), "the error names the conflict: " + result);
         assertEquals(1, workspace.getBacklog().size());
         verify(workspaceStore, never()).update(any());
+        verify(workspaceStore, never()).casRevision(any());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
@@ -4,9 +4,13 @@
  */
 package ai.labs.eddi.engine.mcp;
 
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IGroupConversationService;
@@ -33,6 +37,7 @@ class McpGroupToolsTest {
     private IRestAgentGroupStore groupStore;
     private IGroupConversationService groupConversationService;
     private IJsonSerialization jsonSerialization;
+    private IGroupWorkspaceStore workspaceStore;
     private McpGroupTools tools;
 
     @BeforeEach
@@ -40,6 +45,7 @@ class McpGroupToolsTest {
         groupStore = mock(IRestAgentGroupStore.class);
         groupConversationService = mock(IGroupConversationService.class);
         jsonSerialization = mock(IJsonSerialization.class);
+        workspaceStore = mock(IGroupWorkspaceStore.class);
         lenient().when(jsonSerialization.serialize(any())).thenReturn("{}");
 
         var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
@@ -47,7 +53,7 @@ class McpGroupToolsTest {
         // authorization disabled — OwnershipValidator's checks are no-ops, matching the
         // pre-existing tests. Ownership enforcement is covered separately below.
         tools = new McpGroupTools(groupStore, groupConversationService, jsonSerialization, mockIdentity,
-                new OwnershipValidator(false), false);
+                new OwnershipValidator(false), workspaceStore, false);
     }
 
     // --- describe_discussion_styles ---
@@ -455,7 +461,7 @@ class McpGroupToolsTest {
         lenient().when(identity.getPrincipal()).thenReturn(principal);
         lenient().when(identity.hasRole(role)).thenReturn(true);
         return new McpGroupTools(groupStore, groupConversationService, jsonSerialization, identity,
-                new OwnershipValidator(true), true);
+                new OwnershipValidator(true), workspaceStore, true);
     }
 
     /**
@@ -470,7 +476,7 @@ class McpGroupToolsTest {
         lenient().when(identity.getPrincipal()).thenReturn(principal);
         lenient().when(identity.hasRole(anyString())).thenReturn(true);
         return new McpGroupTools(groupStore, groupConversationService, jsonSerialization, identity,
-                new OwnershipValidator(true), true);
+                new OwnershipValidator(true), workspaceStore, true);
     }
 
     @Test
@@ -685,5 +691,63 @@ class McpGroupToolsTest {
         verify(jsonSerialization).serialize(captor.capture());
         assertEquals(1, captor.getValue().size(), "a non-owner must not see another user's transcript via list");
         assertEquals("gc-mine", captor.getValue().get(0).getId());
+    }
+
+    // --- I13: standing-team backlog ---
+
+    private GroupWorkspace teamWorkspace() throws Exception {
+        var workspace = new GroupWorkspace();
+        workspace.setId("ws-1");
+        workspace.setGroupId("g1");
+        var resourceId = mock(IResourceStore.IResourceId.class);
+        lenient().when(resourceId.getVersion()).thenReturn(1);
+        lenient().when(groupStore.getCurrentResourceId("g1")).thenReturn(resourceId);
+        lenient().when(workspaceStore.readOrCreate("g1")).thenReturn(workspace);
+        lenient().when(workspaceStore.find("g1")).thenReturn(workspace);
+        return workspace;
+    }
+
+    @Test
+    void addTeamTask_persistsWithPriority() throws Exception {
+        var workspace = teamWorkspace();
+
+        String result = tools.add_team_task("g1", "Ship the feature", "with tests", "7");
+
+        assertFalse(result.contains("error"), result);
+        assertEquals(1, workspace.getBacklog().size());
+        assertEquals(7, workspace.getBacklog().getTasks().get(0).priority());
+        verify(workspaceStore).update(workspace);
+    }
+
+    @Test
+    void addTeamTask_backlogCap_isActionable() throws Exception {
+        var workspace = teamWorkspace();
+        for (int i = 0; i < GroupWorkspace.MAX_BACKLOG_SIZE; i++) {
+            workspace.getBacklog().addTask(
+                    new TaskItem("Task " + i, "", 0));
+        }
+
+        String result = tools.add_team_task("g1", "One more", null, null);
+
+        assertTrue(result.contains("complete or delete"), "the cap error says what to do about it: " + result);
+        verify(workspaceStore, never()).update(any());
+    }
+
+    @Test
+    void addTeamTask_blankSubject_errors() throws Exception {
+        assertTrue(tools.add_team_task("g1", "  ", null, null).contains("error"));
+    }
+
+    @Test
+    void listTeamBacklog_serializesTasks_andEmptyWithoutWorkspace() throws Exception {
+        teamWorkspace();
+        tools.add_team_task("g1", "A task", null, null);
+
+        tools.list_team_backlog("g1");
+        verify(jsonSerialization, atLeastOnce()).serialize(any());
+
+        when(workspaceStore.find("g1")).thenReturn(null);
+        String result = tools.list_team_backlog("g1");
+        assertFalse(result.contains("error"), "no workspace is an empty backlog, not an error: " + result);
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
@@ -705,6 +705,7 @@ class McpGroupToolsTest {
         lenient().when(groupStore.getCurrentResourceId("g1")).thenReturn(resourceId);
         lenient().when(workspaceStore.readOrCreate("g1")).thenReturn(workspace);
         lenient().when(workspaceStore.find("g1")).thenReturn(workspace);
+        lenient().when(workspaceStore.casRevision(workspace)).thenReturn(true);
         return workspace;
     }
 
@@ -717,7 +718,8 @@ class McpGroupToolsTest {
         assertFalse(result.contains("error"), result);
         assertEquals(1, workspace.getBacklog().size());
         assertEquals(7, workspace.getBacklog().getTasks().get(0).priority());
-        verify(workspaceStore).update(workspace);
+        verify(workspaceStore).casRevision(workspace);
+        verify(workspaceStore, never()).update(any());
     }
 
     @Test
@@ -737,6 +739,27 @@ class McpGroupToolsTest {
     @Test
     void addTeamTask_blankSubject_errors() throws Exception {
         assertTrue(tools.add_team_task("g1", "  ", null, null).contains("error"));
+    }
+
+    @Test
+    void addTeamTask_lostCas_retriesThenGivesUp() throws Exception {
+        teamWorkspace();
+        // Each read returns a FRESH document — a re-read must reflect the
+        // concurrent writer's state, never this caller's failed mutation.
+        when(workspaceStore.readOrCreate("g1")).thenAnswer(inv -> {
+            var w = new GroupWorkspace();
+            w.setId("ws-1");
+            w.setGroupId("g1");
+            return w;
+        });
+        when(workspaceStore.casRevision(any())).thenReturn(false, true);
+        assertFalse(tools.add_team_task("g1", "Ship it", null, null).contains("error"));
+        verify(workspaceStore, times(2)).readOrCreate("g1");
+
+        when(workspaceStore.casRevision(any())).thenReturn(false);
+        String result = tools.add_team_task("g1", "Another", null, null);
+        assertTrue(result.contains("error"), result);
+        assertTrue(result.contains("concurrently"), "exhausted retries tell the caller to retry: " + result);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.configs.groups.model.SharedTaskList;
 import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
@@ -736,6 +737,29 @@ class McpGroupToolsTest {
     @Test
     void addTeamTask_blankSubject_errors() throws Exception {
         assertTrue(tools.add_team_task("g1", "  ", null, null).contains("error"));
+    }
+
+    @Test
+    void addTeamTask_oversizedFields_error() throws Exception {
+        teamWorkspace();
+        String longSubject = "s".repeat(SharedTaskList.MAX_AGENT_TASK_SUBJECT_LENGTH + 1);
+        assertTrue(tools.add_team_task("g1", longSubject, null, null).contains("error"));
+        String longDescription = "d".repeat(SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH + 1);
+        assertTrue(tools.add_team_task("g1", "Ok", longDescription, null).contains("error"));
+        verify(workspaceStore, never()).update(any());
+    }
+
+    @Test
+    void addTeamTask_duplicateSubject_errors() throws Exception {
+        var workspace = teamWorkspace();
+        workspace.getBacklog().addTask(new TaskItem("Ship it", "", 0));
+
+        String result = tools.add_team_task("g1", "ship IT", null, null);
+
+        assertTrue(result.contains("error"), result);
+        assertTrue(result.contains("subject"), "the error names the conflict: " + result);
+        assertEquals(1, workspace.getBacklog().size());
+        verify(workspaceStore, never()).update(any());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ScheduleFireExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ScheduleFireExecutorTest.java
@@ -34,6 +34,7 @@ class ScheduleFireExecutorTest {
     private IScheduleStore scheduleStore;
     private ai.labs.eddi.engine.internal.HitlTimeoutHandler hitlTimeoutHandler;
     private DreamService dreamService;
+    private TeamCadenceService teamCadenceService;
     private ScheduleFireExecutor executor;
 
     @BeforeEach
@@ -42,6 +43,7 @@ class ScheduleFireExecutorTest {
         scheduleStore = mock(IScheduleStore.class);
         hitlTimeoutHandler = mock(ai.labs.eddi.engine.internal.HitlTimeoutHandler.class);
         dreamService = mock(DreamService.class);
+        teamCadenceService = mock(TeamCadenceService.class);
 
         executor = new ScheduleFireExecutor();
         // Inject mocks via reflection (field injection)
@@ -49,6 +51,7 @@ class ScheduleFireExecutorTest {
         setField(executor, "scheduleStore", scheduleStore);
         setField(executor, "hitlTimeoutHandler", hitlTimeoutHandler);
         setField(executor, "dreamService", dreamService);
+        setField(executor, "teamCadenceService", teamCadenceService);
     }
 
     @Test
@@ -527,6 +530,58 @@ class ScheduleFireExecutorTest {
         } finally {
             Thread.interrupted();
         }
+    }
+
+    private static ScheduleConfiguration makeTeamCadenceSchedule(String id) {
+        var s = new ScheduleConfiguration();
+        s.setId(id);
+        s.setName("team-cadence-group-1");
+        s.setTriggerType(TriggerType.CRON);
+        s.setCronExpression("0 9 * * 1");
+        s.setEnvironment("production");
+        s.setTimeZone("UTC");
+        s.setFireStatus(FireStatus.CLAIMED);
+        s.setNextFire(Instant.now().minusSeconds(1));
+        s.setMetadata(java.util.Map.of(
+                TeamCadenceService.METADATA_TYPE_KEY, TeamCadenceService.METADATA_TYPE_CADENCE,
+                TeamCadenceService.METADATA_GROUP_ID_KEY, "group-1",
+                TeamCadenceService.METADATA_CADENCE_ID_KEY, "cadence-1"));
+        return s;
+    }
+
+    @Test
+    @Timeout(10)
+    void fire_teamCadenceSchedule_dispatchesToTheCadenceService() throws Exception {
+        var schedule = makeTeamCadenceSchedule("sched-cadence-1");
+        when(teamCadenceService.processScheduledFire(any()))
+                .thenReturn(new TeamCadenceService.CadenceResult("group-1", "cadence-1", "gc-1", 3, null, null));
+
+        ScheduleFireLog result = executor.fire(schedule, "instance-1", 1);
+
+        assertEquals(FireStatus.COMPLETED.name(), result.status());
+        assertEquals("gc-1", result.conversationId(), "the fire log records WHICH discussion the cadence started");
+        verify(teamCadenceService).processScheduledFire(schedule.getMetadata());
+        // A cadence pull is orchestration, not a conversation turn.
+        verifyNoInteractions(conversationService);
+    }
+
+    @Test
+    @Timeout(10)
+    void fire_teamCadenceSchedule_skipIsCompleted_failureRetries() throws Exception {
+        var skipped = makeTeamCadenceSchedule("sched-cadence-2");
+        when(teamCadenceService.processScheduledFire(any()))
+                .thenReturn(new TeamCadenceService.CadenceResult("group-1", "cadence-1", null, 0,
+                        "No executable backlog tasks", null));
+        assertEquals(FireStatus.COMPLETED.name(), executor.fire(skipped, "instance-1", 1).status(),
+                "a deliberate skip is a successful fire, not a retryable failure");
+
+        var failing = makeTeamCadenceSchedule("sched-cadence-3");
+        when(teamCadenceService.processScheduledFire(any()))
+                .thenReturn(new TeamCadenceService.CadenceResult("group-1", "cadence-1", null, 0, null,
+                        "No workspace exists for group group-1"));
+        ScheduleFireLog failed = executor.fire(failing, "instance-1", 2);
+        assertEquals(FireStatus.FAILED.name(), failed.status(), "a real failure must retry and dead-letter");
+        assertTrue(failed.errorMessage().contains("No workspace"), failed.errorMessage());
     }
 
     private static ScheduleConfiguration makeDreamSchedule(String id, String userId) {

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -314,8 +315,13 @@ class TeamCadenceServiceTest {
 
         assertFalse(service.writebackCompleted(workspace, gc),
                 "a concurrent reconciler settled first — this caller's writeback must report defeat");
+        // The ONLY store interaction is the failed conditional release — the
+        // in-memory mutations (task statuses, metrics, cleared claim fields) die
+        // with this discarded snapshot; any additional store call here would be a
+        // partial persistence of a lost race (review nitpick: pin the write
+        // surface, not just the update() legacy path).
         verify(workspaceStore).casRunningDiscussion(workspace, GC_ID);
-        verify(workspaceStore, never()).update(any());
+        verifyNoMoreInteractions(workspaceStore);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.runtime.internal;
+
+import ai.labs.eddi.configs.groups.IGroupConversationStore;
+import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TaskDefinition;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace;
+import ai.labs.eddi.configs.groups.model.GroupWorkspace.Cadence;
+import ai.labs.eddi.configs.groups.model.SharedTaskList;
+import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
+import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskStatus;
+import ai.labs.eddi.engine.internal.GroupConversationService;
+import ai.labs.eddi.modules.templating.ITemplatingEngine;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * I13 — {@link TeamCadenceService}: the fire protocol (reconcile → pull → claim
+ * → run), the writeback matrix, and every deliberate skip.
+ */
+class TeamCadenceServiceTest {
+
+    private static final String GROUP_ID = "group-1";
+    private static final String CADENCE_ID = "cadence-1";
+    private static final String GC_ID = "gc-1";
+
+    private IGroupWorkspaceStore workspaceStore;
+    private IGroupConversationStore conversationStore;
+    private GroupConversationService groupConversationService;
+    private ITemplatingEngine templatingEngine;
+    private TeamCadenceService service;
+
+    @BeforeEach
+    void setUp() {
+        workspaceStore = mock(IGroupWorkspaceStore.class);
+        conversationStore = mock(IGroupConversationStore.class);
+        groupConversationService = mock(GroupConversationService.class);
+        templatingEngine = mock(ITemplatingEngine.class);
+        service = new TeamCadenceService(workspaceStore, conversationStore, groupConversationService,
+                templatingEngine, new SimpleMeterRegistry());
+        service.initMetrics();
+    }
+
+    private Map<String, Object> metadata() {
+        return Map.of(TeamCadenceService.METADATA_TYPE_KEY, TeamCadenceService.METADATA_TYPE_CADENCE,
+                TeamCadenceService.METADATA_GROUP_ID_KEY, GROUP_ID,
+                TeamCadenceService.METADATA_CADENCE_ID_KEY, CADENCE_ID);
+    }
+
+    private GroupWorkspace workspace(Cadence cadence, TaskItem... backlogTasks) throws Exception {
+        var workspace = new GroupWorkspace();
+        workspace.setId("ws-1");
+        workspace.setGroupId(GROUP_ID);
+        if (cadence != null) {
+            workspace.getCadences().add(cadence);
+        }
+        for (TaskItem task : backlogTasks) {
+            workspace.getBacklog().addTask(task);
+        }
+        when(workspaceStore.find(GROUP_ID)).thenReturn(workspace);
+        lenient().when(workspaceStore.casRunningDiscussion(any(), anyString())).thenReturn(true);
+        return workspace;
+    }
+
+    private Cadence cadence(int maxTasksPerRun, Double maxCostPerRun) {
+        return new Cadence(CADENCE_ID, "sched-1", null, maxTasksPerRun, maxCostPerRun, "pm@example.com");
+    }
+
+    private GroupConversation startedGc() throws Exception {
+        var gc = new GroupConversation();
+        gc.setId(GC_ID);
+        gc.setGroupId(GROUP_ID);
+        gc.setState(GroupConversationState.IN_PROGRESS);
+        when(groupConversationService.startCadenceDiscussionAsync(eq(GROUP_ID), anyString(), anyString(), anyList(),
+                any(), any())).thenReturn(gc);
+        return gc;
+    }
+
+    // =================================================================
+    // The fire protocol
+    // =================================================================
+
+    @Test
+    @DisplayName("a fire pulls the top-priority executable tasks, starts the discussion, and claims the workspace")
+    void fire_pullsByPriority_startsAndClaims() throws Exception {
+        var workspace = workspace(cadence(2, 3.50),
+                new TaskItem("Low", "low prio", 1),
+                new TaskItem("Urgent", "do first", 9),
+                new TaskItem("Mid", "do second", 5));
+        startedGc();
+
+        var result = service.processScheduledFire(metadata());
+
+        assertTrue(result.isSuccess(), String.valueOf(result.error()));
+        assertNull(result.skippedReason());
+        assertEquals(GC_ID, result.discussionId());
+        assertEquals(2, result.tasksPulled());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<TaskDefinition>> tasksCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<String> questionCaptor = ArgumentCaptor.forClass(String.class);
+        verify(groupConversationService).startCadenceDiscussionAsync(eq(GROUP_ID), questionCaptor.capture(),
+                eq("pm@example.com"), tasksCaptor.capture(), eq(3.50), any());
+        assertEquals(List.of("Urgent", "Mid"), tasksCaptor.getValue().stream().map(TaskDefinition::subject).toList(),
+                "top-N by priority, highest first — 'Low' stays on the backlog");
+        assertTrue(questionCaptor.getValue().contains("Urgent"), questionCaptor.getValue());
+
+        assertEquals(GC_ID, workspace.getRunningDiscussionId());
+        assertEquals(2, workspace.getPulledTaskIds().size());
+        long inProgress = workspace.getBacklog().getTasks().stream()
+                .filter(t -> t.status() == TaskStatus.IN_PROGRESS).count();
+        assertEquals(2, inProgress, "pulled tasks are marked while the discussion owns them");
+        verify(workspaceStore).casRunningDiscussion(workspace, GroupWorkspace.NO_RUNNING_DISCUSSION);
+    }
+
+    @Test
+    void fire_emptyBacklog_skipsWithoutADiscussion() throws Exception {
+        workspace(cadence(5, null));
+
+        var result = service.processScheduledFire(metadata());
+
+        assertTrue(result.isSuccess());
+        assertNotNull(result.skippedReason());
+        verify(groupConversationService, never()).startCadenceDiscussionAsync(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void fire_missingWorkspaceOrCadence_fails() throws Exception {
+        when(workspaceStore.find(GROUP_ID)).thenReturn(null);
+        assertFalse(service.processScheduledFire(metadata()).isSuccess());
+
+        workspace(null, new TaskItem("T", "", 0)); // workspace exists, cadence does not
+        var result = service.processScheduledFire(metadata());
+        assertFalse(result.isSuccess());
+        assertTrue(result.error().contains(CADENCE_ID));
+    }
+
+    @Test
+    void fire_missingMetadata_fails() {
+        assertFalse(service.processScheduledFire(null).isSuccess());
+        assertFalse(service.processScheduledFire(Map.of()).isSuccess());
+    }
+
+    @Test
+    @DisplayName("a previous discussion still in flight (or paused for a human) skips the fire")
+    void fire_previousStillRunning_skips() throws Exception {
+        var workspace = workspace(cadence(5, null), new TaskItem("T", "", 0));
+        workspace.setRunningDiscussionId("older-gc");
+        var runningGc = new GroupConversation();
+        runningGc.setId("older-gc");
+        runningGc.setState(GroupConversationState.AWAITING_APPROVAL);
+        when(conversationStore.read("older-gc")).thenReturn(runningGc);
+
+        var result = service.processScheduledFire(metadata());
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.skippedReason().contains("older-gc"));
+        verify(groupConversationService, never()).startCadenceDiscussionAsync(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("a finished previous discussion is written back FIRST, then the new run starts")
+    void fire_previousTerminal_reconcilesThenRuns() throws Exception {
+        var workspace = workspace(cadence(5, null), new TaskItem("Next", "", 0));
+        workspace.setRunningDiscussionId("done-gc");
+        var doneGc = new GroupConversation();
+        doneGc.setId("done-gc");
+        doneGc.setState(GroupConversationState.COMPLETED);
+        doneGc.setTotalCost(1.25);
+        when(conversationStore.read("done-gc")).thenReturn(doneGc);
+        startedGc();
+
+        var result = service.processScheduledFire(metadata());
+
+        assertTrue(result.isSuccess());
+        assertEquals(GC_ID, result.discussionId());
+        assertEquals(1, workspace.getMetrics().getDiscussions(), "the finished run was settled");
+        assertEquals(1.25, workspace.getMetrics().getTotalCost(), 1e-9);
+    }
+
+    @Test
+    @DisplayName("a lost claim cancels the just-started discussion and stands down")
+    void fire_lostClaim_cancelsAndSkips() throws Exception {
+        workspace(cadence(5, null), new TaskItem("T", "", 0));
+        when(workspaceStore.casRunningDiscussion(any(), anyString())).thenReturn(false);
+        startedGc();
+
+        var result = service.processScheduledFire(metadata());
+
+        assertTrue(result.isSuccess());
+        assertNotNull(result.skippedReason());
+        verify(groupConversationService).cancelDiscussion(eq(GC_ID), any());
+    }
+
+    @Test
+    @DisplayName("a broken input template degrades to the plain backlog summary — a cadence never stops over prose")
+    void fire_templateFailure_usesPlainSummary() throws Exception {
+        var cadence = new Cadence(CADENCE_ID, "sched-1", "{broken", 5, null, "pm@example.com");
+        workspace(cadence, new TaskItem("Fix the flaky test", "", 0));
+        when(templatingEngine.processTemplate(anyString(), any())).thenThrow(new RuntimeException("bad template"));
+        startedGc();
+
+        var result = service.processScheduledFire(metadata());
+
+        assertTrue(result.isSuccess());
+        ArgumentCaptor<String> questionCaptor = ArgumentCaptor.forClass(String.class);
+        verify(groupConversationService).startCadenceDiscussionAsync(eq(GROUP_ID), questionCaptor.capture(),
+                anyString(), anyList(), any(), any());
+        assertTrue(questionCaptor.getValue().contains("Fix the flaky test"));
+    }
+
+    // =================================================================
+    // Writeback matrix
+    // =================================================================
+
+    private GroupWorkspace pulledWorkspace(TaskItem taskA, TaskItem taskB) throws Exception {
+        var workspace = workspace(cadence(5, null), taskA, taskB);
+        workspace.setRunningDiscussionId(GC_ID);
+        workspace.setPulledTaskIds(List.of(taskA.id(), taskB.id()));
+        workspace.getBacklog().updateTask(new TaskItem(taskA.id(), taskA.subject(), taskA.description(),
+                TaskStatus.IN_PROGRESS, null, null, taskA.dependsOnIds(), null, null, false, taskA.priority(),
+                taskA.createdAt(), null));
+        workspace.getBacklog().updateTask(new TaskItem(taskB.id(), taskB.subject(), taskB.description(),
+                TaskStatus.IN_PROGRESS, null, null, taskB.dependsOnIds(), null, null, false, taskB.priority(),
+                taskB.createdAt(), null));
+        return workspace;
+    }
+
+    @Test
+    @DisplayName("COMPLETED writeback: VERIFIED stays (credited to the assignee), anything else returns to PENDING with feedback")
+    void writeback_completed_matrix() throws Exception {
+        var taskA = new TaskItem("Ship feature", "", 3);
+        var taskB = new TaskItem("Write docs", "original description", 1);
+        var workspace = pulledWorkspace(taskA, taskB);
+
+        var gc = new GroupConversation();
+        gc.setId(GC_ID);
+        gc.setState(GroupConversationState.COMPLETED);
+        gc.setTotalCost(2.0);
+        var discussionTasks = new SharedTaskList();
+        var doneA = discussionTasks.addTask(new TaskItem("Ship feature", "", 0));
+        discussionTasks.assignTask(doneA.id(), "agent-a", "Agent A");
+        discussionTasks.startTask(doneA.id());
+        discussionTasks.completeTask(doneA.id(), "shipped");
+        discussionTasks.verifyTask(doneA.id(), true, "looks great");
+        var failedB = discussionTasks.addTask(new TaskItem("Write docs", "", 0));
+        discussionTasks.assignTask(failedB.id(), "agent-b", "Agent B");
+        discussionTasks.startTask(failedB.id());
+        discussionTasks.completeTask(failedB.id(), "half done");
+        discussionTasks.verifyTask(failedB.id(), false, "missing the API section");
+        gc.setTaskList(discussionTasks);
+
+        service.writebackCompleted(workspace, gc);
+
+        TaskItem backlogA = workspace.getBacklog().findById(taskA.id());
+        assertEquals(TaskStatus.VERIFIED, backlogA.status());
+        assertTrue(backlogA.verified());
+        TaskItem backlogB = workspace.getBacklog().findById(taskB.id());
+        assertEquals(TaskStatus.PENDING, backlogB.status(), "failed work returns for the next run — the retry loop");
+        assertTrue(backlogB.description().contains("missing the API section"),
+                "the reviewer's feedback rides the description into the next attempt: " + backlogB.description());
+        assertTrue(backlogB.description().contains("original description"), "the original description is preserved");
+
+        var metrics = workspace.getMetrics();
+        assertEquals(1, metrics.getDiscussions());
+        assertEquals(1, metrics.getTasksVerified());
+        assertEquals(2.0, metrics.getTotalCost(), 1e-9);
+        assertNotNull(metrics.getLastRunAt());
+        assertEquals(1, metrics.getPerMemberStats().get("agent-a").getTasksVerified());
+        assertEquals(1, metrics.getPerMemberStats().get("agent-b").getTasksFailed());
+
+        assertEquals(GroupWorkspace.NO_RUNNING_DISCUSSION, workspace.getRunningDiscussionId());
+        assertTrue(workspace.getPulledTaskIds().isEmpty());
+        verify(workspaceStore).update(workspace);
+    }
+
+    @Test
+    @DisplayName("FAILED/CANCELLED writeback: every pulled task returns to PENDING untouched")
+    void writeback_failure_returnsTasks() throws Exception {
+        var taskA = new TaskItem("A", "", 0);
+        var taskB = new TaskItem("B", "", 0);
+        var workspace = pulledWorkspace(taskA, taskB);
+        var gc = new GroupConversation();
+        gc.setId(GC_ID);
+        gc.setState(GroupConversationState.CANCELLED);
+        gc.setTotalCost(0.5);
+
+        service.writebackFailure(workspace, gc);
+
+        assertEquals(TaskStatus.PENDING, workspace.getBacklog().findById(taskA.id()).status());
+        assertEquals(TaskStatus.PENDING, workspace.getBacklog().findById(taskB.id()).status());
+        assertEquals(1, workspace.getMetrics().getDiscussions());
+        assertEquals(0.5, workspace.getMetrics().getTotalCost(), 1e-9);
+        assertEquals(GroupWorkspace.NO_RUNNING_DISCUSSION, workspace.getRunningDiscussionId());
+    }
+
+    @Test
+    @DisplayName("a vanished discussion releases the claim instead of stalling every future fire")
+    void reconcile_goneDiscussion_releasesClaim() throws Exception {
+        var taskA = new TaskItem("A", "", 0);
+        var workspace = workspace(cadence(5, null), taskA);
+        workspace.setRunningDiscussionId("gone-gc");
+        workspace.setPulledTaskIds(List.of(taskA.id()));
+        when(conversationStore.read("gone-gc")).thenThrow(
+                new ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException("gone"));
+
+        assertTrue(service.reconcile(workspace));
+
+        assertEquals(GroupWorkspace.NO_RUNNING_DISCUSSION, workspace.getRunningDiscussionId());
+        assertEquals(TaskStatus.PENDING, workspace.getBacklog().findById(taskA.id()).status());
+    }
+
+    @Test
+    void reconcile_idleWorkspace_isANoOp() throws Exception {
+        var workspace = workspace(cadence(5, null));
+
+        assertTrue(service.reconcile(workspace));
+
+        verify(workspaceStore, never()).update(any());
+    }
+
+    // =================================================================
+    // Model + contract pins
+    // =================================================================
+
+    @Test
+    void cadence_compactConstructor_defaultsTasksPerRun() {
+        assertEquals(GroupWorkspace.DEFAULT_MAX_BACKLOG_TASKS_PER_RUN,
+                new Cadence("c", "s", null, 0, null, "pm").maxBacklogTasksPerRun());
+        assertEquals(3, new Cadence("c", "s", null, 3, null, "pm").maxBacklogTasksPerRun());
+    }
+
+    @Test
+    void isTeamCadenceSchedule_matchesOnlyItsOwnMetadata() {
+        assertTrue(TeamCadenceService.isTeamCadenceSchedule(metadata()));
+        assertFalse(TeamCadenceService.isTeamCadenceSchedule(Map.of("dreamType", "dream_consolidation")));
+        assertFalse(TeamCadenceService.isTeamCadenceSchedule(null));
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
@@ -276,7 +276,7 @@ class TeamCadenceServiceTest {
         discussionTasks.verifyTask(failedB.id(), false, "missing the API section");
         gc.setTaskList(discussionTasks);
 
-        service.writebackCompleted(workspace, gc);
+        assertTrue(service.writebackCompleted(workspace, gc), "this caller's settle won the race");
 
         TaskItem backlogA = workspace.getBacklog().findById(taskA.id());
         assertEquals(TaskStatus.VERIFIED, backlogA.status());
@@ -297,7 +297,25 @@ class TeamCadenceServiceTest {
 
         assertEquals(GroupWorkspace.NO_RUNNING_DISCUSSION, workspace.getRunningDiscussionId());
         assertTrue(workspace.getPulledTaskIds().isEmpty());
-        verify(workspaceStore).update(workspace);
+        verify(workspaceStore).casRunningDiscussion(workspace, GC_ID);
+        verify(workspaceStore, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("a writeback that loses the settle race drops its mutations instead of clobbering the live claim")
+    void writeback_lostSettleRace_dropsMutations() throws Exception {
+        var taskA = new TaskItem("A", "", 0);
+        var workspace = pulledWorkspace(taskA, new TaskItem("B", "", 0));
+        when(workspaceStore.casRunningDiscussion(any(), anyString())).thenReturn(false);
+        var gc = new GroupConversation();
+        gc.setId(GC_ID);
+        gc.setState(GroupConversationState.COMPLETED);
+        gc.setTaskList(new SharedTaskList());
+
+        assertFalse(service.writebackCompleted(workspace, gc),
+                "a concurrent reconciler settled first — this caller's writeback must report defeat");
+        verify(workspaceStore).casRunningDiscussion(workspace, GC_ID);
+        verify(workspaceStore, never()).update(any());
     }
 
     @Test
@@ -311,7 +329,7 @@ class TeamCadenceServiceTest {
         gc.setState(GroupConversationState.CANCELLED);
         gc.setTotalCost(0.5);
 
-        service.writebackFailure(workspace, gc);
+        assertTrue(service.writebackFailure(workspace, gc));
 
         assertEquals(TaskStatus.PENDING, workspace.getBacklog().findById(taskA.id()).status());
         assertEquals(TaskStatus.PENDING, workspace.getBacklog().findById(taskB.id()).status());
@@ -348,6 +366,40 @@ class TeamCadenceServiceTest {
     // =================================================================
     // Model + contract pins
     // =================================================================
+
+    @Test
+    @DisplayName("a store failure during the claim CAS cancels the just-started discussion before failing")
+    void fire_claimThrows_cancelsStartedDiscussion() throws Exception {
+        workspace(cadence(5, null), new TaskItem("T", "", 0));
+        when(workspaceStore.casRunningDiscussion(any(), anyString())).thenThrow(new RuntimeException("store down"));
+        startedGc();
+
+        var result = service.processScheduledFire(metadata());
+
+        assertFalse(result.isSuccess());
+        verify(groupConversationService).cancelDiscussion(eq(GC_ID), any());
+    }
+
+    @Test
+    @DisplayName("per-run feedback is capped and the accumulated description trimmed from the front")
+    void appendFeedbackBounded_capsSliceAndTotal() {
+        String bounded = TeamCadenceService.appendFeedbackBounded("desc", "run-1",
+                "x".repeat(TeamCadenceService.MAX_FEEDBACK_CHARS + 100));
+        assertTrue(bounded.length() < TeamCadenceService.MAX_FEEDBACK_CHARS + 100,
+                "one run's feedback never rides in whole: " + bounded.length());
+        assertTrue(bounded.startsWith("desc\n[Cadence run run-1] "), bounded.substring(0, 30));
+        assertTrue(bounded.endsWith("…"), "the slice is visibly truncated");
+
+        String longDescription = "y".repeat(SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH);
+        String trimmed = TeamCadenceService.appendFeedbackBounded(longDescription, "run-2", "newest feedback");
+        assertEquals(SharedTaskList.MAX_AGENT_TASK_DESCRIPTION_LENGTH, trimmed.length(),
+                "the persisted description never outgrows the shared task cap");
+        assertTrue(trimmed.startsWith("…"), "oldest feedback is what gets dropped");
+        assertTrue(trimmed.endsWith("newest feedback"), "the newest feedback always survives");
+
+        assertEquals("d\n[Cadence run r] short",
+                TeamCadenceService.appendFeedbackBounded("d", "r", "short"), "short feedback is untouched");
+    }
 
     @Test
     void cadence_compactConstructor_defaultsTasksPerRun() {

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
@@ -78,7 +78,7 @@ class TeamCadenceServiceTest {
         workspace.setId("ws-1");
         workspace.setGroupId(GROUP_ID);
         if (cadence != null) {
-            workspace.getCadences().add(cadence);
+            workspace.addCadence(cadence);
         }
         for (TaskItem task : backlogTasks) {
             workspace.getBacklog().addTask(task);

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/UserMemoryToolScopingTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/UserMemoryToolScopingTest.java
@@ -176,10 +176,12 @@ class UserMemoryToolScopingTest {
     void personalEntriesNeverCrossUsers() throws Exception {
         // The tool always queries by ITS user's id — a shared group cannot widen
         // the personal scope. The store is queried for USER only; nothing about
-        // user-2 is ever requested, and a self entry of another AGENT under the
-        // same user stays hidden too (the existing G1 wall).
-        var otherAgentsPrivate = entry("p-1", "salary", Visibility.self, AGENT_A, List.of("g1"), Instant.now());
-        when(store.filterEntries(USER, "salary")).thenReturn(List.of(otherAgentsPrivate));
+        // user-2 is ever requested. The fixture genuinely belongs to user-2
+        // (review finding: the shared helper stamped USER, so the assert passed
+        // because AGENT_A was foreign, not because the entry crossed users).
+        var otherUsersPrivate = new UserMemoryEntry("p-1", "user-2", "salary", "value-of-salary", "fact",
+                Visibility.self, AGENT_A, List.of("g1"), "conv-x", false, 0, Instant.now(), Instant.now());
+        when(store.filterEntries(USER, "salary")).thenReturn(List.of(otherUsersPrivate));
 
         String result = toolFor(AGENT_B, List.of("g1")).searchMemory("salary");
 

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/UserMemoryToolScopingTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/UserMemoryToolScopingTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -141,6 +142,50 @@ class UserMemoryToolScopingTest {
         assertTrue(result.contains("maxEntriesPerUser"), "the error must tell the caller what to do; got: " + result);
         verify(store, never()).deleteEntry(any());
         verify(store, never()).upsert(any());
+    }
+
+    // ==================== I8 — team-owned lessons ====================
+
+    @Test
+    @DisplayName("I8 — eviction can never touch a team-owned retro lesson, even when it is the oldest entry the store returns")
+    void evictOldestNeverTouchesTeamOwnedLessons() throws Exception {
+        config.setMaxEntriesPerUser(2);
+        config.setOnCapReached("evict_oldest");
+
+        // The lesson lives under the synthetic team owner with the fixed "retro"
+        // source. Structurally it can never surface from getAllEntries(USER) —
+        // but even if a store bug returned it, the sourceAgentId filter is a
+        // second independent wall. This test breaches the first wall on purpose.
+        var teamLesson = new UserMemoryEntry("lesson-1", IUserMemoryStore.TEAM_OWNER_PREFIX + "g1", "retro:abc",
+                "Cap debate rounds", "context", Visibility.group, "retro", List.of("g1"), "gc-1", false, 0,
+                Instant.parse("2019-01-01T00:00:00Z"), Instant.parse("2019-01-01T00:00:00Z"));
+        var own = entry("own-1", "mine", Visibility.self, AGENT_B, List.of(), Instant.parse("2024-01-01T00:00:00Z"));
+        when(store.countEntries(USER)).thenReturn(2L);
+        when(store.getAllEntries(USER)).thenReturn(List.of(teamLesson, own));
+        when(store.upsert(any())).thenReturn("new-id");
+
+        String result = toolFor(AGENT_B, List.of("g1")).rememberFact("fresh_fact", "value", "fact", "self");
+
+        assertTrue(result.contains("✅ Remembered"), result);
+        verify(store, never()).deleteEntry("lesson-1");
+        verify(store).deleteEntry("own-1");
+    }
+
+    @Test
+    @DisplayName("I8 — a personal visibility:self entry never surfaces to another user's tool, groups shared or not")
+    void personalEntriesNeverCrossUsers() throws Exception {
+        // The tool always queries by ITS user's id — a shared group cannot widen
+        // the personal scope. The store is queried for USER only; nothing about
+        // user-2 is ever requested, and a self entry of another AGENT under the
+        // same user stays hidden too (the existing G1 wall).
+        var otherAgentsPrivate = entry("p-1", "salary", Visibility.self, AGENT_A, List.of("g1"), Instant.now());
+        when(store.filterEntries(USER, "salary")).thenReturn(List.of(otherAgentsPrivate));
+
+        String result = toolFor(AGENT_B, List.of("g1")).searchMemory("salary");
+
+        assertFalse(result.contains("value-of-salary"), result);
+        verify(store, never()).filterEntries(eq("user-2"), any());
+        verify(store, never()).getAllEntries("user-2");
     }
 
     @Test


### PR DESCRIPTION
## Summary

I13 from `planning/group-collaboration-improvements-plan.md` — the Wave 3 flagship. A group *conversation* is an episode; a **team** persists. The new `GroupWorkspace` (one document per group config id, own collection) holds what survives between episodes: a **backlog**, the **cadences** that pull from it on a schedule, and the team's running **metrics**. Deliberately thin glue over existing machinery — the backlog IS a `SharedTaskList`, scheduling IS `SchedulePollerService`, the run ceiling IS I1's inherited-ceiling slot, and retro lessons flow through I8 unchanged.

> **Stacked PR:** this branch is the I8 retro-memory branch (#639) plus I13 — the plan wires retro lessons through I8's group memory, so the dependency is real. The diff shrinks to just I13 once #639 merges.

## The cadence fire protocol (crash-proof by construction)

`ScheduleFireExecutor` gains a `teamCadenceType: "team_cadence"` fast-path (the exact DreamService pattern — cluster claim/lease/retry/dead-letter/fire-logs come free). Each fire:

1. **Reconcile** — a finished previous run is written back FIRST; one still in flight (or paused at an HITL gate for days) skips the fire. A vanished discussion releases the claim instead of stalling every future fire.
2. **Pull** — top-N *executable* backlog tasks by priority (`maxBacklogTasksPerRun`, default 5); an empty pull skips, logged. Deliberate skips are COMPLETED fires with the reason; real failures are FAILED so they retry and dead-letter.
3. **Claim** — a conditional store write on `runningDiscussionId` (`storeIfFieldEquals`); two pods firing concurrently cannot both start, without in-JVM locks. A lost claim cancels the just-started discussion and stands down.
4. **Run** — new `GroupConversationService.startCadenceDiscussionAsync`: pulled tasks replace `config.tasks` as a **runtime copy** (the stored config is never written), the cadence's `maxCostPerRun` rides the inherited-ceiling slot (dollar-primary, per the Dream precedent), and the discussion runs under the **cadence creator's identity**, never a synthetic scheduler user.

**Writeback** happens at the next fire or on a workspace read (REST read-repair) — never from the discussion thread, so a pod crash mid-discussion loses nothing: VERIFIED outcomes stay VERIFIED on the backlog and credit the assignee's `perMemberStats`; anything else returns to PENDING with reviewer feedback appended to the description — **the cross-run retry loop**. FAILED/CANCELLED returns every pulled task untouched.

## Surfaces

- REST `/groupstore/groups/{groupId}/workspace` — GET workspace/backlog (read-repair), POST backlog (cap 200 with an actionable 409), POST/DELETE cadences (the cron is validated at creation by computing the first fire; the schedule carries the dispatch metadata).
- MCP `add_team_task`, `list_team_backlog` (whitelisted; filter coverage pins green).
- A **permanent** group deletion cascades to the workspace; a soft (versioned) delete keeps it — the group can come back.

## Scope cuts (deliberate, per plan)

Per-member stats are reliability **recording only** — no routing/weighting (research-adopted substrate). Not in v1: cross-team handoff, Manager UI, reputation weighting.

## Tests

+30 across 5 classes: the fire pulls top-priority tasks and the captured run call carries them, the creator identity and the dollar ceiling; every skip (empty backlog, still-running, lost claim → cancel); reconcile-then-run; the writeback matrix (VERIFIED credited / failed-with-feedback returns / FAILED untouched / vanished releases — the feedback and VERIFIED assertions are the mutation-check); backlog cap actionable on both surfaces; schedule metadata + invalid-cron-fails-at-creation; permanent-delete cascade vs soft-delete keep; fire-executor dispatch (skip=COMPLETED, failure=FAILED). Full `engine.runtime.internal` + `configs.groups` + `engine.mcp` + `engine.internal` suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent standing-team workspaces with shared backlogs, prioritized tasks, scheduled cadences, execution limits, metrics, and task writeback.
  - Added REST and MCP access for workspaces, backlogs, and cadence management.
  - Added RETRO phases that save bounded, team-owned lessons with duplicate prevention and FIFO limits.
  - Added live retrospective events to conversation streams.
- **Bug Fixes**
  - Improved workspace cleanup, cadence recovery, memory visibility, logging safety, cancellation handling, cost-limit persistence, and concurrent discussion handling.
- **Documentation**
  - Documented standing teams, cadences, backlogs, and retrospective memory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->