### PR TITLE
fix(llm): dynamicAgentConfig guardrails failed open on any turn that did not re-inject them

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 🔎 fix(llm): dynamicAgentConfig context boundary — guardrails failed open on every turn that did not re-inject them (2026-08-09)
+
+**Repo:** EDDI (`fix/dynamic-agent-context-boundary`)
+
+Systematic sweep of the Context serialization boundary: for every context the system injects, what type does it hold (a) on the injecting turn, (b) after a store reload, (c) after crash recovery, (d) on another node? Nine context keys; eight are strings, lists or maps and survive unchanged. **`dynamicAgentConfig` is the only typed POJO the system injects — and it is the one that gates the tools that deploy real agents to production.**
+
+1. **`resolveDynamicAgentConfig` failed open in two independent ways.** `MemberTurnExecutor` injects the group's guardrails on every member turn, and deliberately injects an explicitly *disabled* config when the group configured none — its comment says exactly why: a member turn that finds no config falls back to the STANDALONE default, which is fully permissive (creation, recruitment and delegation all on). The resolver defeated that defense twice: it read the **current step only**, so any turn that re-enters without a fresh injection (HITL tool-approval resume, crash recovery, the group follow-up path) saw nothing; and it required a live `DynamicAgentConfig` instance, but `ConversationMemoryStore`/`PostgresConversationMemoryStore` rebuild a stored context as `new Context(type, map)` — so after **any** reload the value is a `Map` and the `instanceof` failed even when the key was present. Both paths landed on the permissive default. Fixed: earlier steps are consulted as a fallback (the shape `ContextualToolsProvider#resolveGroupIds` and `resolveDelegationDepth` already use for exactly the resume case — this was the only sibling that did not), and the map form is coerced back whole-object via Jackson rather than field-by-field, so a guardrail added later cannot silently read back as its permissive Java default.
+2. **Unresolvable guardrails on a group turn now fail CLOSED.** A conversation that demonstrably belongs to a group but whose config cannot be resolved returns a disabled config instead of the permissive default — the discipline `GroupTaskToolsProvider` and `ArtifactToolsProvider` already state. The group probe requires a context entry that actually *carries a value*, not merely a key: "the key exists" is too weak a claim to strip a standalone agent of tools its designer explicitly whitelisted.
+3. **`GroupLifecycleOps.followUp` never injected the guardrails at all.** It injects `groupTranscript`/`groupId`/`groupConversationId` but not `dynamicAgentConfig`, so the defense `MemberTurnExecutor` documents was bypassed on the entire follow-up path — no crash or resume needed. Now injected identically.
+4. **Two disagreeing defaults, and a Javadoc that was not true.** `ToolAssemblyContext`'s compact constructor normalizes a null config to a *disabled* one; `DynamicAgentToolsProvider` used a *permissive* one — and `contribute()` ignored `ctx.dynamicAgentConfig()` entirely and re-resolved from memory, despite `AgentOrchestrator#toolAssemblyContext` documenting that the value is resolved once "so two providers resolving it independently could [not] disagree". The provider now consumes the resolved value.
+5. **Withheld group tools are logged.** `GroupTaskToolsProvider`/`ArtifactToolsProvider` returned an empty contribution silently. Withholding is correct for a forged or finished discussion id — but it is also what happens if the discussion runs on another node, and that failure looked like "the model just lost its tools" with nothing to diagnose from.
+
+**Verified, not changed:** the node-affinity invariant `LiveDiscussionRegistry` rests on. Re-checked against the implementation rather than the note: `NatsConversationCoordinator.publishAndExecute` publishes only `conversationId.getBytes()` as an ordering marker and then runs the callable through `runtime.submitCallable` **locally**; no JetStream consumer deserializes or executes callables, and the payload could not carry one. A member turn cannot be routed off-node.
+
+Suites: 377 across DynamicAgentToolsProvider / AgentOrchestrator / GroupLifecycleOps / MemberTurnExecutor, all green, +7 new (`DynamicAgentConfigContextBoundaryTest`, one nest per observation point a–d).
+
+---
+
 ## 🔎 fix(groups): pre-merge deep review — facilitator HITL bypass, CALL_VOTE guards, metric cardinality, template honesty (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i10-templates`)

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOps.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOps.java
@@ -253,6 +253,16 @@ public class GroupLifecycleOps {
                 context.put("groupTranscript", new Context(Context.ContextType.object, followUpTranscript));
                 context.put("groupId", new Context(Context.ContextType.string, gc.getGroupId()));
                 context.put("groupConversationId", new Context(Context.ContextType.string, gc.getId()));
+                // Same injection, and for the same reason, as MemberTurnExecutor: a member
+                // turn that finds no dynamicAgentConfig falls back to the STANDALONE
+                // default, which is fully permissive. This path omitted it, so a follow-up
+                // question to a member of a group that never opted into dynamic agents
+                // handed that member creation/recruitment/delegation tools. An absent
+                // group config means "not opted in" — send an explicitly disabled one.
+                var dynamicAgentConfig = gc.getDynamicAgentConfig() != null
+                        ? gc.getDynamicAgentConfig()
+                        : new AgentGroupConfiguration.DynamicAgentConfig();
+                context.put("dynamicAgentConfig", new Context(Context.ContextType.object, dynamicAgentConfig));
                 inputData.setContext(context);
 
                 CompletableFuture<String> responseFuture = new CompletableFuture<>();

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ArtifactToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ArtifactToolsProvider.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.modules.llm.tools.impl.ArtifactTools;
 import ai.labs.eddi.modules.llm.tools.spi.ToolAssemblyContext;
 import ai.labs.eddi.modules.llm.tools.spi.ToolContribution;
 import ai.labs.eddi.modules.llm.tools.spi.ToolSourceProvider;
+import ai.labs.eddi.utils.LogSanitizer;
 import org.jboss.logging.Logger;
 
 import java.util.List;
@@ -71,7 +72,8 @@ class ArtifactToolsProvider implements ToolSourceProvider {
             // withholding makes an off-node discussion indistinguishable from a forged
             // id when the tools simply vanish mid-discussion.
             LOGGER.debugf("Withholding artifact tools for agent='%s': conversation '%s' is not a member of a discussion "
-                    + "'%s' running on this node", ctx.agentId(), callerConversationId, groupConversationId);
+                    + "'%s' running on this node", LogSanitizer.sanitize(ctx.agentId()), LogSanitizer.sanitize(callerConversationId),
+                    LogSanitizer.sanitize(groupConversationId));
             return ToolContribution.empty();
         }
         AgentGroupConfiguration groupConfiguration = resolveGroup(live.get().getGroupId());

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ArtifactToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ArtifactToolsProvider.java
@@ -67,6 +67,11 @@ class ArtifactToolsProvider implements ToolSourceProvider {
         String callerConversationId = ctx.memory() != null ? ctx.memory().getConversationId() : null;
         var live = liveDiscussionRegistry.getForMember(groupConversationId, callerConversationId);
         if (live.isEmpty()) {
+            // See GroupTaskToolsProvider: withholding is correct, but silent
+            // withholding makes an off-node discussion indistinguishable from a forged
+            // id when the tools simply vanish mid-discussion.
+            LOGGER.debugf("Withholding artifact tools for agent='%s': conversation '%s' is not a member of a discussion "
+                    + "'%s' running on this node", ctx.agentId(), callerConversationId, groupConversationId);
             return ToolContribution.empty();
         }
         AgentGroupConfiguration groupConfiguration = resolveGroup(live.get().getGroupId());

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/DynamicAgentToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/DynamicAgentToolsProvider.java
@@ -24,6 +24,9 @@ import ai.labs.eddi.modules.llm.tools.TeardownAgentTool;
 import ai.labs.eddi.modules.llm.tools.spi.ToolAssemblyContext;
 import ai.labs.eddi.modules.llm.tools.spi.ToolContribution;
 import ai.labs.eddi.modules.llm.tools.spi.ToolSourceProvider;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
@@ -117,7 +120,12 @@ class DynamicAgentToolsProvider implements ToolSourceProvider {
             return ToolContribution.empty();
         }
         List<Object> tools = new ArrayList<>();
-        addDynamicAgentTools(tools, ctx.builtInToolsWhitelist(), ctx.memory(), ctx.groupConversationId());
+        // The turn's already-resolved guardrails, not a second independent resolve.
+        // AgentOrchestrator#toolAssemblyContext documents that dynamicAgentConfig is
+        // resolved once "so two providers resolving it independently could [not]
+        // disagree" — but this provider re-resolved from memory and ignored the
+        // context, so the inconsistency the Javadoc warns about was in the code.
+        addDynamicAgentTools(tools, ctx.builtInToolsWhitelist(), ctx.memory(), ctx.groupConversationId(), ctx.dynamicAgentConfig());
         if (tools.isEmpty()) {
             return ToolContribution.empty();
         }
@@ -141,6 +149,17 @@ class DynamicAgentToolsProvider implements ToolSourceProvider {
     }
 
     void addDynamicAgentTools(List<Object> tools, List<String> whitelist, IConversationMemory memory, String groupConversationId) {
+        addDynamicAgentTools(tools, whitelist, memory, groupConversationId, null);
+    }
+
+    /**
+     * @param resolvedConfig
+     *            the turn's guardrails as resolved once by the assembly context, or
+     *            {@code null} to resolve them here (the direct-call entry points
+     *            that have no assembly context)
+     */
+    void addDynamicAgentTools(List<Object> tools, List<String> whitelist, IConversationMemory memory, String groupConversationId,
+                              DynamicAgentConfig resolvedConfig) {
         if (whitelist == null || whitelist.isEmpty()) {
             return;
         }
@@ -154,7 +173,7 @@ class DynamicAgentToolsProvider implements ToolSourceProvider {
         Set<String> sharedRetainedIds = ConcurrentHashMap.newKeySet();
         String parentAgentId = memory.getAgentId();
         String userId = memory.getUserId();
-        DynamicAgentConfig dynamicConfig = resolveDynamicAgentConfig(memory);
+        DynamicAgentConfig dynamicConfig = resolvedConfig != null ? resolvedConfig : resolveDynamicAgentConfig(memory);
 
         boolean anyDynamicToolAdded = false;
         if (whitelist.contains("create_sub_agent") && agentSetupService != null && conversationService != null) {
@@ -230,39 +249,190 @@ class DynamicAgentToolsProvider implements ToolSourceProvider {
         }
     }
 
+    /** Context key carrying the group's dynamic-agent guardrails. */
+    static final String CONTEXT_DYNAMIC_AGENT_CONFIG = "context:dynamicAgentConfig";
+
+    /** Context key proving the conversation belongs to a group discussion. */
+    private static final String CONTEXT_GROUP_CONVERSATION_ID = "context:groupConversationId";
+
     /**
-     * Resolves the DynamicAgentConfig for the current conversation. If the agent is
-     * participating in a group discussion, the group's {@link DynamicAgentConfig}
-     * is passed via context variable {@code dynamicAgentConfig} by
-     * {@code GroupConversationService}. If no group config is present (standalone
-     * agent), a permissive default is used.
+     * Tolerant reader for the guardrails, which arrive as a live POJO on the turn
+     * that injects them and as a plain {@code Map} on every turn read back from the
+     * store. Configured to ignore unknown properties so an older stored document
+     * cannot make the whole read fail — a failed read here means "no guardrails",
+     * which is the outcome this class exists to prevent.
+     */
+    private static final ObjectMapper CONFIG_MAPPER = JsonMapper.builder()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
+
+    /**
+     * Resolves the {@link DynamicAgentConfig} governing this turn.
+     * <p>
+     * <b>Why this is more than one {@code instanceof}.</b> The guardrails reach a
+     * member turn as a context variable that {@code MemberTurnExecutor} injects —
+     * deliberately, and with an explicitly <em>disabled</em> config when the group
+     * configured none, precisely so a group can never inherit the permissive
+     * standalone default. This method used to defeat that in two independent ways,
+     * both landing on {@link #createDefaultDynamicConfig()}:
+     * <ol>
+     * <li>It read the CURRENT step only. Any turn that re-enters a member
+     * conversation without a fresh injection — an HITL tool-approval resume, crash
+     * recovery, the group follow-up path — has no such context on its current
+     * step.</li>
+     * <li>It required a live {@link DynamicAgentConfig} instance. Conversation
+     * memory rebuilds a stored context as {@code new Context(type, map)}, so after
+     * any reload the value is a {@code Map} and the {@code instanceof} fails even
+     * when the key IS present.</li>
+     * </ol>
+     * Both are fixed here: earlier steps are consulted as a fallback (the same
+     * shape as {@code ContextualToolsProvider#resolveGroupIds} and
+     * {@link #resolveDelegationDepth}, which already do this for exactly the resume
+     * case), and a {@code Map} is coerced back into the config.
+     * <p>
+     * The remaining case — a conversation that demonstrably belongs to a group but
+     * whose guardrails cannot be resolved at all — now fails CLOSED. Substituting
+     * the permissive default there would hand roster-mutating, agent-deploying
+     * tools to a member of a discussion whose operator never opted in, which is the
+     * discipline every sibling provider in this package already applies.
      *
      * @param memory
      *            the conversation memory to check for group context
-     * @return the resolved DynamicAgentConfig — group-level if available,
-     *         permissive default otherwise
+     * @return the group's guardrails; a disabled config when the turn is part of a
+     *         group but they cannot be resolved; the permissive standalone default
+     *         only for a conversation with no group context at all
      */
     static DynamicAgentConfig resolveDynamicAgentConfig(IConversationMemory memory) {
-        // Check if GroupConversationService injected a DynamicAgentConfig via context
+        DynamicAgentConfig resolved = readDynamicAgentConfig(memory);
+        if (resolved != null) {
+            LOGGER.debugf("[DYNAMIC] Using group-level DynamicAgentConfig for agent='%s'", sanitize(memory.getAgentId()));
+            return resolved;
+        }
+
+        if (hasGroupContext(memory)) {
+            LOGGER.warnf("[DYNAMIC] Conversation of agent='%s' carries group context but no resolvable dynamicAgentConfig — "
+                    + "withholding dynamic-agent capabilities rather than falling back to the permissive standalone default",
+                    sanitize(memory.getAgentId()));
+            return new DynamicAgentConfig();
+        }
+
+        // Genuinely standalone agent — the permissive default it was written for.
+        return createDefaultDynamicConfig();
+    }
+
+    /**
+     * The injected guardrails from the current step, else the most recent earlier
+     * step that carries them, else {@code null}.
+     */
+    private static DynamicAgentConfig readDynamicAgentConfig(IConversationMemory memory) {
         var currentStep = memory.getCurrentStep();
         if (currentStep != null) {
-            var contextData = currentStep.getLatestData("context:dynamicAgentConfig");
-            if (contextData != null) {
-                Object value = contextData.getResult();
-                if (value instanceof Context ctx && ctx.getValue() instanceof DynamicAgentConfig groupConfig) {
-                    LOGGER.debugf("[DYNAMIC] Using group-level DynamicAgentConfig for agent='%s'", sanitize(memory.getAgentId()));
-                    return groupConfig;
+            DynamicAgentConfig fromCurrent = asDynamicAgentConfig(currentStep.getLatestData(CONTEXT_DYNAMIC_AGENT_CONFIG));
+            if (fromCurrent != null) {
+                return fromCurrent;
+            }
+        }
+
+        var allSteps = memory.getAllSteps();
+        if (allSteps != null) {
+            List<IData<Object>> priorEntries = allSteps.getAllLatestData(CONTEXT_DYNAMIC_AGENT_CONFIG);
+            if (priorEntries != null) {
+                for (IData<Object> entry : priorEntries) {
+                    DynamicAgentConfig fromPrior = asDynamicAgentConfig(entry);
+                    if (fromPrior != null) {
+                        return fromPrior;
+                    }
                 }
             }
         }
-        // Fallback: standalone agent — use permissive defaults
-        return createDefaultDynamicConfig();
+        return null;
+    }
+
+    /**
+     * Unwraps a {@code context:*} entry into guardrails, accepting both the live
+     * POJO and the map form read back from the store. Mirrors
+     * {@code AttachmentContextExtractor#asAttachment}, the existing precedent for
+     * this dual read.
+     */
+    private static DynamicAgentConfig asDynamicAgentConfig(IData<?> data) {
+        if (data == null || !(data.getResult() instanceof Context ctx)) {
+            return null;
+        }
+        Object value = ctx.getValue();
+        if (value instanceof DynamicAgentConfig config) {
+            return config;
+        }
+        if (!(value instanceof Map<?, ?> map) || map.isEmpty()) {
+            return null;
+        }
+        try {
+            // Whole-object conversion, not field-by-field: a guardrail added to
+            // DynamicAgentConfig later must not silently read back as its permissive
+            // Java default just because nobody remembered to map it here.
+            return CONFIG_MAPPER.convertValue(map, DynamicAgentConfig.class);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warnf("[DYNAMIC] Stored dynamicAgentConfig context could not be read back (%s) — treating it as unresolvable",
+                    e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Whether this conversation demonstrably belongs to a group discussion — what
+     * tells "standalone agent, use the permissive default" apart from "group member
+     * whose guardrails went missing".
+     * <p>
+     * A group-conversation id that actually carries a value is required, not merely
+     * an entry under the key. "The key exists" is too weak a claim to disable an
+     * agent's configured tools on: a blank or unreadable entry proves nothing, and
+     * treating it as proof would let any malformed step data silently strip a
+     * standalone agent of capabilities its designer explicitly whitelisted.
+     */
+    private static boolean hasGroupContext(IConversationMemory memory) {
+        var currentStep = memory.getCurrentStep();
+        if (currentStep != null && (carriesValue(currentStep.getLatestData(CONTEXT_GROUP_CONVERSATION_ID))
+                || carriesValue(currentStep.getLatestData(CONTEXT_DYNAMIC_AGENT_CONFIG)))) {
+            return true;
+        }
+        var allSteps = memory.getAllSteps();
+        if (allSteps == null) {
+            return false;
+        }
+        return anyCarriesValue(allSteps.getAllLatestData(CONTEXT_GROUP_CONVERSATION_ID))
+                || anyCarriesValue(allSteps.getAllLatestData(CONTEXT_DYNAMIC_AGENT_CONFIG));
+    }
+
+    /** True when the entry is a {@link Context} holding a non-blank value. */
+    private static boolean carriesValue(IData<?> data) {
+        if (data == null || !(data.getResult() instanceof Context ctx) || ctx.getValue() == null) {
+            return false;
+        }
+        return !(ctx.getValue() instanceof String s) || !s.isBlank();
+    }
+
+    private static boolean anyCarriesValue(List<IData<Object>> entries) {
+        if (entries == null) {
+            return false;
+        }
+        for (IData<Object> entry : entries) {
+            if (carriesValue(entry)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
      * Creates a default DynamicAgentConfig for agents without explicit group
      * config. Used when individual agents have dynamic agent tools in their
      * whitelist.
+     * <p>
+     * Permissive by design, and safe ONLY for a genuinely standalone conversation:
+     * the tools it governs are still gated by the agent's own
+     * {@code enableBuiltInTools} switch and built-in tool whitelist, so reaching
+     * this default means an agent designer explicitly asked for these tools outside
+     * any group. {@link #resolveDynamicAgentConfig} must never return it for a turn
+     * that belongs to a group.
      */
     static DynamicAgentConfig createDefaultDynamicConfig() {
         var config = new DynamicAgentConfig();

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/GroupTaskToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/GroupTaskToolsProvider.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.modules.llm.tools.impl.GroupTaskTools;
 import ai.labs.eddi.modules.llm.tools.spi.ToolAssemblyContext;
 import ai.labs.eddi.modules.llm.tools.spi.ToolContribution;
 import ai.labs.eddi.modules.llm.tools.spi.ToolSourceProvider;
+import ai.labs.eddi.utils.LogSanitizer;
 import org.jboss.logging.Logger;
 
 import java.util.List;
@@ -82,7 +83,8 @@ class GroupTaskToolsProvider implements ToolSourceProvider {
             // failure looks like "the model just lost its tools", with nothing to
             // diagnose it from.
             LOGGER.debugf("Withholding group task tools for agent='%s': conversation '%s' is not a member of a discussion "
-                    + "'%s' running on this node", ctx.agentId(), callerConversationId, groupConversationId);
+                    + "'%s' running on this node", LogSanitizer.sanitize(ctx.agentId()), LogSanitizer.sanitize(callerConversationId),
+                    LogSanitizer.sanitize(groupConversationId));
             return ToolContribution.empty();
         }
         AgentGroupConfiguration groupConfiguration = resolveGroup(live.get().getGroupId());

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/GroupTaskToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/GroupTaskToolsProvider.java
@@ -75,6 +75,14 @@ class GroupTaskToolsProvider implements ToolSourceProvider {
         String callerConversationId = ctx.memory() != null ? ctx.memory().getConversationId() : null;
         var live = liveDiscussionRegistry.getForMember(groupConversationId, callerConversationId);
         if (live.isEmpty()) {
+            // Logged, not silent. Withholding is the correct answer for a forged or
+            // finished discussion id, but it is also what happens if the discussion is
+            // running on ANOTHER node — the registry is per-node and correctness rests
+            // on member turns always executing in-process. Without this line that
+            // failure looks like "the model just lost its tools", with nothing to
+            // diagnose it from.
+            LOGGER.debugf("Withholding group task tools for agent='%s': conversation '%s' is not a member of a discussion "
+                    + "'%s' running on this node", ctx.agentId(), callerConversationId, groupConversationId);
             return ToolContribution.empty();
         }
         AgentGroupConfiguration groupConfiguration = resolveGroup(live.get().getGroupId());

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/DynamicAgentConfigContextBoundaryTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/DynamicAgentConfigContextBoundaryTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DynamicAgentConfig;
+import ai.labs.eddi.engine.memory.IConversationMemory;
+import ai.labs.eddi.engine.memory.IConversationMemory.IConversationStepStack;
+import ai.labs.eddi.engine.memory.IConversationMemory.IWritableConversationStep;
+import ai.labs.eddi.engine.memory.IData;
+import ai.labs.eddi.engine.memory.model.Data;
+import ai.labs.eddi.engine.model.Context;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The {@code dynamicAgentConfig} context is the only typed POJO the system
+ * injects into conversation context, and it gates the tools that deploy real
+ * agents to production. These tests pin what it must resolve to on each of the
+ * four occasions the value can be observed: the injecting turn, a turn read
+ * back from the store, a turn with no injection at all, and a genuinely
+ * standalone conversation.
+ */
+@DisplayName("dynamicAgentConfig — context serialization boundary")
+class DynamicAgentConfigContextBoundaryTest {
+
+    private static final String CONTEXT_KEY = "context:dynamicAgentConfig";
+    private static final String GROUP_KEY = "context:groupConversationId";
+
+    /** Guardrails a cautious operator would write: everything off. */
+    private static DynamicAgentConfig restrictiveConfig() {
+        var config = new DynamicAgentConfig();
+        config.setEnabled(false);
+        config.setAllowCreation(false);
+        config.setAllowRecruitment(false);
+        config.setAllowDelegation(false);
+        config.setMaxCreatedAgentsPerDiscussion(1);
+        return config;
+    }
+
+    /**
+     * Exactly what conversation memory does to a stored context: the typed value
+     * becomes a plain map, and is rebuilt as {@code new Context(type, map)}.
+     *
+     * @see ai.labs.eddi.engine.memory.ConversationMemoryStore
+     */
+    private static Context afterStoreRoundTrip(DynamicAgentConfig config) {
+        Map<?, ?> asDocument = new ObjectMapper().convertValue(config, Map.class);
+        return new Context(Context.ContextType.object, asDocument);
+    }
+
+    /**
+     * A memory whose current step holds {@code currentStepData} and whose earlier
+     * steps hold {@code priorStepData} — the shape {@code getAllLatestData}
+     * returns.
+     */
+    private static IConversationMemory memoryWith(Map<String, Object> currentStepData, Map<String, Object> priorStepData) {
+        var memory = mock(IConversationMemory.class);
+        when(memory.getAgentId()).thenReturn("member-agent");
+        when(memory.getUserId()).thenReturn("user-1");
+
+        var currentStep = mock(IWritableConversationStep.class);
+        for (var entry : currentStepData.entrySet()) {
+            when(currentStep.getLatestData(entry.getKey())).thenReturn(new Data<>(entry.getKey(), entry.getValue()));
+        }
+        when(memory.getCurrentStep()).thenReturn(currentStep);
+
+        var allSteps = mock(IConversationStepStack.class);
+        for (var entry : priorStepData.entrySet()) {
+            List<IData<Object>> entries = List.of(new Data<>(entry.getKey(), entry.getValue()));
+            when(allSteps.getAllLatestData(entry.getKey())).thenReturn(entries);
+        }
+        when(memory.getAllSteps()).thenReturn(allSteps);
+        return memory;
+    }
+
+    @Nested
+    @DisplayName("(a) on the injecting turn")
+    class InjectingTurn {
+
+        @Test
+        @DisplayName("the live POJO is used as-is")
+        void livePojoIsUsed() {
+            var injected = restrictiveConfig();
+            var memory = memoryWith(Map.of(CONTEXT_KEY, new Context(Context.ContextType.object, injected)), Map.of());
+
+            assertEquals(injected, DynamicAgentToolsProvider.resolveDynamicAgentConfig(memory));
+        }
+    }
+
+    @Nested
+    @DisplayName("(b) after a store round-trip")
+    class AfterStoreReload {
+
+        /**
+         * The defect: conversation memory rebuilds a stored context with a Map value,
+         * so an {@code instanceof DynamicAgentConfig} check failed even though the key
+         * was present — and the resolver fell through to the fully permissive
+         * standalone default.
+         */
+        @Test
+        @DisplayName("the map form still resolves to the configured guardrails, not the permissive default")
+        void mapFormIsCoerced() {
+            var memory = memoryWith(Map.of(CONTEXT_KEY, afterStoreRoundTrip(restrictiveConfig())), Map.of());
+
+            DynamicAgentConfig resolved = DynamicAgentToolsProvider.resolveDynamicAgentConfig(memory);
+
+            assertFalse(resolved.isEnabled(), "a reloaded turn must not silently become enabled");
+            assertFalse(resolved.isAllowCreation(), "a reloaded turn must not silently gain agent creation");
+            assertFalse(resolved.isAllowRecruitment());
+            assertFalse(resolved.isAllowDelegation());
+            assertEquals(1, resolved.getMaxCreatedAgentsPerDiscussion(), "numeric caps must survive the round-trip too");
+        }
+
+        @Test
+        @DisplayName("a permissive group config still round-trips as permissive")
+        void permissiveConfigSurvivesToo() {
+            var permissive = new DynamicAgentConfig();
+            permissive.setEnabled(true);
+            permissive.setAllowCreation(true);
+            permissive.setMaxCreatedAgentsPerDiscussion(7);
+
+            var memory = memoryWith(Map.of(CONTEXT_KEY, afterStoreRoundTrip(permissive)), Map.of());
+
+            DynamicAgentConfig resolved = DynamicAgentToolsProvider.resolveDynamicAgentConfig(memory);
+            assertTrue(resolved.isEnabled());
+            assertTrue(resolved.isAllowCreation());
+            assertEquals(7, resolved.getMaxCreatedAgentsPerDiscussion(), "coercion must not flatten values back to defaults");
+        }
+    }
+
+    @Nested
+    @DisplayName("(c) on a turn with no fresh injection — resume, crash recovery, follow-up")
+    class NoFreshInjection {
+
+        /**
+         * A resumed turn re-enters without the original context map. The sibling
+         * resolvers ({@code resolveGroupIds}, {@code resolveDelegationDepth}) already
+         * fall back to earlier steps for exactly this reason; this one did not.
+         */
+        @Test
+        @DisplayName("falls back to the guardrails carried by an earlier step")
+        void fallsBackToEarlierStep() {
+            var memory = memoryWith(Map.of(), Map.of(CONTEXT_KEY, afterStoreRoundTrip(restrictiveConfig())));
+
+            DynamicAgentConfig resolved = DynamicAgentToolsProvider.resolveDynamicAgentConfig(memory);
+
+            assertFalse(resolved.isAllowCreation(), "the group's guardrails must survive a turn that carries no context");
+        }
+
+        /**
+         * The fail-closed rule. A conversation that is demonstrably part of a group but
+         * whose guardrails cannot be resolved must not inherit the permissive
+         * standalone default — that would hand agent-deploying tools to a member of a
+         * discussion whose operator never opted in.
+         */
+        @Test
+        @DisplayName("group context with unresolvable guardrails fails CLOSED")
+        void groupContextWithoutConfigFailsClosed() {
+            var memory = memoryWith(Map.of(GROUP_KEY, new Context(Context.ContextType.string, "gc-1")), Map.of());
+
+            DynamicAgentConfig resolved = DynamicAgentToolsProvider.resolveDynamicAgentConfig(memory);
+
+            assertFalse(resolved.isEnabled(), "a group turn with no resolvable config must not be enabled");
+            assertFalse(resolved.isAllowCreation(), "a group turn with no resolvable config must not permit agent creation");
+            assertFalse(resolved.isAllowRecruitment());
+        }
+
+        @Test
+        @DisplayName("an unreadable stored value also fails closed for a group turn")
+        void malformedValueFailsClosed() {
+            var memory = memoryWith(Map.of(CONTEXT_KEY, new Context(Context.ContextType.object, "not-a-config")), Map.of());
+
+            DynamicAgentConfig resolved = DynamicAgentToolsProvider.resolveDynamicAgentConfig(memory);
+
+            assertFalse(resolved.isAllowCreation());
+        }
+    }
+
+    @Nested
+    @DisplayName("(d) a genuinely standalone conversation")
+    class Standalone {
+
+        /**
+         * The permissive default must stay reachable for the case it was written for: a
+         * lone agent whose designer explicitly whitelisted these tools. Failing closed
+         * everywhere would silently disable a supported configuration.
+         */
+        @Test
+        @DisplayName("keeps the permissive default")
+        void permissiveDefaultPreserved() {
+            var memory = memoryWith(Map.of(), Map.of());
+
+            DynamicAgentConfig resolved = DynamicAgentToolsProvider.resolveDynamicAgentConfig(memory);
+
+            assertTrue(resolved.isEnabled());
+            assertTrue(resolved.isAllowCreation());
+            assertTrue(resolved.isAllowRecruitment());
+            assertTrue(resolved.isAllowDelegation());
+        }
+    }
+}


### PR DESCRIPTION
A systematic sweep of the Context serialization boundary: for every context the system injects, what type does it hold **(a)** on the injecting turn, **(b)** after a store reload, **(c)** after crash recovery, **(d)** on another node?

Nine context keys. Eight are strings, lists or maps and survive unchanged. **`dynamicAgentConfig` is the only typed POJO the system injects — and it is the one that gates the tools that deploy real agents to production.**

| key | injected as | after reload | verdict |
|---|---|---|---|
| `groupId`, `groupConversationId`, `groupDepth`, `delegationDepth` | String | String | OK |
| `groupTranscript`, `schedule`, `attachment_N` | List / Map | List / Map | OK |
| `mcp`, `slack`, `lang`, `channelIntent` | String | String | OK |
| **`dynamicAgentConfig`** | **POJO** | **Map** | **broken** |

## 1. The resolver failed open in two independent ways

`MemberTurnExecutor` injects the group's guardrails on every member turn, and deliberately injects an explicitly **disabled** config when the group configured none. Its comment says exactly why: a member turn that finds no config falls back to the STANDALONE default, which is fully permissive — creation, recruitment and delegation all on.

`resolveDynamicAgentConfig` defeated that defense twice:

1. **Current step only.** Any turn that re-enters without a fresh injection — an HITL tool-approval resume, crash recovery, the group follow-up path — saw nothing.
2. **Typed-object assumption.** `ConversationMemoryStore` and `PostgresConversationMemoryStore` both rebuild a stored context as `new Context(type, map.get("value"))`. After **any** reload the value is a `Map`, so the `instanceof DynamicAgentConfig` failed even when the key *was* present.

Both paths landed on the permissive default.

This was the only sibling resolver that did not already handle the resume case — `ContextualToolsProvider#resolveGroupIds` and `resolveDelegationDepth` both fall back to earlier steps, with comments explaining that a resumed turn re-enters without the original context map. Fixed the same way, plus whole-object Jackson coercion of the map form (not field-by-field — a guardrail added later must not silently read back as its permissive Java default).

## 2. Unresolvable guardrails on a group turn now fail CLOSED

A conversation that demonstrably belongs to a group but whose config cannot be resolved returns a disabled config instead of the permissive default — the discipline `GroupTaskToolsProvider` and `ArtifactToolsProvider` already state.

The group probe requires a context entry that actually **carries a value**, not merely a key. "The key exists" is too weak a claim to strip a standalone agent of tools its designer explicitly whitelisted.

## 3. `GroupLifecycleOps.followUp` never injected the guardrails at all

It injects `groupTranscript` / `groupId` / `groupConversationId` but not `dynamicAgentConfig` — so the defense `MemberTurnExecutor` documents was bypassed on the **entire follow-up path**, with no crash or resume needed. Now injected identically.

## 4. Two disagreeing defaults, and a Javadoc that was not true

`ToolAssemblyContext`'s compact constructor normalizes a null config to a **disabled** one. `DynamicAgentToolsProvider` used a **permissive** one. And `contribute()` ignored `ctx.dynamicAgentConfig()` entirely, re-resolving from memory — despite `AgentOrchestrator#toolAssemblyContext` documenting that the value is resolved once "so two providers resolving it independently could [not] disagree". The inconsistency the Javadoc warns about was already in the code. The provider now consumes the resolved value.

## 5. Withheld group tools are logged

`GroupTaskToolsProvider` / `ArtifactToolsProvider` returned an empty contribution silently. Withholding is correct for a forged or finished discussion id — but it is also what happens if the discussion runs on **another node**, and that failure looked like "the model just lost its tools" with nothing to diagnose from.

## Verified, not changed: the node-affinity invariant

`LiveDiscussionRegistry`'s correctness rests on "a member turn always runs in-process". Re-checked against the implementation rather than the changelog note: `NatsConversationCoordinator.publishAndExecute` publishes only `conversationId.getBytes()` as an ordering marker and then runs the callable through `runtime.submitCallable` **locally**. No JetStream consumer deserializes or executes callables, and the payload could not carry one. A member turn cannot be routed off-node. Invariant holds.

## Testing

377 tests across `DynamicAgentToolsProvider` / `AgentOrchestrator` / `GroupLifecycleOps` / `MemberTurnExecutor` stay green. +7 new in `DynamicAgentConfigContextBoundaryTest`, one nest per observation point (a)–(d).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dynamic agent configuration handling across resumed conversations and group follow-ups.
  - Preserved configuration settings when conversations are restored from saved data.
  - Added safer fallback behavior when group configurations are missing or invalid.
  - Ensured earlier conversation context is checked when current configuration is unavailable.

- **Documentation**
  - Added changelog details covering configuration handling, tool access safeguards, and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->