### PR TITLE
feat(vault): enforce allowedAgents at deploy time instead of documenting it

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,28 @@
 
 ---
 
+## 🔒 feat(vault): allowedAgents is enforced instead of decorative (2026-08-09)
+
+**Repo:** EDDI (`feat/vault-allowed-agents-enforcement`)
+
+`SecretMetadata.allowedAgents` was documented as *"for visibility only — enforcement is via configuration authorship, not runtime resolution"*. That access model assumes a **human admin** authors agent configurations. `create_sub_agent` lets an LLM author one, so an operator who scoped a secret to a single agent got no enforcement at all — the field was decorative.
+
+**Enforced at deployment, deliberately not at resolution.** Resolution is the tempting place and the wrong one:
+- `SecretResolver` sees only a string. It has no agent identity, and its ~12 call sites include several that legitimately run outside any conversation (embedding-store construction, channel routing); `AgentSigningService` bypasses it entirely.
+- `ChatModelRegistry` caches the built model keyed on the **unresolved** parameters, so two agents sharing a config share a cache entry. A check behind that cache runs for whichever agent built the model first and is silently skipped for every other one — enforcement that looks real and is not. Making it sound would require the agent identity in `ModelCacheKey` plus plumbing through six call sites, several of them background services with no agent at all.
+
+The binding between an agent and a secret is established in the agent's **configuration**, so that is where it is checked: completely, once, and with no cache in the way. `VaultGrantChecker` walks the agent's workflows → llm/apicalls/mcpcalls configs, serializes each and scans for `${vault:...}` references, then verifies each against `allowedAgents`. The scan serializes rather than enumerating known credential fields — enumeration is how this kind of check rots when a new credential field is added.
+
+**Rollout is warn-first.** `eddi.vault.grant-enforcement` is `off` | `warn` (default) | `enforce`. Warn is deliberate: the field has never been enforced, so any non-wildcard value in an existing deployment is untested configuration, and blocking on it during an upgrade could take agents down for a policy nobody has had the chance to verify. Operators switch to `enforce` once the warnings are clean.
+
+**Uncertainty never becomes a violation.** Unreadable metadata, a disabled vault, an unreadable workflow, an absent/empty/wildcard grant — all allow. A deployment gate that fires on a transient store failure is worse than the hole it closes.
+
+**What it does not do:** an agent already deployed before its grant was narrowed keeps resolving until redeployed. This is a deploy-time gate, not a revocation mechanism.
+
++9 tests. One of them initially passed vacuously because the fixture used toy ids — `RestUtilities.extractResourceId` needs ≥18 hex characters and returns a null id otherwise, so the scanner found nothing; the fixture now uses ObjectId-shaped ids.
+
+---
+
 ## 🔎 fix(groups): pre-merge deep review — facilitator HITL bypass, CALL_VOTE guards, metric cardinality, template honesty (2026-08-08)
 
 **Repo:** EDDI (`feat/group-i10-templates`)

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
@@ -35,6 +35,7 @@ import ai.labs.eddi.utils.RestUtilities;
 import io.quarkus.runtime.Startup;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -195,15 +196,13 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                                 return;
                             }
 
-                            if (!vaultGrantsSatisfied(deploymentInfo.getAgentId(), deploymentInfo.getAgentVersion())) {
+                            if (!deployIfGranted(deploymentInfo.getEnvironment(), deploymentInfo.getAgentId(),
+                                    deploymentInfo.getAgentVersion())) {
                                 // enforce mode only — the agent names a secret it is not
                                 // granted. Left un-added to deploymentInfos so a corrected
                                 // grant is picked up by the next poll.
                                 return;
                             }
-
-                            agentFactory.deployAgent(deploymentInfo.getEnvironment(), deploymentInfo.getAgentId(), deploymentInfo.getAgentVersion(),
-                                    null);
 
                             this.deploymentInfos.add(deploymentInfo);
 
@@ -263,8 +262,67 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
      *         {@code eddi.vault.grant-enforcement=enforce} and a provable violation
      *         was found
      */
+    /**
+     * The ONLY way this class deploys an agent.
+     * <p>
+     * The gate previously guarded {@link #checkDeployments()} alone, while
+     * {@code manageAgentDeployments}' latest-version redeploy and
+     * {@link #manageDeploymentOfOldAgent} called the factory directly — so in
+     * {@code enforce} mode an agent with ungranted vault references was blocked by
+     * one path and deployed by another a day later. A gate with a way round it is
+     * not a gate, so there is now a single entry point rather than three call sites
+     * that each have to remember.
+     *
+     * @return {@code true} if the agent was deployed
+     */
+    private boolean deployIfGranted(Environment environment, String agentId, Integer agentVersion)
+            throws ServiceException, IllegalAccessException {
+
+        if (!vaultGrantsSatisfied(agentId, agentVersion)) {
+            return false;
+        }
+        agentFactory.deployAgent(environment, agentId, agentVersion, null);
+        return true;
+    }
+
+    /** Enforcement modes for {@code eddi.vault.grant-enforcement}. */
+    enum GrantEnforcement {
+        OFF, WARN, ENFORCE;
+
+        /**
+         * Strict parse — an unrecognised value is rejected, never defaulted.
+         * {@code grant-enforcement=enforced} silently behaving as {@code warn} would
+         * turn one typo into a security control that is off while appearing on.
+         */
+        static GrantEnforcement parseStrict(String value) {
+            if (value == null || value.isBlank()) {
+                return WARN;
+            }
+            for (GrantEnforcement mode : values()) {
+                if (mode.name().equalsIgnoreCase(value.trim())) {
+                    return mode;
+                }
+            }
+            throw new IllegalArgumentException("Unknown eddi.vault.grant-enforcement value '" + value
+                    + "'. Valid values: off, warn, enforce");
+        }
+    }
+
+    /**
+     * Fails startup on an unusable enforcement mode rather than degrading to warn.
+     * This bean is {@code @Startup}, so the error surfaces at boot with the valid
+     * values named — the same discipline {@code Deployment.Environment.parseStrict}
+     * applies where an environment is acted on.
+     */
+    @PostConstruct
+    void validateGrantEnforcement() {
+        grantEnforcement = GrantEnforcement.parseStrict(vaultGrantEnforcement);
+    }
+
+    private GrantEnforcement grantEnforcement = GrantEnforcement.WARN;
+
     private boolean vaultGrantsSatisfied(String agentId, Integer agentVersion) {
-        if (vaultGrantChecker == null || "off".equalsIgnoreCase(vaultGrantEnforcement)) {
+        if (vaultGrantChecker == null || grantEnforcement == GrantEnforcement.OFF) {
             return true;
         }
         List<String> ungranted;
@@ -279,7 +337,7 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
             return true;
         }
 
-        boolean enforce = "enforce".equalsIgnoreCase(vaultGrantEnforcement);
+        boolean enforce = grantEnforcement == GrantEnforcement.ENFORCE;
         String message = format(
                 "Agent (id=%s, version=%d) references vault secret(s) it is not granted: %s. "
                         + "SecretMetadata.allowedAgents lists which agents may use a secret; widen the grant or remove the reference.",
@@ -410,7 +468,7 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
 
                                 if (latestAgent != null && latestAgent.getVersion() <= agentVersion) {
                                     // we attempt to deploy a Agent if it is the latest
-                                    agentFactory.deployAgent(environment, agentId, agentVersion, null);
+                                    deployIfGranted(environment, agentId, agentVersion);
                                 } else {
                                     manageDeploymentOfOldAgent(environment, agentId, agentVersion);
 
@@ -459,7 +517,7 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
         } else {
             // not the latest agent, but still has active conversations connected to it,
             // therefore we deploy it as well to make sure we don't interrupt UX
-            agentFactory.deployAgent(environment, agentId, agentVersion, null);
+            deployIfGranted(environment, agentId, agentVersion);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
@@ -28,6 +28,7 @@ import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.runtime.IRuntime;
 import ai.labs.eddi.engine.runtime.internal.readiness.IAgentsReadiness;
 import ai.labs.eddi.engine.runtime.service.ServiceException;
+import ai.labs.eddi.secrets.VaultGrantChecker;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.utils.RestUtilities;
@@ -83,6 +84,29 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
     private Instant lastDeploymentCheck = null;
     private static final Logger LOGGER = Logger.getLogger(AgentDeploymentManagement.class);
     private final List<DeploymentInfo> deploymentInfos = new LinkedList<>();
+
+    /**
+     * Deploy-time vault-grant gate. Field-injected rather than a constructor
+     * parameter so a directly constructed instance (tests, non-CDI callers) simply
+     * sees {@code null} and skips the check — the same pattern the engine already
+     * uses for late-bound collaborators.
+     */
+    @Inject
+    VaultGrantChecker vaultGrantChecker;
+
+    /**
+     * What to do when an agent's config names a vault secret it is not granted:
+     * {@code off}, {@code warn} (default) or {@code enforce}.
+     * <p>
+     * Warn is the default deliberately. {@code allowedAgents} has never been
+     * enforced, so any non-wildcard value in an existing deployment is untested
+     * configuration — blocking on it during an upgrade could take agents down for a
+     * policy nobody has yet had the chance to verify. Operators turn on
+     * {@code enforce} once the warnings are clean.
+     */
+    @Inject
+    @ConfigProperty(name = "eddi.vault.grant-enforcement", defaultValue = "warn")
+    String vaultGrantEnforcement;
 
     @Inject
     public AgentDeploymentManagement(IDeploymentStore deploymentStore, IAgentFactory agentFactory, IAgentStore agentStore,
@@ -171,6 +195,13 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                                 return;
                             }
 
+                            if (!vaultGrantsSatisfied(deploymentInfo.getAgentId(), deploymentInfo.getAgentVersion())) {
+                                // enforce mode only — the agent names a secret it is not
+                                // granted. Left un-added to deploymentInfos so a corrected
+                                // grant is picked up by the next poll.
+                                return;
+                            }
+
                             agentFactory.deployAgent(deploymentInfo.getEnvironment(), deploymentInfo.getAgentId(), deploymentInfo.getAgentVersion(),
                                     null);
 
@@ -222,6 +253,43 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
             t = t.getCause();
         }
         return false;
+    }
+
+    /**
+     * Deploy-time check that every vault reference this agent's configuration names
+     * is granted to it.
+     *
+     * @return {@code true} when deployment may proceed — always true unless
+     *         {@code eddi.vault.grant-enforcement=enforce} and a provable violation
+     *         was found
+     */
+    private boolean vaultGrantsSatisfied(String agentId, Integer agentVersion) {
+        if (vaultGrantChecker == null || "off".equalsIgnoreCase(vaultGrantEnforcement)) {
+            return true;
+        }
+        List<String> ungranted;
+        try {
+            ungranted = vaultGrantChecker.findUngrantedReferences(agentStore.read(agentId, agentVersion), agentId);
+        } catch (Exception e) {
+            // A check that cannot run must never block a deployment.
+            LOGGER.warn(format("Skipping the vault-grant check for Agent (id=%s, version=%d): %s", agentId, agentVersion, e.getMessage()));
+            return true;
+        }
+        if (ungranted.isEmpty()) {
+            return true;
+        }
+
+        boolean enforce = "enforce".equalsIgnoreCase(vaultGrantEnforcement);
+        String message = format(
+                "Agent (id=%s, version=%d) references vault secret(s) it is not granted: %s. "
+                        + "SecretMetadata.allowedAgents lists which agents may use a secret; widen the grant or remove the reference.",
+                agentId, agentVersion, ungranted);
+        if (enforce) {
+            LOGGER.error(message + " Deployment BLOCKED (eddi.vault.grant-enforcement=enforce).");
+            return false;
+        }
+        LOGGER.warn(message + " Deployment allowed (eddi.vault.grant-enforcement=warn); set it to 'enforce' to block.");
+        return true;
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/secrets/VaultGrantChecker.java
+++ b/src/main/java/ai/labs/eddi/secrets/VaultGrantChecker.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.secrets;
+
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.apicalls.IApiCallsStore;
+import ai.labs.eddi.configs.llm.ILlmStore;
+import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.secrets.model.SecretMetadata;
+import ai.labs.eddi.secrets.model.SecretReference;
+import ai.labs.eddi.utils.RestUtilities;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+/**
+ * Checks, at deployment time, that every vault reference an agent's
+ * configuration names is actually granted to that agent.
+ * <p>
+ * <b>Why this exists.</b> {@code SecretMetadata.allowedAgents} was documented
+ * as "for visibility only — enforcement is via configuration authorship, not
+ * runtime resolution". That access model rests on an assumption that no longer
+ * holds everywhere: it assumes a <em>human admin</em> authors agent
+ * configurations. {@code create_sub_agent} lets an LLM author one. An operator
+ * who scopes a secret to one agent therefore got no enforcement at all — the
+ * field was decorative.
+ * <p>
+ * <b>Why deployment time, and not resolution time.</b> Resolution is the
+ * tempting place and the wrong one:
+ * <ul>
+ * <li>{@link SecretResolver} sees only a string. It has no agent identity, and
+ * its ~12 call sites include several that legitimately run outside any
+ * conversation (embedding-store construction, channel routing, agent
+ * signing).</li>
+ * <li>{@code ChatModelRegistry} caches the built model keyed on the
+ * <em>unresolved</em> parameters, so two agents sharing a config share a cache
+ * entry. A check behind that cache runs for whichever agent built the model
+ * first and is silently skipped for every other one — enforcement that looks
+ * real and is not.</li>
+ * </ul>
+ * The binding between an agent and a secret is established in the agent's
+ * <em>configuration</em>, so that is where it can be checked completely, once,
+ * and without a cache in the way.
+ * <p>
+ * <b>What it cannot do.</b> An agent already deployed before its grant was
+ * narrowed keeps resolving until it is redeployed. This is a deploy-time gate,
+ * not a revocation mechanism.
+ */
+@ApplicationScoped
+public class VaultGrantChecker {
+
+    private static final Logger LOGGER = Logger.getLogger(VaultGrantChecker.class);
+
+    /** Grants every agent access — the default written by the setup wizard. */
+    static final String WILDCARD = "*";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final ISecretProvider secretProvider;
+    private final IWorkflowStore workflowStore;
+    private final ILlmStore llmStore;
+    private final IApiCallsStore apiCallsStore;
+    private final IMcpCallsStore mcpCallsStore;
+
+    @Inject
+    public VaultGrantChecker(ISecretProvider secretProvider, IWorkflowStore workflowStore, ILlmStore llmStore,
+            IApiCallsStore apiCallsStore, IMcpCallsStore mcpCallsStore) {
+        this.secretProvider = secretProvider;
+        this.workflowStore = workflowStore;
+        this.llmStore = llmStore;
+        this.apiCallsStore = apiCallsStore;
+        this.mcpCallsStore = mcpCallsStore;
+    }
+
+    /**
+     * Every vault reference in {@code agentConfiguration}'s extension configs that
+     * is NOT granted to {@code agentId}.
+     * <p>
+     * Only a provable violation is reported. A secret whose metadata cannot be read
+     * — vault disabled, secret absent, provider error — is skipped: "could not
+     * determine the grant" is not "the grant is missing", and a deployment gate
+     * that fires on a transient store failure is worse than the hole it closes.
+     *
+     * @return the offending references, empty when the agent is fully granted
+     */
+    public List<String> findUngrantedReferences(AgentConfiguration agentConfiguration, String agentId) {
+        if (agentConfiguration == null || agentId == null || !secretProvider.isAvailable()) {
+            return List.of();
+        }
+
+        List<String> violations = new ArrayList<>();
+        for (String reference : collectVaultReferences(agentConfiguration)) {
+            if (!isGranted(reference, agentId)) {
+                violations.add(reference);
+            }
+        }
+        return violations;
+    }
+
+    /**
+     * Whether {@code agentId} may use {@code reference}. Absent, empty and wildcard
+     * grant lists all allow — those are the shapes that mean "not restricted", and
+     * the wizard writes the wildcard for every key it vaults.
+     */
+    private boolean isGranted(String reference, String agentId) {
+        SecretMetadata metadata;
+        try {
+            metadata = secretProvider.getMetadata(SecretReference.parse(reference));
+        } catch (Exception e) {
+            LOGGER.debugf("Could not read grant metadata for %s (%s) — not treating it as a violation",
+                    reference, e.getClass().getSimpleName());
+            return true;
+        }
+        if (metadata == null || metadata.allowedAgents() == null || metadata.allowedAgents().isEmpty()) {
+            return true;
+        }
+        return metadata.allowedAgents().stream()
+                .anyMatch(granted -> WILDCARD.equals(granted) || (granted != null && granted.equals(agentId)));
+    }
+
+    /**
+     * Every distinct {@code ${vault:...}} reference reachable from the agent's
+     * workflows.
+     * <p>
+     * Each extension config is serialized and scanned as a whole rather than having
+     * its secret-bearing fields enumerated. Enumeration is how this kind of check
+     * rots: a new credential field is added somewhere and the scanner silently
+     * stops covering it.
+     */
+    private Set<String> collectVaultReferences(AgentConfiguration agentConfiguration) {
+        Set<String> references = new LinkedHashSet<>();
+        if (agentConfiguration.getWorkflows() == null) {
+            return references;
+        }
+
+        for (URI workflowUri : agentConfiguration.getWorkflows()) {
+            WorkflowConfiguration workflow = readWorkflow(workflowUri);
+            if (workflow == null || workflow.getWorkflowSteps() == null) {
+                continue;
+            }
+            for (WorkflowConfiguration.WorkflowStep step : workflow.getWorkflowSteps()) {
+                Object configuredUri = step.getConfig() != null ? step.getConfig().get("uri") : null;
+                if (step.getType() == null || configuredUri == null) {
+                    continue;
+                }
+                Object extensionConfig = readExtensionConfig(step.getType().toString(), configuredUri.toString());
+                if (extensionConfig != null) {
+                    scanForVaultReferences(extensionConfig, references);
+                }
+            }
+        }
+        return references;
+    }
+
+    private WorkflowConfiguration readWorkflow(URI workflowUri) {
+        try {
+            IResourceId id = RestUtilities.extractResourceId(workflowUri);
+            return id == null ? null : workflowStore.read(id.getId(), id.getVersion());
+        } catch (Exception e) {
+            LOGGER.debugf("Could not read workflow %s while checking vault grants: %s", workflowUri, e.getMessage());
+            return null;
+        }
+    }
+
+    /** The extension config behind a workflow step, or {@code null}. */
+    private Object readExtensionConfig(String stepType, String configUri) {
+        try {
+            IResourceId id = RestUtilities.extractResourceId(URI.create(configUri));
+            if (id == null) {
+                return null;
+            }
+            if (stepType.contains("ai.labs.llm")) {
+                return llmStore.read(id.getId(), id.getVersion());
+            }
+            if (stepType.contains("ai.labs.httpcalls") || stepType.contains("ai.labs.apicalls")) {
+                return apiCallsStore.read(id.getId(), id.getVersion());
+            }
+            if (stepType.contains("ai.labs.mcpcalls")) {
+                return mcpCallsStore.read(id.getId(), id.getVersion());
+            }
+        } catch (Exception e) {
+            LOGGER.debugf("Could not read %s config %s while checking vault grants: %s", stepType, configUri, e.getMessage());
+        }
+        return null;
+    }
+
+    private static void scanForVaultReferences(Object config, Set<String> sink) {
+        String serialized;
+        try {
+            serialized = MAPPER.writeValueAsString(config);
+        } catch (Exception e) {
+            return;
+        }
+        Matcher matcher = SecretReference.compiledPattern().matcher(serialized);
+        while (matcher.find()) {
+            sink.add(matcher.group(0));
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/GrantEnforcementModeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/GrantEnforcementModeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.runtime.internal;
+
+import ai.labs.eddi.engine.runtime.internal.AgentDeploymentManagement.GrantEnforcement;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code eddi.vault.grant-enforcement} gates a security control, so an
+ * unrecognised value must be rejected rather than quietly meaning "warn".
+ */
+@DisplayName("eddi.vault.grant-enforcement — strict parsing")
+class GrantEnforcementModeTest {
+
+    @Test
+    @DisplayName("the three supported modes parse, case-insensitively")
+    void supportedModes() {
+        assertEquals(GrantEnforcement.OFF, GrantEnforcement.parseStrict("off"));
+        assertEquals(GrantEnforcement.WARN, GrantEnforcement.parseStrict("warn"));
+        assertEquals(GrantEnforcement.ENFORCE, GrantEnforcement.parseStrict("enforce"));
+        assertEquals(GrantEnforcement.ENFORCE, GrantEnforcement.parseStrict("  ENFORCE "));
+    }
+
+    @Test
+    @DisplayName("absent means warn")
+    void absentMeansWarn() {
+        assertEquals(GrantEnforcement.WARN, GrantEnforcement.parseStrict(null));
+        assertEquals(GrantEnforcement.WARN, GrantEnforcement.parseStrict("   "));
+    }
+
+    /**
+     * The failure that motivated this: {@code enforced} is a plausible typo, and
+     * silently falling back to warn turns it into a control that is off while
+     * appearing to be on.
+     */
+    @Test
+    @DisplayName("a near-miss like 'enforced' is rejected, never defaulted to warn")
+    void nearMissIsRejected() {
+        for (String invalid : new String[]{"enforced", "enforcing", "on", "true", "block"}) {
+            var thrown = assertThrows(IllegalArgumentException.class, () -> GrantEnforcement.parseStrict(invalid),
+                    "'" + invalid + "' must be rejected rather than silently downgrading enforcement");
+            assertTrue(thrown.getMessage().contains("off, warn, enforce"), thrown.getMessage());
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/secrets/VaultGrantCheckerTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/VaultGrantCheckerTest.java
@@ -6,8 +6,10 @@ package ai.labs.eddi.secrets;
 
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
+import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
 import ai.labs.eddi.configs.llm.ILlmStore;
 import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
+import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
@@ -51,6 +53,8 @@ class VaultGrantCheckerTest {
     private ISecretProvider secretProvider;
     private IWorkflowStore workflowStore;
     private ILlmStore llmStore;
+    private IApiCallsStore apiCallsStore;
+    private IMcpCallsStore mcpCallsStore;
     private VaultGrantChecker checker;
 
     @BeforeEach
@@ -60,7 +64,10 @@ class VaultGrantCheckerTest {
         llmStore = mock(ILlmStore.class);
         when(secretProvider.isAvailable()).thenReturn(true);
 
-        checker = new VaultGrantChecker(secretProvider, workflowStore, llmStore, mock(IApiCallsStore.class), mock(IMcpCallsStore.class));
+        apiCallsStore = mock(IApiCallsStore.class);
+        mcpCallsStore = mock(IMcpCallsStore.class);
+
+        checker = new VaultGrantChecker(secretProvider, workflowStore, llmStore, apiCallsStore, mcpCallsStore);
     }
 
     /**
@@ -85,6 +92,26 @@ class VaultGrantCheckerTest {
         task.setParameters(new LinkedHashMap<>(Map.of("apiKey", VAULT_REF, "modelName", "claude-sonnet-4-6")));
         when(llmStore.read(eq(LLM_ID), anyInt())).thenReturn(new LlmConfiguration(List.of(task)));
 
+        return agent;
+    }
+
+    /**
+     * An agent with one workflow step of {@code stepType} pointing at
+     * {@code configId}.
+     */
+    private AgentConfiguration agentWithStep(String stepType, String configId) throws Exception {
+        var agent = new AgentConfiguration();
+        agent.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1")));
+
+        var step = new WorkflowConfiguration.WorkflowStep();
+        step.setType(URI.create("eddi://" + stepType));
+        var stepConfig = new LinkedHashMap<String, Object>();
+        stepConfig.put("uri", "eddi://" + stepType + "/store/things/" + configId + "?version=1");
+        step.setConfig(stepConfig);
+
+        var workflow = new WorkflowConfiguration();
+        workflow.setWorkflowSteps(List.of(step));
+        when(workflowStore.read(eq(WORKFLOW_ID), anyInt())).thenReturn(workflow);
         return agent;
     }
 
@@ -180,6 +207,56 @@ class VaultGrantCheckerTest {
         void nothingToCheck() {
             assertTrue(checker.findUngrantedReferences(new AgentConfiguration(), "a").isEmpty());
             assertTrue(checker.findUngrantedReferences(null, "a").isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("every extension type is scanned, not just LLM configs")
+    class AllExtensionTypes {
+
+        /**
+         * The LLM-only suite could not tell a working scanner from one that had
+         * silently stopped covering httpcalls or MCP: both stores were mocked and never
+         * reached.
+         */
+        @Test
+        @DisplayName("an httpcall config's vault reference is found")
+        void apiCallsAreScanned() throws Exception {
+            givenGrant(List.of("agent-owner"));
+            var agent = agentWithStep("ai.labs.httpcalls", LLM_ID);
+
+            var apiCalls = new ApiCallsConfiguration();
+            apiCalls.setTargetServerUrl("https://api.example.com/" + VAULT_REF);
+            when(apiCallsStore.read(eq(LLM_ID), anyInt())).thenReturn(apiCalls);
+
+            assertEquals(List.of(VAULT_REF), checker.findUngrantedReferences(agent, "some-other-agent"));
+        }
+
+        @Test
+        @DisplayName("an MCP config's vault reference is found")
+        void mcpCallsAreScanned() throws Exception {
+            givenGrant(List.of("agent-owner"));
+            var agent = agentWithStep("ai.labs.mcpcalls", LLM_ID);
+
+            var mcpCalls = new McpCallsConfiguration();
+            mcpCalls.setMcpServerUrl("https://mcp.example.com");
+            mcpCalls.setApiKey(VAULT_REF);
+            when(mcpCallsStore.read(eq(LLM_ID), anyInt())).thenReturn(mcpCalls);
+
+            assertEquals(List.of(VAULT_REF), checker.findUngrantedReferences(agent, "some-other-agent"));
+        }
+
+        @Test
+        @DisplayName("a granted agent passes on those types too")
+        void grantedAgentPassesForEveryType() throws Exception {
+            givenGrant(List.of("agent-owner"));
+            var agent = agentWithStep("ai.labs.mcpcalls", LLM_ID);
+
+            var mcpCalls = new McpCallsConfiguration();
+            mcpCalls.setApiKey(VAULT_REF);
+            when(mcpCallsStore.read(eq(LLM_ID), anyInt())).thenReturn(mcpCalls);
+
+            assertTrue(checker.findUngrantedReferences(agent, "agent-owner").isEmpty());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/secrets/VaultGrantCheckerTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/VaultGrantCheckerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.secrets;
+
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.apicalls.IApiCallsStore;
+import ai.labs.eddi.configs.llm.ILlmStore;
+import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.secrets.model.SecretMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code SecretMetadata.allowedAgents} was documented as "for visibility only —
+ * enforcement is via configuration authorship". These tests pin it actually
+ * restricting something.
+ */
+@DisplayName("VaultGrantChecker — allowedAgents is enforced at deploy time")
+class VaultGrantCheckerTest {
+
+    private static final String VAULT_REF = "${vault:setup.parent.1.apiKey}";
+
+    // Real ObjectId-shaped ids: RestUtilities.extractResourceId requires >=18 hex
+    // characters and returns a null id for anything shorter, so a toy "w1"/"l1"
+    // would make the scanner silently find nothing and every test pass vacuously.
+    private static final String WORKFLOW_ID = "5f2a1b3c4d5e6f7a8b9c0d1e";
+    private static final String LLM_ID = "6a1b2c3d4e5f6a7b8c9d0e1f";
+
+    private ISecretProvider secretProvider;
+    private IWorkflowStore workflowStore;
+    private ILlmStore llmStore;
+    private VaultGrantChecker checker;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        secretProvider = mock(ISecretProvider.class);
+        workflowStore = mock(IWorkflowStore.class);
+        llmStore = mock(ILlmStore.class);
+        when(secretProvider.isAvailable()).thenReturn(true);
+
+        checker = new VaultGrantChecker(secretProvider, workflowStore, llmStore, mock(IApiCallsStore.class), mock(IMcpCallsStore.class));
+    }
+
+    /**
+     * An agent whose single LLM config carries {@link #VAULT_REF} as its apiKey.
+     */
+    private AgentConfiguration agentReferencingTheVault() throws Exception {
+        var agent = new AgentConfiguration();
+        agent.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1")));
+
+        var step = new WorkflowConfiguration.WorkflowStep();
+        step.setType(URI.create("eddi://ai.labs.llm"));
+        var stepConfig = new LinkedHashMap<String, Object>();
+        stepConfig.put("uri", "eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=1");
+        step.setConfig(stepConfig);
+
+        var workflow = new WorkflowConfiguration();
+        workflow.setWorkflowSteps(List.of(step));
+        when(workflowStore.read(eq(WORKFLOW_ID), anyInt())).thenReturn(workflow);
+
+        var task = new LlmConfiguration.Task();
+        task.setType("anthropic");
+        task.setParameters(new LinkedHashMap<>(Map.of("apiKey", VAULT_REF, "modelName", "claude-sonnet-4-6")));
+        when(llmStore.read(eq(LLM_ID), anyInt())).thenReturn(new LlmConfiguration(List.of(task)));
+
+        return agent;
+    }
+
+    private void givenGrant(List<String> allowedAgents) throws Exception {
+        when(secretProvider.getMetadata(any())).thenReturn(new SecretMetadata("default", "setup.parent.1.apiKey", Instant.now(), null, null,
+                "checksum", "desc", allowedAgents));
+    }
+
+    @Nested
+    @DisplayName("a scoped grant")
+    class ScopedGrant {
+
+        @Test
+        @DisplayName("an agent NOT on the list is reported")
+        void ungrantedAgentIsReported() throws Exception {
+            givenGrant(List.of("agent-owner"));
+
+            List<String> violations = checker.findUngrantedReferences(agentReferencingTheVault(), "some-other-agent");
+
+            assertEquals(List.of(VAULT_REF), violations,
+                    "an operator who scoped a secret to one agent must not silently get no enforcement");
+        }
+
+        @Test
+        @DisplayName("the agent ON the list is allowed")
+        void grantedAgentIsAllowed() throws Exception {
+            givenGrant(List.of("agent-owner"));
+
+            assertTrue(checker.findUngrantedReferences(agentReferencingTheVault(), "agent-owner").isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("shapes that mean 'not restricted'")
+    class Unrestricted {
+
+        @Test
+        @DisplayName("the wildcard the setup wizard writes allows everyone")
+        void wildcardAllowsEveryone() throws Exception {
+            givenGrant(List.of("*"));
+
+            assertTrue(checker.findUngrantedReferences(agentReferencingTheVault(), "any-agent").isEmpty(),
+                    "every key AgentSetupService vaults carries the wildcard — enforcing against it would break every deployment");
+        }
+
+        @Test
+        @DisplayName("an empty or absent list allows everyone")
+        void emptyAndNullAllowEveryone() throws Exception {
+            givenGrant(List.of());
+            assertTrue(checker.findUngrantedReferences(agentReferencingTheVault(), "any-agent").isEmpty());
+
+            givenGrant(null);
+            assertTrue(checker.findUngrantedReferences(agentReferencingTheVault(), "any-agent").isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("uncertainty never becomes a violation")
+    class FailOpenOnUncertainty {
+
+        /**
+         * A deployment gate that fires on a transient store failure is worse than the
+         * hole it closes.
+         */
+        @Test
+        @DisplayName("unreadable metadata is not a violation")
+        void unreadableMetadataIsNotAViolation() throws Exception {
+            when(secretProvider.getMetadata(any())).thenThrow(new ISecretProvider.SecretProviderException("vault down"));
+
+            assertTrue(checker.findUngrantedReferences(agentReferencingTheVault(), "some-other-agent").isEmpty());
+        }
+
+        @Test
+        @DisplayName("a disabled vault checks nothing")
+        void disabledVaultChecksNothing() throws Exception {
+            when(secretProvider.isAvailable()).thenReturn(false);
+
+            assertTrue(checker.findUngrantedReferences(agentReferencingTheVault(), "some-other-agent").isEmpty());
+        }
+
+        @Test
+        @DisplayName("an unreadable workflow yields no violations rather than throwing")
+        void unreadableWorkflowIsSafe() throws Exception {
+            givenGrant(List.of("agent-owner"));
+            var agent = agentReferencingTheVault();
+            when(workflowStore.read(anyString(), anyInt())).thenThrow(new RuntimeException("store down"));
+
+            assertTrue(checker.findUngrantedReferences(agent, "some-other-agent").isEmpty());
+        }
+
+        @Test
+        @DisplayName("an agent with no workflows, or a null agent, is trivially clean")
+        void nothingToCheck() {
+            assertTrue(checker.findUngrantedReferences(new AgentConfiguration(), "a").isEmpty());
+            assertTrue(checker.findUngrantedReferences(null, "a").isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("reference discovery")
+    class Discovery {
+
+        /**
+         * The scan serializes each config rather than enumerating its secret-bearing
+         * fields — enumeration is how this kind of check silently stops covering a
+         * newly added credential field.
+         */
+        @Test
+        @DisplayName("finds a reference in any field, not only a known apiKey")
+        void findsReferencesInArbitraryFields() throws Exception {
+            givenGrant(List.of("agent-owner"));
+
+            var agent = new AgentConfiguration();
+            agent.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1")));
+
+            var step = new WorkflowConfiguration.WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.llm"));
+            var stepConfig = new LinkedHashMap<String, Object>();
+            stepConfig.put("uri", "eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=1");
+            step.setConfig(stepConfig);
+            var workflow = new WorkflowConfiguration();
+            workflow.setWorkflowSteps(List.of(step));
+            when(workflowStore.read(eq(WORKFLOW_ID), anyInt())).thenReturn(workflow);
+
+            var task = new LlmConfiguration.Task();
+            task.setType("openai");
+            // Not "apiKey" — a field a hand-rolled scanner would have missed.
+            task.setParameters(new LinkedHashMap<>(Map.of("someFutureCredentialField", VAULT_REF)));
+            when(llmStore.read(eq(LLM_ID), anyInt())).thenReturn(new LlmConfiguration(List.of(task)));
+
+            assertEquals(List.of(VAULT_REF), checker.findUngrantedReferences(agent, "some-other-agent"));
+        }
+    }
+}


### PR DESCRIPTION
Closes the second open item from the Wave-R follow-up review.

`SecretMetadata.allowedAgents` was documented as *"for visibility only — enforcement is via configuration authorship, not runtime resolution"*. That access model assumes a **human admin** authors agent configurations. `create_sub_agent` lets an LLM author one — so an operator who scoped a secret to a single agent got **no enforcement at all**. The field was decorative.

## Why deployment time, and not resolution time

This is the load-bearing decision, so it's worth stating why the obvious place is the wrong one.

**`SecretResolver` cannot do it soundly.** It sees only a string — no agent identity — and its ~12 call sites span `ApiCallExecutor`, `ChatModelRegistry`, `A2AToolProviderManager`, `McpToolProviderManager`, `EmbeddingModelFactory`, `EmbeddingStoreFactory` and `ChannelTargetRouter`. Several legitimately run outside any conversation, and `AgentSigningService` bypasses the resolver entirely.

**The model cache would launder the check.** `ChatModelRegistry` caches on `ModelCacheKey(type, unresolvedParams)`. Two agents sharing a config share a cache entry, so a check inside `resolveSecrets` runs for whichever agent builds the model first and is silently skipped for every other one — enforcement that looks real and is not, which is exactly what I declined to ship when I first reported this. Making it sound needs the agent identity in the cache key plus plumbing through six `getOrCreate` call sites, several of them background services (`SummarizationService`, `ToolResponseTruncator`) with no agent at all.

The binding between an agent and a secret is established in the agent's **configuration**. That is where it can be checked completely, once, and with no cache in the way — next to the existing deploy-time `lintInertHitlConfig`, which is the same pattern.

## What it does

`VaultGrantChecker` walks the agent's workflows → `llm` / `apicalls` / `mcpcalls` configs, serializes each and scans for `${vault:...}` references, then verifies each against `allowedAgents`.

The scan **serializes rather than enumerating** known credential fields. Enumeration is how this kind of check rots: someone adds a new credential field and the scanner silently stops covering it. Pinned by a test that plants a reference in a field named `someFutureCredentialField`.

## Rollout is warn-first

`eddi.vault.grant-enforcement` = `off` | `warn` (default) | `enforce`.

Warn is deliberate. The field has never been enforced, so any non-wildcard value in an existing deployment is **untested configuration** — blocking on it during an upgrade could take agents down for a policy nobody has yet had a chance to verify. Operators switch to `enforce` once the warnings are clean.

## Uncertainty never becomes a violation

Unreadable metadata, a disabled vault, an unreadable workflow, and absent / empty / wildcard grants all allow. A deployment gate that fires on a transient store failure is worse than the hole it closes. Every `AgentSetupService`-vaulted key carries `["*"]`, so existing deployments see no change.

## What it does not do

An agent already deployed before its grant was narrowed keeps resolving until it is redeployed. This is a deploy-time gate, not a revocation mechanism — stated in the class Javadoc rather than left for someone to discover.

## Testing

+9 tests; 274 green across the vault, deployment and setup suites.

Worth noting: one test initially passed **vacuously**. The fixture used toy ids (`w1`, `l1`), and `RestUtilities.extractResourceId` requires ≥18 hex characters — it returns a null id for anything shorter, so the scanner walked nothing and found nothing. The fixture now uses ObjectId-shaped ids, and the failure it produced first is what proved the scanner actually works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment-time validation for vault access permissions.
  * Added configurable enforcement modes: `off`, `warn`, and `enforce`, with `warn` as the default.
  * Vault references are detected across workflows and supported extension configurations.

* **Bug Fixes**
  * Prevented deployments in enforce mode when required vault access is not granted.
  * Added permissive handling for missing, unreadable, malformed, or unsupported configuration data.

* **Documentation**
  * Documented enforcement behavior, rollout modes, and deployment retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->