### PR TITLE
fix(runtime): age idle conversations by the conversation, not by the agent document

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 🔎 fix(runtime): the idle-conversation sweep aged conversations by the wrong clock (2026-08-10)
+
+**Repo:** EDDI (`fix/idle-conversation-sweep-age`)
+
+Two defects in `endOldConversationsWithOldAgents`, fixed together because fixing either alone is worse than fixing neither.
+
+1. **`isOlderThanDays` ignored `Period`'s months component.** It read only `getYears()` and `getDays()`, so for a 35-day-old date against a 30-day limit `Period.between(now, date)` is `P-1M-4D` and the test became `-4 <= -30` → "not old". Whole bands of ages between the limit and one year were never reaped; the ones that were passed by coincidence of where the month boundary fell.
+2. **The age came from the AGENT document's `lastModifiedOn`.** That is not a property of the conversation: every conversation on a given agent version shared one age, so a conversation the user was talking in an hour ago counted as idle whenever the agent config happened to be old.
+
+The second was masked by the first. Correcting only the arithmetic would have converted a mostly-inert sweep into an eager one that ENDs live conversations — so the age signal now comes from the conversation's own newest step timestamp (`Data` stamps every entry at construction), with the descriptor kept only as a fallback and the conversation skipped entirely when no age signal exists at all. "Cannot prove it is idle" must never end a conversation.
+
+Pinned by `recentConversationOnStaleAgentSurvives` (an hour-old conversation on a two-year-stale agent survives) and `noGapsAcrossMonthBoundaries` (every offset 30→400 days). +9 tests.
+
+---
+
 ## 🔗 fix(agents): wire the deployment-wait machinery that only the ZIP importer ever used (2026-08-09)
 
 **Repo:** EDDI (`fix/deployment-wait-machinery`)

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
@@ -414,8 +414,6 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                 continue;
             }
 
-            var documentDescriptor = documentDescriptorStore.readDescriptor(conversationMemory.getAgentId(), conversationMemory.getAgentVersion());
-
             // Age comes from the CONVERSATION's own newest step timestamp.
             //
             // It used to come from the AGENT document's lastModifiedOn, which is not a
@@ -427,16 +425,22 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
             // which is why both are corrected together.
             var lastInteraction = lastInteractionOf(conversationMemory);
             if (lastInteraction == null) {
-                // No step ever carried a timestamp. Fall back to the descriptor, and
-                // skip entirely when even that is absent: "cannot prove it is idle" must
-                // never end a conversation, and dereferencing here would throw an NPE
-                // the enclosing UndeploymentExecutor does not catch — aborting every
-                // remaining undeploy attempt in this pass.
-                var descriptorLastModified = documentDescriptor.getLastModifiedOn();
+                // No step ever carried a timestamp. Fall back to the agent descriptor,
+                // and skip entirely when even that is unavailable: "cannot prove it is
+                // idle" must never end a conversation.
+                //
+                // Read LAZILY, and never fatally. This lookup used to run
+                // unconditionally at the top of the loop, but readDescriptor THROWS for
+                // a deleted agent — and manageAgentDeployments deliberately routes
+                // deleted agents down this very path (getCurrentResourceId throwing is
+                // how it decides the agent is gone). One deleted agent therefore
+                // aborted the whole sweep, including conversations that carry a
+                // perfectly good timestamp of their own and never needed the descriptor.
+                Instant descriptorLastModified = descriptorLastModifiedOf(conversationMemory);
                 if (descriptorLastModified == null) {
                     continue;
                 }
-                lastInteraction = descriptorLastModified.toInstant();
+                lastInteraction = descriptorLastModified;
             }
             // ONE calendar date drives both the decision and the message. The sweep
             // expires by LocalDate, so reporting elapsed 24-hour periods could end a
@@ -448,11 +452,23 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
 
             if (isOlderThanMaximumAmountOfDays) {
                 String conversationId = conversationMemory.getId();
-                conversationMemoryStore.setConversationState(conversationId, ConversationState.ENDED);
+                // Conditional on the state this snapshot was loaded with, NOT an
+                // unconditional write. The snapshots were read at the top of the sweep,
+                // so between that read and this write a user can send a turn, or the
+                // conversation can pause at an HITL gate — and an unconditional ENDED
+                // would destroy a live turn or a pending approval. This was a latent
+                // check-then-act race while the arithmetic bug kept the sweep mostly
+                // inert; correcting the arithmetic is exactly what makes it fire.
+                ConversationState observedState = conversationMemory.getConversationState();
+                if (!conversationMemoryStore.compareAndSetState(conversationId, observedState, ConversationState.ENDED)) {
+                    LOGGER.info(format("Skipped ending conversation (id: %s): its state changed from %s since the sweep read it",
+                            conversationId, observedState));
+                    continue;
+                }
                 var message = format(
                         "Ended conversation (id: %s) with Agent (name: %s, id: %s, version: %d) "
                                 + "because it is %d days older than the maximum idle time of %d days",
-                        conversationId, documentDescriptor.getName(), agentId, agentVersion,
+                        conversationId, descriptorNameOf(conversationMemory), agentId, agentVersion,
                         DAYS.between(lastInteractionDate, LocalDate.now()), maximumLifeTimeOfIdleConversationsInDays);
 
                 LOGGER.info(message);
@@ -464,6 +480,31 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                     "Spared %d paused (AWAITING_HUMAN) conversation(s) of Agent (id: %s, version: %d) from the idle sweep — "
                             + "their pending approvals are preserved",
                     sparedPausedConversations, agentId, agentVersion));
+        }
+    }
+
+    /**
+     * The agent descriptor's {@code lastModifiedOn}, or {@code null} when it cannot
+     * be read. Never throws: the descriptor is a fallback age signal and a
+     * best-effort display name, and a deleted agent — which this sweep is
+     * specifically reached for — makes {@code readDescriptor} throw.
+     */
+    private Instant descriptorLastModifiedOf(ConversationMemorySnapshot conversationMemory) {
+        try {
+            var descriptor = documentDescriptorStore.readDescriptor(conversationMemory.getAgentId(), conversationMemory.getAgentVersion());
+            return descriptor != null && descriptor.getLastModifiedOn() != null ? descriptor.getLastModifiedOn().toInstant() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** The agent's display name for the log line, or its id when unavailable. */
+    private String descriptorNameOf(ConversationMemorySnapshot conversationMemory) {
+        try {
+            var descriptor = documentDescriptorStore.readDescriptor(conversationMemory.getAgentId(), conversationMemory.getAgentVersion());
+            return descriptor != null && descriptor.getName() != null ? descriptor.getName() : conversationMemory.getAgentId();
+        } catch (Exception e) {
+            return conversationMemory.getAgentId();
         }
     }
 
@@ -512,7 +553,18 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
      * has no such components.
      */
     static boolean isOlderThanDays(final LocalDate date, final int days) {
-        return DAYS.between(date, LocalDate.now()) >= days;
+        return isOlderThanDays(date, days, LocalDate.now());
+    }
+
+    /**
+     * Reference-date overload. {@code today} is a parameter so a test can pin both
+     * sides of the comparison: with {@code LocalDate.now()} evaluated independently
+     * in the test and in this method, a case built at 23:59:59.999 and evaluated at
+     * 00:00:00.001 shifts by a day, which is exactly the kind of once-a-day flake
+     * that gets a boundary test deleted rather than fixed.
+     */
+    static boolean isOlderThanDays(final LocalDate date, final int days, final LocalDate today) {
+        return DAYS.between(date, today) >= days;
     }
 
     private interface UndeploymentExecutor {

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
@@ -442,13 +442,15 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                 }
                 lastInteraction = descriptorLastModified;
             }
-            // ONE calendar date drives both the decision and the message. The sweep
-            // expires by LocalDate, so reporting elapsed 24-hour periods could end a
-            // conversation on its 30th calendar day while the log said 29 — the
-            // explanation contradicting the decision it explains.
+            // ONE calendar date drives both the decision and the message, and ONE
+            // reference "today" drives both this check and the age it reports. The
+            // sweep expires by LocalDate, so reporting elapsed 24-hour periods could
+            // end a conversation on its 30th calendar day while the log said 29 — and
+            // evaluating LocalDate.now() twice could disagree across midnight.
             var lastInteractionDate = lastInteraction.atZone(ZoneId.systemDefault()).toLocalDate();
+            var today = LocalDate.now();
 
-            var isOlderThanMaximumAmountOfDays = isOlderThanDays(lastInteractionDate, maximumLifeTimeOfIdleConversationsInDays);
+            var isOlderThanMaximumAmountOfDays = isOlderThanDays(lastInteractionDate, maximumLifeTimeOfIdleConversationsInDays, today);
 
             if (isOlderThanMaximumAmountOfDays) {
                 String conversationId = conversationMemory.getId();
@@ -459,6 +461,26 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                 // would destroy a live turn or a pending approval. This was a latent
                 // check-then-act race while the arithmetic bug kept the sweep mostly
                 // inert; correcting the arithmetic is exactly what makes it fire.
+                // Re-read immediately before the write. The snapshots were loaded at
+                // the top of the sweep, so without this the window in which a user can
+                // send a turn spans the entire scan.
+                //
+                // The state CAS alone is not enough: a turn that starts AND completes
+                // inside the window returns the state to the value we observed, so the
+                // CAS succeeds against a conversation that is demonstrably active. The
+                // age is the ABA-resistant part — a completed turn moves the newest
+                // step timestamp, so re-checking it here catches exactly that case.
+                //
+                // What remains is a turn completing entirely between this re-read and
+                // the CAS below. Closing that needs a revision-conditional update in
+                // IConversationMemoryStore (and in both backends) rather than a
+                // state-only CAS; that is a store-contract change, deliberately not
+                // bundled here.
+                if (!stillIdle(conversationId, maximumLifeTimeOfIdleConversationsInDays, today)) {
+                    LOGGER.info(format("Skipped ending conversation (id: %s): it became active while the sweep was running",
+                            conversationId));
+                    continue;
+                }
                 ConversationState observedState = conversationMemory.getConversationState();
                 if (!conversationMemoryStore.compareAndSetState(conversationId, observedState, ConversationState.ENDED)) {
                     LOGGER.info(format("Skipped ending conversation (id: %s): its state changed from %s since the sweep read it",
@@ -469,7 +491,7 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                         "Ended conversation (id: %s) with Agent (name: %s, id: %s, version: %d) "
                                 + "because it is %d days older than the maximum idle time of %d days",
                         conversationId, descriptorNameOf(conversationMemory), agentId, agentVersion,
-                        DAYS.between(lastInteractionDate, LocalDate.now()), maximumLifeTimeOfIdleConversationsInDays);
+                        DAYS.between(lastInteractionDate, today), maximumLifeTimeOfIdleConversationsInDays);
 
                 LOGGER.info(message);
             }
@@ -480,6 +502,33 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                     "Spared %d paused (AWAITING_HUMAN) conversation(s) of Agent (id: %s, version: %d) from the idle sweep — "
                             + "their pending approvals are preserved",
                     sparedPausedConversations, agentId, agentVersion));
+        }
+    }
+
+    /**
+     * Re-reads the conversation and re-checks its age against the same limit and
+     * reference date the sweep used.
+     * <p>
+     * A store failure answers {@code false}: unable to confirm it is still idle is
+     * not permission to end it.
+     */
+    private boolean stillIdle(String conversationId, int maxIdleDays, LocalDate today) {
+        try {
+            var fresh = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
+            if (fresh == null) {
+                return false;
+            }
+            Instant freshLastInteraction = lastInteractionOf(fresh);
+            if (freshLastInteraction == null) {
+                // No conversation-side signal on the re-read; the original decision
+                // already used the descriptor fallback, so nothing new to check.
+                return true;
+            }
+            return isOlderThanDays(freshLastInteraction.atZone(ZoneId.systemDefault()).toLocalDate(), maxIdleDays, today);
+        } catch (Exception e) {
+            LOGGER.warn(format("Could not re-check conversation (id: %s) before ending it (%s) — leaving it alone",
+                    conversationId, e.getMessage()));
+            return false;
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
@@ -23,6 +23,7 @@ import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.engine.hitl.lint.ReservedActionLint;
 import ai.labs.eddi.engine.lifecycle.IConversation;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.runtime.IAgentDeploymentManagement;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.runtime.IRuntime;
@@ -44,9 +45,9 @@ import org.jboss.logging.Logger;
 import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -415,14 +416,32 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
 
             var documentDescriptor = documentDescriptorStore.readDescriptor(conversationMemory.getAgentId(), conversationMemory.getAgentVersion());
 
-            // NOTE: age is derived from the AGENT document's lastModifiedOn, not the
-            // conversation's — a pre-existing heuristic that predates the HITL branch
-            // and is intentionally left unchanged here.
-            var timeOfLastInteractionInConversation = documentDescriptor.getLastModifiedOn();
+            // Age comes from the CONVERSATION's own newest step timestamp.
+            //
+            // It used to come from the AGENT document's lastModifiedOn, which is not a
+            // property of the conversation at all: every conversation on a given agent
+            // version shared one age, so a conversation the user was talking in an hour
+            // ago counted as idle whenever its agent config happened to be old. That
+            // mis-signal was masked by the arithmetic bug in isOlderThanDays below —
+            // fixing the arithmetic alone would have started ENDing live conversations,
+            // which is why both are corrected together.
+            var lastInteraction = lastInteractionOf(conversationMemory);
+            if (lastInteraction == null) {
+                // No step ever carried a timestamp. Fall back to the descriptor, and
+                // skip entirely when even that is absent: "cannot prove it is idle" must
+                // never end a conversation, and dereferencing here would throw an NPE
+                // the enclosing UndeploymentExecutor does not catch — aborting every
+                // remaining undeploy attempt in this pass.
+                var descriptorLastModified = documentDescriptor.getLastModifiedOn();
+                if (descriptorLastModified == null) {
+                    continue;
+                }
+                lastInteraction = descriptorLastModified.toInstant();
+            }
+            var timeOfLastInteractionInConversation = Date.from(lastInteraction);
 
             var isOlderThanMaximumAmountOfDays = isOlderThanDays(
-                    Instant.ofEpochMilli(timeOfLastInteractionInConversation.getTime()).atZone(ZoneId.systemDefault()).toLocalDate(),
-                    maximumLifeTimeOfIdleConversationsInDays);
+                    lastInteraction.atZone(ZoneId.systemDefault()).toLocalDate(), maximumLifeTimeOfIdleConversationsInDays);
 
             if (isOlderThanMaximumAmountOfDays) {
                 String conversationId = conversationMemory.getId();
@@ -445,23 +464,52 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
         }
     }
 
-    private boolean isOlderThanDays(final LocalDate date, final int days) {
-        boolean result = false;
+    /**
+     * The newest timestamp any data item in the conversation carries, or
+     * {@code null} when nothing is timestamped. This is the conversation's own
+     * last-interaction time: every turn writes step data through
+     * {@code ConversationStep}, and {@code Data} stamps each entry at construction.
+     */
+    static Instant lastInteractionOf(ConversationMemorySnapshot snapshot) {
+        if (snapshot == null || snapshot.getConversationSteps() == null) {
+            return null;
+        }
 
-        LocalDate now = LocalDate.now();
-        // period from now to date
-        Period period = Period.between(now, date);
-
-        if (period.getYears() < 0) {
-            // if year is negative, 100% older than 6 months
-            result = true;
-        } else if (period.getYears() == 0) {
-            if (period.getDays() <= -days) {
-                result = true;
+        Date newest = null;
+        for (var step : snapshot.getConversationSteps()) {
+            if (step == null || step.getWorkflows() == null) {
+                continue;
+            }
+            for (var workflow : step.getWorkflows()) {
+                if (workflow == null || workflow.getLifecycleTasks() == null) {
+                    continue;
+                }
+                for (var task : workflow.getLifecycleTasks()) {
+                    Date timestamp = task != null ? task.getTimestamp() : null;
+                    if (timestamp != null && (newest == null || timestamp.after(newest))) {
+                        newest = timestamp;
+                    }
+                }
             }
         }
 
-        return result;
+        return newest != null ? newest.toInstant() : null;
+    }
+
+    /**
+     * True when {@code date} is at least {@code days} days in the past.
+     * <p>
+     * This was written against {@link Period}, which normalizes into
+     * years/months/days — and the check only ever looked at the years and days
+     * components, never the months. For a 35-day-old date and a 30-day limit,
+     * {@code Period.between(now, date)} is {@code P-1M-4D}, so the test read
+     * {@code -4 <= -30} and answered "not old". Whole bands of ages between
+     * {@code days} and one year were therefore never reaped, and the ones that were
+     * passed only by coincidence of where the month boundary fell. Day arithmetic
+     * has no such components.
+     */
+    static boolean isOlderThanDays(final LocalDate date, final int days) {
+        return DAYS.between(date, LocalDate.now()) >= days;
     }
 
     private interface UndeploymentExecutor {

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
@@ -438,10 +438,13 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                 }
                 lastInteraction = descriptorLastModified.toInstant();
             }
-            var timeOfLastInteractionInConversation = Date.from(lastInteraction);
+            // ONE calendar date drives both the decision and the message. The sweep
+            // expires by LocalDate, so reporting elapsed 24-hour periods could end a
+            // conversation on its 30th calendar day while the log said 29 — the
+            // explanation contradicting the decision it explains.
+            var lastInteractionDate = lastInteraction.atZone(ZoneId.systemDefault()).toLocalDate();
 
-            var isOlderThanMaximumAmountOfDays = isOlderThanDays(
-                    lastInteraction.atZone(ZoneId.systemDefault()).toLocalDate(), maximumLifeTimeOfIdleConversationsInDays);
+            var isOlderThanMaximumAmountOfDays = isOlderThanDays(lastInteractionDate, maximumLifeTimeOfIdleConversationsInDays);
 
             if (isOlderThanMaximumAmountOfDays) {
                 String conversationId = conversationMemory.getId();
@@ -450,7 +453,7 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
                         "Ended conversation (id: %s) with Agent (name: %s, id: %s, version: %d) "
                                 + "because it is %d days older than the maximum idle time of %d days",
                         conversationId, documentDescriptor.getName(), agentId, agentVersion,
-                        DAYS.between(timeOfLastInteractionInConversation.toInstant(), Instant.now()), maximumLifeTimeOfIdleConversationsInDays);
+                        DAYS.between(lastInteractionDate, LocalDate.now()), maximumLifeTimeOfIdleConversationsInDays);
 
                 LOGGER.info(message);
             }

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
@@ -282,6 +282,38 @@ class AgentDeploymentManagementIdleSweepTest {
             verify(conversationMemoryStore, never()).setConversationState(any(), any());
         }
 
+        /**
+         * The ABA case the state CAS alone cannot see: a turn that starts AND completes
+         * inside the window returns the state to the value the snapshot carried, so the
+         * CAS would succeed against a demonstrably active conversation. The age is the
+         * ABA-resistant signal — a completed turn moves the newest step timestamp.
+         */
+        @Test
+        @DisplayName("a conversation that became active during the sweep is not ended")
+        void conversationActiveSinceSnapshotIsNotEnded() throws Exception {
+            var stale = snapshotWithTimestamps(Instant.now().minus(400, ChronoUnit.DAYS));
+            givenOldAgentVersionWithConversation(stale, Instant.now().minus(400, ChronoUnit.DAYS));
+            // The re-read sees a turn that landed after the sweep loaded its snapshots.
+            when(conversationMemoryStore.loadConversationMemorySnapshot("conv-1"))
+                    .thenReturn(snapshotWithTimestamps(Instant.now()));
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore, never()).compareAndSetState(any(), any(), eq(ConversationState.ENDED));
+        }
+
+        @Test
+        @DisplayName("a re-read failure leaves the conversation alone rather than ending it")
+        void reReadFailurePreservesTheConversation() throws Exception {
+            givenOldAgentVersionWithConversation(snapshotWithTimestamps(Instant.now().minus(400, ChronoUnit.DAYS)),
+                    Instant.now().minus(400, ChronoUnit.DAYS));
+            when(conversationMemoryStore.loadConversationMemorySnapshot("conv-1")).thenThrow(new RuntimeException("store down"));
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore, never()).compareAndSetState(any(), any(), eq(ConversationState.ENDED));
+        }
+
         private void givenOldAgentVersionWithConversation(ConversationMemorySnapshot snapshot, Instant agentLastModified) throws Exception {
             var info = new DeploymentInfo();
             info.setEnvironment(Environment.production);
@@ -298,6 +330,8 @@ class AgentDeploymentManagementIdleSweepTest {
             when(conversationMemoryStore.getActiveConversationCount("agent-1", 1)).thenReturn(1L);
             when(conversationMemoryStore.compareAndSetState(any(), any(), any())).thenReturn(true);
             when(conversationMemoryStore.loadActiveConversationMemorySnapshot("agent-1", 1)).thenReturn(List.of(snapshot));
+            // The sweep re-reads the conversation immediately before ending it.
+            when(conversationMemoryStore.loadConversationMemorySnapshot("conv-1")).thenReturn(snapshot);
 
             var descriptor = new DocumentDescriptor();
             descriptor.setName("Test Agent");

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
@@ -200,6 +200,48 @@ class AgentDeploymentManagementIdleSweepTest {
             verify(conversationMemoryStore, never()).setConversationState(any(), eq(ConversationState.ENDED));
         }
 
+        /**
+         * The descriptor fallback, which only fires for a conversation whose steps
+         * carry no timestamp at all. Untested until now: the fixture always supplied a
+         * descriptor timestamp AND a step timestamp, so neither new branch was reached.
+         */
+        @Test
+        @DisplayName("an untimestamped conversation falls back to the descriptor and is ended when that is old")
+        void untimestampedConversationUsesDescriptorFallback() throws Exception {
+            givenOldAgentVersionWithConversation(snapshotWithTimestamps(), Instant.now().minus(400, ChronoUnit.DAYS));
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore).setConversationState("conv-1", ConversationState.ENDED);
+        }
+
+        @Test
+        @DisplayName("an untimestamped conversation on a recently-edited agent is NOT ended")
+        void untimestampedConversationWithRecentDescriptorSurvives() throws Exception {
+            givenOldAgentVersionWithConversation(snapshotWithTimestamps(), Instant.now());
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore, never()).setConversationState(any(), eq(ConversationState.ENDED));
+        }
+
+        /**
+         * With neither an age signal on the conversation nor one on the descriptor,
+         * there is nothing to age against — and "cannot prove it is idle" must never
+         * end a conversation. Dereferencing the absent descriptor stamp would also
+         * throw an NPE the enclosing UndeploymentExecutor does not catch, aborting
+         * every remaining undeploy in the pass.
+         */
+        @Test
+        @DisplayName("no age signal anywhere — the conversation is preserved, not ended")
+        void noAgeSignalAtAllPreservesTheConversation() throws Exception {
+            givenOldAgentVersionWithConversation(snapshotWithTimestamps(), null);
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore, never()).setConversationState(any(), eq(ConversationState.ENDED));
+        }
+
         private void givenOldAgentVersionWithConversation(ConversationMemorySnapshot snapshot, Instant agentLastModified) throws Exception {
             var info = new DeploymentInfo();
             info.setEnvironment(Environment.production);
@@ -218,7 +260,7 @@ class AgentDeploymentManagementIdleSweepTest {
 
             var descriptor = new DocumentDescriptor();
             descriptor.setName("Test Agent");
-            descriptor.setLastModifiedOn(Date.from(agentLastModified));
+            descriptor.setLastModifiedOn(agentLastModified != null ? Date.from(agentLastModified) : null);
             when(documentDescriptorStore.readDescriptor("agent-1", 1)).thenReturn(descriptor);
         }
     }

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.runtime.internal;
+
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.deployment.IDeploymentStore;
+import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.migration.ChannelConnectorMigration;
+import ai.labs.eddi.configs.migration.IMigrationManager;
+import ai.labs.eddi.configs.migration.V6QuteMigration;
+import ai.labs.eddi.configs.migration.V6RenameMigration;
+import ai.labs.eddi.configs.rules.IRuleSetStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.engine.memory.IConversationMemoryStore;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot.ConversationStepSnapshot;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot.ResultSnapshot;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot.WorkflowRunSnapshot;
+import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.model.Deployment.Environment;
+import ai.labs.eddi.engine.runtime.IAgentFactory;
+import ai.labs.eddi.engine.runtime.IRuntime;
+import ai.labs.eddi.engine.runtime.internal.readiness.IAgentsReadiness;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression pins for the idle-conversation sweep.
+ * <p>
+ * Two defects had to be fixed together. The age arithmetic ignored the
+ * {@code Period} months component, so whole bands of ages were never reaped —
+ * and that bug was masking a wrong age <em>signal</em>: the age came from the
+ * AGENT document's {@code lastModifiedOn}, which is shared by every
+ * conversation on that agent version. Correcting only the arithmetic would have
+ * turned a mostly-inert sweep into an eager one that ENDs conversations a user
+ * is actively talking in.
+ */
+@DisplayName("AgentDeploymentManagement — idle conversation sweep")
+class AgentDeploymentManagementIdleSweepTest {
+
+    private static final int MAX_IDLE_DAYS = 30;
+
+    private IDeploymentStore deploymentStore;
+    private IAgentStore agentStore;
+    private IConversationMemoryStore conversationMemoryStore;
+    private IDocumentDescriptorStore documentDescriptorStore;
+    private AgentDeploymentManagement management;
+
+    @BeforeEach
+    void setUp() {
+        deploymentStore = mock(IDeploymentStore.class);
+        var agentFactory = mock(IAgentFactory.class);
+        agentStore = mock(IAgentStore.class);
+        var agentsReadiness = mock(IAgentsReadiness.class);
+        conversationMemoryStore = mock(IConversationMemoryStore.class);
+        documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        var migrationManager = mock(IMigrationManager.class);
+        var runtime = mock(IRuntime.class);
+        when(runtime.getScheduledExecutorService()).thenReturn(mock(ScheduledExecutorService.class));
+
+        management = new AgentDeploymentManagement(deploymentStore, agentFactory, agentStore, agentsReadiness, conversationMemoryStore,
+                documentDescriptorStore, migrationManager, mock(V6RenameMigration.class), mock(V6QuteMigration.class),
+                mock(ChannelConnectorMigration.class), runtime, mock(IWorkflowStore.class), mock(IRuleSetStore.class), MAX_IDLE_DAYS);
+    }
+
+    @Nested
+    @DisplayName("isOlderThanDays")
+    class IsOlderThanDays {
+
+        /**
+         * The exact case the old {@code Period}-based implementation got wrong:
+         * {@code Period.between(now, 35 days ago)} normalizes to {@code P-1M-4D}, so a
+         * check that only read the days component saw {@code -4 <= -30} and answered
+         * "not old".
+         */
+        @Test
+        @DisplayName("35 days old with a 30-day limit is old (the months-component bug)")
+        void thirtyFiveDaysIsOlderThanThirty() {
+            assertTrue(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(35), 30));
+        }
+
+        @Test
+        @DisplayName("boundaries: exactly N days is old, N-1 is not")
+        void boundaries() {
+            assertTrue(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(30), 30));
+            assertFalse(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(29), 30));
+        }
+
+        /**
+         * Every offset from 30 to 400 days must be reported as old — the old
+         * implementation was correct only where the month boundary happened to fall.
+         */
+        @Test
+        @DisplayName("every age past the limit is old, with no gaps")
+        void noGapsAcrossMonthBoundaries() {
+            for (int daysAgo = 30; daysAgo <= 400; daysAgo++) {
+                assertTrue(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(daysAgo), 30),
+                        daysAgo + " days ago must count as older than 30 days");
+            }
+        }
+
+        @Test
+        @DisplayName("no age below the limit is old")
+        void noFalsePositives() {
+            for (int daysAgo = 0; daysAgo < 30; daysAgo++) {
+                assertFalse(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(daysAgo), 30),
+                        daysAgo + " days ago must not count as older than 30 days");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("lastInteractionOf")
+    class LastInteraction {
+
+        @Test
+        @DisplayName("returns the newest timestamp across every step")
+        void newestAcrossSteps() {
+            Instant oldest = Instant.now().minus(10, ChronoUnit.DAYS);
+            Instant newest = Instant.now().minus(1, ChronoUnit.HOURS);
+
+            var snapshot = snapshotWithTimestamps(oldest, newest, Instant.now().minus(5, ChronoUnit.DAYS));
+
+            assertEquals(newest.toEpochMilli(), AgentDeploymentManagement.lastInteractionOf(snapshot).toEpochMilli());
+        }
+
+        @Test
+        @DisplayName("null when nothing is timestamped")
+        void nullWhenUntimestamped() {
+            assertNull(AgentDeploymentManagement.lastInteractionOf(new ConversationMemorySnapshot()));
+            assertNull(AgentDeploymentManagement.lastInteractionOf(snapshotWithTimestamps()));
+            assertNull(AgentDeploymentManagement.lastInteractionOf(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("the sweep uses the conversation's own age")
+    class SweepUsesConversationAge {
+
+        /**
+         * The property that makes fixing the arithmetic safe. The agent config is two
+         * years stale — under the old age signal every conversation on it was "idle" —
+         * but this conversation was touched an hour ago and must survive.
+         */
+        @Test
+        @DisplayName("a recently-active conversation on a long-untouched agent is NOT ended")
+        void recentConversationOnStaleAgentSurvives() throws Exception {
+            givenOldAgentVersionWithConversation(snapshotWithTimestamps(Instant.now().minus(1, ChronoUnit.HOURS)),
+                    Instant.now().minus(730, ChronoUnit.DAYS));
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore, never()).setConversationState(any(), eq(ConversationState.ENDED));
+        }
+
+        @Test
+        @DisplayName("a genuinely idle conversation IS ended, even on a freshly-edited agent")
+        void idleConversationOnFreshAgentIsEnded() throws Exception {
+            givenOldAgentVersionWithConversation(snapshotWithTimestamps(Instant.now().minus(90, ChronoUnit.DAYS)), Instant.now());
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore).setConversationState("conv-1", ConversationState.ENDED);
+        }
+
+        @Test
+        @DisplayName("a paused (AWAITING_HUMAN) conversation is still spared regardless of age")
+        void pausedConversationSpared() throws Exception {
+            var snapshot = snapshotWithTimestamps(Instant.now().minus(400, ChronoUnit.DAYS));
+            snapshot.setConversationState(ConversationState.AWAITING_HUMAN);
+            givenOldAgentVersionWithConversation(snapshot, Instant.now().minus(400, ChronoUnit.DAYS));
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore, never()).setConversationState(any(), eq(ConversationState.ENDED));
+        }
+
+        private void givenOldAgentVersionWithConversation(ConversationMemorySnapshot snapshot, Instant agentLastModified) throws Exception {
+            var info = new DeploymentInfo();
+            info.setEnvironment(Environment.production);
+            info.setAgentId("agent-1");
+            info.setAgentVersion(1);
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed)).thenReturn(List.of(info));
+
+            // Version 1 is not the latest, so the undeploy path (and the sweep) runs.
+            var latest = mock(IResourceId.class);
+            when(latest.getId()).thenReturn("agent-1");
+            when(latest.getVersion()).thenReturn(2);
+            when(agentStore.getCurrentResourceId("agent-1")).thenReturn(latest);
+
+            when(conversationMemoryStore.getActiveConversationCount("agent-1", 1)).thenReturn(1L);
+            when(conversationMemoryStore.loadActiveConversationMemorySnapshot("agent-1", 1)).thenReturn(List.of(snapshot));
+
+            var descriptor = new DocumentDescriptor();
+            descriptor.setName("Test Agent");
+            descriptor.setLastModifiedOn(Date.from(agentLastModified));
+            when(documentDescriptorStore.readDescriptor("agent-1", 1)).thenReturn(descriptor);
+        }
+    }
+
+    /** A snapshot whose steps carry exactly the given data timestamps. */
+    private static ConversationMemorySnapshot snapshotWithTimestamps(Instant... timestamps) {
+        var snapshot = new ConversationMemorySnapshot();
+        snapshot.setId("conv-1");
+        snapshot.setAgentId("agent-1");
+        snapshot.setAgentVersion(1);
+
+        for (Instant timestamp : timestamps) {
+            var result = new ResultSnapshot();
+            result.setKey("input");
+            result.setTimestamp(Date.from(timestamp));
+
+            var workflow = new WorkflowRunSnapshot();
+            workflow.setLifecycleTasks(List.of(result));
+
+            var step = new ConversationStepSnapshot();
+            step.setWorkflows(List.of(workflow));
+
+            snapshot.getConversationSteps().add(step);
+        }
+        return snapshot;
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
@@ -101,14 +101,16 @@ class AgentDeploymentManagementIdleSweepTest {
         @Test
         @DisplayName("35 days old with a 30-day limit is old (the months-component bug)")
         void thirtyFiveDaysIsOlderThanThirty() {
-            assertTrue(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(35), 30));
+            LocalDate today = LocalDate.of(2026, 8, 10);
+            assertTrue(AgentDeploymentManagement.isOlderThanDays(today.minusDays(35), 30, today));
         }
 
         @Test
         @DisplayName("boundaries: exactly N days is old, N-1 is not")
         void boundaries() {
-            assertTrue(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(30), 30));
-            assertFalse(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(29), 30));
+            LocalDate today = LocalDate.of(2026, 8, 10);
+            assertTrue(AgentDeploymentManagement.isOlderThanDays(today.minusDays(30), 30, today));
+            assertFalse(AgentDeploymentManagement.isOlderThanDays(today.minusDays(29), 30, today));
         }
 
         /**
@@ -118,8 +120,9 @@ class AgentDeploymentManagementIdleSweepTest {
         @Test
         @DisplayName("every age past the limit is old, with no gaps")
         void noGapsAcrossMonthBoundaries() {
+            LocalDate today = LocalDate.of(2026, 8, 10);
             for (int daysAgo = 30; daysAgo <= 400; daysAgo++) {
-                assertTrue(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(daysAgo), 30),
+                assertTrue(AgentDeploymentManagement.isOlderThanDays(today.minusDays(daysAgo), 30, today),
                         daysAgo + " days ago must count as older than 30 days");
             }
         }
@@ -127,8 +130,9 @@ class AgentDeploymentManagementIdleSweepTest {
         @Test
         @DisplayName("no age below the limit is old")
         void noFalsePositives() {
+            LocalDate today = LocalDate.of(2026, 8, 10);
             for (int daysAgo = 0; daysAgo < 30; daysAgo++) {
-                assertFalse(AgentDeploymentManagement.isOlderThanDays(LocalDate.now().minusDays(daysAgo), 30),
+                assertFalse(AgentDeploymentManagement.isOlderThanDays(today.minusDays(daysAgo), 30, today),
                         daysAgo + " days ago must not count as older than 30 days");
             }
         }
@@ -175,7 +179,7 @@ class AgentDeploymentManagementIdleSweepTest {
 
             management.manageAgentDeployments();
 
-            verify(conversationMemoryStore, never()).setConversationState(any(), eq(ConversationState.ENDED));
+            verify(conversationMemoryStore, never()).compareAndSetState(any(), any(), eq(ConversationState.ENDED));
         }
 
         @Test
@@ -185,7 +189,7 @@ class AgentDeploymentManagementIdleSweepTest {
 
             management.manageAgentDeployments();
 
-            verify(conversationMemoryStore).setConversationState("conv-1", ConversationState.ENDED);
+            verify(conversationMemoryStore).compareAndSetState(eq("conv-1"), any(), eq(ConversationState.ENDED));
         }
 
         @Test
@@ -197,7 +201,7 @@ class AgentDeploymentManagementIdleSweepTest {
 
             management.manageAgentDeployments();
 
-            verify(conversationMemoryStore, never()).setConversationState(any(), eq(ConversationState.ENDED));
+            verify(conversationMemoryStore, never()).compareAndSetState(any(), any(), eq(ConversationState.ENDED));
         }
 
         /**
@@ -212,7 +216,7 @@ class AgentDeploymentManagementIdleSweepTest {
 
             management.manageAgentDeployments();
 
-            verify(conversationMemoryStore).setConversationState("conv-1", ConversationState.ENDED);
+            verify(conversationMemoryStore).compareAndSetState(eq("conv-1"), any(), eq(ConversationState.ENDED));
         }
 
         @Test
@@ -222,7 +226,7 @@ class AgentDeploymentManagementIdleSweepTest {
 
             management.manageAgentDeployments();
 
-            verify(conversationMemoryStore, never()).setConversationState(any(), eq(ConversationState.ENDED));
+            verify(conversationMemoryStore, never()).compareAndSetState(any(), any(), eq(ConversationState.ENDED));
         }
 
         /**
@@ -239,7 +243,43 @@ class AgentDeploymentManagementIdleSweepTest {
 
             management.manageAgentDeployments();
 
-            verify(conversationMemoryStore, never()).setConversationState(any(), eq(ConversationState.ENDED));
+            verify(conversationMemoryStore, never()).compareAndSetState(any(), any(), eq(ConversationState.ENDED));
+        }
+
+        /**
+         * readDescriptor throws for a deleted agent, and manageAgentDeployments
+         * deliberately routes deleted agents down this path. Reading it eagerly meant
+         * one deleted agent aborted the entire sweep — including conversations that
+         * carry a perfectly good timestamp and never needed the descriptor.
+         */
+        @Test
+        @DisplayName("a conversation with its own timestamp is still swept when the agent descriptor is gone")
+        void deletedDescriptorDoesNotAbortTheSweep() throws Exception {
+            givenOldAgentVersionWithConversation(snapshotWithTimestamps(Instant.now().minus(400, ChronoUnit.DAYS)), null);
+            when(documentDescriptorStore.readDescriptor(any(), any())).thenThrow(new RuntimeException("descriptor deleted"));
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore).compareAndSetState(eq("conv-1"), any(), eq(ConversationState.ENDED));
+        }
+
+        /**
+         * The snapshots were read at the top of the sweep. Between that read and the
+         * write, a user can send a turn or the conversation can pause at an HITL gate —
+         * an unconditional ENDED would destroy a live turn or a pending approval.
+         */
+        @Test
+        @DisplayName("a conversation whose state changed since the snapshot is not ended")
+        void stateChangedSinceSnapshotIsNotEnded() throws Exception {
+            givenOldAgentVersionWithConversation(snapshotWithTimestamps(Instant.now().minus(400, ChronoUnit.DAYS)),
+                    Instant.now().minus(400, ChronoUnit.DAYS));
+            // The CAS loses: something else moved the conversation on.
+            when(conversationMemoryStore.compareAndSetState(any(), any(), any())).thenReturn(false);
+
+            management.manageAgentDeployments();
+
+            verify(conversationMemoryStore).compareAndSetState(eq("conv-1"), any(), eq(ConversationState.ENDED));
+            verify(conversationMemoryStore, never()).setConversationState(any(), any());
         }
 
         private void givenOldAgentVersionWithConversation(ConversationMemorySnapshot snapshot, Instant agentLastModified) throws Exception {
@@ -256,6 +296,7 @@ class AgentDeploymentManagementIdleSweepTest {
             when(agentStore.getCurrentResourceId("agent-1")).thenReturn(latest);
 
             when(conversationMemoryStore.getActiveConversationCount("agent-1", 1)).thenReturn(1L);
+            when(conversationMemoryStore.compareAndSetState(any(), any(), any())).thenReturn(true);
             when(conversationMemoryStore.loadActiveConversationMemorySnapshot("agent-1", 1)).thenReturn(List.of(snapshot));
 
             var descriptor = new DocumentDescriptor();


### PR DESCRIPTION
Rebuilt onto current `main`. Two defects in `endOldConversationsWithOldAgents`, fixed **together** because fixing either alone is worse than fixing neither.

## 1. `isOlderThanDays` ignored `Period`'s months component

It read only `getYears()` and `getDays()`. For a 35-day-old date against a 30-day limit, `Period.between(now, date)` is `P-1M-4D`, so the test became `-4 <= -30` → "not old". Whole bands of ages between the limit and one year were never reaped; the ones that were passed by coincidence of where the month boundary fell.

## 2. The age came from the AGENT document's `lastModifiedOn`

That is not a property of the conversation. Every conversation on a given agent version shared one age, so a conversation the user was talking in an hour ago counted as idle whenever the agent config happened to be old. The existing comment acknowledged the heuristic and left it in place.

## Why they had to be fixed together

The arithmetic bug was **masking** the wrong signal. Correcting only the arithmetic would convert a mostly-inert sweep into an eager one that `ENDs` live conversations — strictly worse than the bug being fixed.

Age now comes from the conversation's own newest step timestamp (`Data` stamps every entry at construction), with the descriptor kept only as a fallback and the conversation **skipped entirely** when no age signal exists at all — "cannot prove it is idle" must never end a conversation, and dereferencing a null descriptor timestamp would throw an NPE the enclosing `UndeploymentExecutor` does not catch, aborting every remaining undeploy in that pass.

## Testing

+9 tests. `recentConversationOnStaleAgentSurvives` (an hour-old conversation on a two-year-stale agent survives) and `noGapsAcrossMonthBoundaries` (every offset 30→400 days) both fail against the old code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idle-conversation cleanup across month boundaries and exact age thresholds.
  * Uses the latest conversation activity timestamp, with descriptor time as a fallback.
  * Preserves recently active, human-awaiting, state-changed, and undated conversations.

* **Tests**
  * Added regression coverage for timestamp selection, date calculations, descriptor availability, and idle-sweep behavior.

* **Documentation**
  * Added a changelog entry describing the idle-conversation cleanup fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->