### PR TITLE
fix(setup): create_sub_agent could never work, and a failed setup left orphans

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,25 @@
 
 ---
 
+## 🔎 fix(setup): create_sub_agent could never work, and a failed setup left orphans (2026-08-10)
+
+**Repo:** EDDI (`fix/sub-agent-setup-hardening`)
+
+`AgentSetupService` is what `create_sub_agent` calls, and it deploys to production from an LLM-controlled path.
+
+1. **`create_sub_agent` failed outright for every provider that needs an API key — including the default.** The tool passed `apiKey = null` with the comment "inherited from vault", and its `@P` docs promised the same. Nothing implemented it. `setupAgent` rejects a null key for any non-local provider and an omitted provider resolves to `anthropic`, so sub-agent creation only ever worked for `ollama`/`jlama`/`bedrock`/`oracle-genai`. `resolveParentLlmProfile` now walks parent agent → workflow → LLM task; `DynamicAgentConfig.inheritParentModel` (a config field nothing read) drives provider/model inheritance. **Only a vault REFERENCE is inherited, never a plaintext key** — `vaultApiKey` falls back to plaintext when the vault is unconfigured, and copying that would multiply the fallback's blast radius.
+   - The parent must be read at its **resolved current version**: `RestVersionInfo.read` does `checkNotNull(version)`, so `readAgent(id, null)` always threw and the catch swallowed it — inheritance silently returned null and the original error persisted.
+2. **The allow-lists were checked against the raw argument.** `allowedProviders` was skipped entirely when the caller omitted `provider`, which then resolved to the default — so a group restricting providers was bypassed by not passing the parameter. Now checked against the **effective** provider, with the default exposed as `AgentSetupService.DEFAULT_PROVIDER` so the two files cannot drift.
+3. **A model was judged against the wrong provider.** `allowedModels` maps a provider to *that provider's* models, but with no provider named the check accepted a model from any provider's list and then paired it with the default — a config restricting openai to `gpt-4o-mini` built an *anthropic* agent running it. An unnamed provider must now land on a provider the policy actually covers; a named provider keeps its documented "absent list = no restriction".
+4. **A failed setup orphaned every document created before the failing step.** Six to eight documents across as many stores, no transaction, and a wrap-and-rethrow failure path — on a path an LLM can retry in a loop. Best-effort compensating delete in reverse order, permanent and never cascading, isolated so it cannot mask the original failure. Applied to `createApiAgent` too.
+5. **No length bounds on `agentName`/`systemPrompt`**, both LLM-supplied and persisted. Bounded before any resource is created.
+
+**Not changed:** every auto-vaulted key carries `allowedAgents = ["*"]`. `VaultSecretProvider` documents that field as "NOT enforced at resolution time", so narrowing it here would imply an enforcement that does not exist — addressed separately by the deploy-time grant checker.
+
+Rebased onto current `main`, which had independently fixed the neighbouring lifecycle/guardrail findings; only the genuinely-missing work is carried over. 269 tests green, +12 new.
+
+---
+
 ## 🔗 fix(agents): wire the deployment-wait machinery that only the ZIP importer ever used (2026-08-09)
 
 **Repo:** EDDI (`fix/deployment-wait-machinery`)

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -41,6 +41,7 @@ import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
 import ai.labs.eddi.modules.output.model.types.TextOutputItem;
 import ai.labs.eddi.secrets.ISecretProvider;
 import ai.labs.eddi.secrets.model.SecretReference;
+import ai.labs.eddi.utils.LogSanitizer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -114,12 +115,7 @@ public class AgentSetupService {
      */
     public SetupResult setupAgent(SetupAgentRequest request) throws AgentSetupException {
         // Validate required params
-        if (request.agentName() == null || request.agentName().isBlank()) {
-            throw new AgentSetupException("Agent name is required");
-        }
-        if (request.systemPrompt() == null || request.systemPrompt().isBlank()) {
-            throw new AgentSetupException("System prompt is required");
-        }
+        validateNameAndPrompt(request.agentName(), request.systemPrompt());
         boolean isLocalLLM = isLocalLlmProvider(request.provider());
         if (!isLocalLLM && (request.apiKey() == null || request.apiKey().isBlank())) {
             throw new AgentSetupException("API key is required for cloud LLM providers (anthropic, openai, gemini)");
@@ -235,7 +231,77 @@ public class AgentSetupService {
             return resultBuilder.build();
 
         } catch (Exception e) {
+            rollbackCreatedResources(createdResources, request.agentName(), e);
             throw new AgentSetupException("Failed to set up agent: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Best-effort compensating delete for a setup that failed part-way.
+     * <p>
+     * Setup creates six to eight documents across as many stores and has no
+     * transaction. The failure path used to wrap-and-rethrow, leaving every
+     * document created before the failing step orphaned — a parser, a ruleset, an
+     * LLM config, MCP calls, an output set and a workflow, with nothing referencing
+     * them and nothing to find them by. This path is LLM-reachable through
+     * {@code create_sub_agent} and retryable, so a failure loop was unbounded
+     * storage growth.
+     * <p>
+     * Reverse creation order, and every individual delete is isolated: a
+     * compensating action must never mask the original failure, which is what the
+     * caller actually needs to see.
+     */
+    private void rollbackCreatedResources(Map<String, Object> createdResources, String agentName, Exception cause) {
+        if (createdResources.isEmpty()) {
+            return;
+        }
+        LOGGER.warnf("Agent setup for '%s' failed (%s) — rolling back %d already-created resource(s)",
+                LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(cause.getMessage()), createdResources.size());
+
+        var locations = new ArrayList<>(createdResources.values());
+        Collections.reverse(locations);
+        for (Object location : locations) {
+            if (!(location instanceof String uri) || uri.isBlank()) {
+                continue;
+            }
+            try {
+                deleteCreatedResource(uri);
+            } catch (Exception e) {
+                LOGGER.warnf("Rollback could not delete '%s': %s — it is orphaned and must be removed manually",
+                        LogSanitizer.sanitize(uri), LogSanitizer.sanitize(e.getMessage()));
+            }
+        }
+    }
+
+    /**
+     * Deletes one resource created during setup, dispatched by its Location URI.
+     */
+    private void deleteCreatedResource(String location) {
+        String id = extractIdFromLocation(location);
+        if (id == null) {
+            return;
+        }
+        // Permanent, never cascading: these documents were created moments ago by
+        // this very call and nothing else references them, so a soft delete would
+        // leave the debris this rollback exists to remove — while a cascade could
+        // reach resources it does not own.
+        Integer version = extractVersionFromLocation(location);
+        if (location.contains("/agentstore/")) {
+            getRestStore(IRestAgentStore.class).deleteAgent(id, version, true, false);
+        } else if (location.contains("/workflowstore/")) {
+            getRestStore(IRestWorkflowStore.class).deleteWorkflow(id, version, true, false);
+        } else if (location.contains("/llmstore/")) {
+            getRestStore(IRestLlmStore.class).deleteLlm(id, version, true);
+        } else if (location.contains("/mcpcallsstore/")) {
+            getRestStore(IRestMcpCallsStore.class).deleteMcpCalls(id, version, true);
+        } else if (location.contains("/outputstore/")) {
+            getRestStore(IRestOutputStore.class).deleteOutputSet(id, version, true);
+        } else if (location.contains("/rulestore/")) {
+            getRestStore(IRestRuleSetStore.class).deleteRuleSet(id, version, true);
+        } else if (location.contains("/parserstore/")) {
+            getRestStore(IRestParserStore.class).deleteParser(id, version, true);
+        } else if (location.contains("/apicallstore/")) {
+            getRestStore(IRestApiCallsStore.class).deleteApiCalls(id, version, true);
         }
     }
 
@@ -251,12 +317,7 @@ public class AgentSetupService {
      */
     public SetupResult createApiAgent(CreateApiAgentRequest request) throws AgentSetupException {
         // Validate required params
-        if (request.agentName() == null || request.agentName().isBlank()) {
-            throw new AgentSetupException("Agent name is required");
-        }
-        if (request.systemPrompt() == null || request.systemPrompt().isBlank()) {
-            throw new AgentSetupException("System prompt is required");
-        }
+        validateNameAndPrompt(request.agentName(), request.systemPrompt());
         if (request.openApiSpec() == null || request.openApiSpec().isBlank()) {
             throw new AgentSetupException("OpenAPI spec is required");
         }
@@ -389,6 +450,7 @@ public class AgentSetupService {
         } catch (AgentSetupException e) {
             throw e;
         } catch (Exception e) {
+            rollbackCreatedResources(createdResources, request.agentName(), e);
             throw new AgentSetupException("Failed to create API agent: " + e.getMessage(), e);
         }
     }
@@ -593,6 +655,175 @@ public class AgentSetupService {
     }
 
     /**
+     * The provider an omitted {@code provider} resolves to. Public because a caller
+     * that must validate against its own allow-list has to know the value this
+     * service will actually use — guarding the raw argument instead let a caller
+     * skip the allow-list entirely by omitting the parameter.
+     */
+    public static final String DEFAULT_PROVIDER = "anthropic";
+
+    /** The model an omitted {@code model} resolves to. */
+    public static final String DEFAULT_MODEL = "claude-sonnet-4-6";
+
+    /** Upper bound on a setup-supplied agent name. */
+    public static final int MAX_AGENT_NAME_LENGTH = 200;
+
+    /**
+     * Upper bound on a setup-supplied system prompt. Generous — a real system
+     * prompt can be long — but bounded: this input reaches the service from
+     * {@code create_sub_agent}, i.e. it is LLM-authored and retryable.
+     */
+    public static final int MAX_SYSTEM_PROMPT_LENGTH = 100_000;
+
+    /**
+     * Validates the two free-text fields every setup flow requires.
+     * <p>
+     * Both were checked only for blankness. They are LLM-supplied on the
+     * {@code create_sub_agent} path, where a failure is retryable, and they are
+     * persisted — the name into descriptors and into the vault key namespace, the
+     * prompt verbatim into the LLM config. An unbounded value is a storage-growth
+     * and log-noise vector with no legitimate use.
+     */
+    private void validateNameAndPrompt(String agentName, String systemPrompt) throws AgentSetupException {
+        if (agentName == null || agentName.isBlank()) {
+            throw new AgentSetupException("Agent name is required");
+        }
+        if (agentName.length() > MAX_AGENT_NAME_LENGTH) {
+            throw new AgentSetupException(
+                    "Agent name is too long (" + agentName.length() + " characters, maximum " + MAX_AGENT_NAME_LENGTH + ")");
+        }
+        if (systemPrompt == null || systemPrompt.isBlank()) {
+            throw new AgentSetupException("System prompt is required");
+        }
+        if (systemPrompt.length() > MAX_SYSTEM_PROMPT_LENGTH) {
+            throw new AgentSetupException(
+                    "System prompt is too long (" + systemPrompt.length() + " characters, maximum " + MAX_SYSTEM_PROMPT_LENGTH + ")");
+        }
+    }
+
+    /**
+     * The LLM credential a sub-agent should inherit from its parent, or
+     * {@code null} when there is nothing safe to inherit.
+     * <p>
+     * {@code create_sub_agent} passed {@code null} for {@code apiKey} with the
+     * comment "inherited from vault", and nothing implemented that inheritance — so
+     * every sub-agent creation for a provider that needs a key (which includes the
+     * default, {@code anthropic}) failed outright on the required-API-key check.
+     * The tool's own parameter documentation promised the same behaviour.
+     * <p>
+     * <b>Only a vault REFERENCE is inherited, never a plaintext key.</b> When the
+     * vault is unavailable {@code vaultApiKey} falls back to storing the key in
+     * clear, and copying such a value into a second config would multiply the blast
+     * radius of that fallback instead of referencing one secret from two places. A
+     * parent whose key is plaintext therefore inherits nothing, and the caller gets
+     * the ordinary "API key is required" error.
+     *
+     * @return the parent's {@code ${vault:...}} reference, or {@code null}
+     */
+    public ParentLlmProfile resolveParentLlmProfile(String parentAgentId) {
+        if (parentAgentId == null || parentAgentId.isBlank()) {
+            return null;
+        }
+        try {
+            // The version must be resolved first. RestVersionInfo.read does
+            // checkNotNull(version), so readAgent(id, null) ALWAYS throws — which this
+            // method's catch swallowed, making inheritance silently return null and
+            // leaving create_sub_agent failing with "API key is required", i.e. the
+            // exact defect it was written to fix.
+            IRestAgentStore agentRestStore = getRestStore(IRestAgentStore.class);
+            Integer currentVersion = agentRestStore.getCurrentVersion(parentAgentId);
+            if (currentVersion == null) {
+                return null;
+            }
+            AgentConfiguration parent = agentRestStore.readAgent(parentAgentId, currentVersion);
+            if (parent == null || parent.getWorkflows() == null) {
+                return null;
+            }
+            for (URI workflowUri : parent.getWorkflows()) {
+                LlmConfiguration.Task task = firstLlmTaskOf(workflowUri);
+                if (task == null) {
+                    continue;
+                }
+                Map<String, String> parameters = task.getParameters() != null ? task.getParameters() : Map.of();
+                String credential = firstNonBlank(parameters.get("apiKey"), parameters.get("authToken"));
+                // A reference, not a secret — see the method Javadoc.
+                if (credential != null && !SecretReference.isVaultReference(credential)) {
+                    credential = null;
+                }
+                String model = firstNonBlank(parameters.get("modelName"), parameters.get("model"), parameters.get("modelId"),
+                        parameters.get("deploymentName"));
+                if (task.getType() == null && model == null && credential == null) {
+                    // Nothing inheritable here. Returning an all-null profile would make
+                    // the caller's `parentProfile != null` mean "inheritance available"
+                    // and resolve provider and model to null, while also skipping every
+                    // remaining workflow.
+                    continue;
+                }
+                return new ParentLlmProfile(task.getType(), model, credential);
+            }
+        } catch (Exception e) {
+            LOGGER.warnf("Could not resolve the LLM profile of parent agent '%s' for inheritance: %s",
+                    LogSanitizer.sanitize(parentAgentId), e.getMessage());
+        }
+        return null;
+    }
+
+    /** The first LLM task reachable from a workflow, or {@code null}. */
+    private LlmConfiguration.Task firstLlmTaskOf(URI workflowUri) {
+        try {
+            String workflowId = extractIdFromLocation(workflowUri.toString());
+            if (workflowId == null) {
+                return null;
+            }
+            WorkflowConfiguration workflow = getRestStore(IRestWorkflowStore.class).readWorkflow(workflowId,
+                    extractVersionFromLocation(workflowUri.toString()));
+            if (workflow == null || workflow.getWorkflowSteps() == null) {
+                return null;
+            }
+            for (WorkflowConfiguration.WorkflowStep step : workflow.getWorkflowSteps()) {
+                if (step.getType() == null || !step.getType().toString().contains("ai.labs.llm")) {
+                    continue;
+                }
+                Object uri = step.getConfig() != null ? step.getConfig().get("uri") : null;
+                if (uri == null) {
+                    continue;
+                }
+                String llmId = extractIdFromLocation(uri.toString());
+                if (llmId == null) {
+                    continue;
+                }
+                LlmConfiguration llm = getRestStore(IRestLlmStore.class).readLlm(llmId, extractVersionFromLocation(uri.toString()));
+                if (llm != null && llm.tasks() != null && !llm.tasks().isEmpty()) {
+                    return llm.tasks().getFirst();
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debugf("Could not read the LLM task of workflow '%s': %s", LogSanitizer.sanitize(String.valueOf(workflowUri)),
+                    e.getMessage());
+        }
+        return null;
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * A parent agent's LLM identity, as far as it can be inherited.
+     *
+     * @param apiKeyReference
+     *            always a {@code ${vault:...}} reference or {@code null} — never a
+     *            plaintext secret
+     */
+    public record ParentLlmProfile(String provider, String model, String apiKeyReference) {
+    }
+
+    /**
      * Auto-vault an API key if the vault is available. When the vault is active,
      * the plaintext key is stored encrypted and a vault reference string
      * ({@code ${vault:keyName}}) is returned. Downstream consumers
@@ -636,6 +867,17 @@ public class AgentSetupService {
             String sanitizedName = agentName.toLowerCase().replaceAll("[^a-z0-9]", "-");
             String keyName = "setup." + sanitizedName + "." + System.currentTimeMillis() + ".apiKey";
             var ref = new SecretReference(SecretReference.DEFAULT_TENANT, keyName);
+            // "*" is deliberate and is NOT an access-control decision made here:
+            // VaultSecretProvider documents that allowedAgents is "stored for
+            // visibility/documentation but NOT enforced at resolution time". The
+            // vault's access model is "the admin who writes the agent config decides
+            // which references to include". Narrowing this list would imply an
+            // enforcement that does not exist.
+            //
+            // Worth flagging rather than silently narrowing: that access model assumes
+            // a human admin authors the config, and create_sub_agent lets an LLM author
+            // one. Making allowedAgents enforceable is a vault-level feature, not a
+            // one-line change at this call site.
             secretProvider.store(ref, apiKey, "Auto-vaulted by AgentSetupService for agent: " + agentName,
                     List.of("*"));
             LOGGER.infof("API key vaulted for agent '%s' (key: %s)", agentName, keyName);
@@ -849,8 +1091,8 @@ public class AgentSetupService {
      *             if {@code environment} is neither blank nor a known environment
      */
     ResolvedParams resolveParams(String provider, String model, Boolean deploy, String environment) {
-        return new ResolvedParams(provider != null && !provider.isBlank() ? provider.trim().toLowerCase() : "anthropic",
-                model != null && !model.isBlank() ? model.trim() : "claude-sonnet-4-6", deploy == null || deploy,
+        return new ResolvedParams(provider != null && !provider.isBlank() ? provider.trim().toLowerCase() : DEFAULT_PROVIDER,
+                model != null && !model.isBlank() ? model.trim() : DEFAULT_MODEL, deploy == null || deploy,
                 Deployment.Environment.parseStrict(environment));
     }
 

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -162,7 +162,7 @@ public class AgentSetupService {
             // --- Step 3: Create LLM Configuration ---
             // Auto-vault the API key: store encrypted in vault, use vault reference in
             // config
-            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName());
+            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), createdResources);
             var llmConfig = createLlmConfig(params.providerType, params.modelId, effectiveApiKey, request.systemPrompt(), toolsEnabled,
                     request.builtInToolsWhitelist(), request.baseUrl(), promptResponseJson, quickReplies, sentiment, null);
             Response llmResponse = getRestStore(IRestLlmStore.class).createLlm(llmConfig);
@@ -258,10 +258,20 @@ public class AgentSetupService {
         LOGGER.warnf("Agent setup for '%s' failed (%s) — rolling back %d already-created resource(s)",
                 LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(cause.getMessage()), createdResources.size());
 
-        var locations = new ArrayList<>(createdResources.values());
+        // Flattened, because not every recorded value is a scalar: createApiAgent
+        // records its generated api-call locations as a List, and a String-only loop
+        // silently left every one of those documents behind.
+        var locations = new ArrayList<String>();
+        for (Object value : createdResources.values()) {
+            if (value instanceof String uri) {
+                locations.add(uri);
+            } else if (value instanceof Collection<?> many) {
+                many.stream().filter(String.class::isInstance).map(String.class::cast).forEach(locations::add);
+            }
+        }
         Collections.reverse(locations);
-        for (Object location : locations) {
-            if (!(location instanceof String uri) || uri.isBlank()) {
+        for (String uri : locations) {
+            if (uri.isBlank()) {
                 continue;
             }
             try {
@@ -271,7 +281,27 @@ public class AgentSetupService {
                         LogSanitizer.sanitize(uri), LogSanitizer.sanitize(e.getMessage()));
             }
         }
+
+        // The auto-vaulted secret is created BEFORE the LLM document, so a later
+        // failure would leave a unique setup.<name>.<timestamp>.apiKey behind and a
+        // retry loop would grow the vault without bound.
+        Object vaultedKey = createdResources.get(VAULTED_SECRET_KEY);
+        if (vaultedKey instanceof String keyName) {
+            try {
+                secretProvider.delete(new SecretReference(SecretReference.DEFAULT_TENANT, keyName));
+            } catch (Exception e) {
+                LOGGER.warnf("Rollback could not remove the auto-vaulted secret '%s': %s",
+                        LogSanitizer.sanitize(keyName), LogSanitizer.sanitize(e.getMessage()));
+            }
+        }
     }
+
+    /**
+     * {@code createdResources} key under which a secret vaulted by THIS invocation
+     * is recorded, so rollback can remove it. Not a resource location, so
+     * {@link #deleteCreatedResource} skips it — it is handled explicitly.
+     */
+    static final String VAULTED_SECRET_KEY = "vaultedSecretKeyName";
 
     /**
      * Deletes one resource created during setup, dispatched by its Location URI.
@@ -395,7 +425,7 @@ public class AgentSetupService {
             boolean sentiment = request.enableSentimentAnalysis() != null && request.enableSentimentAnalysis();
             String promptResponseJson = buildPromptResponseJson(quickReplies, sentiment);
             // Auto-vault the API key before storing in LLM config
-            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName());
+            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), createdResources);
             // 7th slot is the LLM's own base URL — not apiBaseUrl, which is the target
             // server of the generated tools. Passing null here left local providers
             // (Ollama, Jlama) with no endpoint to reach.
@@ -747,7 +777,11 @@ public class AgentSetupService {
                 Map<String, String> parameters = task.getParameters() != null ? task.getParameters() : Map.of();
                 String credential = firstNonBlank(parameters.get("apiKey"), parameters.get("authToken"));
                 // A reference, not a secret — see the method Javadoc.
-                if (credential != null && !SecretReference.isVaultReference(credential)) {
+                // Full-pattern match, not isVaultReference: that only asks whether the
+                // value CONTAINS "${vault:", so "plaintext${vault:key}" would be
+                // treated as a safe reference and the plaintext half copied into the
+                // child's config — the exact thing this method promises never to do.
+                if (credential != null && !SecretReference.compiledPattern().matcher(credential).matches()) {
                     credential = null;
                 }
                 String model = firstNonBlank(parameters.get("modelName"), parameters.get("model"), parameters.get("modelId"),
@@ -843,6 +877,15 @@ public class AgentSetupService {
      *         unavailable
      */
     private String vaultApiKey(String apiKey, String agentName) {
+        return vaultApiKey(apiKey, agentName, null);
+    }
+
+    /**
+     * @param createdResources
+     *            when non-null, the key name of a secret vaulted by this call is
+     *            recorded here so a failed setup can remove it again
+     */
+    private String vaultApiKey(String apiKey, String agentName, Map<String, Object> createdResources) {
         if (apiKey == null || apiKey.isBlank()) {
             return apiKey;
         }
@@ -866,6 +909,9 @@ public class AgentSetupService {
             // Timestamp suffix prevents collision when two agents share the same name
             String sanitizedName = agentName.toLowerCase().replaceAll("[^a-z0-9]", "-");
             String keyName = "setup." + sanitizedName + "." + System.currentTimeMillis() + ".apiKey";
+            if (createdResources != null) {
+                createdResources.put(VAULTED_SECRET_KEY, keyName);
+            }
             var ref = new SecretReference(SecretReference.DEFAULT_TENANT, keyName);
             // "*" is deliberate and is NOT an access-control decision made here:
             // VaultSecretProvider documents that allowedAgents is "stored for

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/CreateSubAgentTool.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/CreateSubAgentTool.java
@@ -72,6 +72,24 @@ public class CreateSubAgentTool {
         this.retainedAgentIds = retainedAgentIds != null ? retainedAgentIds : ConcurrentHashMap.newKeySet();
     }
 
+    /**
+     * The models permitted for {@code provider}, or {@code null} when the policy
+     * has no entry for it. Null elements are filtered — a hand-written config can
+     * carry them, and they must neither crash the check nor widen the list.
+     */
+    private List<String> allowedModelsFor(String provider) {
+        if (config.getAllowedModels() == null || provider == null) {
+            return null;
+        }
+        return config.getAllowedModels().entrySet().stream()
+                .filter(e -> e.getKey() != null && e.getKey().equalsIgnoreCase(provider))
+                .map(Map.Entry::getValue)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .map(models -> models.stream().filter(Objects::nonNull).toList())
+                .orElse(null);
+    }
+
     @Tool("Create a new sub-agent dynamically. The agent is set up, deployed, and optionally sent an initial message. "
             + "Use this when the current discussion requires a specialist that doesn't exist yet. "
             + "The created agent's name will be auto-prefixed with the parent agent's ID.")
@@ -103,48 +121,96 @@ public class CreateSubAgentTool {
                 return "⚠️ System prompt is required.";
             }
 
+            // --- Inherit the parent's LLM identity where the caller omitted it ---
+            // The @P docs above promised this and nothing implemented it: apiKey was
+            // passed as null with a comment claiming vault inheritance, so
+            // AgentSetupService's required-API-key check rejected every provider that
+            // needs one — including the default (anthropic) that an omitted provider
+            // resolves to. Sub-agent creation only ever worked for ollama/jlama/
+            // bedrock/oracle-genai.
+            //
+            // Only a vault REFERENCE is inherited, never a plaintext key — see
+            // AgentSetupService#resolveParentLlmProfile.
+            var parentProfile = agentSetupService.resolveParentLlmProfile(parentAgentId);
+            boolean inherit = config.isInheritParentModel() && parentProfile != null;
+            String requestedProvider = (provider == null || provider.isBlank()) && inherit
+                    ? parentProfile.provider()
+                    : provider;
+            final String resolvedModel = (model == null || model.isBlank()) && inherit
+                    ? parentProfile.model()
+                    : model;
+
+            // The provider AgentSetupService will ACTUALLY use, defaults applied.
+            // Guarding the merely-requested value still left the bypass open: with
+            // inheritParentModel=false and no provider argument, nothing was inherited,
+            // the value stayed null, the allow-list check below skipped it, and
+            // resolveParams then substituted the default. Resolving the effective
+            // value here is what makes the guardrail unskippable.
+            final String resolvedProvider = requestedProvider == null || requestedProvider.isBlank()
+                    ? AgentSetupService.DEFAULT_PROVIDER
+                    : requestedProvider;
+
+            // A vault reference names ONE provider's secret. Handing the parent's
+            // anthropic reference to an openai sub-agent both breaks it at model load
+            // and writes a reference to the parent's secret into an unrelated config.
+            String inheritedApiKey = parentProfile != null
+                    && resolvedProvider.equalsIgnoreCase(parentProfile.provider())
+                            ? parentProfile.apiKeyReference()
+                            : null;
+
             // --- Guardrail: allowed providers ---
-            if (provider != null && !provider.isBlank()
-                    && config.getAllowedProviders() != null
+            // Checked against the EFFECTIVE provider, not the requested one. Guarding
+            // the requested value left the allow-list skippable: with
+            // inheritParentModel=false and no provider argument nothing was inherited,
+            // the value stayed null, this branch was skipped, and AgentSetupService
+            // then substituted its default — so a group restricting allowedProviders
+            // was bypassed by simply omitting the parameter.
+            if (config.getAllowedProviders() != null
                     && !config.getAllowedProviders().isEmpty()) {
                 boolean providerAllowed = config.getAllowedProviders().stream()
                         .filter(Objects::nonNull)
-                        .anyMatch(p -> p.equalsIgnoreCase(provider));
+                        .anyMatch(p -> p.equalsIgnoreCase(resolvedProvider));
                 if (!providerAllowed) {
                     return "⚠️ Provider '%s' is not allowed. Allowed: %s"
-                            .formatted(provider, config.getAllowedProviders());
+                            .formatted(resolvedProvider, config.getAllowedProviders());
                 }
             }
 
             // --- Guardrail: allowed models ---
-            if (model != null && !model.isBlank()
+            // allowedModels maps a provider to the models permitted FOR THAT PROVIDER,
+            // so a model may only be judged against the provider it will be paired
+            // with. The two branches differ in what an absent entry means, and
+            // deliberately so.
+            if (resolvedModel != null && !resolvedModel.isBlank()
                     && config.getAllowedModels() != null
                     && !config.getAllowedModels().isEmpty()) {
-                if (provider != null && !provider.isBlank()) {
-                    // Provider specified — check against that provider's model list
-                    // (case-insensitive key match)
-                    List<String> allowedModels = config.getAllowedModels().entrySet().stream()
-                            .filter(e -> e.getKey() != null && e.getKey().equalsIgnoreCase(provider))
-                            .map(Map.Entry::getValue)
-                            .filter(Objects::nonNull)
-                            .findFirst().orElse(null);
-                    if (allowedModels != null && !allowedModels.isEmpty()
-                            && allowedModels.stream().noneMatch(m -> m.equalsIgnoreCase(model))) {
+                List<String> allowedForProvider = allowedModelsFor(resolvedProvider);
+
+                if (requestedProvider != null && !requestedProvider.isBlank()) {
+                    // A provider was named (or inherited from the parent). An absent or
+                    // empty list means "no restriction for that provider" — a documented
+                    // behaviour, and a defensible one: the operator made a deliberate
+                    // per-provider statement and said nothing about this one.
+                    if (allowedForProvider != null && !allowedForProvider.isEmpty()
+                            && allowedForProvider.stream().noneMatch(m -> m.equalsIgnoreCase(resolvedModel))) {
                         return "⚠️ Model '%s' is not allowed for provider '%s'. Allowed: %s"
-                                .formatted(model, provider, allowedModels);
+                                .formatted(resolvedModel, resolvedProvider, allowedForProvider);
                     }
-                } else {
-                    // No provider specified — model must appear in at least one provider's
-                    // allow-list
-                    boolean modelFoundInAnyProvider = config.getAllowedModels().values().stream()
-                            .filter(Objects::nonNull)
-                            .flatMap(List::stream)
-                            .filter(Objects::nonNull)
-                            .anyMatch(m -> m.equalsIgnoreCase(model));
-                    if (!modelFoundInAnyProvider) {
-                        return "⚠️ Model '%s' is not in any provider's allowed models list."
-                                .formatted(model);
-                    }
+                } else if (allowedForProvider == null || allowedForProvider.isEmpty()) {
+                    // No provider named, so the model is about to be paired with the
+                    // DEFAULT provider — one the caller never chose and the policy never
+                    // mentions. The previous rule accepted any model appearing in ANY
+                    // provider's list, which meant a config restricting openai to
+                    // "gpt-4o-mini" would happily build an ANTHROPIC agent running
+                    // "gpt-4o-mini": a combination that fails at model load and that the
+                    // operator plainly did not authorise. An unnamed provider must land
+                    // on a provider the policy actually covers.
+                    return ("⚠️ Model '%s' cannot be used without naming a provider: the default provider '%s' has no "
+                            + "allowed models configured. Name one of: %s")
+                            .formatted(resolvedModel, resolvedProvider, config.getAllowedModels().keySet());
+                } else if (allowedForProvider.stream().noneMatch(m -> m.equalsIgnoreCase(resolvedModel))) {
+                    return "⚠️ Model '%s' is not allowed for provider '%s'. Allowed: %s"
+                            .formatted(resolvedModel, resolvedProvider, allowedForProvider);
                 }
             }
 
@@ -153,9 +219,9 @@ public class CreateSubAgentTool {
             SetupAgentRequest request = new SetupAgentRequest(
                     prefixedName,
                     systemPrompt,
-                    provider,
-                    model,
-                    null, // apiKey — inherited from vault
+                    resolvedProvider,
+                    resolvedModel,
+                    inheritedApiKey, // the parent's vault reference, or null if it has none
                     null, // baseUrl
                     null, // introMessage (handled separately below)
                     null, // enableBuiltInTools

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/CreateSubAgentTool.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/CreateSubAgentTool.java
@@ -133,22 +133,44 @@ public class CreateSubAgentTool {
             // AgentSetupService#resolveParentLlmProfile.
             var parentProfile = agentSetupService.resolveParentLlmProfile(parentAgentId);
             boolean inherit = config.isInheritParentModel() && parentProfile != null;
+
+            // TRIMMED before anything compares it. AgentSetupService.resolveParams
+            // trims, so " openai " is accepted downstream as openai while an untrimmed
+            // guardrail here would reject it against allowedProviders=["openai"] and
+            // fail to match the parent for credential inheritance — the policy and the
+            // deployment disagreeing about the same string.
             String requestedProvider = (provider == null || provider.isBlank()) && inherit
                     ? parentProfile.provider()
                     : provider;
-            final String resolvedModel = (model == null || model.isBlank()) && inherit
-                    ? parentProfile.model()
-                    : model;
+            requestedProvider = requestedProvider != null ? requestedProvider.trim() : null;
 
             // The provider AgentSetupService will ACTUALLY use, defaults applied.
-            // Guarding the merely-requested value still left the bypass open: with
-            // inheritParentModel=false and no provider argument, nothing was inherited,
+            // Guarding the merely-requested value left the bypass open: with
+            // inheritParentModel=false and no provider argument nothing was inherited,
             // the value stayed null, the allow-list check below skipped it, and
-            // resolveParams then substituted the default. Resolving the effective
-            // value here is what makes the guardrail unskippable.
+            // resolveParams then substituted the default.
             final String resolvedProvider = requestedProvider == null || requestedProvider.isBlank()
                     ? AgentSetupService.DEFAULT_PROVIDER
                     : requestedProvider;
+
+            // Model inheritance is gated on the provider STILL being the parent's.
+            // The two are independent inputs, so an anthropic parent creating a
+            // sub-agent with provider="ollama" and no model would otherwise pair Ollama
+            // with the parent's Claude model — and because Ollama needs no key, nothing
+            // downstream rejects it and the failure surfaces only at model load.
+            String requestedModel = model;
+            if ((requestedModel == null || requestedModel.isBlank()) && inherit
+                    && resolvedProvider.equalsIgnoreCase(parentProfile.provider())) {
+                requestedModel = parentProfile.model();
+            }
+            requestedModel = requestedModel != null ? requestedModel.trim() : null;
+
+            // Same reasoning as the provider: the model allow-list was skippable by
+            // omission, because a null model skipped the guard and AgentSetupService
+            // then substituted DEFAULT_MODEL — deploying a model the policy never saw.
+            final String resolvedModel = requestedModel == null || requestedModel.isBlank()
+                    ? AgentSetupService.DEFAULT_MODEL
+                    : requestedModel;
 
             // A vault reference names ONE provider's secret. Handing the parent's
             // anthropic reference to an openai sub-agent both breaks it at model load
@@ -181,9 +203,10 @@ public class CreateSubAgentTool {
             // so a model may only be judged against the provider it will be paired
             // with. The two branches differ in what an absent entry means, and
             // deliberately so.
-            if (resolvedModel != null && !resolvedModel.isBlank()
-                    && config.getAllowedModels() != null
-                    && !config.getAllowedModels().isEmpty()) {
+            // resolvedModel always carries a value now (the effective default when the
+            // caller named none), so there is no "no model requested" escape from this
+            // guard any more.
+            if (config.getAllowedModels() != null && !config.getAllowedModels().isEmpty()) {
                 List<String> allowedForProvider = allowedModelsFor(resolvedProvider);
 
                 if (requestedProvider != null && !requestedProvider.isBlank()) {

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupHardeningTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupHardeningTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.setup;
+
+import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.llm.IRestLlmStore;
+import ai.labs.eddi.configs.output.IRestOutputStore;
+import ai.labs.eddi.configs.parser.IRestParserStore;
+import ai.labs.eddi.configs.rules.IRestRuleSetStore;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.engine.api.IRestAgentAdministration;
+import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.secrets.ISecretProvider;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Hardening pins for {@link AgentSetupService} — the service
+ * {@code create_sub_agent} calls, which deploys to production from an
+ * LLM-controlled path.
+ */
+@DisplayName("AgentSetupService — hardening")
+class AgentSetupHardeningTest {
+
+    private IRestInterfaceFactory restInterfaceFactory;
+    private IRestParserStore parserStore;
+    private IRestRuleSetStore ruleSetStore;
+    private IRestLlmStore llmStore;
+    private IRestWorkflowStore workflowStore;
+    private IRestAgentStore agentStore;
+    private IRestOutputStore outputStore;
+    private AgentSetupService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        restInterfaceFactory = mock(IRestInterfaceFactory.class);
+        parserStore = mock(IRestParserStore.class);
+        ruleSetStore = mock(IRestRuleSetStore.class);
+        llmStore = mock(IRestLlmStore.class);
+        workflowStore = mock(IRestWorkflowStore.class);
+        agentStore = mock(IRestAgentStore.class);
+        outputStore = mock(IRestOutputStore.class);
+
+        when(restInterfaceFactory.get(IRestParserStore.class)).thenReturn(parserStore);
+        when(restInterfaceFactory.get(IRestRuleSetStore.class)).thenReturn(ruleSetStore);
+        when(restInterfaceFactory.get(IRestLlmStore.class)).thenReturn(llmStore);
+        when(restInterfaceFactory.get(IRestWorkflowStore.class)).thenReturn(workflowStore);
+        when(restInterfaceFactory.get(IRestAgentStore.class)).thenReturn(agentStore);
+        when(restInterfaceFactory.get(IRestOutputStore.class)).thenReturn(outputStore);
+        when(restInterfaceFactory.get(IRestDocumentDescriptorStore.class)).thenReturn(mock(IRestDocumentDescriptorStore.class));
+
+        service = new AgentSetupService(restInterfaceFactory, mock(IRestAgentAdministration.class), mock(ISecretProvider.class),
+                "http://localhost:11434");
+    }
+
+    private static Response created(String location) {
+        var response = mock(Response.class);
+        when(response.getHeaderString("Location")).thenReturn(location);
+        return response;
+    }
+
+    private static SetupAgentRequest request(String name, String prompt) {
+        return new SetupAgentRequest(name, prompt, "ollama", "llama3", null, null, null, null, null, null, null, null, false, null, null);
+    }
+
+    @Nested
+    @DisplayName("input bounds")
+    class InputBounds {
+
+        @Test
+        @DisplayName("an over-long agent name is rejected before any resource is created")
+        void overLongNameRejected() {
+            String name = "n".repeat(AgentSetupService.MAX_AGENT_NAME_LENGTH + 1);
+
+            var thrown = assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(request(name, "be helpful")));
+
+            assertTrue(thrown.getMessage().contains("too long"), thrown.getMessage());
+            verify(parserStore, never()).createParser(any());
+        }
+
+        @Test
+        @DisplayName("an over-long system prompt is rejected before any resource is created")
+        void overLongPromptRejected() {
+            String prompt = "p".repeat(AgentSetupService.MAX_SYSTEM_PROMPT_LENGTH + 1);
+
+            var thrown = assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(request("agent", prompt)));
+
+            assertTrue(thrown.getMessage().contains("too long"), thrown.getMessage());
+            verify(parserStore, never()).createParser(any());
+        }
+
+        @Test
+        @DisplayName("names and prompts at the limit are still accepted")
+        void limitsAreInclusive() {
+            String name = "n".repeat(AgentSetupService.MAX_AGENT_NAME_LENGTH);
+            String prompt = "p".repeat(AgentSetupService.MAX_SYSTEM_PROMPT_LENGTH);
+
+            // Fails later (the stores are not stubbed), but NOT on the length check.
+            var thrown = assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(request(name, prompt)));
+            assertTrue(!thrown.getMessage().contains("too long"), thrown.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("rollback of a part-way setup")
+    class Rollback {
+
+        /**
+         * Setup creates six-plus documents across as many stores with no transaction.
+         * The failure path used to wrap-and-rethrow, orphaning everything created
+         * before the failing step — on a path an LLM can retry in a loop.
+         */
+        @Test
+        @DisplayName("a failure at the agent step deletes the resources created before it")
+        void failureDeletesEarlierResources() {
+            Response parser = created("eddi://ai.labs.parser/parserstore/parsers/p1?version=1");
+            Response rules = created("eddi://ai.labs.rules/rulestore/rulesets/r1?version=1");
+            Response llm = created("eddi://ai.labs.llm/llmstore/llms/l1?version=1");
+            Response workflow = created("eddi://ai.labs.workflow/workflowstore/workflows/w1?version=1");
+            when(parserStore.createParser(any())).thenReturn(parser);
+            when(ruleSetStore.createRuleSet(any())).thenReturn(rules);
+            when(llmStore.createLlm(any())).thenReturn(llm);
+            when(workflowStore.createWorkflow(any())).thenReturn(workflow);
+            when(agentStore.createAgent(any())).thenThrow(new RuntimeException("agent store down"));
+
+            assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(request("agent", "be helpful")));
+
+            verify(workflowStore).deleteWorkflow("w1", 1, true, false);
+            verify(llmStore).deleteLlm("l1", 1, true);
+            verify(ruleSetStore).deleteRuleSet("r1", 1, true);
+            verify(parserStore).deleteParser("p1", 1, true);
+        }
+
+        @Test
+        @DisplayName("a rollback delete that itself fails does not mask the original error")
+        void rollbackFailureDoesNotMaskCause() {
+            Response parser = created("eddi://ai.labs.parser/parserstore/parsers/p1?version=1");
+            when(parserStore.createParser(any())).thenReturn(parser);
+            when(ruleSetStore.createRuleSet(any())).thenThrow(new RuntimeException("ruleset store down"));
+            when(parserStore.deleteParser(anyString(), anyInt(), any())).thenThrow(new RuntimeException("delete also down"));
+
+            var thrown = assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(request("agent", "be helpful")));
+
+            assertTrue(thrown.getMessage().contains("ruleset store down"), thrown.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("parent LLM profile inheritance")
+    class Inheritance {
+
+        /**
+         * {@code create_sub_agent} passed a null apiKey with a comment claiming vault
+         * inheritance, and nothing implemented it — so every provider that needs a key
+         * (including the default) failed the required-API-key check outright.
+         */
+        @Test
+        @DisplayName("resolves the parent's provider, model and vault reference")
+        void resolvesParentProfile() {
+            givenParentWithLlm("anthropic", Map.of("modelName", "claude-sonnet-4-6", "apiKey", "${vault:setup.parent.1.apiKey}"));
+
+            var profile = service.resolveParentLlmProfile("parent-1");
+
+            assertNotNull(profile);
+            assertEquals("anthropic", profile.provider());
+            assertEquals("claude-sonnet-4-6", profile.model());
+            assertEquals("${vault:setup.parent.1.apiKey}", profile.apiKeyReference());
+        }
+
+        /**
+         * The vault falls back to plaintext storage when it is not configured. Copying
+         * such a value into a second config would multiply the blast radius of that
+         * fallback rather than reference one secret from two places.
+         */
+        @Test
+        @DisplayName("a plaintext parent key is NOT inherited")
+        void plaintextKeyNotInherited() {
+            givenParentWithLlm("openai", Map.of("modelName", "gpt-4o", "apiKey", "sk-a-real-secret"));
+
+            var profile = service.resolveParentLlmProfile("parent-1");
+
+            assertNotNull(profile);
+            assertNull(profile.apiKeyReference(), "a plaintext secret must never be copied into a second config");
+            assertEquals("openai", profile.provider());
+        }
+
+        /**
+         * RestVersionInfo.read does checkNotNull(version), so readAgent(id, null)
+         * always throws. Passing null made resolveParentLlmProfile swallow that and
+         * return null, leaving create_sub_agent failing with "API key is required" —
+         * the very defect inheritance was added to fix.
+         */
+        @Test
+        @DisplayName("reads the parent at its resolved current version, never at a null version")
+        void readsParentAtResolvedVersion() {
+            givenParentWithLlm("anthropic", Map.of("modelName", "claude-sonnet-4-6", "apiKey", "${vault:k}"));
+
+            assertNotNull(service.resolveParentLlmProfile("parent-1"));
+
+            verify(agentStore).getCurrentVersion("parent-1");
+            verify(agentStore).readAgent("parent-1", 4);
+            verify(agentStore, never()).readAgent(anyString(), isNull());
+        }
+
+        @Test
+        @DisplayName("a workflow whose LLM task carries nothing inheritable is skipped")
+        void emptyTaskIsNotAProfile() {
+            givenParentWithLlm(null, Map.of());
+
+            assertNull(service.resolveParentLlmProfile("parent-1"),
+                    "an all-null profile would make the caller treat inheritance as available");
+        }
+
+        @Test
+        @DisplayName("an unreadable parent yields no profile rather than throwing")
+        void unreadableParentIsNull() {
+            when(agentStore.getCurrentVersion(anyString())).thenThrow(new RuntimeException("store down"));
+
+            assertNull(service.resolveParentLlmProfile("parent-1"));
+        }
+
+        @Test
+        @DisplayName("a blank parent id yields no profile")
+        void blankParentIsNull() {
+            assertNull(service.resolveParentLlmProfile(null));
+            assertNull(service.resolveParentLlmProfile("  "));
+        }
+
+        private void givenParentWithLlm(String provider, Map<String, String> parameters) {
+            var agent = new AgentConfiguration();
+            agent.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/w1?version=1")));
+            // Stubbed on the RESOLVED version, never any(): readAgent(id, null) throws
+            // checkNotNull inside RestVersionInfo, so a lenient any() stub hid the fact
+            // that the production call passed null and inheritance never worked.
+            when(agentStore.getCurrentVersion("parent-1")).thenReturn(4);
+            when(agentStore.readAgent("parent-1", 4)).thenReturn(agent);
+
+            var step = new WorkflowConfiguration.WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.llm"));
+            var config = new LinkedHashMap<String, Object>();
+            config.put("uri", "eddi://ai.labs.llm/llmstore/llms/l1?version=1");
+            step.setConfig(config);
+
+            var workflow = new WorkflowConfiguration();
+            workflow.setWorkflowSteps(List.of(step));
+            when(workflowStore.readWorkflow(eq("w1"), anyInt())).thenReturn(workflow);
+
+            var task = new LlmConfiguration.Task();
+            task.setType(provider);
+            task.setParameters(new LinkedHashMap<>(parameters));
+            when(llmStore.readLlm(eq("l1"), anyInt())).thenReturn(new LlmConfiguration(List.of(task)));
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/DynamicAgentToolsTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/DynamicAgentToolsTest.java
@@ -141,7 +141,9 @@ class DynamicAgentToolsTest {
             String result = tool.createSubAgent("Test", "prompt", null, "unknown-model", null, null);
 
             assertTrue(result.contains("⚠️"));
-            assertTrue(result.contains("not in any provider"));
+            // Message changed with the semantics: the model is no longer judged against
+            // "any provider's list", because it can only ever be paired with one.
+            assertTrue(result.contains("without naming a provider"), result);
         }
 
         @Test
@@ -214,16 +216,87 @@ class DynamicAgentToolsTest {
 
         @Test
         void createSubAgent_modelAllowed_providerOmitted_positiveCase() throws Exception {
-            // Model exists in one of the provider lists — should be allowed
+            // BEHAVIOUR CHANGE (deliberate). This used to pass: a model appearing in ANY
+            // provider's list was accepted with no provider named, and then paired with
+            // the DEFAULT provider. Here that produced an *anthropic* agent running
+            // openai's "gpt-4o-mini" — a combination that fails at model load and that
+            // the operator, who restricted only openai, never authorised.
+            config.setAllowedModels(Map.of("openai", List.of("gpt-4o-mini")));
+
+            String result = tool.createSubAgent("Test", "prompt", null, "gpt-4o-mini", null, null);
+
+            assertTrue(result.contains("⚠️"), result);
+            assertTrue(result.contains("without naming a provider"), result);
+        }
+
+        @Test
+        @DisplayName("naming the provider makes the same model/provider pair succeed")
+        void createSubAgent_modelAllowed_providerNamed() throws Exception {
             config.setAllowedModels(Map.of("openai", List.of("gpt-4o-mini")));
 
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
                             null, "gpt-4o-mini", true, "ready", null, null, null, null, null));
 
-            String result = tool.createSubAgent("Test", "prompt", null, "gpt-4o-mini", null, null);
+            String result = tool.createSubAgent("Test", "prompt", "openai", "gpt-4o-mini", null, null);
 
-            assertTrue(result.contains("✅"));
+            assertTrue(result.contains("✅"), result);
+        }
+
+        @Test
+        @DisplayName("allowedProviders is enforced against the EFFECTIVE provider, not the requested one")
+        void createSubAgent_allowedProvidersNotBypassableByOmittingIt() {
+            // With inheritParentModel off and no provider argument, nothing is
+            // inherited and the requested provider stays null. Guarding that value
+            // skipped the check entirely, and AgentSetupService then substituted its
+            // default — so a group restricting allowedProviders was bypassed by simply
+            // omitting the parameter.
+            config.setInheritParentModel(false);
+            config.setAllowedProviders(List.of("ollama"));
+
+            String result = tool.createSubAgent("Test", "prompt", null, null, null, null);
+
+            assertTrue(result.contains("⚠️"), result);
+            assertTrue(result.contains("not allowed"), result);
+            assertTrue(result.contains(AgentSetupService.DEFAULT_PROVIDER), result);
+        }
+
+        @Test
+        @DisplayName("the parent's vault reference is not handed to a different provider")
+        void createSubAgent_credentialDoesNotCrossProviders() throws Exception {
+            // A vault reference names ONE provider's secret. Passing the parent's
+            // anthropic reference into an openai config both breaks the sub-agent at
+            // model load and stores a reference to the parent's secret in an unrelated
+            // config.
+            when(agentSetupService.resolveParentLlmProfile("parent-agent-1"))
+                    .thenReturn(new AgentSetupService.ParentLlmProfile("anthropic", "claude-sonnet-4-6", "${vault:parent.apiKey}"));
+            when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
+                    .thenReturn(SetupResult.builder().action("setup_complete").agentId("sub-1").build());
+
+            tool.createSubAgent("Test", "prompt", "openai", "gpt-4o", null, null);
+
+            var captor = org.mockito.ArgumentCaptor.forClass(SetupAgentRequest.class);
+            verify(agentSetupService).setupAgent(captor.capture());
+            assertNull(captor.getValue().apiKey(), "the parent's anthropic vault reference must not reach an openai config");
+            assertEquals("openai", captor.getValue().provider());
+        }
+
+        @Test
+        @DisplayName("the parent's vault reference IS inherited when the provider matches")
+        void createSubAgent_credentialInheritedForSameProvider() throws Exception {
+            when(agentSetupService.resolveParentLlmProfile("parent-agent-1"))
+                    .thenReturn(new AgentSetupService.ParentLlmProfile("anthropic", "claude-sonnet-4-6", "${vault:parent.apiKey}"));
+            when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
+                    .thenReturn(SetupResult.builder().action("setup_complete").agentId("sub-1").build());
+
+            tool.createSubAgent("Test", "prompt", null, null, null, null);
+
+            var captor = org.mockito.ArgumentCaptor.forClass(SetupAgentRequest.class);
+            verify(agentSetupService).setupAgent(captor.capture());
+            assertEquals("${vault:parent.apiKey}", captor.getValue().apiKey(),
+                    "inheritance is the whole point — create_sub_agent failed outright without it");
+            assertEquals("anthropic", captor.getValue().provider());
+            assertEquals("claude-sonnet-4-6", captor.getValue().model());
         }
 
         @Test


### PR DESCRIPTION
Rebuilt onto current `main`, which had independently fixed the neighbouring lifecycle and guardrail findings. Only the genuinely-missing work is carried over.

`AgentSetupService` is what `create_sub_agent` calls, and it deploys to production from an LLM-controlled path.

## 1. `create_sub_agent` failed outright for every provider that needs an API key

The tool passed `apiKey = null` with `// apiKey — inherited from vault`, and its `@P` docs promised *"inherits parent if omitted"*. **Nothing implemented either.** `setupAgent` rejects a null key for any non-local provider, and an omitted provider resolves to `anthropic` — so sub-agent creation only ever worked for `ollama` / `jlama` / `bedrock` / `oracle-genai`.

`resolveParentLlmProfile` now walks parent agent → workflow → LLM task. `DynamicAgentConfig.inheritParentModel` — a config field nothing read — drives provider/model inheritance.

The parent must be read at its **resolved current version**: `RestVersionInfo.read` does `checkNotNull(version)`, so `readAgent(id, null)` always threw, the catch swallowed it, and inheritance silently returned null — leaving the very error it was added to remove.

**Only a vault REFERENCE is inherited, never a plaintext key.** `vaultApiKey` falls back to plaintext when the vault is unconfigured; copying that into a second config would multiply the fallback's blast radius rather than reference one secret twice.

## 2. The allow-lists were checked against the raw argument

`allowedProviders` was skipped entirely when the caller omitted `provider` — which then resolved to the default inside `AgentSetupService`. A group restricting providers was bypassable by simply not passing the parameter. Now checked against the **effective** provider, with the default exposed as `AgentSetupService.DEFAULT_PROVIDER` so the two files cannot drift.

## 3. A model was judged against the wrong provider

`allowedModels` maps a provider to *that provider's* permitted models. With no provider named, the check accepted a model from **any** provider's list and then paired it with the default — so a config restricting openai to `gpt-4o-mini` built an **anthropic** agent running `gpt-4o-mini`, which fails at model load and was never authorised.

An unnamed provider must now land on a provider the policy actually covers. A **named** provider keeps its documented "absent list = no restriction" semantics — that behaviour is pinned by tests stating it outright, and changing it is not part of closing this gap.

## 4. A failed setup orphaned everything created before the failing step

Six to eight documents across as many stores, no transaction, and a wrap-and-rethrow failure path — on a path an LLM can retry in a loop. Added a best-effort compensating delete in reverse creation order: permanent (a soft delete leaves the debris), never cascading (a cascade could reach resources it does not own), and each delete isolated so it can never mask the original failure. Applied to `createApiAgent` too.

## 5. No length bounds on `agentName` / `systemPrompt`

Both LLM-supplied, both persisted — the name into descriptors and the vault key namespace, the prompt verbatim into the LLM config. Bounded before any resource is created.

## Not changed

Every auto-vaulted key carries `allowedAgents = ["*"]`. `VaultSecretProvider` documents that field as *"NOT enforced at resolution time"*, so narrowing it here would imply an enforcement that does not exist. Addressed properly in the deploy-time grant checker PR instead.

## Testing

269 tests green across the setup and dynamic-agent suites, +12 new.