### PR TITLE
chore(vault): default grant-enforcement to enforce

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ Safe as a shipped default for two reasons, both worth knowing before relying on 
 1. **Inert without a master key.** `eddi.vault.master-key` is empty by default; with the vault disabled the checker returns "no violations" without looking at anything.
 2. **Wildcard grants.** Every key `AgentSetupService` vaults carries `allowedAgents = ["*"]`. Only a grant an operator has deliberately narrowed can produce a violation.
 
+The code fallback moved with it. `@ConfigProperty(defaultValue = ...)` and the absent/blank branch of `parseStrict` both resolve to `DEFAULT_MODE_NAME` — the same constant the bundled property uses. A property file saying `enforce` beside a code fallback saying `warn` would mean an external configuration that omits or blanks the key silently downgrades the control while every visible sign still says it is on. Turning enforcement down is now always explicit.
+
 **Operational note:** on a deployment that has *both* a master key and narrowed grants, run once on `warn` and confirm the log is free of `references vault secret(s) it is not granted` before enabling this. In `enforce` mode that condition is an ERROR that stops the agent deploying — there is no warning to notice first.
 
 No shipped agent configuration (initial-agents, docs/agent-configs) contains a vault reference, so nothing in the repo can trip the check.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,22 @@
 
 ---
 
+## 🔒 chore(vault): default grant-enforcement to enforce (2026-08-11)
+
+**Repo:** EDDI (`chore/vault-grant-enforce`)
+
+`eddi.vault.grant-enforcement` now ships as `enforce` rather than `warn`, so an agent whose configuration names a vault secret its `allowedAgents` does not grant is blocked at deployment instead of merely logged.
+
+Safe as a shipped default for two reasons, both worth knowing before relying on it:
+1. **Inert without a master key.** `eddi.vault.master-key` is empty by default; with the vault disabled the checker returns "no violations" without looking at anything.
+2. **Wildcard grants.** Every key `AgentSetupService` vaults carries `allowedAgents = ["*"]`. Only a grant an operator has deliberately narrowed can produce a violation.
+
+**Operational note:** on a deployment that has *both* a master key and narrowed grants, run once on `warn` and confirm the log is free of `references vault secret(s) it is not granted` before enabling this. In `enforce` mode that condition is an ERROR that stops the agent deploying — there is no warning to notice first.
+
+No shipped agent configuration (initial-agents, docs/agent-configs) contains a vault reference, so nothing in the repo can trip the check.
+
+---
+
 ## 🔒 feat(vault): allowedAgents is enforced instead of decorative (2026-08-10)
 
 **Repo:** EDDI (`feat/vault-grant-enforcement`)

--- a/src/main/java/ai/labs/eddi/secrets/VaultGrantGate.java
+++ b/src/main/java/ai/labs/eddi/secrets/VaultGrantGate.java
@@ -28,6 +28,17 @@ public class VaultGrantGate {
 
     private static final Logger LOGGER = Logger.getLogger(VaultGrantGate.class);
 
+    /**
+     * The mode applied when the property is absent or blank.
+     * <p>
+     * Deliberately the SAME value the bundled {@code application.properties} ships.
+     * When the two disagree — a property saying {@code enforce} and a code fallback
+     * saying {@code warn} — an external configuration that omits or blanks the key
+     * silently downgrades the control while every visible sign still says it is on.
+     * Fail closed, and keep the two definitions in one place.
+     */
+    public static final String DEFAULT_MODE_NAME = "enforce";
+
     /** Enforcement modes for {@code eddi.vault.grant-enforcement}. */
     public enum Mode {
         OFF, WARN, ENFORCE;
@@ -36,10 +47,14 @@ public class VaultGrantGate {
          * Strict parse — an unrecognised value is rejected, never defaulted.
          * {@code grant-enforcement=enforced} silently behaving as {@code warn} would
          * turn one typo into a security control that is off while appearing on.
+         * <p>
+         * Absent or blank resolves to {@link #DEFAULT_MODE_NAME}, not to a weaker mode:
+         * an operator who blanks the value gets the shipped behaviour, never a quieter
+         * one. Turning enforcement down has to be explicit.
          */
         public static Mode parseStrict(String value) {
             if (value == null || value.isBlank()) {
-                return WARN;
+                return valueOf(DEFAULT_MODE_NAME.toUpperCase());
             }
             for (Mode mode : values()) {
                 if (mode.name().equalsIgnoreCase(value.trim())) {
@@ -56,10 +71,10 @@ public class VaultGrantGate {
 
     @Inject
     public VaultGrantGate(VaultGrantChecker checker,
-            @ConfigProperty(name = "eddi.vault.grant-enforcement", defaultValue = "warn") String grantEnforcement) {
+            @ConfigProperty(name = "eddi.vault.grant-enforcement", defaultValue = DEFAULT_MODE_NAME) String grantEnforcement) {
         this.checker = checker;
         // Parsed in the constructor so an unusable value fails bean creation, i.e.
-        // startup, rather than silently degrading to warn.
+        // startup, rather than silently degrading.
         this.mode = Mode.parseStrict(grantEnforcement);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -96,6 +96,26 @@ eddi.vault.master-key=
 eddi.vault.cache-ttl-minutes=5
 eddi.vault.cache-max-size=1000
 
+# What happens when an agent's configuration names a vault secret whose
+# SecretMetadata.allowedAgents does not grant it: off | warn | enforce.
+# Checked at the single deployment boundary (AgentFactory#deployAgent), so it
+# covers the scheduled redeploy poll, the REST deploy and deploy-on-demand alike.
+#
+# enforce BLOCKS the deployment. Two things make that safe to ship as the
+# default here, and both are worth knowing before relying on it:
+#   1. It is inert unless eddi.vault.master-key is set — with no master key the
+#      vault is disabled and the check returns "no violations" without looking.
+#   2. Every key AgentSetupService vaults carries allowedAgents = ["*"], which
+#      grants every agent. Only a grant an operator has deliberately narrowed
+#      can produce a violation.
+# An unrecognised value fails startup rather than degrading to warn: a typo such
+# as "enforced" must not leave a security control off while appearing on.
+#
+# Before enabling this on a deployment that HAS a master key and narrowed
+# grants, run once with 'warn' and confirm the log is clean — in enforce mode a
+# violation is an ERROR that stops the agent deploying, not a warning.
+eddi.vault.grant-enforcement=enforce
+
 # Tenant Quotas — SaaS foundation (per-tenant rate limits + usage metering)
 # Set to -1 for unlimited. Disabled by default — zero impact on existing deployments.
 eddi.tenant.default-id=default

--- a/src/test/java/ai/labs/eddi/secrets/VaultGrantGateModeTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/VaultGrantGateModeTest.java
@@ -40,8 +40,8 @@ class VaultGrantGateModeTest {
         assertEquals(Mode.OFF, Mode.parseStrict("off"));
         assertEquals(Mode.WARN, Mode.parseStrict("warn"));
         assertEquals(Mode.ENFORCE, Mode.parseStrict("  ENFORCE "));
-        assertEquals(Mode.WARN, Mode.parseStrict(null));
-        assertEquals(Mode.WARN, Mode.parseStrict("   "));
+        // null/blank are covered by absentMeansShippedDefault — they resolve to the
+        // shipped default, not to a fixed mode named here.
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/secrets/VaultGrantGateModeTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/VaultGrantGateModeTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,6 +43,62 @@ class VaultGrantGateModeTest {
         assertEquals(Mode.ENFORCE, Mode.parseStrict("  ENFORCE "));
         // null/blank are covered by absentMeansShippedDefault — they resolve to the
         // shipped default, not to a fixed mode named here.
+    }
+
+    /**
+     * Absent or blank must resolve to the SHIPPED default, never to something
+     * weaker. A bundled {@code application.properties} saying {@code enforce}
+     * beside a code fallback saying {@code warn} means an external configuration
+     * that omits or blanks the key runs with the control off while every visible
+     * sign still says it is on.
+     */
+    @Test
+    @DisplayName("absent or blank resolves to the shipped default, never to something weaker")
+    void absentMeansShippedDefault() {
+        Mode shipped = Mode.valueOf(VaultGrantGate.DEFAULT_MODE_NAME.toUpperCase());
+
+        assertEquals(shipped, Mode.parseStrict(null));
+        assertEquals(shipped, Mode.parseStrict(""));
+        assertEquals(shipped, Mode.parseStrict("   "));
+        // Pinned concretely as well as relatively: asserting only "equals the
+        // constant" would still pass if the constant itself were weakened to warn.
+        assertEquals(Mode.ENFORCE, shipped, "the shipped default must be enforce");
+    }
+
+    /**
+     * The bundled property and the code fallback are two definitions of one fact,
+     * and the whole finding here was that they had drifted apart.
+     * <p>
+     * Read from {@code src/main/resources} on disk rather than the classpath:
+     * {@code src/test/resources/application.properties} shadows the shipped file
+     * during tests and does NOT set this key, so a classpath read would assert
+     * against the wrong file — and, being absent there, would assert nothing at
+     * all. (That shadowing is also why the drift this test guards was invisible in
+     * the test environment: tests take the code fallback, which is exactly the
+     * value that had diverged.)
+     */
+    @Test
+    @DisplayName("the bundled application.properties matches the code fallback")
+    void bundledPropertyMatchesTheCodeFallback() throws Exception {
+        var shippedProperties = java.nio.file.Path.of("src", "main", "resources", "application.properties");
+        assertTrue(java.nio.file.Files.exists(shippedProperties), "expected the shipped application.properties at " + shippedProperties);
+
+        var configured = java.nio.file.Files.readAllLines(shippedProperties).stream()
+                .map(String::trim)
+                .filter(line -> line.startsWith("eddi.vault.grant-enforcement="))
+                .map(line -> line.substring(line.indexOf('=') + 1).trim())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("eddi.vault.grant-enforcement is not set in application.properties"));
+
+        assertEquals(VaultGrantGate.DEFAULT_MODE_NAME, configured,
+                "the bundled property and DEFAULT_MODE_NAME must not drift — that drift IS the vulnerability");
+    }
+
+    @Test
+    @DisplayName("turning enforcement down is explicit, never implicit")
+    void weakeningIsExplicit() {
+        assertEquals(Mode.WARN, Mode.parseStrict("warn"));
+        assertEquals(Mode.OFF, Mode.parseStrict("off"));
     }
 
     /**


### PR DESCRIPTION
Flips `eddi.vault.grant-enforcement` from `warn` to `enforce`, so an agent whose configuration names a vault secret its `allowedAgents` does not grant is **blocked at deployment** rather than logged.

## Why this is safe to ship as a default

1. **Inert without a master key.** `eddi.vault.master-key` is empty by default. With the vault disabled, `VaultGrantChecker` returns "no violations" without inspecting anything, so the mode makes no difference at all.
2. **Wildcard grants.** Every key `AgentSetupService` vaults carries `allowedAgents = ["*"]`, which grants every agent. Only a grant an operator has deliberately narrowed can produce a violation.
3. **No shipped config can trip it.** No agent configuration in `initial-agents/` or `docs/agent-configs/` contains a `${vault:...}` reference.

## What I verified, and what I did not

| Check | Result |
|---|---|
| Value parses to `ENFORCE` | ✅ `VaultGrantGateModeTest` |
| `enforce` blocks a violation; `warn`/`off` do not | ✅ pinned |
| Unrecognised value fails startup rather than degrading | ✅ pinned |
| Affected suites with the property in place | ✅ 319 green |
| Vault references in shipped configs | ✅ none |
| **"No violations" against real agent data** | ❌ **not verified** |

The last row is the important one. The check reads agent configurations from the store at deploy time, so "no violations" is a property of a *running deployment* and cannot be established from the repository. There is also no `@QuarkusTest` covering `secrets/`, so this change has not been observed booting a real CDI container — only its parser has been exercised.

## Before relying on this

On a deployment that has **both** a master key **and** narrowed grants, run once on `warn` and confirm the log is free of:

```
references vault secret(s) it is not granted
```

In `enforce` mode that condition is an `ERROR` that stops the agent deploying — there is no warning to notice first, which is the whole reason the feature shipped warn-first. Deployments without a master key, or with only wildcard grants, are unaffected either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault secret access is now enforced by default during agent deployment.
  * Unauthorized vault-secret references block deployment instead of only generating warnings.
  * Enforcement can be configured to disable checks, issue warnings, or block deployment.
  * Enforcement remains inactive when no vault master key is configured.

* **Documentation**
  * Added migration guidance, wildcard grant details, and configuration behavior to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->