### PR TITLE
fix(deps): clear four OSV advisories flagged by Scorecard

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,36 @@
 
 ---
 
+## 🛡️ fix(deps): clear the four OSV advisories dragging Scorecard's Vulnerabilities check to 6 (2026-08-11)
+
+**Repo:** EDDI (`fix/dependency-vulnerabilities`)
+
+OpenSSF Scorecard's `Vulnerabilities` check fell from 10 to 6 — `4 existing vulnerabilities detected`. Four advisories across **three** libraries; jackson-databind carries two of them.
+
+| Advisory | Package | Was | Now | Reached us via |
+| -------- | ------- | --- | --- | -------------- |
+| GHSA-5gvw-p9qm-jgwh (6.5) | jackson-databind | 2.22.0 | 2.22.1 | `quarkus-jackson:3.38.1` |
+| GHSA-5jmj-h7xm-6q6v (5.3) | jackson-databind | 2.22.0 | 2.22.1 | same |
+| GHSA-pmhh-3w7g-xqp8 (4.7) | jsoup | 1.22.2 | 1.23.1 | direct dependency |
+| GHSA-mx76-r943-rf8g | bcprov-lts8on | 2.73.10 | 2.73.12 | `io.nats:jnats:2.26.0` |
+
+**None of the four is reachable from our code**, checked against each advisory's stated precondition rather than assumed:
+
+- GHSA-5gvw needs `@JsonView` on an `@JsonUnwrapped` container — `@JsonView` appears in **zero** files under `src/main/java`.
+- GHSA-5jmj needs *per-property* `@JsonIgnoreProperties` **and** case-insensitive deserialization. All six usages are class-level `ignoreUnknown = true` with no property list, and `ACCEPT_CASE_INSENSITIVE_PROPERTIES` is enabled nowhere — every "case-insensitive" hit in the tree is `Pattern.CASE_INSENSITIVE` or a doc comment.
+- GHSA-pmhh is specific to jsoup's `Cleaner` sanitiser. `WebScraperTool` is the only jsoup consumer and calls **only `Jsoup.parse()`** — never `Cleaner`, `Safelist` or `clean()`.
+- GHSA-mx76 is a GCM chunking defect that throws a bad-tag exception on decryption — availability, not confidentiality — under the NATS client.
+
+They are fixed anyway because Scorecard counts advisories regardless of reachability, and because staying current is cheaper than re-litigating reachability every scan. This is score hygiene and dependency freshness, not an incident.
+
+**Why two of the three are `dependencyManagement` overrides.** jsoup is a direct dependency, so it is a version bump. jackson-databind is managed by the Quarkus BOM at 2.22.0, exactly like `jackson-core` — which this POM already pins to 2.22.1 for GHSA-r7wm-3cxj-wff9 — so the new entry follows that established pattern rather than importing `jackson-bom` ahead of the platform BOM. bcprov-lts8on needed a pin because the obvious alternative does not work: **`io.nats:jnats` 2.26.1 still declares 2.73.10**, verified by reading its POM, so bumping the parent would not have cleared it.
+
+**Known, pre-existing version skew.** databind and core now sit at 2.22.1 while the rest of the Jackson family (`datatype-jsr310`, `datatype-jdk8`, `module-parameter-names`, the `dataformat-*` set) stays at 2.22.0 and `jackson-annotations` at 2.22. That skew already existed for `jackson-core` alone; patch-level differences inside 2.22.x are binary-compatible. Aligning the whole family via `jackson-bom` would be tidier but moves more versions than Quarkus 3.38.1 was tested against, so it was deliberately not done here.
+
+Resolved versions confirmed with `dependency:tree` after the change, not inferred from the POM.
+
+---
+
 ## 🔒 feat(vault): allowedAgents is enforced instead of decorative (2026-08-10)
 
 **Repo:** EDDI (`feat/vault-grant-enforcement`)

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,18 @@
                 <artifactId>jackson-core</artifactId>
                 <version>2.22.1</version>
             </dependency>
+            <!-- Override jackson-databind to fix GHSA-5gvw-p9qm-jgwh (@JsonView bypassed for
+                 @JsonUnwrapped containers) and GHSA-5jmj-h7xm-6q6v (case-insensitive
+                 deserialization bypasses per-property @JsonIgnoreProperties), both <2.22.1.
+                 Managed by the Quarkus BOM at 2.22.0, same as jackson-core above. Neither is
+                 reachable from our code — @JsonView is unused and every @JsonIgnoreProperties
+                 is class-level ignoreUnknown — but OpenSSF Scorecard counts advisories
+                 regardless of reachability. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.22.1</version>
+            </dependency>
             <!-- Override reactor-netty-http to fix CVE-2025-22227 (pulled by langchain4j-azure-open-ai) -->
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
@@ -71,6 +83,15 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>42.7.13</version>
+            </dependency>
+            <!-- Override bcprov-lts8on to fix GHSA-mx76-r943-rf8g (native GCM chunking can throw
+                 a bad-tag exception on decryption, 2.73.0–2.73.10). Pulled by io.nats:jnats at
+                 2.73.10; jnats 2.26.1 still declares 2.73.10, so a bump of the parent does not
+                 clear it and the version has to be pinned here. -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-lts8on</artifactId>
+                <version>2.73.12</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -288,7 +309,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.22.2</version>
+            <version>1.23.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
OpenSSF Scorecard's `Vulnerabilities` check dropped **10 → 6** (`4 existing vulnerabilities detected`). Four advisories across **three** libraries — jackson-databind carries two.

| Advisory | Package | Was | Now | Reached us via |
| -------- | ------- | --- | --- | -------------- |
| GHSA-5gvw-p9qm-jgwh (6.5) | jackson-databind | 2.22.0 | 2.22.1 | `quarkus-jackson:3.38.1` |
| GHSA-5jmj-h7xm-6q6v (5.3) | jackson-databind | 2.22.0 | 2.22.1 | same |
| GHSA-pmhh-3w7g-xqp8 (4.7) | jsoup | 1.22.2 | 1.23.1 | direct dependency |
| GHSA-mx76-r943-rf8g | bcprov-lts8on | 2.73.10 | 2.73.12 | `io.nats:jnats:2.26.0` |

## None of the four is reachable from our code

Checked against each advisory's stated precondition rather than assumed:

- **GHSA-5gvw** needs `@JsonView` on an `@JsonUnwrapped` container — `@JsonView` appears in **zero** files under `src/main/java`.
- **GHSA-5jmj** needs *per-property* `@JsonIgnoreProperties` **and** case-insensitive deserialization. All six usages are class-level `ignoreUnknown = true` with no property list, and `ACCEPT_CASE_INSENSITIVE_PROPERTIES` is enabled nowhere — every "case-insensitive" hit in the tree is `Pattern.CASE_INSENSITIVE` or a doc comment.
- **GHSA-pmhh** is specific to jsoup's `Cleaner` sanitiser. `WebScraperTool` is the only jsoup consumer and calls **only `Jsoup.parse()`** — never `Cleaner`, `Safelist` or `clean()`.
- **GHSA-mx76** is a GCM chunking defect throwing a bad-tag exception on decryption — availability, not confidentiality — under the NATS client.

Fixed anyway: Scorecard counts advisories regardless of reachability, and staying current is cheaper than re-litigating reachability every scan. This is score hygiene, not an incident.

## Why two of three are `dependencyManagement` overrides

- **jsoup** is a direct dependency → plain version bump.
- **jackson-databind** is Quarkus-BOM-managed at 2.22.0, exactly like `jackson-core` — which this POM **already pins to 2.22.1** for GHSA-r7wm-3cxj-wff9. The new entry follows that established pattern rather than importing `jackson-bom` ahead of the platform BOM, keeping the blast radius small.
- **bcprov-lts8on** needed a pin because the tidier option does not work: **`io.nats:jnats` 2.26.1 still declares 2.73.10**, verified by reading its POM, so bumping the parent would not clear it.

## Known, pre-existing version skew

`databind` and `core` now sit at 2.22.1 while the rest of the Jackson family (`datatype-*`, `dataformat-*`) stays at 2.22.0 and `jackson-annotations` at 2.22. That skew already existed for `jackson-core` alone; patch differences inside 2.22.x are binary-compatible. Aligning the family via `jackson-bom` would be tidier but moves more versions than Quarkus 3.38.1 was tested against — deliberately not done here.

## Verification

- `dependency:tree` re-run after the change confirms all three resolve to the patched versions — not inferred from the POM
- `./mvnw compile` → `BUILD SUCCESS`, no formatter churn

Local `compile` is a weak signal for a dependency change; `./mvnw verify` with the integration tests in CI is the real gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Addressed multiple dependency security vulnerabilities.
  - Updated jsoup and pinned secure versions of Jackson Databind and Bouncy Castle components.
  - Improved application security while preserving existing functionality.

- **Documentation**
  - Added changelog details covering the security updates and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->