### PR TITLE
chore: replace 575 inline fully-qualified names with imports

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,41 @@
 
 
 
+## 🔤 chore: replace 575 inline fully-qualified names with imports (2026-08-12)
+
+**Repo:** EDDI (`chore/inline-fqn-cleanup`, stacked on `fix/review-defects`)
+
+The mechanical half of the repository review, split from it so the substantive fixes could be
+reviewed at all — at 302 files both CodeRabbit (>100) and Copilot (>300) decline outright, and this
+is the part that does not need line-by-line reading.
+
+AGENTS.md §4.7 asks for a top-level import and the simple name. These were **not** the permitted
+disambiguation case: `PendingApprovalSummary`, `HitlDecision`, `ToolApprovalsConfig`,
+`ConversationMemorySnapshot` and `ControlSignal` each resolve to exactly one class, and
+`IConversationService` imported `java.util.List` on line 17 while writing `java.util.List<…>`
+fully-qualified on line 355. The two genuine cases — `mongo.HistorizedResourceStore extends
+datastore.HistorizedResourceStore` and its Modifiable twin — were detected and left alone.
+
+**`ImportStyleTest` ships with the cleanup rather than after it**, because it is what stops the
+problem recurring: these accumulate precisely because nothing fails when one is added — the code
+compiles either way, so the rule was advice only a reviewer's eye enforced. Writing it also showed
+the original audit had **under-counted**: its pattern required a package segment after `java.util`,
+so `java.util.List` never matched. The real total was 575, not the 141 first reported. The one
+permitted exception is an explicit allowlist, so adding to it is a reviewable act rather than drift.
+
+Verified beyond a green build:
+
+- **Clean** `test-compile`, not incremental — a reused stale class hides exactly this kind of break
+  in a caller that was never edited.
+- **Every string literal in all 273 changed files compared against `origin/main`: byte-identical.**
+  This is the check that matters for a rewrite this broad. A substitution that reached inside a
+  literal — a reflective class name, a config key, a log format — would still compile, still pass
+  every test, and show up nowhere else.
+
+---
+
+
+
 ## 🧪 test: regression cover for every fix in this branch, and a bug the coverage work found (2026-08-12)
 
 **Repo:** EDDI (`fix/code-review-defects-and-docs`)

--- a/src/main/java/ai/labs/eddi/backup/IZipArchive.java
+++ b/src/main/java/ai/labs/eddi/backup/IZipArchive.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.backup;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 
 /**
  * @author ginccc
@@ -14,7 +15,7 @@ import java.io.InputStream;
 public interface IZipArchive {
     void createZip(String sourceDirPath, String targetZipPath) throws IOException;
 
-    void createZip(String sourceDirPath, String targetZipPath, java.nio.file.Path allowedBaseDir) throws IOException;
+    void createZip(String sourceDirPath, String targetZipPath, Path allowedBaseDir) throws IOException;
 
     void unzip(InputStream zipFile, File targetDir) throws IOException;
 }

--- a/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
@@ -48,6 +48,7 @@ import ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore;
 import ai.labs.eddi.configs.propertysetter.model.PropertySetterConfiguration;
 import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
 import ai.labs.eddi.configs.dictionary.model.DictionaryConfiguration;
+import ai.labs.eddi.configs.hitl.HitlConfigValidation;
 import ai.labs.eddi.utils.LogSanitizer;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
@@ -468,7 +469,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                     // otherwise the store-level validation only fires at agent
                     // creation, after all extensions already landed (partial
                     // import), and surfaced as a 500 instead of a 400.
-                    ai.labs.eddi.configs.hitl.HitlConfigValidation.validate(agentConfig.getHitlConfig());
+                    HitlConfigValidation.validate(agentConfig.getHitlConfig());
 
                     agentConfig.getWorkflows()
                             .forEach(workflowUri -> parseWorkflow(targetDirPath, workflowUri, agentConfig, isMerge, selectedSet, transaction));

--- a/src/main/java/ai/labs/eddi/backup/impl/StructuralMatcher.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/StructuralMatcher.java
@@ -11,8 +11,16 @@ import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
 import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
+import ai.labs.eddi.configs.llm.IRestLlmStore;
+import ai.labs.eddi.configs.mcpcalls.IRestMcpCallsStore;
+import ai.labs.eddi.configs.output.IRestOutputStore;
+import ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore;
+import ai.labs.eddi.configs.rag.IRestRagStore;
+import ai.labs.eddi.configs.rules.IRestRuleSetStore;
 import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
 import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
@@ -357,28 +365,28 @@ public class StructuralMatcher {
 
         return switch (stepType) {
             case "ai.labs.dictionary" -> restInterfaceFactory.get(
-                    ai.labs.eddi.configs.dictionary.IRestDictionaryStore.class)
+                    IRestDictionaryStore.class)
                     .readRegularDictionary(resId.getId(), resId.getVersion(), "", "", 0, 0);
             case "ai.labs.rules" -> restInterfaceFactory.get(
-                    ai.labs.eddi.configs.rules.IRestRuleSetStore.class)
+                    IRestRuleSetStore.class)
                     .readRuleSet(resId.getId(), resId.getVersion());
             case "ai.labs.apicalls" -> restInterfaceFactory.get(
-                    ai.labs.eddi.configs.apicalls.IRestApiCallsStore.class)
+                    IRestApiCallsStore.class)
                     .readApiCalls(resId.getId(), resId.getVersion());
             case "ai.labs.llm" -> restInterfaceFactory.get(
-                    ai.labs.eddi.configs.llm.IRestLlmStore.class)
+                    IRestLlmStore.class)
                     .readLlm(resId.getId(), resId.getVersion());
             case "ai.labs.property" -> restInterfaceFactory.get(
-                    ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore.class)
+                    IRestPropertySetterStore.class)
                     .readPropertySetter(resId.getId(), resId.getVersion());
             case "ai.labs.output" -> restInterfaceFactory.get(
-                    ai.labs.eddi.configs.output.IRestOutputStore.class)
+                    IRestOutputStore.class)
                     .readOutputSet(resId.getId(), resId.getVersion(), "", "", 0, 0);
             case "ai.labs.mcpcalls" -> restInterfaceFactory.get(
-                    ai.labs.eddi.configs.mcpcalls.IRestMcpCallsStore.class)
+                    IRestMcpCallsStore.class)
                     .readMcpCalls(resId.getId(), resId.getVersion());
             case "ai.labs.rag" -> restInterfaceFactory.get(
-                    ai.labs.eddi.configs.rag.IRestRagStore.class)
+                    IRestRagStore.class)
                     .readRag(resId.getId(), resId.getVersion());
             default -> {
                 LOGGER.debugf("Unknown step type for typed read: %s", stepType);

--- a/src/main/java/ai/labs/eddi/configs/OpenApiTagSortFilter.java
+++ b/src/main/java/ai/labs/eddi/configs/OpenApiTagSortFilter.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs;
 
 import io.quarkus.smallrye.openapi.OpenApiFilter;
+import java.util.ArrayList;
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 
@@ -22,7 +23,7 @@ public class OpenApiTagSortFilter implements OASFilter {
     @Override
     public void filterOpenAPI(OpenAPI openAPI) {
         if (openAPI.getTags() != null) {
-            var sorted = new java.util.ArrayList<>(openAPI.getTags());
+            var sorted = new ArrayList<>(openAPI.getTags());
             sorted.sort(Comparator.comparing(
                     org.eclipse.microprofile.openapi.models.tags.Tag::getName));
             openAPI.setTags(sorted);

--- a/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.configs.agents;
+import ai.labs.eddi.configs.agents.crypto.SignedEnvelope;
 
 import ai.labs.eddi.secrets.ISecretProvider;
 import ai.labs.eddi.secrets.model.SecretReference;
@@ -286,8 +287,7 @@ public class AgentSigningService {
     }
 
     /**
-     * Sign a {@link ai.labs.eddi.configs.agents.crypto.SignedEnvelope} using the
-     * agent's versioned key.
+     * Sign a {@link SignedEnvelope} using the agent's versioned key.
      *
      * @param tenantId
      *            the tenant identifier
@@ -301,10 +301,10 @@ public class AgentSigningService {
      * @throws AgentSigningException
      *             if signing fails
      */
-    public ai.labs.eddi.configs.agents.crypto.SignedEnvelope signEnvelope(
-                                                                          String tenantId, String agentId,
-                                                                          ai.labs.eddi.configs.agents.crypto.SignedEnvelope envelope,
-                                                                          int keyVersion)
+    public SignedEnvelope signEnvelope(
+                                       String tenantId, String agentId,
+                                       SignedEnvelope envelope,
+                                       int keyVersion)
             throws AgentSigningException {
         try {
             String canonicalForm = envelope.canonicalForm();
@@ -355,7 +355,7 @@ public class AgentSigningService {
      *            the Base64-encoded public key
      * @return true if the signature is valid
      */
-    public boolean verifyEnvelope(ai.labs.eddi.configs.agents.crypto.SignedEnvelope envelope, String publicKeyB64) {
+    public boolean verifyEnvelope(SignedEnvelope envelope, String publicKeyB64) {
         try {
             String canonicalForm = envelope.canonicalForm();
             return verify(publicKeyB64, canonicalForm, envelope.signature());

--- a/src/main/java/ai/labs/eddi/configs/agents/CapabilityRegistryService.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/CapabilityRegistryService.java
@@ -15,6 +15,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.*;
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -189,9 +190,9 @@ public class CapabilityRegistryService {
                     return false;
                 }
                 // Support comma-separated lists: "en,de,fr" matches "de"
-                var items = java.util.Arrays.stream(attrValue.split(","))
+                var items = Arrays.stream(attrValue.split(","))
                         .map(String::trim)
-                        .collect(java.util.stream.Collectors.toSet());
+                        .collect(Collectors.toSet());
                 if (!items.contains(req.getValue())) {
                     return false;
                 }

--- a/src/main/java/ai/labs/eddi/configs/agents/model/AgentConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/model/AgentConfiguration.java
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.configs.agents.model;
+import ai.labs.eddi.configs.agents.crypto.AgentPublicKey;
 
 import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -278,7 +280,7 @@ public class AgentConfiguration {
         /**
          * Versioned key list for rotation. If empty, falls back to {@code publicKey}.
          */
-        private List<ai.labs.eddi.configs.agents.crypto.AgentPublicKey> keys = new ArrayList<>();
+        private List<AgentPublicKey> keys = new ArrayList<>();
 
         public AgentIdentity() {
         }
@@ -304,11 +306,11 @@ public class AgentConfiguration {
             this.publicKey = publicKey;
         }
 
-        public List<ai.labs.eddi.configs.agents.crypto.AgentPublicKey> getKeys() {
+        public List<AgentPublicKey> getKeys() {
             return keys;
         }
 
-        public void setKeys(List<ai.labs.eddi.configs.agents.crypto.AgentPublicKey> keys) {
+        public void setKeys(List<AgentPublicKey> keys) {
             this.keys = keys != null ? keys : new ArrayList<>();
         }
 
@@ -326,7 +328,7 @@ public class AgentConfiguration {
             }
             String versioned = keys.stream()
                     .filter(k -> k.version() == version)
-                    .map(ai.labs.eddi.configs.agents.crypto.AgentPublicKey::publicKeyB64)
+                    .map(AgentPublicKey::publicKeyB64)
                     .findFirst()
                     .orElse(null);
             // Version 0 means "signed before key versioning existed", so the legacy
@@ -355,7 +357,7 @@ public class AgentConfiguration {
             return keys.stream()
                     .filter(k -> k.isValidAt(epochMs))
                     .reduce((a, b) -> a.version() > b.version() ? a : b)
-                    .map(ai.labs.eddi.configs.agents.crypto.AgentPublicKey::publicKeyB64)
+                    .map(AgentPublicKey::publicKeyB64)
                     .orElse(publicKey);
         }
     }
@@ -1048,13 +1050,13 @@ public class AgentConfiguration {
          *
          * @since 6.0.0
          */
-        private ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig toolApprovals;
+        private ToolApprovalsConfig toolApprovals;
 
-        public ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig getToolApprovals() {
+        public ToolApprovalsConfig getToolApprovals() {
             return toolApprovals;
         }
 
-        public void setToolApprovals(ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig toolApprovals) {
+        public void setToolApprovals(ToolApprovalsConfig toolApprovals) {
             this.toolApprovals = toolApprovals;
         }
     }

--- a/src/main/java/ai/labs/eddi/configs/deployment/model/DeploymentInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/deployment/model/DeploymentInfo.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.deployment.model;
 
 import ai.labs.eddi.engine.model.Deployment.Environment;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -57,13 +58,13 @@ public class DeploymentInfo {
             return true;
         if (!(o instanceof DeploymentInfo that))
             return false;
-        return java.util.Objects.equals(agentId, that.agentId)
-                && java.util.Objects.equals(agentVersion, that.agentVersion)
+        return Objects.equals(agentId, that.agentId)
+                && Objects.equals(agentVersion, that.agentVersion)
                 && environment == that.environment;
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(agentId, agentVersion, environment);
+        return Objects.hash(agentId, agentVersion, environment);
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupConversationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/GroupConversationStore.java
@@ -16,6 +16,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -112,10 +113,10 @@ public class GroupConversationStore implements IGroupConversationStore {
             // Anchored exact match (see SAFE_ID): findResources turns a String
             // filter value into an unanchored regex, so a raw groupId would
             // substring-match other groups.
-            var filter = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(
-                    java.util.List.of(new ai.labs.eddi.datastore.IResourceFilter.QueryFilter(
+            var filter = new IResourceFilter.QueryFilters(
+                    List.of(new IResourceFilter.QueryFilter(
                             "groupId", "^" + groupId + "$")));
-            var resourceIds = storage.findResources(new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{filter}, "lastModified", index, limit);
+            var resourceIds = storage.findResources(new IResourceFilter.QueryFilters[]{filter}, "lastModified", index, limit);
             for (var resourceId : resourceIds) {
                 try {
                     var resource = storage.read(resourceId.getId(), SINGLE_VERSION);
@@ -144,7 +145,7 @@ public class GroupConversationStore implements IGroupConversationStore {
             return false;
         }
         gc.setState(newState);
-        gc.setLastModified(java.time.Instant.now());
+        gc.setLastModified(Instant.now());
         try {
             // Conditional write — the persisted state must STILL be expectedState. The
             // read-check above alone was a read-check-update (single-node only): two
@@ -311,8 +312,8 @@ public class GroupConversationStore implements IGroupConversationStore {
     @Override
     public List<GroupConversation> findByState(GroupConversation.GroupConversationState state, String groupId, int limit)
             throws IResourceStore.ResourceStoreException {
-        var filterList = new ArrayList<ai.labs.eddi.datastore.IResourceFilter.QueryFilter>();
-        filterList.add(new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("state", "^" + state.name() + "$"));
+        var filterList = new ArrayList<IResourceFilter.QueryFilter>();
+        filterList.add(new IResourceFilter.QueryFilter("state", "^" + state.name() + "$"));
         if (groupId != null) {
             if (!SAFE_ID.matcher(groupId).matches()) {
                 LOGGER.warnf("findByState called with non-id groupId — returning empty");
@@ -320,11 +321,11 @@ public class GroupConversationStore implements IGroupConversationStore {
             }
             // Anchored exact match (see SAFE_ID): a raw groupId would leak
             // conversations from other groups whose id contains it as a substring.
-            filterList.add(new ai.labs.eddi.datastore.IResourceFilter.QueryFilter(
+            filterList.add(new IResourceFilter.QueryFilter(
                     "groupId", "^" + groupId + "$"));
         }
-        var filters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{
-                new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(filterList)};
+        var filters = new IResourceFilter.QueryFilters[]{
+                new IResourceFilter.QueryFilters(filterList)};
         List<IResourceStore.IResourceId> ids = storage.findResources(filters, "lastModified", 0, limit);
         List<GroupConversation> out = new ArrayList<>();
         for (var id : ids) {

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
@@ -22,6 +22,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
+import java.time.DateTimeException;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -239,7 +240,7 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
             return Response.status(Response.Status.CREATED).entity(cadence).build();
         } catch (IResourceStore.ResourceNotFoundException e) {
             return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", e.getMessage())).build();
-        } catch (IllegalArgumentException | java.time.DateTimeException e) {
+        } catch (IllegalArgumentException | DateTimeException e) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(Map.of("error", "Invalid cadence definition: " + e.getMessage())).build();
         } catch (Exception e) {

--- a/src/main/java/ai/labs/eddi/configs/output/model/OutputConfigurationSet.java
+++ b/src/main/java/ai/labs/eddi/configs/output/model/OutputConfigurationSet.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.output.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -38,11 +39,11 @@ public class OutputConfigurationSet {
         if (o == null || getClass() != o.getClass())
             return false;
         OutputConfigurationSet that = (OutputConfigurationSet) o;
-        return java.util.Objects.equals(lang, that.lang) && java.util.Objects.equals(outputSet, that.outputSet);
+        return Objects.equals(lang, that.lang) && Objects.equals(outputSet, that.outputSet);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(lang, outputSet);
+        return Objects.hash(lang, outputSet);
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/properties/model/Property.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/model/Property.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.properties.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class Property {
     private String name;
@@ -177,15 +178,15 @@ public class Property {
         if (o == null || getClass() != o.getClass())
             return false;
         Property that = (Property) o;
-        return java.util.Objects.equals(name, that.name) && java.util.Objects.equals(valueString, that.valueString)
-                && java.util.Objects.equals(valueObject, that.valueObject) && java.util.Objects.equals(valueList, that.valueList)
-                && java.util.Objects.equals(valueInt, that.valueInt) && java.util.Objects.equals(valueFloat, that.valueFloat)
-                && java.util.Objects.equals(valueBoolean, that.valueBoolean) && java.util.Objects.equals(scope, that.scope)
-                && java.util.Objects.equals(visibility, that.visibility);
+        return Objects.equals(name, that.name) && Objects.equals(valueString, that.valueString)
+                && Objects.equals(valueObject, that.valueObject) && Objects.equals(valueList, that.valueList)
+                && Objects.equals(valueInt, that.valueInt) && Objects.equals(valueFloat, that.valueFloat)
+                && Objects.equals(valueBoolean, that.valueBoolean) && Objects.equals(scope, that.scope)
+                && Objects.equals(visibility, that.visibility);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(name, valueString, valueObject, valueList, valueInt, valueFloat, valueBoolean, scope, visibility);
+        return Objects.hash(name, valueString, valueObject, valueList, valueInt, valueFloat, valueBoolean, scope, visibility);
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/properties/model/PropertyInstruction.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/model/PropertyInstruction.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.properties.model;
 
 import ai.labs.eddi.configs.apicalls.model.HttpCodeValidator;
+import java.util.Objects;
 
 public class PropertyInstruction extends Property {
     private String fromObjectPath = "";
@@ -84,15 +85,15 @@ public class PropertyInstruction extends Property {
         if (!super.equals(o))
             return false;
         PropertyInstruction that = (PropertyInstruction) o;
-        return java.util.Objects.equals(fromObjectPath, that.fromObjectPath) && java.util.Objects.equals(toObjectPath, that.toObjectPath)
-                && java.util.Objects.equals(convertToObject, that.convertToObject) && java.util.Objects.equals(override, that.override)
-                && java.util.Objects.equals(runOnValidationError, that.runOnValidationError)
-                && java.util.Objects.equals(httpCodeValidator, that.httpCodeValidator);
+        return Objects.equals(fromObjectPath, that.fromObjectPath) && Objects.equals(toObjectPath, that.toObjectPath)
+                && Objects.equals(convertToObject, that.convertToObject) && Objects.equals(override, that.override)
+                && Objects.equals(runOnValidationError, that.runOnValidationError)
+                && Objects.equals(httpCodeValidator, that.httpCodeValidator);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(super.hashCode(), fromObjectPath, toObjectPath, convertToObject, override, runOnValidationError,
+        return Objects.hash(super.hashCode(), fromObjectPath, toObjectPath, convertToObject, override, runOnValidationError,
                 httpCodeValidator);
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
@@ -19,6 +19,7 @@ import com.mongodb.client.result.DeleteResult;
 import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Duration;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
@@ -381,7 +382,7 @@ public class MongoUserMemoryStore implements IUserMemoryStore {
 
     @Override
     public long deleteOlderThan(int olderThanDays) throws IResourceStore.ResourceStoreException {
-        Instant cutoff = Instant.now().minus(java.time.Duration.ofDays(olderThanDays));
+        Instant cutoff = Instant.now().minus(Duration.ofDays(olderThanDays));
         // Exclude GDPR system keys (e.g. _gdpr_processing_restricted) from retention
         // cleanup
         Bson filter = and(

--- a/src/main/java/ai/labs/eddi/configs/rules/model/RuleConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/rules/model/RuleConfiguration.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.rules.model;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -50,12 +51,12 @@ public class RuleConfiguration {
         if (o == null || getClass() != o.getClass())
             return false;
         RuleConfiguration that = (RuleConfiguration) o;
-        return java.util.Objects.equals(name, that.name) && java.util.Objects.equals(actions, that.actions)
-                && java.util.Objects.equals(conditions, that.conditions);
+        return Objects.equals(name, that.name) && Objects.equals(actions, that.actions)
+                && Objects.equals(conditions, that.conditions);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(name, actions, conditions);
+        return Objects.hash(name, actions, conditions);
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/shared/RetryConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/shared/RetryConfiguration.java
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.configs.shared;
+import ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException;
 
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import org.jboss.logging.Logger;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Shared retry configuration and execution utility.
@@ -113,7 +115,7 @@ public class RetryConfiguration {
                 // travel up UNCHANGED — it is not a retryable failure. Rethrow before
                 // any retry/backoff or LifecycleException wrapping so the pause signal
                 // reaches LifecycleManager intact. Applies to LLM and MCP callers.
-                if (e instanceof ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException tare) {
+                if (e instanceof ToolApprovalRequiredException tare) {
                     throw tare;
                 }
                 lastException = e;
@@ -183,7 +185,7 @@ public class RetryConfiguration {
         while (current != null) {
             // 1. Typed exception matching
             if (current instanceof java.net.SocketTimeoutException
-                    || current instanceof java.util.concurrent.TimeoutException
+                    || current instanceof TimeoutException
                     || current instanceof java.net.ConnectException
                     || current instanceof java.net.UnknownHostException) {
                 return true;

--- a/src/main/java/ai/labs/eddi/datastore/DataStoreProducers.java
+++ b/src/main/java/ai/labs/eddi/datastore/DataStoreProducers.java
@@ -14,6 +14,7 @@ import ai.labs.eddi.configs.variables.IGlobalVariableStore;
 import ai.labs.eddi.configs.variables.mongo.GlobalVariableStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.mongo.MongoUserMemoryStore;
+import ai.labs.eddi.datastore.mongo.GridFsAttachmentStore;
 import ai.labs.eddi.datastore.mongo.MongoResourceStorageFactory;
 import ai.labs.eddi.datastore.postgres.PostgresAuditStore;
 import ai.labs.eddi.datastore.postgres.PostgresAttachmentStore;
@@ -38,10 +39,14 @@ import ai.labs.eddi.engine.memory.ConversationMemoryStore;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.memory.IConversationCheckpointStore;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
+import ai.labs.eddi.engine.memory.MongoConversationCheckpointStore;
 import ai.labs.eddi.engine.runtime.DatabaseLogs;
 import ai.labs.eddi.engine.runtime.IDatabaseLogs;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.mongo.MongoScheduleStore;
+import ai.labs.eddi.engine.tenancy.ITenantQuotaStore;
+import ai.labs.eddi.engine.tenancy.MongoTenantQuotaStore;
+import ai.labs.eddi.engine.tenancy.PostgresTenantQuotaStore;
 import ai.labs.eddi.engine.triggermanagement.IAgentTriggerStore;
 import ai.labs.eddi.engine.triggermanagement.IUserConversationStore;
 import ai.labs.eddi.engine.triggermanagement.mongo.AgentTriggerStore;
@@ -170,7 +175,7 @@ public class DataStoreProducers {
     @Produces
     @ApplicationScoped
     public IConversationCheckpointStore conversationCheckpointStore(
-                                                                    Instance<ai.labs.eddi.engine.memory.MongoConversationCheckpointStore> mongo,
+                                                                    Instance<MongoConversationCheckpointStore> mongo,
                                                                     Instance<PostgresConversationCheckpointStore> postgres) {
         return isPostgres() ? postgres.get() : mongo.get();
     }
@@ -178,16 +183,16 @@ public class DataStoreProducers {
     @Produces
     @ApplicationScoped
     public IAttachmentStore attachmentStore(
-                                            Instance<ai.labs.eddi.datastore.mongo.GridFsAttachmentStore> mongo,
+                                            Instance<GridFsAttachmentStore> mongo,
                                             Instance<PostgresAttachmentStore> postgres) {
         return isPostgres() ? postgres.get() : mongo.get();
     }
 
     @Produces
     @ApplicationScoped
-    public ai.labs.eddi.engine.tenancy.ITenantQuotaStore tenantQuotaStore(
-                                                                          Instance<ai.labs.eddi.engine.tenancy.MongoTenantQuotaStore> mongo,
-                                                                          Instance<ai.labs.eddi.engine.tenancy.PostgresTenantQuotaStore> postgres) {
+    public ITenantQuotaStore tenantQuotaStore(
+                                              Instance<MongoTenantQuotaStore> mongo,
+                                              Instance<PostgresTenantQuotaStore> postgres) {
         return isPostgres() ? postgres.get() : mongo.get();
     }
 }

--- a/src/main/java/ai/labs/eddi/datastore/model/ResourceId.java
+++ b/src/main/java/ai/labs/eddi/datastore/model/ResourceId.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.datastore.model;
 
 import ai.labs.eddi.datastore.IResourceStore;
+import java.util.Objects;
 
 public class ResourceId implements IResourceStore.IResourceId {
     private String id;
@@ -38,12 +39,12 @@ public class ResourceId implements IResourceStore.IResourceId {
         if (o == null || getClass() != o.getClass())
             return false;
         ResourceId that = (ResourceId) o;
-        return java.util.Objects.equals(id, that.id) && java.util.Objects.equals(version, that.version);
+        return Objects.equals(id, that.id) && Objects.equals(version, that.version);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(id, version);
+        return Objects.hash(id, version);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/datastore/mongo/MongoResourceStorage.java
+++ b/src/main/java/ai/labs/eddi/datastore/mongo/MongoResourceStorage.java
@@ -23,7 +23,9 @@ import org.bson.types.ObjectId;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -372,9 +374,9 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
 
     @Override
     public List<IResourceStore.IResourceId> findResourceIdsContaining(String jsonPath, String value) {
-        Document filter = new Document(jsonPath, new Document("$in", java.util.Collections.singletonList(value)));
+        Document filter = new Document(jsonPath, new Document("$in", Collections.singletonList(value)));
 
-        List<IResourceStore.IResourceId> results = new java.util.LinkedList<>();
+        List<IResourceStore.IResourceId> results = new LinkedList<>();
         currentCollection.find(filter).forEach(doc -> {
             String docId = doc.getObjectId(ID_FIELD).toString();
             Integer version = doc.getInteger(VERSION_FIELD);
@@ -385,9 +387,9 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
 
     @Override
     public List<IResourceStore.IResourceId> findHistoryResourceIdsContaining(String jsonPath, String value) {
-        Document filter = new Document(jsonPath, new Document("$in", java.util.Collections.singletonList(value)));
+        Document filter = new Document(jsonPath, new Document("$in", Collections.singletonList(value)));
 
-        List<IResourceStore.IResourceId> results = new java.util.LinkedList<>();
+        List<IResourceStore.IResourceId> results = new LinkedList<>();
         historyCollection.find(filter).forEach(doc -> {
             Object idObject = doc.get(ID_FIELD);
             if (idObject instanceof Document idDoc) {
@@ -402,9 +404,9 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
     @Override
     public List<IResourceStore.IResourceId> findResources(IResourceFilter.QueryFilters[] allQueryFilters, String sortField, int skip, int limit) {
 
-        List<Bson> connectedFilters = new java.util.ArrayList<>();
+        List<Bson> connectedFilters = new ArrayList<>();
         for (IResourceFilter.QueryFilters queryFilters : allQueryFilters) {
-            List<Bson> filters = new java.util.ArrayList<>();
+            List<Bson> filters = new ArrayList<>();
             for (IResourceFilter.QueryFilter queryFilter : queryFilters.getQueryFilters()) {
                 if (queryFilter.getFilter() instanceof String) {
                     filters.add(Filters.regex(queryFilter.getField(), queryFilter.getFilter().toString()));
@@ -425,7 +427,7 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
 
         var iterable = currentCollection.find(query.toBsonDocument()).sort(sort).limit(effectiveLimit).skip(skip > 0 ? skip : 0);
 
-        List<IResourceStore.IResourceId> results = new java.util.LinkedList<>();
+        List<IResourceStore.IResourceId> results = new LinkedList<>();
         iterable.forEach(doc -> {
             String docId = doc.get(ID_FIELD).toString();
             Object versionField = doc.get(VERSION_FIELD);

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresConversationMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresConversationMemoryStore.java
@@ -10,6 +10,8 @@ import ai.labs.eddi.engine.memory.IConversationMemoryStore;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import io.quarkus.arc.DefaultBean;
 import org.jboss.logging.Logger;
 
@@ -19,7 +21,9 @@ import jakarta.enterprise.inject.Instance;
 import javax.sql.DataSource;
 import java.io.IOException;
 import java.sql.*;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
@@ -382,7 +386,7 @@ public class PostgresConversationMemoryStore implements IConversationMemoryStore
             + "FROM conversation_memories WHERE conversation_state = ?";
 
     @Override
-    public List<ai.labs.eddi.engine.model.PendingApprovalSummary> findPendingApprovalSummaries(int limit)
+    public List<PendingApprovalSummary> findPendingApprovalSummaries(int limit)
             throws IResourceStore.ResourceStoreException {
         ensureSchema();
         // Single bounded query with JSONB field extraction — this listing is
@@ -399,7 +403,7 @@ public class PostgresConversationMemoryStore implements IConversationMemoryStore
     }
 
     @Override
-    public List<ai.labs.eddi.engine.model.PendingApprovalSummary> findPendingApprovalSummaries(String ownerUserId, int limit)
+    public List<PendingApprovalSummary> findPendingApprovalSummaries(String ownerUserId, int limit)
             throws IResourceStore.ResourceStoreException {
         ensureSchema();
         // Owner filter INSIDE the query: the limit applies after the restriction,
@@ -415,13 +419,13 @@ public class PostgresConversationMemoryStore implements IConversationMemoryStore
         }
     }
 
-    private List<ai.labs.eddi.engine.model.PendingApprovalSummary> readPendingSummaries(PreparedStatement ps)
+    private List<PendingApprovalSummary> readPendingSummaries(PreparedStatement ps)
             throws SQLException {
-        List<ai.labs.eddi.engine.model.PendingApprovalSummary> out = new ArrayList<>();
+        List<PendingApprovalSummary> out = new ArrayList<>();
         try (ResultSet rs = ps.executeQuery()) {
             while (rs.next()) {
                 String id = rs.getString("id");
-                var summary = new ai.labs.eddi.engine.model.PendingApprovalSummary(
+                var summary = new PendingApprovalSummary(
                         id, rs.getString("AGENT_ID"), rs.getString("user_id"),
                         parseInstantJson(id, rs.getString("paused_at_json")),
                         rs.getString("pause_reason"), rs.getString("timeout_policy"));
@@ -439,12 +443,12 @@ public class PostgresConversationMemoryStore implements IConversationMemoryStore
      * keeping the JSON representation) through the SAME mapper that serialized the
      * snapshot — correct for both ISO-string and numeric-timestamp configurations.
      */
-    private java.time.Instant parseInstantJson(String conversationId, String rawJson) {
+    private Instant parseInstantJson(String conversationId, String rawJson) {
         if (rawJson == null || rawJson.isBlank() || "null".equals(rawJson)) {
             return null;
         }
         try {
-            return jsonSerialization.deserialize(rawJson, java.time.Instant.class);
+            return jsonSerialization.deserialize(rawJson, Instant.class);
         } catch (Exception e) {
             LOGGER.warnf("Unparseable hitlPausedAt for conversation %s: %s", conversationId, e.getMessage());
             return null;
@@ -462,12 +466,12 @@ public class PostgresConversationMemoryStore implements IConversationMemoryStore
         }
         try {
             var calls = jsonSerialization.deserialize(rawJson,
-                    ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall[].class);
+                    PendingToolCallBatch.PendingToolCall[].class);
             if (calls == null) {
                 return null;
             }
-            return java.util.Arrays.stream(calls)
-                    .map(ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall::getToolName)
+            return Arrays.stream(calls)
+                    .map(PendingToolCallBatch.PendingToolCall::getToolName)
                     .toList();
         } catch (Exception e) {
             LOGGER.warnf("Unparseable hitlPendingToolCalls for conversation %s: %s", conversationId, e.getMessage());

--- a/src/main/java/ai/labs/eddi/engine/api/IConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IConversationService.java
@@ -9,9 +9,13 @@ import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.lifecycle.TaskId;
+import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
+import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.model.InputData;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 
 import java.net.URI;
 import java.util.List;
@@ -283,7 +287,7 @@ public interface IConversationService {
      *             on persistence failures
      */
     default CancelOutcome cancelConversation(String conversationId,
-                                             ai.labs.eddi.engine.lifecycle.model.ControlSignal mode)
+                                             ControlSignal mode)
             throws ResourceStoreException {
         return cancelConversation(conversationId, mode, null);
     }
@@ -295,7 +299,7 @@ public interface IConversationService {
      * recorded as {@code unknown}.
      */
     CancelOutcome cancelConversation(String conversationId,
-                                     ai.labs.eddi.engine.lifecycle.model.ControlSignal mode,
+                                     ControlSignal mode,
                                      String cancelledBy)
             throws ResourceStoreException;
 
@@ -328,7 +332,7 @@ public interface IConversationService {
      *             if the conversation is not found
      */
     void resumeConversation(String conversationId,
-                            ai.labs.eddi.engine.lifecycle.model.HitlDecision decision,
+                            HitlDecision decision,
                             ConversationResponseHandler responseHandler)
             throws ResourceStoreException, ResourceNotFoundException;
 
@@ -340,7 +344,7 @@ public interface IConversationService {
      * @throws ResourceNotFoundException
      *             if the conversation is not found
      */
-    ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot getConversationMemorySnapshot(String conversationId)
+    ConversationMemorySnapshot getConversationMemorySnapshot(String conversationId)
             throws ResourceStoreException, ResourceNotFoundException;
 
     /**
@@ -352,7 +356,7 @@ public interface IConversationService {
      * @throws ResourceStoreException
      *             on persistence failures
      */
-    java.util.List<ai.labs.eddi.engine.model.PendingApprovalSummary> listPendingApprovals(int limit)
+    List<PendingApprovalSummary> listPendingApprovals(int limit)
             throws ResourceStoreException;
 
     /**
@@ -361,7 +365,7 @@ public interface IConversationService {
      * restriction — a non-admin caller's approval inbox cannot be starved by other
      * users' backlog.
      */
-    java.util.List<ai.labs.eddi.engine.model.PendingApprovalSummary> listPendingApprovals(String ownerUserId, int limit)
+    List<PendingApprovalSummary> listPendingApprovals(String ownerUserId, int limit)
             throws ResourceStoreException;
 
     // --- Domain exceptions (no JAX-RS dependency) ---

--- a/src/main/java/ai/labs/eddi/engine/api/IGroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IGroupConversationService.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.engine.internal.GroupApprovalRequest;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.memory.model.Attachment;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 
 import java.util.List;
 
@@ -206,7 +207,7 @@ public interface IGroupConversationService {
      * @param limit
      *            maximum number of summaries to return (clamped to [1, 1000])
      */
-    List<ai.labs.eddi.engine.model.PendingApprovalSummary> listGroupPendingApprovals(String groupId, int limit)
+    List<PendingApprovalSummary> listGroupPendingApprovals(String groupId, int limit)
             throws IResourceStore.ResourceStoreException;
 
     // --- Event listener for SSE streaming ---

--- a/src/main/java/ai/labs/eddi/engine/api/IRestGroupConversation.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IRestGroupConversation.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.api;
 import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.engine.internal.GroupApprovalRequest;
 import ai.labs.eddi.engine.memory.model.validation.MaxInlineAttachmentSize;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -369,10 +370,10 @@ public interface IRestGroupConversation {
     @Operation(summary = "List pending HITL approvals",
                description = "Lists this group's conversations currently awaiting human approval (summaries).")
     @APIResponse(responseCode = "200", description = "List of pending approval summaries.")
-    List<ai.labs.eddi.engine.model.PendingApprovalSummary> listGroupPendingApprovals(
-                                                                                     @PathParam("groupId") String groupId,
-                                                                                     @QueryParam("limit")
-                                                                                     @DefaultValue("100") Integer limit);
+    List<PendingApprovalSummary> listGroupPendingApprovals(
+                                                           @PathParam("groupId") String groupId,
+                                                           @QueryParam("limit")
+                                                           @DefaultValue("100") Integer limit);
 
     /**
      * Cross-group HITL inbox (#21): all group conversations currently awaiting
@@ -389,7 +390,7 @@ public interface IRestGroupConversation {
     @Operation(summary = "List all pending group HITL approvals",
                description = "Lists group conversations awaiting human approval across all groups (summaries).")
     @APIResponse(responseCode = "200", description = "List of pending approval summaries.")
-    List<ai.labs.eddi.engine.model.PendingApprovalSummary> listAllGroupPendingApprovals(
-                                                                                        @QueryParam("limit")
-                                                                                        @DefaultValue("100") Integer limit);
+    List<PendingApprovalSummary> listAllGroupPendingApprovals(
+                                                              @QueryParam("limit")
+                                                              @DefaultValue("100") Integer limit);
 }

--- a/src/main/java/ai/labs/eddi/engine/hitl/HitlCrashRecoveryObserver.java
+++ b/src/main/java/ai/labs/eddi/engine/hitl/HitlCrashRecoveryObserver.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 
 /**
  * Startup observer that REPAIRS HITL state after a crash or restart — it never
@@ -453,7 +454,7 @@ public class HitlCrashRecoveryObserver {
      */
     private boolean rearmSchedule(String scheduleName, String surface, String conversationId,
                                   String agentId, HitlTimeoutPolicy policy, String approvalTimeout,
-                                  Instant pausedAt, java.util.function.BooleanSupplier stillPaused) {
+                                  Instant pausedAt, BooleanSupplier stillPaused) {
         return rearmSchedule(scheduleName, surface, conversationId, agentId, policy.name(), approvalTimeout,
                 pausedAt, stillPaused);
     }
@@ -465,7 +466,7 @@ public class HitlCrashRecoveryObserver {
      */
     private boolean rearmSchedule(String scheduleName, String surface, String conversationId,
                                   String agentId, String policyName, String approvalTimeout,
-                                  Instant pausedAt, java.util.function.BooleanSupplier stillPaused) {
+                                  Instant pausedAt, BooleanSupplier stillPaused) {
         if (approvalTimeout == null || approvalTimeout.isBlank() || pausedAt == null) {
             LOGGER.warnf("Cannot re-arm HITL timeout for %s: missing approvalTimeout/pausedAt in bookmark",
                     conversationId);

--- a/src/main/java/ai/labs/eddi/engine/hitl/lint/ReservedActionLint.java
+++ b/src/main/java/ai/labs/eddi/engine/hitl/lint/ReservedActionLint.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.rules.model.RuleGroupConfiguration;
 import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.engine.hitl.tools.ToolApprovalPatterns;
 import ai.labs.eddi.engine.lifecycle.IConversation;
+import java.util.ArrayList;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -67,7 +68,7 @@ public final class ReservedActionLint {
         }
 
         Set<String> flaggedActions = new LinkedHashSet<>();
-        List<String> warnings = new java.util.ArrayList<>();
+        List<String> warnings = new ArrayList<>();
 
         for (RuleGroupConfiguration group : ruleSet.getBehaviorGroups()) {
             if (group == null || group.getRules() == null) {

--- a/src/main/java/ai/labs/eddi/engine/hitl/tools/IHitlToolJournalStore.java
+++ b/src/main/java/ai/labs/eddi/engine/hitl/tools/IHitlToolJournalStore.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.hitl.tools;
+import java.time.Instant;
 
 import java.util.Optional;
 
@@ -22,7 +23,7 @@ public interface IHitlToolJournalStore {
 
     record JournalEntry(String conversationId, String pauseEpoch, String callId,
             String toolName, Status status, String resultCapped,
-            java.time.Instant executedAt, String decidedBy) {
+            Instant executedAt, String decidedBy) {
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/httpclient/impl/HttpClientWrapper.java
+++ b/src/main/java/ai/labs/eddi/engine/httpclient/impl/HttpClientWrapper.java
@@ -22,9 +22,11 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @ApplicationScoped
 public class HttpClientWrapper implements IHttpClient {
@@ -188,7 +190,7 @@ public class HttpClientWrapper implements IHttpClient {
                 // block indefinitely
                 // if the callback never fires (though Vert.x should handle the timeout).
                 return future.get(currentTimeout + 1000, TimeUnit.MILLISECONDS);
-            } catch (java.util.concurrent.TimeoutException e) {
+            } catch (TimeoutException e) {
                 throw new HttpRequestException("Request timed out while waiting for response", e);
             } catch (InterruptedException | ExecutionException e) {
                 if (e instanceof InterruptedException) {
@@ -334,15 +336,15 @@ public class HttpClientWrapper implements IHttpClient {
             if (o == null || getClass() != o.getClass())
                 return false;
             RequestWrapper that = (RequestWrapper) o;
-            return maxLength == that.maxLength && currentTimeout == that.currentTimeout && java.util.Objects.equals(uri, that.uri)
-                    && java.util.Objects.equals(request, that.request) && java.util.Objects.equals(method, that.method)
-                    && java.util.Objects.equals(requestBody, that.requestBody) && java.util.Objects.equals(requestEncoding, that.requestEncoding)
-                    && java.util.Objects.equals(queryParamsMap, that.queryParamsMap);
+            return maxLength == that.maxLength && currentTimeout == that.currentTimeout && Objects.equals(uri, that.uri)
+                    && Objects.equals(request, that.request) && Objects.equals(method, that.method)
+                    && Objects.equals(requestBody, that.requestBody) && Objects.equals(requestEncoding, that.requestEncoding)
+                    && Objects.equals(queryParamsMap, that.queryParamsMap);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(uri, request, method, maxLength, requestBody, requestEncoding, currentTimeout, queryParamsMap);
+            return Objects.hash(uri, request, method, maxLength, requestBody, requestEncoding, currentTimeout, queryParamsMap);
         }
     }
 
@@ -401,13 +403,13 @@ public class HttpClientWrapper implements IHttpClient {
             if (o == null || getClass() != o.getClass())
                 return false;
             ResponseWrapper that = (ResponseWrapper) o;
-            return httpCode == that.httpCode && java.util.Objects.equals(contentAsString, that.contentAsString)
-                    && java.util.Objects.equals(httpCodeMessage, that.httpCodeMessage) && java.util.Objects.equals(httpHeader, that.httpHeader);
+            return httpCode == that.httpCode && Objects.equals(contentAsString, that.contentAsString)
+                    && Objects.equals(httpCodeMessage, that.httpCodeMessage) && Objects.equals(httpHeader, that.httpHeader);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(contentAsString, httpCode, httpCodeMessage, httpHeader);
+            return Objects.hash(contentAsString, httpCode, httpCodeMessage, httpHeader);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationHitlService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationHitlService.java
@@ -18,9 +18,11 @@ import ai.labs.eddi.engine.hitl.HitlSchedules;
 import ai.labs.eddi.engine.events.HitlResumeCompletedEvent;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResponseHandler;
+import ai.labs.eddi.engine.audit.model.AuditEntry;
 import ai.labs.eddi.engine.lifecycle.IConversation;
 import ai.labs.eddi.engine.lifecycle.exceptions.ConversationPauseException;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
+import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.lifecycle.model.ToolCallDecision;
 import ai.labs.eddi.engine.runtime.ExecutionAbandonedException;
 import ai.labs.eddi.engine.runtime.IDiscardableTask;
@@ -30,6 +32,7 @@ import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.security.CallerIdentity;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.runtime.IConversationCoordinator;
 import ai.labs.eddi.engine.runtime.IRuntime;
@@ -37,6 +40,7 @@ import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.enterprise.event.Event;
@@ -132,7 +136,7 @@ class ConversationHitlService {
 
     // --- HITL lifecycle ---
     public IConversationService.CancelOutcome cancelConversation(String conversationId,
-                                                                 ai.labs.eddi.engine.lifecycle.model.ControlSignal mode,
+                                                                 ControlSignal mode,
                                                                  String cancelledBy)
             throws ResourceStoreException {
         ConversationState currentState = conversationMemoryStore.getConversationState(conversationId);
@@ -206,7 +210,7 @@ class ConversationHitlService {
         }
     }
     public void resumeConversation(String conversationId,
-                                   ai.labs.eddi.engine.lifecycle.model.HitlDecision decision,
+                                   HitlDecision decision,
                                    ConversationResponseHandler handler)
             throws ResourceStoreException, ResourceNotFoundException {
         // See resumeConversation's @throws IllegalArgumentException javadoc
@@ -415,7 +419,7 @@ class ConversationHitlService {
                             if (noProgress == NoProgressOutcome.ABORT) {
                                 // Cancel owns the terminal state — do NOT persist a re-pause.
                                 cancelConversation(conversationId,
-                                        ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL,
+                                        ControlSignal.CANCEL_GRACEFUL,
                                         "system:no-progress");
                                 return;
                             }
@@ -569,7 +573,7 @@ class ConversationHitlService {
      * Semantics: calls not listed in {@code toolDecisions} inherit the top-level
      * {@link HitlDecision#getVerdict()} — they are not required to appear here.
      */
-    void validateToolDecisions(HitlDecision decision, ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot snapshot) {
+    void validateToolDecisions(HitlDecision decision, ConversationMemorySnapshot snapshot) {
         Map<String, ToolCallDecision> toolDecisions = decision.getToolDecisions();
 
         if (!"TOOL_CALL".equals(snapshot.getHitlPauseType())) {
@@ -690,7 +694,7 @@ class ConversationHitlService {
      */
     NoProgressOutcome evaluateAndApplyNoProgressGuard(String conversationId, String agentId,
                                                       Integer agentVersion, IConversationMemory memory, Environment environment,
-                                                      ai.labs.eddi.engine.lifecycle.model.HitlDecision decision,
+                                                      HitlDecision decision,
                                                       String prePauseFingerprint, int prePauseAutoApproveCount) {
         PendingToolCallBatch newBatch = memory.getHitlPendingToolCalls();
         if (newBatch == null) {
@@ -794,8 +798,8 @@ class ConversationHitlService {
      * human.
      */
     void issueNoProgressRejectAllResume(String conversationId) {
-        var reject = new ai.labs.eddi.engine.lifecycle.model.HitlDecision();
-        reject.setVerdict(ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict.REJECTED);
+        var reject = new HitlDecision();
+        reject.setVerdict(HitlDecision.HitlVerdict.REJECTED);
         reject.setDecidedBy("system:no-progress");
         reject.setNote("Automatic reject-all: repeated identical tool-call pause made no progress");
         try {
@@ -840,7 +844,7 @@ class ConversationHitlService {
             if (fingerprint != null) {
                 detail.put("fingerprint", fingerprint);
             }
-            auditLedgerService.submit(new ai.labs.eddi.engine.audit.model.AuditEntry(
+            auditLedgerService.submit(new AuditEntry(
                     UUID.randomUUID().toString(), conversationId, agentId, agentVersion, userId,
                     environment != null ? environment.toString() : null, -1,
                     "hitl.tool." + guard, "hitl", -1, 0L,
@@ -858,7 +862,7 @@ class ConversationHitlService {
      */
     void auditHitlDecision(String conversationId, String agentId, Integer agentVersion,
                            String userId, Environment environment,
-                           ai.labs.eddi.engine.lifecycle.model.HitlDecision decision,
+                           HitlDecision decision,
                            boolean toolCallPause, PendingToolCallBatch pendingBatch) {
         if (!auditLedgerService.isEnabled()) {
             return;
@@ -880,7 +884,7 @@ class ConversationHitlService {
                 detail.put("pauseType", ConversationPauseException.PauseOrigin.TOOL_CALL.name());
                 detail.put("toolDecisions", buildToolDecisionSummary(decision, pendingBatch));
             }
-            auditLedgerService.submit(new ai.labs.eddi.engine.audit.model.AuditEntry(
+            auditLedgerService.submit(new AuditEntry(
                     UUID.randomUUID().toString(), conversationId, agentId, agentVersion, userId,
                     environment != null ? environment.toString() : null, -1,
                     "hitl.approval", "hitl", -1, 0L,
@@ -902,7 +906,7 @@ class ConversationHitlService {
      * written.
      */
     List<Map<String, Object>> buildToolDecisionSummary(
-                                                       ai.labs.eddi.engine.lifecycle.model.HitlDecision decision,
+                                                       HitlDecision decision,
                                                        PendingToolCallBatch pendingBatch) {
         List<Map<String, Object>> summary = new ArrayList<>();
         if (pendingBatch == null || pendingBatch.getCalls() == null) {
@@ -947,7 +951,7 @@ class ConversationHitlService {
     /**
      * Aggregate verdict for the tool-resume metric: approved | rejected | mixed.
      */
-    void recordToolResumeMetric(ai.labs.eddi.engine.lifecycle.model.HitlDecision decision,
+    void recordToolResumeMetric(HitlDecision decision,
                                 PendingToolCallBatch pendingBatch) {
         String verdict = aggregateVerdict(decision, pendingBatch);
         meterRegistry.counter("eddi_hitl_tool_resume_count", "verdict", verdict).increment();
@@ -958,7 +962,7 @@ class ConversationHitlService {
      * every call resolves APPROVED, {@code rejected} when every call resolves
      * REJECTED, {@code mixed} otherwise (per-call verdicts diverge).
      */
-    static String aggregateVerdict(ai.labs.eddi.engine.lifecycle.model.HitlDecision decision,
+    static String aggregateVerdict(HitlDecision decision,
                                    PendingToolCallBatch pendingBatch) {
         var top = decision.getVerdict();
         Map<String, ToolCallDecision> perCall = decision.getToolDecisions() != null
@@ -994,7 +998,7 @@ class ConversationHitlService {
      */
     void fireHitlResumeCompleted(String conversationId, Environment environment,
                                  IConversationMemory memory,
-                                 ai.labs.eddi.engine.lifecycle.model.HitlDecision decision) {
+                                 HitlDecision decision) {
         try {
             var snapshot = convertSimpleConversationMemorySnapshot(memory, false, true, List.of());
             snapshot.setEnvironment(environment);
@@ -1045,7 +1049,7 @@ class ConversationHitlService {
      * Audits the termination of a pending human approval by cancel/ABORT — cancels
      * are HITL decisions too and must be attributable in the oversight trail.
      */
-    void auditHitlCancellation(String conversationId, ai.labs.eddi.engine.lifecycle.model.ControlSignal mode,
+    void auditHitlCancellation(String conversationId, ControlSignal mode,
                                String cancelledBy) {
         if (!auditLedgerService.isEnabled()) {
             return;
@@ -1056,7 +1060,7 @@ class ConversationHitlService {
             detail.put("mode", mode != null ? mode.name() : "CANCEL_GRACEFUL");
             detail.put("decidedBy", cancelledBy != null ? cancelledBy : "unknown");
             detail.put("automated", cancelledBy != null && cancelledBy.startsWith("system:"));
-            auditLedgerService.submit(new ai.labs.eddi.engine.audit.model.AuditEntry(
+            auditLedgerService.submit(new AuditEntry(
                     UUID.randomUUID().toString(), conversationId, null, null, null,
                     null, -1, "hitl.approval", "hitl", -1, 0L,
                     Map.of(), detail, null, null, List.of(), 0.0,
@@ -1291,7 +1295,7 @@ class ConversationHitlService {
             return null;
         }
     }
-    public ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot getConversationMemorySnapshot(String conversationId)
+    public ConversationMemorySnapshot getConversationMemorySnapshot(String conversationId)
             throws ResourceStoreException, ResourceNotFoundException {
         var snapshot = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
         if (snapshot == null) {
@@ -1299,13 +1303,13 @@ class ConversationHitlService {
         }
         return snapshot;
     }
-    public java.util.List<ai.labs.eddi.engine.model.PendingApprovalSummary> listPendingApprovals(int limit)
+    public List<PendingApprovalSummary> listPendingApprovals(int limit)
             throws ResourceStoreException {
         // #17: bounded, projection-based listing — never deserializes full
         // conversation documents on the Mongo backend.
         return conversationMemoryStore.findPendingApprovalSummaries(Math.max(1, Math.min(limit, 1000)));
     }
-    public java.util.List<ai.labs.eddi.engine.model.PendingApprovalSummary> listPendingApprovals(String ownerUserId, int limit)
+    public List<PendingApprovalSummary> listPendingApprovals(String ownerUserId, int limit)
             throws ResourceStoreException {
         // Owner filter is pushed into the query so the limit applies AFTER the
         // restriction — a non-admin inbox can't be starved by others' backlog.

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
@@ -25,16 +25,20 @@ import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.IConversation;
 import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
+import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
+import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.memory.ConversationLogGenerator;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
 import ai.labs.eddi.engine.memory.IPropertiesHandler;
 import ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.model.InputData;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.runtime.IConversationCoordinator;
@@ -58,6 +62,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1140,7 +1145,7 @@ public class ConversationService implements IConversationService {
 
     @Override
     public CancelOutcome cancelConversation(String conversationId,
-                                            ai.labs.eddi.engine.lifecycle.model.ControlSignal mode,
+                                            ControlSignal mode,
                                             String cancelledBy)
             throws ResourceStoreException {
         return conversationHitlService.cancelConversation(conversationId, mode, cancelledBy);
@@ -1148,26 +1153,26 @@ public class ConversationService implements IConversationService {
 
     @Override
     public void resumeConversation(String conversationId,
-                                   ai.labs.eddi.engine.lifecycle.model.HitlDecision decision,
+                                   HitlDecision decision,
                                    ConversationResponseHandler handler)
             throws ResourceStoreException, ResourceNotFoundException {
         conversationHitlService.resumeConversation(conversationId, decision, handler);
     }
 
     @Override
-    public ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot getConversationMemorySnapshot(String conversationId)
+    public ConversationMemorySnapshot getConversationMemorySnapshot(String conversationId)
             throws ResourceStoreException, ResourceNotFoundException {
         return conversationHitlService.getConversationMemorySnapshot(conversationId);
     }
 
     @Override
-    public java.util.List<ai.labs.eddi.engine.model.PendingApprovalSummary> listPendingApprovals(int limit)
+    public List<PendingApprovalSummary> listPendingApprovals(int limit)
             throws ResourceStoreException {
         return conversationHitlService.listPendingApprovals(limit);
     }
 
     @Override
-    public java.util.List<ai.labs.eddi.engine.model.PendingApprovalSummary> listPendingApprovals(String ownerUserId, int limit)
+    public List<PendingApprovalSummary> listPendingApprovals(String ownerUserId, int limit)
             throws ResourceStoreException {
         return conversationHitlService.listPendingApprovals(ownerUserId, limit);
     }

--- a/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/GroupConversationService.java
@@ -66,6 +66,8 @@ import io.micrometer.core.instrument.Timer;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.lifecycle.model.DiscussionControlToken;
+import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -698,7 +700,7 @@ public class GroupConversationService implements IGroupConversationService {
         // AtomicInteger: shared across the phase loop; parallel phases increment
         // from virtual threads. Seed from pausedTurnCount to preserve budget across
         // resumes (M3).
-        var turnCounter = new java.util.concurrent.atomic.AtomicInteger(
+        var turnCounter = new AtomicInteger(
                 gc.getPausedTurnCount() > 0 ? gc.getPausedTurnCount() : 0);
 
         // Resolve HITL granularity from group config
@@ -1647,7 +1649,7 @@ public class GroupConversationService implements IGroupConversationService {
     }
 
     @Override
-    public List<ai.labs.eddi.engine.model.PendingApprovalSummary> listGroupPendingApprovals(String groupId, int limit)
+    public List<PendingApprovalSummary> listGroupPendingApprovals(String groupId, int limit)
             throws IResourceStore.ResourceStoreException {
         return lifecycleOps().listGroupPendingApprovals(groupId, limit);
     }
@@ -1669,7 +1671,7 @@ public class GroupConversationService implements IGroupConversationService {
     }
 
     public static void propagateDynamicAgentTracking(
-                                                     ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot snapshot,
+                                                     SimpleConversationMemorySnapshot snapshot,
                                                      GroupConversation gc) {
         GroupLifecycleOps.propagateDynamicAgentTracking(snapshot, gc);
     }
@@ -2006,14 +2008,14 @@ public class GroupConversationService implements IGroupConversationService {
 
     private void executeTaskPhase(GroupConversation gc, AgentGroupConfiguration config, List<GroupMember> speakers,
                                   DiscussionPhase phase, ProtocolConfig protocol, String question, int phaseIdx,
-                                  GroupDiscussionEventListener listener, java.util.concurrent.atomic.AtomicInteger turnCounter, int maxTurns)
+                                  GroupDiscussionEventListener listener, AtomicInteger turnCounter, int maxTurns)
             throws GroupDiscussionException {
         taskForceEngine.executeTaskPhase(gc, config, speakers, phase, protocol, question, phaseIdx, listener, turnCounter, maxTurns);
     }
 
     private void executeTaskExecutionPhase(GroupConversation gc, AgentGroupConfiguration config, List<GroupMember> speakers,
                                            DiscussionPhase phase, ProtocolConfig protocol, String question, int phaseIdx,
-                                           GroupDiscussionEventListener listener, java.util.concurrent.atomic.AtomicInteger turnCounter, int maxTurns)
+                                           GroupDiscussionEventListener listener, AtomicInteger turnCounter, int maxTurns)
             throws GroupDiscussionException {
         taskForceEngine.executeTaskExecutionPhase(gc, config, speakers, phase, protocol, question, phaseIdx, listener, turnCounter, maxTurns);
     }
@@ -2024,7 +2026,7 @@ public class GroupConversationService implements IGroupConversationService {
 
     private void executeTaskVerificationPhase(GroupConversation gc, AgentGroupConfiguration config, List<GroupMember> speakers,
                                               DiscussionPhase phase, ProtocolConfig protocol, String question, int phaseIdx,
-                                              GroupDiscussionEventListener listener, java.util.concurrent.atomic.AtomicInteger turnCounter,
+                                              GroupDiscussionEventListener listener, AtomicInteger turnCounter,
                                               int maxTurns)
             throws GroupDiscussionException {
         taskForceEngine.executeTaskVerificationPhase(gc, config, speakers, phase, protocol, question, phaseIdx, listener, turnCounter, maxTurns);
@@ -2073,7 +2075,7 @@ public class GroupConversationService implements IGroupConversationService {
     // just one calling convention, when sweeping for these).
     private void executeParallelPhase(GroupConversation gc, AgentGroupConfiguration config, List<GroupMember> speakers, DiscussionPhase phase,
                                       ProtocolConfig protocol, String question, int phaseIdx, GroupDiscussionEventListener listener,
-                                      java.util.concurrent.atomic.AtomicInteger turnCounter, int maxTurns)
+                                      AtomicInteger turnCounter, int maxTurns)
             throws GroupDiscussionException {
         phaseExecutionEngine.executeParallelPhase(gc, config, speakers, phase, protocol, question, phaseIdx, listener, turnCounter, maxTurns);
     }
@@ -2083,7 +2085,7 @@ public class GroupConversationService implements IGroupConversationService {
      */
     private void executeParallelPhase(GroupConversation gc, AgentGroupConfiguration config, List<GroupMember> speakers, DiscussionPhase phase,
                                       ProtocolConfig protocol, String question, int phaseIdx, GroupDiscussionEventListener listener,
-                                      java.util.concurrent.atomic.AtomicInteger turnCounter, int maxTurns, Integer humanResumeIdx)
+                                      AtomicInteger turnCounter, int maxTurns, Integer humanResumeIdx)
             throws GroupDiscussionException {
         phaseExecutionEngine.executeParallelPhase(gc, config, speakers, phase, protocol, question, phaseIdx, listener, turnCounter, maxTurns,
                 humanResumeIdx);
@@ -2224,7 +2226,7 @@ public class GroupConversationService implements IGroupConversationService {
      * reflection, and public since GroupLifecycleOps.followUpWithMember (Wave R, R1
      * step 8) calls it back.
      */
-    public String extractResponse(ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot snapshot) {
+    public String extractResponse(SimpleConversationMemorySnapshot snapshot) {
         return contextBuilder.extractResponse(snapshot);
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/HitlTimeoutHandler.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/HitlTimeoutHandler.java
@@ -5,7 +5,10 @@
 package ai.labs.eddi.engine.internal;
 
 import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
+import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.hitl.HitlSchedules;
+import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -25,10 +28,10 @@ public class HitlTimeoutHandler {
     private static final Logger LOGGER = Logger.getLogger(HitlTimeoutHandler.class);
 
     @Inject
-    ai.labs.eddi.engine.api.IConversationService conversationService;
+    IConversationService conversationService;
 
     @Inject
-    ai.labs.eddi.engine.api.IGroupConversationService groupConversationService;
+    IGroupConversationService groupConversationService;
 
     @Inject
     MeterRegistry meterRegistry;
@@ -96,7 +99,7 @@ public class HitlTimeoutHandler {
         try {
             if ("ABORT".equals(policyStr)) {
                 boolean cancelled = groupConversationService.cancelDiscussion(gcId,
-                        ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL);
+                        ControlSignal.CANCEL_GRACEFUL);
                 LOGGER.infof("Human-turn timeout ABORT for group conversation %s%s", gcId,
                         cancelled ? "" : " skipped — already terminal");
                 return;
@@ -136,7 +139,7 @@ public class HitlTimeoutHandler {
         String conversationId = (String) metadata.get(HitlSchedules.METADATA_CONVERSATION_ID_KEY);
         try {
             conversationService.cancelConversation(conversationId,
-                    ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL, "system:timeout");
+                    ControlSignal.CANCEL_GRACEFUL, "system:timeout");
             LOGGER.infof("HITL timeout ABORT for conversation %s", conversationId);
         } catch (Exception e) {
             LOGGER.errorf(e, "Failed to abort conversation %s on HITL timeout", conversationId);
@@ -147,7 +150,7 @@ public class HitlTimeoutHandler {
         String gcId = (String) metadata.get(HitlSchedules.METADATA_CONVERSATION_ID_KEY);
         try {
             boolean cancelled = groupConversationService.cancelDiscussion(gcId,
-                    ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL);
+                    ControlSignal.CANCEL_GRACEFUL);
             if (cancelled) {
                 LOGGER.infof("HITL timeout ABORT for group conversation %s", gcId);
             } else {

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
@@ -31,6 +31,7 @@ import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.time.Instant;
 import org.jboss.logging.Logger;
 import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
 
@@ -399,7 +400,7 @@ public class RestAgentAdministration implements IRestAgentAdministration {
             var schedules = scheduleStore.readSchedulesByAgentId(agentId);
             for (var schedule : schedules) {
                 if (!schedule.isEnabled()) {
-                    var nextFire = schedule.getNextFire() != null ? schedule.getNextFire() : java.time.Instant.now();
+                    var nextFire = schedule.getNextFire() != null ? schedule.getNextFire() : Instant.now();
                     scheduleStore.setScheduleEnabled(schedule.getId(), true, nextFire);
                     log.infof("[SCHEDULE] Auto-enabled schedule '%s' (id=%s) on Agent %s deploy", schedule.getName(), schedule.getId(), agentId);
                 }

--- a/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.internal;
+import ai.labs.eddi.configs.groups.IGroupConversationStore;
 
 import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.SharedTaskList;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IGroupConversationService;
@@ -15,6 +17,7 @@ import ai.labs.eddi.engine.api.IRestGroupConversation;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.hitl.HitlAccessGuard;
 import ai.labs.eddi.engine.memory.model.Attachment;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import ai.labs.eddi.engine.security.OwnershipValidator;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -29,6 +32,7 @@ import org.jboss.logging.Logger;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -390,7 +394,7 @@ public class RestGroupConversation implements IRestGroupConversation {
             var gc = groupConversationService.readGroupConversation(gcId);
             return Response.ok(gc).build();
         } catch (IResourceStore.ResourceNotFoundException
-                | ai.labs.eddi.configs.groups.IGroupConversationStore.GroupConversationGoneException e) {
+                | IGroupConversationStore.GroupConversationGoneException e) {
             // Curated body: GroupConversationGoneException embeds the caller-supplied
             // gcId — never reflect it (CodeQL reflected-value/XSS) and never echo the
             // raw exception text; the detail is logged server-side with the id sanitized
@@ -433,7 +437,7 @@ public class RestGroupConversation implements IRestGroupConversation {
             return Response.status(Response.Status.CONFLICT).type(TEXT_PLAIN)
                     .entity("The group conversation was modified concurrently — reload and retry.").build();
         } catch (IResourceStore.ResourceNotFoundException
-                | ai.labs.eddi.configs.groups.IGroupConversationStore.GroupConversationGoneException e) {
+                | IGroupConversationStore.GroupConversationGoneException e) {
             // deleted concurrently — a genuine 404, not a state conflict
             LOGGER.infof("Approve of group conversation %s → not found: %s", sanitize(gcId), e.getMessage());
             return Response.status(Response.Status.NOT_FOUND).type(TEXT_PLAIN)
@@ -483,7 +487,7 @@ public class RestGroupConversation implements IRestGroupConversation {
             return Response.status(Response.Status.CONFLICT).type(TEXT_PLAIN)
                     .entity("The group conversation was modified concurrently — reload and retry.").build();
         } catch (IResourceStore.ResourceNotFoundException
-                | ai.labs.eddi.configs.groups.IGroupConversationStore.GroupConversationGoneException e) {
+                | IGroupConversationStore.GroupConversationGoneException e) {
             LOGGER.infof("Human input for group conversation %s → not found: %s", sanitize(gcId), e.getMessage());
             return Response.status(Response.Status.NOT_FOUND).type(TEXT_PLAIN)
                     .entity("Group conversation not found.").build();
@@ -665,7 +669,7 @@ public class RestGroupConversation implements IRestGroupConversation {
                     "The group conversation was modified concurrently — reload and retry.");
             closeQuietly(eventSink);
         } catch (IResourceStore.ResourceNotFoundException
-                | ai.labs.eddi.configs.groups.IGroupConversationStore.GroupConversationGoneException e) {
+                | IGroupConversationStore.GroupConversationGoneException e) {
             // deleted concurrently — a genuine 404 equivalent
             sendErrorEvent(eventSink, sse, "Group conversation not found.");
             closeQuietly(eventSink);
@@ -766,11 +770,11 @@ public class RestGroupConversation implements IRestGroupConversation {
             // never mislead dashboards.
             List<String> awaitingTaskIds = paused && gc.getTaskList() != null
                     ? gc.getTaskList().all().stream()
-                            .filter(t -> t.status() == ai.labs.eddi.configs.groups.model.SharedTaskList.TaskStatus.AWAITING_APPROVAL)
-                            .map(ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem::id)
+                            .filter(t -> t.status() == SharedTaskList.TaskStatus.AWAITING_APPROVAL)
+                            .map(SharedTaskList.TaskItem::id)
                             .toList()
                     : List.of();
-            var summary = new java.util.LinkedHashMap<String, Object>();
+            var summary = new LinkedHashMap<String, Object>();
             summary.put("groupConversationId", gcId);
             summary.put("state", gc.getState() != null ? gc.getState().name() : "");
             summary.put("pausedAt", paused && gc.getPausedAt() != null ? gc.getPausedAt().toString() : "");
@@ -1005,14 +1009,14 @@ public class RestGroupConversation implements IRestGroupConversation {
     }
 
     @Override
-    public List<ai.labs.eddi.engine.model.PendingApprovalSummary> listGroupPendingApprovals(String groupId, Integer limit) {
+    public List<PendingApprovalSummary> listGroupPendingApprovals(String groupId, Integer limit) {
         // Scoped to the group in the path — the query-level filter keeps the listing
         // from leaking other groups.
         return listPendingApprovals(groupId, limit);
     }
 
     @Override
-    public List<ai.labs.eddi.engine.model.PendingApprovalSummary> listAllGroupPendingApprovals(Integer limit) {
+    public List<PendingApprovalSummary> listAllGroupPendingApprovals(Integer limit) {
         // #21: cross-group inbox — groupId=null lists pending approvals across all
         // groups (the store's existing findByState(state, null, limit) variant, the
         // same one crash recovery uses). Same authz as the per-group endpoint.
@@ -1025,7 +1029,7 @@ public class RestGroupConversation implements IRestGroupConversation {
      * see all pending items, other callers only their own conversations; anonymous
      * or principal-less callers see nothing (fail-closed).
      */
-    private List<ai.labs.eddi.engine.model.PendingApprovalSummary> listPendingApprovals(String groupId, Integer limit) {
+    private List<PendingApprovalSummary> listPendingApprovals(String groupId, Integer limit) {
         try {
             // Owner-scoping (admins/approvers see all; others see only their own;
             // anonymous sees nothing) lives in HitlAccessGuard so the MCP surface

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManager.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManager.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.lifecycle.internal;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
+import ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException;
 import ai.labs.eddi.engine.lifecycle.IComponentCache;
 import ai.labs.eddi.engine.lifecycle.IConversation;
 import ai.labs.eddi.engine.lifecycle.ILifecycleManager;
@@ -29,10 +30,12 @@ import io.opentelemetry.context.Scope;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Counter;
+import java.time.Duration;
 
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeoutException;
 
 import static ai.labs.eddi.engine.memory.MemoryKeys.ACTIONS;
 import static ai.labs.eddi.engine.memory.MemoryKeys.AUDIT_CASCADE_MODEL;
@@ -369,7 +372,7 @@ public class LifecycleManager implements ILifecycleManager {
                 // and strict-write rollback — the partially-executed step data (incl. the
                 // pending batch just written to memory) must survive into the pause
                 // snapshot, exactly like the rule-based PAUSE_CONVERSATION path.
-                if (e instanceof ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException tare) {
+                if (e instanceof ToolApprovalRequiredException tare) {
                     taskSpan.setAttribute("eddi.hitl.pause", "tool_call");
                     throw new ConversationPauseException(workflowId.getId(), absoluteIndex,
                             tare.getPauseReason(), ConversationPauseException.PauseOrigin.TOOL_CALL);
@@ -462,7 +465,7 @@ public class LifecycleManager implements ILifecycleManager {
                         .tag("task.type", taskType)
                         .description("Pipeline task execution duration")
                         .publishPercentileHistogram()
-                        .register(Metrics.globalRegistry)).record(java.time.Duration.ofMillis(durationMs));
+                        .register(Metrics.globalRegistry)).record(Duration.ofMillis(durationMs));
 
                 taskSpan.end();
             }
@@ -978,7 +981,7 @@ public class LifecycleManager implements ILifecycleManager {
     static String classifyError(Throwable e) {
         for (Throwable current = e; current != null; current = current.getCause()) {
             if (current instanceof java.net.SocketTimeoutException
-                    || current instanceof java.util.concurrent.TimeoutException) {
+                    || current instanceof TimeoutException) {
                 return "timeout";
             }
             if (current instanceof java.net.ConnectException

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/model/HitlDecision.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/model/HitlDecision.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.lifecycle.model;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Human decision on a paused conversation or group discussion.
@@ -33,7 +35,7 @@ public class HitlDecision {
                 return null;
             }
             try {
-                return HitlVerdict.valueOf(value.trim().toUpperCase(java.util.Locale.ROOT));
+                return HitlVerdict.valueOf(value.trim().toUpperCase(Locale.ROOT));
             } catch (IllegalArgumentException unrecognized) {
                 return null;
             }
@@ -48,7 +50,7 @@ public class HitlDecision {
      * Per-tool-call verdicts, keyed by {@code callId} — TOOL_CALL pauses only.
      * Calls not listed here inherit the top-level {@link #verdict}.
      */
-    private java.util.Map<String, ToolCallDecision> toolDecisions;
+    private Map<String, ToolCallDecision> toolDecisions;
 
     public HitlVerdict getVerdict() {
         return verdict;
@@ -74,11 +76,11 @@ public class HitlDecision {
         this.decidedBy = decidedBy;
     }
 
-    public java.util.Map<String, ToolCallDecision> getToolDecisions() {
+    public Map<String, ToolCallDecision> getToolDecisions() {
         return toolDecisions;
     }
 
-    public void setToolDecisions(java.util.Map<String, ToolCallDecision> toolDecisions) {
+    public void setToolDecisions(Map<String, ToolCallDecision> toolDecisions) {
         this.toolDecisions = toolDecisions;
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpAdminTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpAdminTools.java
@@ -13,6 +13,8 @@ import ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
+import ai.labs.eddi.configs.channels.IRestChannelIntegrationStore;
+import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.configs.mcpcalls.IRestMcpCallsStore;
 import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
 import ai.labs.eddi.configs.llm.IRestLlmStore;
@@ -110,7 +112,7 @@ public class McpAdminTools {
             Response response = agentAdmin.deployAgent(env, agentId, ver, true, true);
             int httpStatus = response.getStatus();
 
-            var result = new java.util.LinkedHashMap<String, Object>();
+            var result = new LinkedHashMap<String, Object>();
             result.put("agentId", agentId);
             result.put("version", ver);
             result.put("environment", env.name());
@@ -120,7 +122,7 @@ public class McpAdminTools {
                 // Read actual deployment status from response body
                 try {
                     @SuppressWarnings("unchecked")
-                    var body = (java.util.Map<String, Object>) response.getEntity();
+                    var body = (Map<String, Object>) response.getEntity();
                     if (body != null && body.containsKey("status")) {
                         String deployStatus = body.get("status").toString();
                         result.put("deploymentStatus", deployStatus);
@@ -1192,7 +1194,7 @@ public class McpAdminTools {
             int limitInt = limit != null ? limit : 20;
             String filterStr = filter != null ? filter : "";
             var channelStore = getRestStore(
-                    ai.labs.eddi.configs.channels.IRestChannelIntegrationStore.class);
+                    IRestChannelIntegrationStore.class);
             var descriptors = channelStore.readChannelDescriptors(filterStr, 0, limitInt);
             return jsonSerialization.serialize(descriptors);
         } catch (Exception e) {
@@ -1211,7 +1213,7 @@ public class McpAdminTools {
             return errorJson("resourceId is required");
         try {
             var channelStore = getRestStore(
-                    ai.labs.eddi.configs.channels.IRestChannelIntegrationStore.class);
+                    IRestChannelIntegrationStore.class);
             int ver = version != null ? version : channelStore.getCurrentVersion(resourceId);
             var config = channelStore.readChannel(resourceId, ver);
 
@@ -1236,9 +1238,9 @@ public class McpAdminTools {
             return errorJson("config is required");
         try {
             var channelConfig = jsonSerialization.deserialize(config,
-                    ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration.class);
+                    ChannelIntegrationConfiguration.class);
             var channelStore = getRestStore(
-                    ai.labs.eddi.configs.channels.IRestChannelIntegrationStore.class);
+                    IRestChannelIntegrationStore.class);
             Response response = channelStore.createChannel(channelConfig);
             String location = response.getHeaderString("Location");
             String newId = extractIdFromLocation(location);
@@ -1269,9 +1271,9 @@ public class McpAdminTools {
         try {
             int ver = version != null ? version : 1;
             var channelConfig = jsonSerialization.deserialize(config,
-                    ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration.class);
+                    ChannelIntegrationConfiguration.class);
             var channelStore = getRestStore(
-                    ai.labs.eddi.configs.channels.IRestChannelIntegrationStore.class);
+                    IRestChannelIntegrationStore.class);
             Response response = channelStore.updateChannel(resourceId, ver, channelConfig);
             String location = response.getHeaderString("Location");
             int newVersion = extractVersionFromLocation(location);
@@ -1299,7 +1301,7 @@ public class McpAdminTools {
             int ver = version != null ? version : 1;
             boolean isPermanent = permanent != null ? permanent : false;
             var channelStore = getRestStore(
-                    ai.labs.eddi.configs.channels.IRestChannelIntegrationStore.class);
+                    IRestChannelIntegrationStore.class);
             Response response = channelStore.deleteChannel(resourceId, ver, isPermanent);
 
             return resultJson("deleted", Map.of(

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpConversationTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpConversationTools.java
@@ -20,13 +20,16 @@ import ai.labs.eddi.engine.audit.model.AuditEntry;
 import ai.labs.eddi.engine.audit.rest.IRestAuditStore;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.descriptor.model.ConversationDescriptor;
+import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.model.*;
 import ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.model.Deployment;
 import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
 import ai.labs.eddi.engine.model.LogEntry;
 import ai.labs.eddi.engine.memory.rest.IRestConversationStore;
+import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.runtime.BoundedLogStore;
 import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
 import ai.labs.eddi.engine.runtime.client.factory.RestInterfaceFactory;
@@ -45,7 +48,10 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.util.*;
+import java.util.ArrayList;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static ai.labs.eddi.engine.mcp.McpToolUtils.*;
@@ -332,7 +338,7 @@ public class McpConversationTools {
                 if (!requestedFullSection) {
                     var filteredOutputs = snapshot.getConversationOutputs().stream()
                             .map(output -> {
-                                var filtered = new ai.labs.eddi.engine.memory.model.ConversationOutput();
+                                var filtered = new ConversationOutput();
                                 output.forEach((key, value) -> {
                                     if (key instanceof String s && trimmedFields.stream().anyMatch(f -> s.equals(f) || s.startsWith(f + ":"))) {
                                         filtered.put(key, value);
@@ -782,8 +788,8 @@ public class McpConversationTools {
         var batch = snapshot.getHitlPendingToolCalls();
         if (batch != null && batch.getCalls() != null) {
             var toolNames = batch.getCalls().stream()
-                    .map(ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall::getToolName)
-                    .filter(java.util.Objects::nonNull)
+                    .map(PendingToolCallBatch.PendingToolCall::getToolName)
+                    .filter(Objects::nonNull)
                     .toList();
             if (!toolNames.isEmpty()) {
                 result.put("tools", toolNames);
@@ -851,7 +857,7 @@ public class McpConversationTools {
         // Start a new conversation — use ConversationService directly to avoid
         // the JAX-RS layer which converts exceptions to HTTP responses that are
         // hard to inspect programmatically.
-        var initialContext = new HashMap<String, ai.labs.eddi.engine.model.Context>(deployment.getInitialContext());
+        var initialContext = new HashMap<String, Context>(deployment.getInitialContext());
         var convResult = conversationService.startConversation(usedEnv, agentId, userId, initialContext);
         String conversationId = convResult.conversationId();
 
@@ -901,7 +907,7 @@ public class McpConversationTools {
 
         try {
             return responseFuture.get(CONVERSATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        } catch (java.util.concurrent.ExecutionException e) {
+        } catch (ExecutionException e) {
             // Unwrap the skip signal so callers can catch it directly.
             if (e.getCause() instanceof ConversationSkippedException cse) {
                 throw cse;
@@ -972,7 +978,7 @@ public class McpConversationTools {
             // Agent response text — extract text strings from output items
             var outputItems = lastOutput.get("output");
             if (outputItems instanceof List<?> items) {
-                var texts = new java.util.ArrayList<String>();
+                var texts = new ArrayList<String>();
                 for (var item : items) {
                     if (item instanceof Map<?, ?> map && map.containsKey("text")) {
                         texts.add(String.valueOf(map.get("text")));
@@ -989,7 +995,7 @@ public class McpConversationTools {
             // QuickReplies — extract value strings for easy AI consumption
             var quickReplies = lastOutput.get("quickReplies");
             if (quickReplies instanceof List<?> qrList && !qrList.isEmpty()) {
-                var qrValues = new java.util.ArrayList<String>();
+                var qrValues = new ArrayList<String>();
                 for (var qr : qrList) {
                     if (qr instanceof Map<?, ?> map && map.containsKey("value")) {
                         qrValues.add(String.valueOf(map.get("value")));

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
@@ -454,7 +454,7 @@ public class McpGroupTools {
         try {
             String user = resolveOwner(userId);
             GroupConversation gc = groupConversationService.startAndDiscussAsync(groupId, question, user, null);
-            return jsonSerialization.serialize(java.util.Map.of(
+            return jsonSerialization.serialize(Map.of(
                     "groupConversationId", gc.getId(),
                     "state", String.valueOf(gc.getState()),
                     "message", "Discussion started. Poll read_group_conversation with this ID to check progress."));

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpHitlTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpHitlTools.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.mcp;
+import ai.labs.eddi.configs.groups.IGroupConversationStore;
 
 import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.configs.groups.model.SharedTaskList;
@@ -436,7 +437,7 @@ public class McpHitlTools {
             // (e.g. {"t1": 5}) would otherwise survive to resumeDiscussion and throw
             // a ClassCastException that surfaces as INTERNAL instead of the correct
             // BAD_REQUEST. Fail fast with a clear message; keys are always JSON strings.
-            taskApprovals = new java.util.LinkedHashMap<>();
+            taskApprovals = new LinkedHashMap<>();
             for (var entry : rawApprovals.entrySet()) {
                 if (!(entry.getValue() instanceof String value) || value.isBlank()) {
                     return errorJson("Invalid taskApprovals: each value must be a non-empty string "
@@ -464,7 +465,7 @@ public class McpHitlTools {
         } catch (IResourceStore.ResourceModifiedException e) {
             return errorJson("The group conversation was modified concurrently — reload and retry", "CONFLICT", null);
         } catch (ResourceNotFoundException
-                | ai.labs.eddi.configs.groups.IGroupConversationStore.GroupConversationGoneException e) {
+                | IGroupConversationStore.GroupConversationGoneException e) {
             return errorJson("Group conversation not found", "NOT_FOUND", null);
         } catch (IGroupConversationService.GroupDiscussionException e) {
             return errorJson("Group conversation is not awaiting approval — it may have been resolved, cancelled, "
@@ -510,7 +511,7 @@ public class McpHitlTools {
         } catch (IResourceStore.ResourceModifiedException e) {
             return errorJson("The group conversation was modified concurrently — reload and retry", "CONFLICT", null);
         } catch (ResourceNotFoundException
-                | ai.labs.eddi.configs.groups.IGroupConversationStore.GroupConversationGoneException e) {
+                | IGroupConversationStore.GroupConversationGoneException e) {
             return errorJson("Group conversation not found", "NOT_FOUND", null);
         } catch (IGroupConversationService.GroupDiscussionException e) {
             return errorJson("Group conversation is not awaiting human input — the turn may have been resolved, "
@@ -550,7 +551,7 @@ public class McpHitlTools {
         } catch (jakarta.ws.rs.NotFoundException e) {
             return errorJson("Group conversation not found", "NOT_FOUND", null);
         } catch (ResourceNotFoundException
-                | ai.labs.eddi.configs.groups.IGroupConversationStore.GroupConversationGoneException e) {
+                | IGroupConversationStore.GroupConversationGoneException e) {
             return errorJson("Group conversation not found", "NOT_FOUND", null);
         } catch (Exception e) {
             LOGGER.warn("MCP cancel_group_discussion failed", e);

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationLogGenerator.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationLogGenerator.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static ai.labs.eddi.engine.memory.model.ConversationLog.ConversationPart.ContentType.*;
@@ -122,7 +123,7 @@ public class ConversationLogGenerator {
                             var mapList = (List<Map<String, Object>>) outputList;
                             var joinedOutput = mapList.stream()
                                     .map(item -> item.get(KEY_TEXT))
-                                    .filter(java.util.Objects::nonNull)
+                                    .filter(Objects::nonNull)
                                     .map(Object::toString)
                                     .collect(Collectors.joining(" "));
                             content.setType(text);

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryStore.java
@@ -9,6 +9,8 @@ import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
@@ -247,7 +249,7 @@ public class ConversationMemoryStore implements IConversationMemoryStore, IResou
             "hitlPauseType", "hitlPendingToolCalls.calls.toolName");
 
     @Override
-    public List<ai.labs.eddi.engine.model.PendingApprovalSummary> findPendingApprovalSummaries(int limit) {
+    public List<PendingApprovalSummary> findPendingApprovalSummaries(int limit) {
         // Single bounded, projected query on the indexed state field — the
         // (potentially multi-MB) step/output data of paused conversations is
         // never deserialized, and there are no per-id point-reads (this listing
@@ -259,7 +261,7 @@ public class ConversationMemoryStore implements IConversationMemoryStore, IResou
     }
 
     @Override
-    public List<ai.labs.eddi.engine.model.PendingApprovalSummary> findPendingApprovalSummaries(String ownerUserId, int limit) {
+    public List<PendingApprovalSummary> findPendingApprovalSummaries(String ownerUserId, int limit) {
         // Owner filter INSIDE the query: the limit applies after the restriction,
         // so a user's inbox is complete even behind a large global backlog.
         return collectPendingSummaries(
@@ -270,11 +272,11 @@ public class ConversationMemoryStore implements IConversationMemoryStore, IResou
                         .limit(limit));
     }
 
-    private List<ai.labs.eddi.engine.model.PendingApprovalSummary> collectPendingSummaries(
-                                                                                           com.mongodb.client.FindIterable<ConversationMemorySnapshot> snapshots) {
-        List<ai.labs.eddi.engine.model.PendingApprovalSummary> out = new ArrayList<>();
+    private List<PendingApprovalSummary> collectPendingSummaries(
+                                                                 com.mongodb.client.FindIterable<ConversationMemorySnapshot> snapshots) {
+        List<PendingApprovalSummary> out = new ArrayList<>();
         snapshots.forEach(snapshot -> {
-            var summary = new ai.labs.eddi.engine.model.PendingApprovalSummary(
+            var summary = new PendingApprovalSummary(
                     snapshot.getConversationId(), snapshot.getAgentId(), snapshot.getUserId(),
                     snapshot.getHitlPausedAt(), snapshot.getHitlPauseReason(),
                     snapshot.getHitlTimeoutPolicy() != null ? snapshot.getHitlTimeoutPolicy().name() : null);
@@ -282,7 +284,7 @@ public class ConversationMemoryStore implements IConversationMemoryStore, IResou
             summary.setPauseType(snapshot.getHitlPauseType());
             if (snapshot.getHitlPendingToolCalls() != null && snapshot.getHitlPendingToolCalls().getCalls() != null) {
                 summary.setToolNames(snapshot.getHitlPendingToolCalls().getCalls().stream()
-                        .map(ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall::getToolName)
+                        .map(PendingToolCallBatch.PendingToolCall::getToolName)
                         .toList());
             }
             out.add(summary);

--- a/src/main/java/ai/labs/eddi/engine/memory/IConversationMemory.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/IConversationMemory.java
@@ -6,11 +6,14 @@ package ai.labs.eddi.engine.memory;
 
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.engine.audit.IAuditEntryCollector;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.configs.properties.model.Property;
+import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 
 import java.io.Serializable;
 import java.time.Instant;
@@ -208,30 +211,30 @@ public interface IConversationMemory extends Serializable {
      * The interrupted tool-call batch (durable); null unless a tool pause is
      * active.
      */
-    default ai.labs.eddi.engine.memory.model.PendingToolCallBatch getHitlPendingToolCalls() {
+    default PendingToolCallBatch getHitlPendingToolCalls() {
         return null;
     }
-    default void setHitlPendingToolCalls(ai.labs.eddi.engine.memory.model.PendingToolCallBatch batch) {
+    default void setHitlPendingToolCalls(PendingToolCallBatch batch) {
     }
 
     /**
      * Agent-level tool-approval config carried onto memory at conversation start
      * (NOT persisted).
      */
-    default ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig getAgentToolApprovalsConfig() {
+    default ToolApprovalsConfig getAgentToolApprovalsConfig() {
         return null;
     }
-    default void setAgentToolApprovalsConfig(ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig config) {
+    default void setAgentToolApprovalsConfig(ToolApprovalsConfig config) {
     }
 
     /**
      * The human decision being applied during an in-JVM tool-pause resume (NOT
      * persisted).
      */
-    default ai.labs.eddi.engine.lifecycle.model.HitlDecision getHitlResumeDecision() {
+    default HitlDecision getHitlResumeDecision() {
         return null;
     }
-    default void setHitlResumeDecision(ai.labs.eddi.engine.lifecycle.model.HitlDecision decision) {
+    default void setHitlResumeDecision(HitlDecision decision) {
     }
 
     // === Deferred user-memory writes ===

--- a/src/main/java/ai/labs/eddi/engine/memory/IConversationMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/IConversationMemoryStore.java
@@ -7,8 +7,10 @@ package ai.labs.eddi.engine.memory;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -103,7 +105,7 @@ public interface IConversationMemoryStore {
      * @throws IResourceStore.ResourceStoreException
      *             on persistence failures
      */
-    List<ai.labs.eddi.engine.model.PendingApprovalSummary> findPendingApprovalSummaries(int limit)
+    List<PendingApprovalSummary> findPendingApprovalSummaries(int limit)
             throws IResourceStore.ResourceStoreException;
 
     /**
@@ -122,11 +124,11 @@ public interface IConversationMemoryStore {
      * @throws IResourceStore.ResourceStoreException
      *             on persistence failures
      */
-    default List<ai.labs.eddi.engine.model.PendingApprovalSummary> findPendingApprovalSummaries(
-                                                                                                String ownerUserId, int limit)
+    default List<PendingApprovalSummary> findPendingApprovalSummaries(
+                                                                      String ownerUserId, int limit)
             throws IResourceStore.ResourceStoreException {
         return findPendingApprovalSummaries(limit).stream()
-                .filter(summary -> java.util.Objects.equals(ownerUserId, summary.getUserId()))
+                .filter(summary -> Objects.equals(ownerUserId, summary.getUserId()))
                 .toList();
     }
 

--- a/src/main/java/ai/labs/eddi/engine/memory/model/ConversationLog.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/model/ConversationLog.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.engine.memory.model;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ConversationLog {
@@ -59,12 +60,12 @@ public class ConversationLog {
                 if (o == null || getClass() != o.getClass())
                     return false;
                 Content that = (Content) o;
-                return java.util.Objects.equals(type, that.type) && java.util.Objects.equals(value, that.value);
+                return Objects.equals(type, that.type) && Objects.equals(value, that.value);
             }
 
             @Override
             public int hashCode() {
-                return java.util.Objects.hash(type, value);
+                return Objects.hash(type, value);
             }
 
             @Override
@@ -108,12 +109,12 @@ public class ConversationLog {
             if (o == null || getClass() != o.getClass())
                 return false;
             ConversationPart that = (ConversationPart) o;
-            return java.util.Objects.equals(role, that.role) && java.util.Objects.equals(content, that.content);
+            return Objects.equals(role, that.role) && Objects.equals(content, that.content);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(role, content);
+            return Objects.hash(role, content);
         }
 
         @Override
@@ -144,11 +145,11 @@ public class ConversationLog {
         if (o == null || getClass() != o.getClass())
             return false;
         ConversationLog that = (ConversationLog) o;
-        return java.util.Objects.equals(messages, that.messages);
+        return Objects.equals(messages, that.messages);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(messages);
+        return Objects.hash(messages);
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/memory/model/MemoryCheckpoint.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/model/MemoryCheckpoint.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Immutable snapshot of conversation state at a specific point in time. Used
@@ -66,7 +67,7 @@ public record MemoryCheckpoint(
     public static MemoryCheckpoint create(String conversationId, int stepIndex,
                                           Map<String, Property> properties, String triggeredBy, String triggeredByClass) {
         return new MemoryCheckpoint(
-                java.util.UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
                 conversationId,
                 null,
                 stepIndex,

--- a/src/main/java/ai/labs/eddi/engine/rest/RestAgentSetup.java
+++ b/src/main/java/ai/labs/eddi/engine/rest/RestAgentSetup.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.engine.setup.SetupResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
+import java.util.Map;
 import org.jboss.logging.Logger;
 
 /**
@@ -40,10 +41,10 @@ public class RestAgentSetup implements IRestAgentSetup {
             return Response.status(Response.Status.CREATED).entity(result).build();
         } catch (AgentSetupException e) {
             LOGGER.warnf("Agent setup validation failed: %s", e.getMessage());
-            return Response.status(Response.Status.BAD_REQUEST).entity(java.util.Map.of("error", e.getMessage())).build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(Map.of("error", e.getMessage())).build();
         } catch (Exception e) {
             LOGGER.error("Agent setup failed", e);
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(java.util.Map.of("error", "Agent setup failed: " + e.getMessage()))
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(Map.of("error", "Agent setup failed: " + e.getMessage()))
                     .build();
         }
     }
@@ -55,11 +56,11 @@ public class RestAgentSetup implements IRestAgentSetup {
             return Response.status(Response.Status.CREATED).entity(result).build();
         } catch (AgentSetupException e) {
             LOGGER.warnf("API agent setup validation failed: %s", e.getMessage());
-            return Response.status(Response.Status.BAD_REQUEST).entity(java.util.Map.of("error", e.getMessage())).build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(Map.of("error", e.getMessage())).build();
         } catch (Exception e) {
             LOGGER.error("API agent setup failed", e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(java.util.Map.of("error", "API agent setup failed: " + e.getMessage())).build();
+                    .entity(Map.of("error", "API agent setup failed: " + e.getMessage())).build();
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/runtime/BoundedLogStore.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/BoundedLogStore.java
@@ -17,6 +17,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
+import java.util.logging.LogRecord;
 
 /**
  * In-memory ring buffer that captures log records with MDC context. Provides:
@@ -135,7 +136,7 @@ public class BoundedLogStore {
      * @param record
      *            the JUL LogRecord (actually a JBoss ExtLogRecord at runtime)
      */
-    public void capture(java.util.logging.LogRecord record) {
+    public void capture(LogRecord record) {
         if (record == null)
             return;
 
@@ -327,7 +328,7 @@ public class BoundedLogStore {
      * {@link org.jboss.logmanager.ExtLogRecord#getFormattedMessage()}. For plain
      * JUL LogRecords, we fall back to manual MessageFormat.
      */
-    private static String formatRecord(java.util.logging.LogRecord record) {
+    private static String formatRecord(LogRecord record) {
         String msg = record.getMessage();
         if (msg == null)
             return "";

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Agent.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Agent.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.runtime.internal;
 
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.engine.lifecycle.IConversation;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import ai.labs.eddi.engine.memory.ConversationMemory;
@@ -30,7 +31,7 @@ public class Agent implements IAgent {
     private Deployment.Status deploymentStatus;
     private AgentConfiguration.UserMemoryConfig userMemoryConfig;
     private AgentConfiguration.MemoryPolicy memoryPolicy;
-    private ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig toolApprovalsConfig;
+    private ToolApprovalsConfig toolApprovalsConfig;
 
     public Agent(String agentId, Integer agentVersion) {
         this.agentId = agentId;
@@ -100,7 +101,7 @@ public class Agent implements IAgent {
         this.userMemoryConfig = userMemoryConfig;
     }
 
-    public void setToolApprovalsConfig(ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig toolApprovalsConfig) {
+    public void setToolApprovalsConfig(ToolApprovalsConfig toolApprovalsConfig) {
         this.toolApprovalsConfig = toolApprovalsConfig;
     }
 

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentFactory.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentFactory.java
@@ -26,6 +26,7 @@ import org.jboss.logging.Logger;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 import java.util.*;
+import java.util.Objects;
 import java.util.concurrent.*;
 
 /**
@@ -418,12 +419,12 @@ public class AgentFactory implements IAgentFactory {
             if (o == null || getClass() != o.getClass())
                 return false;
             AgentId that = (AgentId) o;
-            return java.util.Objects.equals(id, that.id) && java.util.Objects.equals(version, that.version);
+            return Objects.equals(id, that.id) && Objects.equals(version, that.version);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(id, version);
+            return Objects.hash(id, version);
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -27,6 +27,7 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.ArrayList;
 
 import static ai.labs.eddi.engine.memory.ContextUtilities.storeContextLanguageInLongTermMemory;
 import static ai.labs.eddi.engine.memory.IConversationMemory.IWritableConversationStep;
@@ -1070,7 +1071,7 @@ public class Conversation implements IConversation {
             return;
         List<String> actions = actionData.getResult();
         if (actions != null && actions.contains(IConversation.PAUSE_CONVERSATION)) {
-            List<String> cleaned = new java.util.ArrayList<>(actions);
+            List<String> cleaned = new ArrayList<>(actions);
             cleaned.remove(IConversation.PAUSE_CONVERSATION);
             IData<List<String>> replacement = new Data<>(ACTIONS.key(), cleaned);
             step.storeData(replacement);

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/CronDescriber.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/CronDescriber.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.engine.runtime.internal;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Converts 5-field cron expressions to human-readable descriptions.
@@ -156,7 +157,7 @@ public final class CronDescriber {
             return v >= 0 && v < labels.length ? labels[v] : String.valueOf(v);
         }
         return values.stream().map(v -> v >= 0 && v < labels.length ? labels[v] : String.valueOf(v))
-                .collect(java.util.stream.Collectors.joining(", "));
+                .collect(Collectors.joining(", "));
     }
 
     private static String substituteNames(String field, Map<String, String> names) {

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinator.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinator.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -241,7 +242,7 @@ public class NatsConversationCoordinator implements IConversationCoordinator {
         if (!conversationQueues.containsKey(conversationId) && conversationQueues.size() >= maxActiveConversations) {
             log.warnf("Coordinator capacity exceeded (%d active conversations). Rejecting new conversationId=%s", maxActiveConversations,
                     safeConversationId);
-            throw new java.util.concurrent.RejectedExecutionException(
+            throw new RejectedExecutionException(
                     "Coordinator capacity exceeded: " + maxActiveConversations + " active conversations. Try again later.");
         }
 
@@ -269,7 +270,7 @@ public class NatsConversationCoordinator implements IConversationCoordinator {
                 boolean enqueued = queue.offer(retryable);
                 if (!enqueued) {
                     log.warnf("Failed to enqueue task for conversationId=%s", safeConversationId);
-                    throw new java.util.concurrent.RejectedExecutionException(
+                    throw new RejectedExecutionException(
                             "Failed to enqueue task for conversationId=" + safeConversationId);
                 }
 

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/ScheduleFireExecutor.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/ScheduleFireExecutor.java
@@ -9,6 +9,8 @@ import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration.TriggerType;
 import ai.labs.eddi.engine.schedule.model.ScheduleFireLog;
 import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.hitl.HitlSchedules;
+import ai.labs.eddi.engine.internal.HitlTimeoutHandler;
 import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.model.InputData;
@@ -58,7 +60,7 @@ public class ScheduleFireExecutor {
     IScheduleStore scheduleStore;
 
     @Inject
-    ai.labs.eddi.engine.internal.HitlTimeoutHandler hitlTimeoutHandler;
+    HitlTimeoutHandler hitlTimeoutHandler;
 
     @Inject
     DreamService dreamService;
@@ -80,7 +82,7 @@ public class ScheduleFireExecutor {
      */
     public ScheduleFireLog fire(ScheduleConfiguration schedule, String instanceId, int attemptNumber) {
         Map<String, Object> md = schedule.getMetadata();
-        if (ai.labs.eddi.engine.hitl.HitlSchedules.isHitlTimeout(md)) {
+        if (HitlSchedules.isHitlTimeout(md)) {
             // HITL timeout fast-path — isolate exceptions and record a fire log for
             // parity with the normal path (observability + retry diagnostics).
             Instant hitlStartedAt = Instant.now();
@@ -96,7 +98,7 @@ public class ScheduleFireExecutor {
             var hitlFireLog = new ScheduleFireLog(UUID.randomUUID().toString(), schedule.getId(),
                     schedule.getFireId(), schedule.getNextFire(), hitlStartedAt, Instant.now(),
                     hitlStatus, instanceId,
-                    (String) md.get(ai.labs.eddi.engine.hitl.HitlSchedules.METADATA_CONVERSATION_ID_KEY),
+                    (String) md.get(HitlSchedules.METADATA_CONVERSATION_ID_KEY),
                     hitlError, attemptNumber, 0.0);
             try {
                 scheduleStore.logFire(hitlFireLog);

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -50,6 +50,7 @@ import org.jboss.logging.Logger;
 
 import java.net.URI;
 import java.util.*;
+import java.util.Map;
 
 /**
  * Service that encapsulates the business logic for setting up EDDI agents. Used
@@ -1153,7 +1154,7 @@ public class AgentSetupService {
             if (httpStatus == 200) {
                 try {
                     @SuppressWarnings("unchecked")
-                    var body = (java.util.Map<String, Object>) response.getEntity();
+                    var body = (Map<String, Object>) response.getEntity();
                     String deployStatus = body != null && body.containsKey("status") ? body.get("status").toString() : "UNKNOWN";
                     result.put("deployed", "READY".equals(deployStatus));
                     result.put("deploymentStatus", deployStatus);

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackEventHandler.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackEventHandler.java
@@ -19,6 +19,7 @@ import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
 import ai.labs.eddi.integrations.channels.ChannelTargetRouter;
 import ai.labs.eddi.integrations.channels.ChannelTargetRouter.ResolvedTarget;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -29,6 +30,7 @@ import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -396,8 +398,8 @@ public class SlackEventHandler {
      * last read produced — possibly {@code null} — so the notices degrade
      * gracefully.
      */
-    private ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot loadHitlBookmark(String conversationId) {
-        ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot last = null;
+    private ConversationMemorySnapshot loadHitlBookmark(String conversationId) {
+        ConversationMemorySnapshot last = null;
         for (int attempt = 0; attempt < HITL_BOOKMARK_READ_ATTEMPTS; attempt++) {
             try {
                 last = conversationService.getConversationMemorySnapshot(conversationId);
@@ -424,7 +426,7 @@ public class SlackEventHandler {
      * Build the in-thread pause notice, appending the pause reason from the HITL
      * bookmark when available.
      */
-    private String buildPauseNotice(ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot bookmark) {
+    private String buildPauseNotice(ConversationMemorySnapshot bookmark) {
         String reason = bookmark != null ? bookmark.getHitlPauseReason() : null;
         if (reason != null && !reason.isBlank()) {
             return SlackHitlSupport.PAUSE_NOTICE + "\n> " + reason;
@@ -444,7 +446,7 @@ public class SlackEventHandler {
     // Package-private for unit testing (F12): the idempotency keying and
     // failed-delivery marker-clear are verified directly against this method.
     void notifyApprovers(ResolvedTarget resolved, String conversationId,
-                         String agentId, ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot bookmark) {
+                         String agentId, ConversationMemorySnapshot bookmark) {
         var integration = resolved.integration();
         if (integration == null || integration.getPlatformConfig() == null) {
             return; // legacy connectors have no HITL config
@@ -594,7 +596,7 @@ public class SlackEventHandler {
      */
     private void registerAgentThreadMappings(SlackGroupDiscussionListener listener) {
         // Wait for the group discussion to complete via the listener's latch
-        boolean completed = listener.awaitCompletion(300, java.util.concurrent.TimeUnit.SECONDS);
+        boolean completed = listener.awaitCompletion(300, TimeUnit.SECONDS);
         if (!completed) {
             LOGGER.warnf("Group discussion did not complete within timeout — follow-up routing may be incomplete");
         }

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackWebApiClient.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackWebApiClient.java
@@ -15,6 +15,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +61,7 @@ public class SlackWebApiClient {
     public SlackWebApiClient(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
         this.httpClient = HttpClient.newBuilder()
-                .connectTimeout(java.time.Duration.ofSeconds(10))
+                .connectTimeout(Duration.ofSeconds(10))
                 .build();
     }
 

--- a/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.modules.apicalls.impl;
 
 import ai.labs.eddi.configs.apicalls.model.*;
+import ai.labs.eddi.configs.apicalls.model.HttpPostResponse;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
 import ai.labs.eddi.engine.security.CallerIdentityResolver;
@@ -389,7 +390,7 @@ public class ApiCallExecutor implements IApiCallExecutor {
         // attempt 1. Keyed on the instruction being present and actually able
         // to fire (maxRetries >= 1), which is exactly what retryCall() tests.
         var postResponse = call.getPostResponse();
-        if (postResponse instanceof ai.labs.eddi.configs.apicalls.model.HttpPostResponse httpPostResponse) {
+        if (postResponse instanceof HttpPostResponse httpPostResponse) {
             var retry = httpPostResponse.getRetryApiCallInstruction();
             return retry != null && retry.getMaxRetries() >= 1;
         }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutor.java
@@ -31,7 +31,9 @@ import org.jboss.logging.Logger;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Executes a multi-model cascade: tries a cheap/fast model first, evaluates
@@ -669,7 +671,7 @@ class CascadingModelExecutor {
             throws LifecycleException {
 
         List<ChatMessage> chatMessagesWithoutSystem = originalMessages.stream().filter(m -> !(m instanceof SystemMessage))
-                .collect(java.util.stream.Collectors.toList());
+                .collect(Collectors.toList());
 
         var agentResult = agentOrchestrator.executeIfToolsEnabled(chatModel, systemMessage, chatMessagesWithoutSystem, task, memory,
                 effectiveToolApprovals, llmTaskIndex, transcriptMaxBytes, jsonPolicy);
@@ -902,7 +904,7 @@ class CascadingModelExecutor {
     private static boolean isRetryableError(Exception e) {
         Throwable current = e;
         while (current != null) {
-            if (current instanceof java.net.SocketTimeoutException || current instanceof java.util.concurrent.TimeoutException
+            if (current instanceof java.net.SocketTimeoutException || current instanceof TimeoutException
                     || current instanceof java.net.ConnectException || current instanceof java.net.UnknownHostException) {
                 return true;
             }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ConversationOutputUtils.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ConversationOutputUtils.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.engine.memory.model.ConversationOutput;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Shared utility for extracting text from conversation outputs.
@@ -42,7 +43,7 @@ public final class ConversationOutputUtils {
             if (outputList.getFirst() instanceof Map) {
                 var mapList = (List<Map<String, Object>>) outputList;
                 String result = mapList.stream().filter(m -> m.get("text") != null).map(m -> m.get("text").toString())
-                        .collect(java.util.stream.Collectors.joining(" "));
+                        .collect(Collectors.joining(" "));
                 return result.isEmpty() ? null : result;
             }
         }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/SummarizationService.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/SummarizationService.java
@@ -19,6 +19,7 @@ import org.jboss.logging.Logger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Shared LLM summarization infrastructure.
@@ -209,7 +210,7 @@ public class SummarizationService {
                     llmProvider, llmModel, e.getMessage());
             throw new RuntimeException(e);
         } finally {
-            durationTimer.record(System.nanoTime() - start, java.util.concurrent.TimeUnit.NANOSECONDS);
+            durationTimer.record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/modules/llm/model/CustomToolConfiguration.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/model/CustomToolConfiguration.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.modules.llm.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Configuration for custom tools defined via JSON config. Phase 4: Allows users
@@ -126,14 +127,14 @@ public class CustomToolConfiguration {
             if (o == null || getClass() != o.getClass())
                 return false;
             ToolParameter that = (ToolParameter) o;
-            return java.util.Objects.equals(name, that.name) && java.util.Objects.equals(description, that.description)
-                    && java.util.Objects.equals(type, that.type) && required == that.required
-                    && java.util.Objects.equals(defaultValue, that.defaultValue);
+            return Objects.equals(name, that.name) && Objects.equals(description, that.description)
+                    && Objects.equals(type, that.type) && required == that.required
+                    && Objects.equals(defaultValue, that.defaultValue);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(name, description, type, required, defaultValue);
+            return Objects.hash(name, description, type, required, defaultValue);
         }
 
         @Override
@@ -268,16 +269,16 @@ public class CustomToolConfiguration {
         if (o == null || getClass() != o.getClass())
             return false;
         CustomToolConfiguration that = (CustomToolConfiguration) o;
-        return java.util.Objects.equals(name, that.name) && java.util.Objects.equals(description, that.description)
-                && java.util.Objects.equals(type, that.type) && java.util.Objects.equals(parameters, that.parameters)
-                && java.util.Objects.equals(config, that.config) && requiresAuth == that.requiresAuth
-                && Double.compare(that.costPerExecution, costPerExecution) == 0 && java.util.Objects.equals(cacheTtlMs, that.cacheTtlMs)
-                && java.util.Objects.equals(rateLimit, that.rateLimit);
+        return Objects.equals(name, that.name) && Objects.equals(description, that.description)
+                && Objects.equals(type, that.type) && Objects.equals(parameters, that.parameters)
+                && Objects.equals(config, that.config) && requiresAuth == that.requiresAuth
+                && Double.compare(that.costPerExecution, costPerExecution) == 0 && Objects.equals(cacheTtlMs, that.cacheTtlMs)
+                && Objects.equals(rateLimit, that.rateLimit);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(name, description, type, parameters, config, requiresAuth, costPerExecution, cacheTtlMs, rateLimit);
+        return Objects.hash(name, description, type, parameters, config, requiresAuth, costPerExecution, cacheTtlMs, rateLimit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/modules/llm/model/LlmConfiguration.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/model/LlmConfiguration.java
@@ -6,9 +6,11 @@ package ai.labs.eddi.modules.llm.model;
 
 import ai.labs.eddi.configs.apicalls.model.PostResponse;
 import ai.labs.eddi.configs.apicalls.model.PreRequest;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.shared.RetryConfiguration;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
 
 import java.util.List;
 import java.util.Map;
@@ -502,7 +504,7 @@ public record LlmConfiguration(@JsonProperty("tasks") List<Task> tasks) {
          * FULLY REPLACES the agent-level {@code hitlConfig.toolApprovals} for this task
          * (no list merging). Absent = inherit the agent-level default.
          */
-        private ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig toolApprovals;
+        private ToolApprovalsConfig toolApprovals;
 
         // === Helper Methods ===
 
@@ -558,11 +560,11 @@ public record LlmConfiguration(@JsonProperty("tasks") List<Task> tasks) {
             this.id = id;
         }
 
-        public ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig getToolApprovals() {
+        public ToolApprovalsConfig getToolApprovals() {
             return toolApprovals;
         }
 
-        public void setToolApprovals(ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig toolApprovals) {
+        public void setToolApprovals(ToolApprovalsConfig toolApprovals) {
             this.toolApprovals = toolApprovals;
         }
 
@@ -1942,7 +1944,7 @@ public record LlmConfiguration(@JsonProperty("tasks") List<Task> tasks) {
      */
     public static class IdentityMaskingConfig {
         private boolean enabled = false;
-        private List<String> rules = new java.util.ArrayList<>();
+        private List<String> rules = new ArrayList<>();
 
         public boolean isEnabled() {
             return enabled;

--- a/src/main/java/ai/labs/eddi/modules/llm/model/ToolExecutionTrace.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/model/ToolExecutionTrace.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Tracks tool calls made during agent execution for debugging, logging, and
@@ -194,15 +195,15 @@ public class ToolExecutionTrace {
             if (o == null || getClass() != o.getClass())
                 return false;
             ToolCall that = (ToolCall) o;
-            return java.util.Objects.equals(toolName, that.toolName) && java.util.Objects.equals(arguments, that.arguments)
-                    && java.util.Objects.equals(result, that.result) && executionTimeMs == that.executionTimeMs
-                    && java.util.Objects.equals(error, that.error) && success == that.success && Double.compare(that.cost, cost) == 0
+            return Objects.equals(toolName, that.toolName) && Objects.equals(arguments, that.arguments)
+                    && Objects.equals(result, that.result) && executionTimeMs == that.executionTimeMs
+                    && Objects.equals(error, that.error) && success == that.success && Double.compare(that.cost, cost) == 0
                     && fromCache == that.fromCache && timestamp == that.timestamp;
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(toolName, arguments, result, executionTimeMs, error, success, cost, fromCache, timestamp);
+            return Objects.hash(toolName, arguments, result, executionTimeMs, error, success, cost, fromCache, timestamp);
         }
 
         @Override
@@ -333,7 +334,7 @@ public class ToolExecutionTrace {
             if (o == null || getClass() != o.getClass())
                 return false;
             ToolMetrics that = (ToolMetrics) o;
-            return java.util.Objects.equals(toolName, that.toolName) && totalCalls == that.totalCalls && successfulCalls == that.successfulCalls
+            return Objects.equals(toolName, that.toolName) && totalCalls == that.totalCalls && successfulCalls == that.successfulCalls
                     && failedCalls == that.failedCalls && totalExecutionTimeMs == that.totalExecutionTimeMs
                     && minExecutionTimeMs == that.minExecutionTimeMs && maxExecutionTimeMs == that.maxExecutionTimeMs
                     && Double.compare(that.totalCost, totalCost) == 0 && cacheHits == that.cacheHits;
@@ -341,7 +342,7 @@ public class ToolExecutionTrace {
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(toolName, totalCalls, successfulCalls, failedCalls, totalExecutionTimeMs, minExecutionTimeMs,
+            return Objects.hash(toolName, totalCalls, successfulCalls, failedCalls, totalExecutionTimeMs, minExecutionTimeMs,
                     maxExecutionTimeMs, totalCost, cacheHits);
         }
 
@@ -525,14 +526,14 @@ public class ToolExecutionTrace {
         if (o == null || getClass() != o.getClass())
             return false;
         ToolExecutionTrace that = (ToolExecutionTrace) o;
-        return java.util.Objects.equals(toolCalls, that.toolCalls) && totalExecutionTimeMs == that.totalExecutionTimeMs && hasErrors == that.hasErrors
+        return Objects.equals(toolCalls, that.toolCalls) && totalExecutionTimeMs == that.totalExecutionTimeMs && hasErrors == that.hasErrors
                 && Double.compare(that.totalCost, totalCost) == 0 && cacheHits == that.cacheHits && cacheMisses == that.cacheMisses
-                && java.util.Objects.equals(toolMetrics, that.toolMetrics);
+                && Objects.equals(toolMetrics, that.toolMetrics);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(toolCalls, totalExecutionTimeMs, hasErrors, totalCost, cacheHits, cacheMisses, toolMetrics);
+        return Objects.hash(toolCalls, totalExecutionTimeMs, hasErrors, totalCost, cacheHits, cacheMisses, toolMetrics);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/modules/llm/rest/RestToolHistory.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/rest/RestToolHistory.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.modules.llm.rest;
+import ai.labs.eddi.datastore.IResourceStore;
 
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
@@ -119,7 +120,7 @@ public class RestToolHistory {
 
             return Response.ok(trace).build();
 
-        } catch (ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException e) {
+        } catch (IResourceStore.ResourceNotFoundException e) {
             return Response.status(Response.Status.NOT_FOUND).entity(Map.of("error", "Conversation not found")).build();
         } catch (Exception e) {
             return internalError("Error retrieving tool history", e);

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/ConverseWithAgentTool.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/ConverseWithAgentTool.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.modules.llm.tools;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DynamicAgentConfig;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResult;
+import ai.labs.eddi.engine.memory.ConversationOutputExtractor;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall;
@@ -25,6 +26,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -193,7 +196,7 @@ public class ConverseWithAgentTool {
             inputData.setContext(new HashMap<>(delegationContext));
 
             CompletableFuture<SimpleConversationMemorySnapshot> responseFuture = new CompletableFuture<>();
-            final java.util.concurrent.atomic.AtomicBoolean skipped = new java.util.concurrent.atomic.AtomicBoolean();
+            final AtomicBoolean skipped = new AtomicBoolean();
             final String convId = conversationId;
 
             // Finding H7: a busy-skip (onSkipped, e.g. IN_PROGRESS) must NOT be
@@ -260,7 +263,7 @@ public class ConverseWithAgentTool {
             // Already-paused at submit — no snapshot available here, so we cannot
             // determine the pause type; report the base (RULE-shaped) message.
             return pausedForApprovalMessage(conversationId, null);
-        } catch (java.util.concurrent.TimeoutException e) {
+        } catch (TimeoutException e) {
             LOGGER.warnf("[CONVERSE] Timeout waiting for agent '%s' response", agentId);
             // The number has to come from the same config the wait used, or the
             // message tells the model a limit that was never applied — which is how
@@ -322,6 +325,6 @@ public class ConverseWithAgentTool {
      * Delegates to shared utility.
      */
     private String extractResponse(SimpleConversationMemorySnapshot snapshot) {
-        return ai.labs.eddi.engine.memory.ConversationOutputExtractor.extractResponse(snapshot);
+        return ConversationOutputExtractor.extractResponse(snapshot);
     }
 }

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/CreateSubAgentTool.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/CreateSubAgentTool.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.modules.llm.tools;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DynamicAgentConfig;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResult;
+import ai.labs.eddi.engine.memory.ConversationOutputExtractor;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.model.InputData;
 import ai.labs.eddi.engine.setup.AgentSetupService;
@@ -30,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.Objects;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 
 /**
  * LLM tool for dynamically creating sub-agents during group conversations.
@@ -373,8 +375,8 @@ public class CreateSubAgentTool {
      * Extracts the human-readable text from a conversation memory snapshot.
      * Delegates to shared utility.
      */
-    private String extractResponse(ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot snapshot) {
-        return ai.labs.eddi.engine.memory.ConversationOutputExtractor.extractResponse(snapshot);
+    private String extractResponse(SimpleConversationMemorySnapshot snapshot) {
+        return ConversationOutputExtractor.extractResponse(snapshot);
     }
 
     /**
@@ -382,7 +384,7 @@ public class CreateSubAgentTool {
      * the gated tool NAMES (names ONLY — never arguments, raw or redacted). Empty
      * for a RULE pause so the existing message shape is preserved.
      */
-    private String toolPauseSuffix(ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot snapshot) {
+    private String toolPauseSuffix(SimpleConversationMemorySnapshot snapshot) {
         if (snapshot == null || !"TOOL_CALL".equals(snapshot.getHitlPauseType())) {
             return "";
         }
@@ -390,7 +392,7 @@ public class CreateSubAgentTool {
         var batch = snapshot.getHitlPendingToolCalls();
         if (batch != null && batch.getCalls() != null) {
             var toolNames = batch.getCalls().stream()
-                    .map(ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall::getToolName)
+                    .map(PendingToolCallBatch.PendingToolCall::getToolName)
                     .filter(Objects::nonNull)
                     .toList();
             if (!toolNames.isEmpty()) {

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/PaginatedResponseStore.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/PaginatedResponseStore.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.engine.caching.ICacheFactory;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import org.jboss.logging.Logger;
 
 import java.util.List;
@@ -104,7 +105,7 @@ public class PaginatedResponseStore {
     private List<String> splitIntoPages(String text, int pageSize) {
         int totalLength = text.length();
         int pageCount = (totalLength + pageSize - 1) / pageSize;
-        var pages = new java.util.ArrayList<String>(pageCount);
+        var pages = new ArrayList<String>(pageCount);
 
         for (int i = 0; i < totalLength; i += pageSize) {
             pages.add(text.substring(i, Math.min(i + pageSize, totalLength)));

--- a/src/main/java/ai/labs/eddi/modules/nlp/IInputParser.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/IInputParser.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.modules.nlp.extensions.dictionaries.IDictionary;
 import ai.labs.eddi.modules.nlp.internal.matches.RawSolution;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -71,7 +72,7 @@ public interface IInputParser {
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(appendExpressions, includeUnused, includeUnknown);
+            return Objects.hash(appendExpressions, includeUnused, includeUnknown);
         }
 
         @Override

--- a/src/main/java/ai/labs/eddi/modules/nlp/Solution.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/Solution.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.modules.nlp.expressions.Expressions;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -45,12 +46,12 @@ public class Solution {
         if (o == null || getClass() != o.getClass())
             return false;
         Solution that = (Solution) o;
-        return java.util.Objects.equals(expressions, that.expressions);
+        return Objects.equals(expressions, that.expressions);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(expressions);
+        return Objects.hash(expressions);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/modules/nlp/expressions/Expression.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/expressions/Expression.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.utils.CharacterUtilities;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -199,7 +200,7 @@ public class Expression implements Cloneable {
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(expressionName, Arrays.hashCode(getSubExpressions()));
+        return Objects.hash(expressionName, Arrays.hashCode(getSubExpressions()));
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/modules/nlp/internal/matches/MatchMatrix.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/internal/matches/MatchMatrix.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.modules.nlp.internal.matches;
 
 import java.util.*;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -42,12 +43,12 @@ public class MatchMatrix implements Iterable<Suggestion> {
             if (o == null || getClass() != o.getClass())
                 return false;
             Match that = (Match) o;
-            return index == that.index && java.util.Objects.equals(inputTerm, that.inputTerm);
+            return index == that.index && Objects.equals(inputTerm, that.inputTerm);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(index, inputTerm);
+            return Objects.hash(index, inputTerm);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/modules/nlp/model/FoundDictionaryEntry.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/model/FoundDictionaryEntry.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.modules.nlp.model;
 
 import ai.labs.eddi.modules.nlp.expressions.Expressions;
 import ai.labs.eddi.modules.nlp.extensions.dictionaries.IDictionary;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -55,6 +56,6 @@ public class FoundDictionaryEntry extends DictionaryEntry {
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(super.hashCode(), isCorrected, matchingAccuracy);
+        return Objects.hash(super.hashCode(), isCorrected, matchingAccuracy);
     }
 }

--- a/src/main/java/ai/labs/eddi/modules/output/model/OutputValue.java
+++ b/src/main/java/ai/labs/eddi/modules/output/model/OutputValue.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.modules.output.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -34,11 +35,11 @@ public class OutputValue {
         if (o == null || getClass() != o.getClass())
             return false;
         OutputValue that = (OutputValue) o;
-        return java.util.Objects.equals(valueAlternatives, that.valueAlternatives);
+        return Objects.equals(valueAlternatives, that.valueAlternatives);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(valueAlternatives);
+        return Objects.hash(valueAlternatives);
     }
 }

--- a/src/main/java/ai/labs/eddi/modules/output/model/QuickReply.java
+++ b/src/main/java/ai/labs/eddi/modules/output/model/QuickReply.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.modules.output.model;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -57,12 +58,12 @@ public class QuickReply {
         if (o == null || getClass() != o.getClass())
             return false;
         QuickReply that = (QuickReply) o;
-        return java.util.Objects.equals(value, that.value) && java.util.Objects.equals(expressions, that.expressions)
-                && java.util.Objects.equals(isDefault, that.isDefault);
+        return Objects.equals(value, that.value) && Objects.equals(expressions, that.expressions)
+                && Objects.equals(isDefault, that.isDefault);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(value, expressions, isDefault);
+        return Objects.hash(value, expressions, isDefault);
     }
 }

--- a/src/main/java/ai/labs/eddi/modules/rules/impl/Rule.java
+++ b/src/main/java/ai/labs/eddi/modules/rules/impl/Rule.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.modules.rules.impl.conditions.IRuleCondition.ExecutionState;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -76,7 +77,7 @@ public class Rule implements Cloneable {
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(name);
+        return Objects.hash(name);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/modules/rules/impl/conditions/CapabilityMatchCondition.java
+++ b/src/main/java/ai/labs/eddi/modules/rules/impl/conditions/CapabilityMatchCondition.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.agents.CapabilityRegistryService.CapabilityMatch;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
+import ai.labs.eddi.engine.memory.model.Data;
 import ai.labs.eddi.modules.rules.impl.Rule;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import org.jboss.logging.Logger;
@@ -151,7 +152,7 @@ public class CapabilityMatchCondition implements IRuleCondition {
                     .map(CapabilityMatch::agentId)
                     .toList();
 
-            var data = new ai.labs.eddi.engine.memory.model.Data<>(MEMORY_KEY, matchedAgentIds);
+            var data = new Data<>(MEMORY_KEY, matchedAgentIds);
             memory.getCurrentStep().storeData(data);
 
             // Audit: log capability selection decision for compliance traceability

--- a/src/main/java/ai/labs/eddi/modules/rules/impl/conditions/ContextMatcher.java
+++ b/src/main/java/ai/labs/eddi/modules/rules/impl/conditions/ContextMatcher.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author ginccc
@@ -278,12 +279,12 @@ public class ContextMatcher implements IRuleCondition {
             if (o == null || getClass() != o.getClass())
                 return false;
             ObjectValue that = (ObjectValue) o;
-            return java.util.Objects.equals(objectKeyPath, that.objectKeyPath) && java.util.Objects.equals(objectValue, that.objectValue);
+            return Objects.equals(objectKeyPath, that.objectKeyPath) && Objects.equals(objectValue, that.objectValue);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(objectKeyPath, objectValue);
+            return Objects.hash(objectKeyPath, objectValue);
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/ImportStyleTest.java
+++ b/src/test/java/ai/labs/eddi/ImportStyleTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Enforces AGENTS.md §4.7: reference types by their simple name with a
+ * top-level import, never by an inline fully-qualified name.
+ * <p>
+ * A repository review found 366 of these across 168 files. None were the
+ * permitted disambiguation case — {@code PendingApprovalSummary},
+ * {@code HitlDecision}, {@code ToolApprovalsConfig},
+ * {@code ConversationMemorySnapshot} and {@code ControlSignal} each resolve to
+ * exactly one class, and {@code IConversationService} imported
+ * {@code java.util.List} on one line while writing {@code java.util.List<…>}
+ * fully-qualified on another. They accumulate precisely because nothing fails
+ * when one is added: the code compiles either way, so the rule was advice that
+ * only a reviewer's eye enforced.
+ * <p>
+ * The genuine exception AGENTS.md allows — two classes sharing a simple name,
+ * both needed in one file — is listed explicitly in {@link #ALLOWED}, so an
+ * addition to it is a deliberate, reviewable act rather than a silent drift.
+ */
+@DisplayName("import style (AGENTS.md 4.7)")
+class ImportStyleTest {
+
+    /**
+     * An inline FQN: a package path in EDDI's own namespace (or a common JDK one)
+     * followed by a capitalised type name.
+     */
+    // The trailing package segments are optional (*, not +). With '+' this missed
+    // `java.util.List` entirely — there is no further lowercase segment after
+    // `util` — which is exactly how the original audit under-counted.
+    private static final Pattern INLINE_FQN = Pattern.compile(
+            "\\b((?:ai\\.labs\\.eddi|java\\.util|java\\.time|java\\.nio\\.file)(?:\\.[a-z][A-Za-z0-9_]*)*\\.[A-Z][A-Za-z0-9_]*)");
+
+    /**
+     * The only permitted inline FQNs: each of these files declares a class whose
+     * simple name collides with the superclass it extends, so one of the two can
+     * only be named in full.
+     */
+    private static final Set<String> ALLOWED = Set.of(
+            "src/main/java/ai/labs/eddi/datastore/mongo/HistorizedResourceStore.java",
+            "src/main/java/ai/labs/eddi/datastore/mongo/ModifiableHistorizedResourceStore.java");
+
+    /** Blanks out comments and string literals so neither is ever matched. */
+    private static String stripNonCode(String source) {
+        StringBuilder out = new StringBuilder(source.length());
+        int i = 0;
+        int n = source.length();
+        while (i < n) {
+            char c = source.charAt(i);
+            if (c == '"') {
+                int j = i + 1;
+                while (j < n && !(source.charAt(j) == '"' && source.charAt(j - 1) != '\\')) {
+                    j++;
+                }
+                out.append(" ".repeat(Math.min(j - i + 1, n - i)));
+                i = j + 1;
+            } else if (source.startsWith("//", i)) {
+                int j = source.indexOf('\n', i);
+                j = j < 0 ? n : j;
+                out.append(" ".repeat(j - i));
+                i = j;
+            } else if (source.startsWith("/*", i)) {
+                int j = source.indexOf("*/", i);
+                j = j < 0 ? n : j + 2;
+                out.append(" ".repeat(j - i));
+                i = j;
+            } else {
+                out.append(c);
+                i++;
+            }
+        }
+        return out.toString();
+    }
+
+    private static Path repoRoot() {
+        Path root = Path.of("").toAbsolutePath();
+        assertTrue(Files.isRegularFile(root.resolve("pom.xml")),
+                "expected the working directory to be the project root, was " + root);
+        return root;
+    }
+
+    @Test
+    @DisplayName("no inline fully-qualified names outside the declared disambiguation cases")
+    void noInlineFullyQualifiedNames() {
+        Path root = repoRoot();
+        List<String> offenders = new ArrayList<>();
+
+        for (Path dir : List.of(root.resolve("src/main/java"), root.resolve("src/test/java"))) {
+            try (Stream<Path> paths = Files.walk(dir)) {
+                for (Path file : paths.filter(Files::isRegularFile)
+                        .filter(p -> p.getFileName().toString().endsWith(".java"))
+                        .toList()) {
+                    String relative = root.relativize(file).toString().replace('\\', '/');
+                    if (ALLOWED.contains(relative)) {
+                        continue;
+                    }
+                    String masked;
+                    try {
+                        masked = stripNonCode(Files.readString(file, StandardCharsets.UTF_8));
+                    } catch (IOException | RuntimeException e) {
+                        continue;
+                    }
+                    int lineNo = 0;
+                    for (String line : masked.split("\n", -1)) {
+                        lineNo++;
+                        String trimmed = line.stripLeading();
+                        if (trimmed.startsWith("import ") || trimmed.startsWith("package ")) {
+                            continue;
+                        }
+                        Matcher m = INLINE_FQN.matcher(line);
+                        while (m.find()) {
+                            offenders.add(relative + ":" + lineNo + "  " + m.group(1));
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        assertEquals(List.of(), offenders,
+                "AGENTS.md 4.7: use a top-level import and the simple name. If two classes genuinely share a "
+                        + "simple name in one file, add that file to ALLOWED with a note.\n  "
+                        + String.join("\n  ", offenders));
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/AbstractBackupServiceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/AbstractBackupServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -173,7 +174,7 @@ class AbstractBackupServiceTest {
                     "eddi://ai.labs.rag/ragstore/rags/x6?version=1");
         }
 
-        private void assertUriExtraction(java.util.regex.Pattern pattern, String uri) throws Exception {
+        private void assertUriExtraction(Pattern pattern, String uri) throws Exception {
             String json = "{\"uri\":\"" + uri + "\"}";
             List<URI> result = service.extractResourcesUris(json, pattern);
             assertEquals(1, result.size(), "Pattern should match " + uri);

--- a/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceDeepCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceDeepCoverageTest.java
@@ -16,7 +16,9 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -237,7 +239,7 @@ class RemoteApiResourceSourceDeepCoverageTest {
         WorkflowConfiguration.WorkflowStep unknownStep = new WorkflowConfiguration.WorkflowStep();
         unknownStep.setType(URI.create("ai.labs.unknown"));
         unknownStep
-                .setExtensions(new java.util.HashMap<>(java.util.Map.<String, Object>of("uri", "eddi://ai.labs.unknown/store/things/t1?version=1")));
+                .setExtensions(new HashMap<>(Map.<String, Object>of("uri", "eddi://ai.labs.unknown/store/things/t1?version=1")));
 
         wfConfig.setWorkflowSteps(List.of(nullTypeStep, unknownStep));
         doReturn(wfConfig).when(jsonSerialization).deserialize(anyString(), eq(WorkflowConfiguration.class));
@@ -315,7 +317,7 @@ class RemoteApiResourceSourceDeepCoverageTest {
         WorkflowConfiguration wfConfig = new WorkflowConfiguration();
         WorkflowConfiguration.WorkflowStep step = new WorkflowConfiguration.WorkflowStep();
         step.setType(URI.create("ai.labs.llm"));
-        step.setExtensions(new java.util.HashMap<>(java.util.Map.<String, Object>of("uri", "eddi://ai.labs.llm/llmstore/llms/llm1?version=1")));
+        step.setExtensions(new HashMap<>(Map.<String, Object>of("uri", "eddi://ai.labs.llm/llmstore/llms/llm1?version=1")));
         wfConfig.setWorkflowSteps(List.of(step));
         doReturn(wfConfig).when(jsonSerialization).deserialize(anyString(), eq(WorkflowConfiguration.class));
         doReturn(null).when(jsonSerialization).deserialize(anyString(), eq(DocumentDescriptor[].class));

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedBranchTest.java
@@ -37,6 +37,8 @@ import org.mockito.Mock;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -109,10 +111,10 @@ class RestExportServiceExtendedBranchTest {
         @DisplayName("empty referenced names — returns early")
         void emptyReferencedNames() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", java.nio.file.Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class);
             method.setAccessible(true);
             // Should not throw; no snippets directory creation attempted
-            method.invoke(exportService, java.nio.file.Files.createTempDirectory("test-snippets"), new LinkedHashSet<>());
+            method.invoke(exportService, Files.createTempDirectory("test-snippets"), new LinkedHashSet<>());
             verify(documentDescriptorStore, never()).readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean());
         }
 
@@ -120,7 +122,7 @@ class RestExportServiceExtendedBranchTest {
         @DisplayName("null descriptors from store — returns early")
         void nullDescriptors() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", java.nio.file.Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class);
             method.setAccessible(true);
 
             when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false)))
@@ -128,14 +130,14 @@ class RestExportServiceExtendedBranchTest {
 
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting");
-            method.invoke(exportService, java.nio.file.Files.createTempDirectory("test-snippets"), names);
+            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
         }
 
         @Test
         @DisplayName("empty descriptors from store — returns early")
         void emptyDescriptors() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", java.nio.file.Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class);
             method.setAccessible(true);
 
             when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false)))
@@ -143,14 +145,14 @@ class RestExportServiceExtendedBranchTest {
 
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting");
-            method.invoke(exportService, java.nio.file.Files.createTempDirectory("test-snippets"), names);
+            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
         }
 
         @Test
         @DisplayName("snippet with null name is skipped")
         void snippetWithNullNameSkipped() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", java.nio.file.Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class);
             method.setAccessible(true);
 
             DocumentDescriptor desc = new DocumentDescriptor();
@@ -164,14 +166,14 @@ class RestExportServiceExtendedBranchTest {
 
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting");
-            method.invoke(exportService, java.nio.file.Files.createTempDirectory("test-snippets"), names);
+            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
         }
 
         @Test
         @DisplayName("snippet not in referenced set is skipped")
         void snippetNotReferencedSkipped() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", java.nio.file.Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class);
             method.setAccessible(true);
 
             DocumentDescriptor desc = new DocumentDescriptor();
@@ -185,14 +187,14 @@ class RestExportServiceExtendedBranchTest {
 
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting"); // only "greeting" is referenced
-            method.invoke(exportService, java.nio.file.Files.createTempDirectory("test-snippets"), names);
+            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
         }
 
         @Test
         @DisplayName("ResourceNotFoundException on snippet read is handled gracefully")
         void snippetResourceNotFound() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", java.nio.file.Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class);
             method.setAccessible(true);
 
             DocumentDescriptor desc = new DocumentDescriptor();
@@ -205,7 +207,7 @@ class RestExportServiceExtendedBranchTest {
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting");
             // Should not throw
-            method.invoke(exportService, java.nio.file.Files.createTempDirectory("test-snippets"), names);
+            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
         }
     }
 
@@ -221,12 +223,12 @@ class RestExportServiceExtendedBranchTest {
         @DisplayName("empty schedules — returns early")
         void emptySchedules() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSchedules", String.class, java.nio.file.Path.class);
+                    "exportSchedules", String.class, Path.class);
             method.setAccessible(true);
 
             when(scheduleStore.readSchedulesByAgentId("agent1")).thenReturn(Collections.emptyList());
 
-            method.invoke(exportService, "agent1", java.nio.file.Files.createTempDirectory("test-sched"));
+            method.invoke(exportService, "agent1", Files.createTempDirectory("test-sched"));
             // No files should be written
         }
 
@@ -234,7 +236,7 @@ class RestExportServiceExtendedBranchTest {
         @DisplayName("schedule export exception is handled gracefully")
         void scheduleExportException() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSchedules", String.class, java.nio.file.Path.class);
+                    "exportSchedules", String.class, Path.class);
             method.setAccessible(true);
 
             when(scheduleStore.readSchedulesByAgentId("agent1"))
@@ -242,7 +244,7 @@ class RestExportServiceExtendedBranchTest {
 
             // Should not throw
             assertDoesNotThrow(() -> method.invoke(exportService, "agent1",
-                    java.nio.file.Files.createTempDirectory("test-sched")));
+                    Files.createTempDirectory("test-sched")));
         }
     }
 
@@ -360,10 +362,10 @@ class RestExportServiceExtendedBranchTest {
         @DisplayName("null selectedIds writes all configs")
         void nullSelectedIdsWritesAll() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "writeSelectedConfigs", java.nio.file.Path.class, Map.class, String.class, Set.class);
+                    "writeSelectedConfigs", Path.class, Map.class, String.class, Set.class);
             method.setAccessible(true);
             // Should call writeConfigs with all configs — just verify no NPE
-            method.invoke(exportService, java.nio.file.Files.createTempDirectory("test"),
+            method.invoke(exportService, Files.createTempDirectory("test"),
                     Collections.emptyMap(), "ext", null);
         }
 
@@ -371,10 +373,10 @@ class RestExportServiceExtendedBranchTest {
         @DisplayName("non-null selectedIds filters configs")
         void nonNullSelectedIdsFilters() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "writeSelectedConfigs", java.nio.file.Path.class, Map.class, String.class, Set.class);
+                    "writeSelectedConfigs", Path.class, Map.class, String.class, Set.class);
             method.setAccessible(true);
             // Should call writeConfigs with filtered configs
-            method.invoke(exportService, java.nio.file.Files.createTempDirectory("test"),
+            method.invoke(exportService, Files.createTempDirectory("test"),
                     Collections.emptyMap(), "ext", Set.of("r1"));
         }
     }

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.*;
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -600,7 +601,7 @@ class RestExportServiceTest {
         void multipleSnippets() {
             String config = "{{snippets.intro}} and {{snippets.outro}} and {snippets.middle_part}";
             var matcher = SNIPPET_REF_PATTERN.matcher(config);
-            var names = new java.util.ArrayList<String>();
+            var names = new ArrayList<String>();
             while (matcher.find()) {
                 names.add(matcher.group(1));
             }

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
@@ -10,11 +10,14 @@ import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
 import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import ai.labs.eddi.backup.model.SyncMapping;
 import ai.labs.eddi.backup.model.SyncRequest;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
+import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
+import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
@@ -577,26 +580,26 @@ class RestImportServiceExtendedTest {
                     .thenThrow(new IResourceStore.ResourceNotFoundException("nf"));
 
             // Snippet deserialization
-            var snippet = new ai.labs.eddi.configs.snippets.model.PromptSnippet();
+            var snippet = new PromptSnippet();
             snippet.setName("cautious_mode");
             snippet.setContent("Be cautious");
             when(jsonSerialization.deserialize(
                     eq("{\"name\":\"cautious_mode\",\"content\":\"Be cautious\"}"),
-                    eq(ai.labs.eddi.configs.snippets.model.PromptSnippet.class)))
+                    eq(PromptSnippet.class)))
                     .thenReturn(snippet);
 
             // Mock CDI for IRestPromptSnippetStore (used by addSnippetDiffs →
             // getRestResourceStore)
-            var snippetStore = mock(ai.labs.eddi.configs.snippets.IRestPromptSnippetStore.class);
+            var snippetStore = mock(IRestPromptSnippetStore.class);
             // readSnippetDescriptors returns empty → no existing snippets
             when(snippetStore.readSnippetDescriptors(eq(""), eq(0), eq(0))).thenReturn(List.of());
 
             try (var cdiMock = org.mockito.Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class)) {
                 var cdi = mock(jakarta.enterprise.inject.spi.CDI.class);
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdi);
-                var instance = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.snippets.IRestPromptSnippetStore>) mock(
+                var instance = (jakarta.enterprise.inject.Instance<IRestPromptSnippetStore>) mock(
                         jakarta.enterprise.inject.Instance.class);
-                when(cdi.select(ai.labs.eddi.configs.snippets.IRestPromptSnippetStore.class)).thenReturn(instance);
+                when(cdi.select(IRestPromptSnippetStore.class)).thenReturn(instance);
                 when(instance.get()).thenReturn(snippetStore);
 
                 ImportPreview result = importService.previewImport(
@@ -646,16 +649,16 @@ class RestImportServiceExtendedTest {
                     .thenThrow(new IResourceStore.ResourceNotFoundException("nf"));
 
             // Snippet deserialization
-            var snippet = new ai.labs.eddi.configs.snippets.model.PromptSnippet();
+            var snippet = new PromptSnippet();
             snippet.setName("safety_prompt");
             snippet.setContent("Be safe");
             when(jsonSerialization.deserialize(
                     eq("{\"name\":\"safety_prompt\",\"content\":\"Be safe\"}"),
-                    eq(ai.labs.eddi.configs.snippets.model.PromptSnippet.class)))
+                    eq(PromptSnippet.class)))
                     .thenReturn(snippet);
 
             // Mock CDI for snippet store
-            var snippetStore = mock(ai.labs.eddi.configs.snippets.IRestPromptSnippetStore.class);
+            var snippetStore = mock(IRestPromptSnippetStore.class);
             // Existing snippet descriptor
             String existingSnippetId = "eeee11112222333344445555";
             var existingDesc = new DocumentDescriptor();
@@ -665,16 +668,16 @@ class RestImportServiceExtendedTest {
                     .thenReturn(List.of(existingDesc));
 
             // readSnippet returns a snippet with the same name
-            var existingSnippet = new ai.labs.eddi.configs.snippets.model.PromptSnippet();
+            var existingSnippet = new PromptSnippet();
             existingSnippet.setName("safety_prompt");
             when(snippetStore.readSnippet(existingSnippetId, 1)).thenReturn(existingSnippet);
 
             try (var cdiMock = org.mockito.Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class)) {
                 var cdi = mock(jakarta.enterprise.inject.spi.CDI.class);
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdi);
-                var instance = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.snippets.IRestPromptSnippetStore>) mock(
+                var instance = (jakarta.enterprise.inject.Instance<IRestPromptSnippetStore>) mock(
                         jakarta.enterprise.inject.Instance.class);
-                when(cdi.select(ai.labs.eddi.configs.snippets.IRestPromptSnippetStore.class)).thenReturn(instance);
+                when(cdi.select(IRestPromptSnippetStore.class)).thenReturn(instance);
                 when(instance.get()).thenReturn(snippetStore);
 
                 ImportPreview result = importService.previewImport(
@@ -838,7 +841,7 @@ class RestImportServiceExtendedTest {
                     .thenReturn(zipDescriptor);
 
             // Mock CDI for IAgentStore.create
-            var agentStore = mock(ai.labs.eddi.configs.agents.IAgentStore.class);
+            var agentStore = mock(IAgentStore.class);
             IResourceId createdId = testResourceId(newAgentId, 1);
             when(agentStore.create(any())).thenReturn(createdId);
 
@@ -856,9 +859,9 @@ class RestImportServiceExtendedTest {
                 var cdi = mock(jakarta.enterprise.inject.spi.CDI.class);
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdi);
 
-                var agentStoreInstance = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.agents.IAgentStore>) mock(
+                var agentStoreInstance = (jakarta.enterprise.inject.Instance<IAgentStore>) mock(
                         jakarta.enterprise.inject.Instance.class);
-                when(cdi.select(ai.labs.eddi.configs.agents.IAgentStore.class)).thenReturn(agentStoreInstance);
+                when(cdi.select(IAgentStore.class)).thenReturn(agentStoreInstance);
                 when(agentStoreInstance.get()).thenReturn(agentStore);
 
                 Response response = importService.importAgent(

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceHelpersTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceHelpersTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.*;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.Set;
 import java.util.List;
 
@@ -273,7 +274,7 @@ class RestImportServiceHelpersTest {
         private void deleteRecursive(Path path) {
             try {
                 Files.walk(path)
-                        .sorted(java.util.Comparator.reverseOrder())
+                        .sorted(Comparator.reverseOrder())
                         .forEach(p -> {
                             try {
                                 Files.deleteIfExists(p);

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUncoveredBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUncoveredBranchTest.java
@@ -199,7 +199,7 @@ class RestImportServiceUncoveredBranchTest {
         @SuppressWarnings("unchecked")
         private List<URI> invokeExtractResourcesUris(String input, Pattern pattern) throws Exception {
             Method method = AbstractBackupService.class.getDeclaredMethod(
-                    "extractResourcesUris", String.class, java.util.regex.Pattern.class);
+                    "extractResourcesUris", String.class, Pattern.class);
             method.setAccessible(true);
             return (List<URI>) method.invoke(service, input, pattern);
         }
@@ -615,7 +615,7 @@ class RestImportServiceUncoveredBranchTest {
                     "createResourcePath", Path.class, String.class, String.class);
             method.setAccessible(true);
 
-            Path workflowPath = java.nio.file.Paths.get("tmp", "import");
+            Path workflowPath = Paths.get("tmp", "import");
             Path result = (Path) method.invoke(service, workflowPath, "out1", "output");
             assertTrue(result.toString().endsWith("out1.output.json"));
         }
@@ -627,7 +627,7 @@ class RestImportServiceUncoveredBranchTest {
                     "createResourcePath", Path.class, String.class, String.class);
             method.setAccessible(true);
 
-            Path workflowPath = java.nio.file.Paths.get("data");
+            Path workflowPath = Paths.get("data");
             Path result = (Path) method.invoke(service, workflowPath, "p1", "property");
             assertTrue(result.toString().endsWith("p1.property.json"));
         }
@@ -639,7 +639,7 @@ class RestImportServiceUncoveredBranchTest {
                     "createResourcePath", Path.class, String.class, String.class);
             method.setAccessible(true);
 
-            Path workflowPath = java.nio.file.Paths.get("data");
+            Path workflowPath = Paths.get("data");
             Path result = (Path) method.invoke(service, workflowPath, "h1", "httpcalls");
             assertTrue(result.toString().endsWith("h1.httpcalls.json"));
         }
@@ -651,7 +651,7 @@ class RestImportServiceUncoveredBranchTest {
                     "createResourcePath", Path.class, String.class, String.class);
             method.setAccessible(true);
 
-            Path workflowPath = java.nio.file.Paths.get("data");
+            Path workflowPath = Paths.get("data");
             Path result = (Path) method.invoke(service, workflowPath, "m1", "mcpcalls");
             assertTrue(result.toString().endsWith("m1.mcpcalls.json"));
         }
@@ -663,7 +663,7 @@ class RestImportServiceUncoveredBranchTest {
                     "createResourcePath", Path.class, String.class, String.class);
             method.setAccessible(true);
 
-            Path workflowPath = java.nio.file.Paths.get("data");
+            Path workflowPath = Paths.get("data");
             Path result = (Path) method.invoke(service, workflowPath, "s1", "snippet");
             assertTrue(result.toString().endsWith("s1.snippet.json"));
         }
@@ -894,9 +894,9 @@ class RestImportServiceUncoveredBranchTest {
         }
 
         @SuppressWarnings("unchecked")
-        private List<URI> extractUris(String input, java.util.regex.Pattern pattern) throws Exception {
+        private List<URI> extractUris(String input, Pattern pattern) throws Exception {
             Method method = AbstractBackupService.class.getDeclaredMethod(
-                    "extractResourcesUris", String.class, java.util.regex.Pattern.class);
+                    "extractResourcesUris", String.class, Pattern.class);
             method.setAccessible(true);
             return (List<URI>) method.invoke(service, input, pattern);
         }

--- a/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherTest.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
+import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
@@ -346,7 +347,7 @@ class StructuralMatcherTest {
             when(snippetStore.readSnippetDescriptors(anyString(), anyInt(), anyInt()))
                     .thenReturn(List.of(descriptor));
 
-            var mockSnippet = mock(ai.labs.eddi.configs.snippets.model.PromptSnippet.class);
+            var mockSnippet = mock(PromptSnippet.class);
             when(mockSnippet.getName()).thenReturn("fallback_name");
             when(snippetStore.readSnippet("snip1", 1)).thenReturn(mockSnippet);
 

--- a/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
@@ -11,13 +11,32 @@ import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
 import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
+import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
+import ai.labs.eddi.configs.dictionary.model.DictionaryConfiguration;
+import ai.labs.eddi.configs.llm.IRestLlmStore;
+import ai.labs.eddi.configs.mcpcalls.IRestMcpCallsStore;
+import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
+import ai.labs.eddi.configs.output.IRestOutputStore;
+import ai.labs.eddi.configs.output.model.OutputConfigurationSet;
+import ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore;
+import ai.labs.eddi.configs.propertysetter.model.PropertySetterConfiguration;
+import ai.labs.eddi.configs.rag.IRagStore;
+import ai.labs.eddi.configs.rag.IRestRagStore;
+import ai.labs.eddi.configs.rag.model.RagConfiguration;
+import ai.labs.eddi.configs.rules.IRestRuleSetStore;
+import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
 import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -273,9 +292,9 @@ class UpgradeExecutorTest {
             when(descriptorStore.readDescriptor(eq("target-1"), isNull())).thenReturn(descriptor);
 
             // Mock LLM store via CDI (getStore now uses CDI.current().select())
-            var llmStore = Mockito.mock(ai.labs.eddi.configs.llm.IRestLlmStore.class);
+            var llmStore = Mockito.mock(IRestLlmStore.class);
             when(jsonSerialization.deserialize(eq("{\"model\":\"gpt-4\"}"), any()))
-                    .thenReturn(new ai.labs.eddi.modules.llm.model.LlmConfiguration(List.of()));
+                    .thenReturn(new LlmConfiguration(List.of()));
             when(llmStore.updateLlm(eq(extId), eq(2), any())).thenReturn(Response.ok().build());
 
             // Workflow config with workflowStep referencing old extension URI
@@ -299,9 +318,9 @@ class UpgradeExecutorTest {
             try (cdiMock) {
                 var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.llm.IRestLlmStore>) Mockito
+                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
                         .mock(jakarta.enterprise.inject.Instance.class);
-                when(cdiInstance.select(ai.labs.eddi.configs.llm.IRestLlmStore.class)).thenReturn(instanceLlm);
+                when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(llmStore);
 
                 URI result = executor.executeUpgrade(source, "target-1", null, null);
@@ -338,9 +357,9 @@ class UpgradeExecutorTest {
             when(descriptorStore.readDescriptor(eq("target-1"), isNull())).thenReturn(descriptor);
 
             // Mock RAG direct store via CDI for create (dispatchCreateDirect uses CDI)
-            var ragDirectStore = Mockito.mock(ai.labs.eddi.configs.rag.IRagStore.class);
-            var ragRestStore = Mockito.mock(ai.labs.eddi.configs.rag.IRestRagStore.class);
-            var ragResourceId = new ai.labs.eddi.datastore.IResourceStore.IResourceId() {
+            var ragDirectStore = Mockito.mock(IRagStore.class);
+            var ragRestStore = Mockito.mock(IRestRagStore.class);
+            var ragResourceId = new IResourceStore.IResourceId() {
                 @Override
                 public String getId() {
                     return "newragid1234567890123456";
@@ -351,7 +370,7 @@ class UpgradeExecutorTest {
                 }
             };
             when(jsonSerialization.deserialize(eq("{\"vectorStore\":\"pgvector\"}"), any()))
-                    .thenReturn(new ai.labs.eddi.configs.rag.model.RagConfiguration());
+                    .thenReturn(new RagConfiguration());
             when(ragDirectStore.create(any())).thenReturn(ragResourceId);
 
             // Workflow config (empty steps — no URI rewriting needed for CREATE)
@@ -370,15 +389,15 @@ class UpgradeExecutorTest {
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
 
                 // CDI lookup for IRestRagStore (getStore in resolveExtensionOps)
-                var instanceRestRag = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.rag.IRestRagStore>) Mockito
+                var instanceRestRag = (jakarta.enterprise.inject.Instance<IRestRagStore>) Mockito
                         .mock(jakarta.enterprise.inject.Instance.class);
-                when(cdiInstance.select(ai.labs.eddi.configs.rag.IRestRagStore.class)).thenReturn(instanceRestRag);
+                when(cdiInstance.select(IRestRagStore.class)).thenReturn(instanceRestRag);
                 when(instanceRestRag.get()).thenReturn(ragRestStore);
 
                 // CDI lookup for IRagStore (dispatchCreateDirect)
-                var instanceRag = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.rag.IRagStore>) Mockito
+                var instanceRag = (jakarta.enterprise.inject.Instance<IRagStore>) Mockito
                         .mock(jakarta.enterprise.inject.Instance.class);
-                when(cdiInstance.select(ai.labs.eddi.configs.rag.IRagStore.class)).thenReturn(instanceRag);
+                when(cdiInstance.select(IRagStore.class)).thenReturn(instanceRag);
                 when(instanceRag.get()).thenReturn(ragDirectStore);
 
                 executor.executeUpgrade(source, "target-1", null, null);
@@ -411,8 +430,8 @@ class UpgradeExecutorTest {
 
             // Mock IWorkflowStore via CDI for direct create
             String newWfId = "newwfid123456789012";
-            var wfDirectStore = Mockito.mock(ai.labs.eddi.configs.workflows.IWorkflowStore.class);
-            var wfResourceId = new ai.labs.eddi.datastore.IResourceStore.IResourceId() {
+            var wfDirectStore = Mockito.mock(IWorkflowStore.class);
+            var wfResourceId = new IResourceStore.IResourceId() {
                 @Override
                 public String getId() {
                     return newWfId;
@@ -429,9 +448,9 @@ class UpgradeExecutorTest {
             try (cdiMock) {
                 var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceWf = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.workflows.IWorkflowStore>) Mockito
+                var instanceWf = (jakarta.enterprise.inject.Instance<IWorkflowStore>) Mockito
                         .mock(jakarta.enterprise.inject.Instance.class);
-                when(cdiInstance.select(ai.labs.eddi.configs.workflows.IWorkflowStore.class)).thenReturn(instanceWf);
+                when(cdiInstance.select(IWorkflowStore.class)).thenReturn(instanceWf);
                 when(instanceWf.get()).thenReturn(wfDirectStore);
 
                 URI result = executor.executeUpgrade(source, "target-1", null, null);
@@ -606,9 +625,9 @@ class UpgradeExecutorTest {
 
             setupPreviewAndAgent("target-1", 1, diffs);
 
-            var llmStore = Mockito.mock(ai.labs.eddi.configs.llm.IRestLlmStore.class);
+            var llmStore = Mockito.mock(IRestLlmStore.class);
             when(jsonSerialization.deserialize(eq("{\"model\":\"gpt-4\"}"), any()))
-                    .thenReturn(new ai.labs.eddi.modules.llm.model.LlmConfiguration(List.of()));
+                    .thenReturn(new LlmConfiguration(List.of()));
             // Return 500 instead of 200
             when(llmStore.updateLlm(eq(extId), eq(2), any()))
                     .thenReturn(Response.serverError().build());
@@ -620,9 +639,9 @@ class UpgradeExecutorTest {
             try (cdiMock) {
                 var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.llm.IRestLlmStore>) Mockito
+                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
                         .mock(jakarta.enterprise.inject.Instance.class);
-                when(cdiInstance.select(ai.labs.eddi.configs.llm.IRestLlmStore.class)).thenReturn(instanceLlm);
+                when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(llmStore);
 
                 URI result = executor.executeUpgrade(source, "target-1", null, null);
@@ -663,9 +682,9 @@ class UpgradeExecutorTest {
             try (cdiMock) {
                 var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceWf = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.workflows.IWorkflowStore>) Mockito
+                var instanceWf = (jakarta.enterprise.inject.Instance<IWorkflowStore>) Mockito
                         .mock(jakarta.enterprise.inject.Instance.class);
-                when(cdiInstance.select(ai.labs.eddi.configs.workflows.IWorkflowStore.class)).thenReturn(instanceWf);
+                when(cdiInstance.select(IWorkflowStore.class)).thenReturn(instanceWf);
                 when(instanceWf.get()).thenThrow(new RuntimeException("CDI lookup failed"));
 
                 // Should NOT throw — createNewWorkflow catches and returns null
@@ -706,9 +725,9 @@ class UpgradeExecutorTest {
 
             setupPreviewAndAgent("target-1", 1, diffs);
 
-            var llmStore = Mockito.mock(ai.labs.eddi.configs.llm.IRestLlmStore.class);
+            var llmStore = Mockito.mock(IRestLlmStore.class);
             when(jsonSerialization.deserialize(eq("{\"model\":\"gpt-4\"}"), any()))
-                    .thenReturn(new ai.labs.eddi.modules.llm.model.LlmConfiguration(List.of()));
+                    .thenReturn(new LlmConfiguration(List.of()));
             when(llmStore.updateLlm(eq(extId), eq(2), any())).thenReturn(Response.ok().build());
 
             // Workflow config with a step that has NULL type
@@ -723,9 +742,9 @@ class UpgradeExecutorTest {
             try (cdiMock) {
                 var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.llm.IRestLlmStore>) Mockito
+                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
                         .mock(jakarta.enterprise.inject.Instance.class);
-                when(cdiInstance.select(ai.labs.eddi.configs.llm.IRestLlmStore.class)).thenReturn(instanceLlm);
+                when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(llmStore);
 
                 URI result = executor.executeUpgrade(source, "target-1", null, null);
@@ -889,10 +908,10 @@ class UpgradeExecutorTest {
             try (cdiMock) {
                 var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
                 cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<ai.labs.eddi.configs.llm.IRestLlmStore>) Mockito
+                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
                         .mock(jakarta.enterprise.inject.Instance.class);
-                when(cdiInstance.select(ai.labs.eddi.configs.llm.IRestLlmStore.class)).thenReturn(instanceLlm);
-                when(instanceLlm.get()).thenReturn(Mockito.mock(ai.labs.eddi.configs.llm.IRestLlmStore.class));
+                when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
+                when(instanceLlm.get()).thenReturn(Mockito.mock(IRestLlmStore.class));
 
                 // Should NOT throw — extension processing catches and logs
                 URI result = executor.executeUpgrade(source, "target-1", null, null);
@@ -912,8 +931,8 @@ class UpgradeExecutorTest {
         @SuppressWarnings("unchecked")
         void dispatchDictionary() throws Exception {
             verifyDispatchUpdate("regulardictionary", "ai.labs.parser",
-                    ai.labs.eddi.configs.dictionary.model.DictionaryConfiguration.class,
-                    ai.labs.eddi.configs.dictionary.IRestDictionaryStore.class);
+                    DictionaryConfiguration.class,
+                    IRestDictionaryStore.class);
         }
 
         @Test
@@ -921,8 +940,8 @@ class UpgradeExecutorTest {
         @SuppressWarnings("unchecked")
         void dispatchRuleSet() throws Exception {
             verifyDispatchUpdate("behavior", "ai.labs.behavior",
-                    ai.labs.eddi.configs.rules.model.RuleSetConfiguration.class,
-                    ai.labs.eddi.configs.rules.IRestRuleSetStore.class);
+                    RuleSetConfiguration.class,
+                    IRestRuleSetStore.class);
         }
 
         @Test
@@ -930,8 +949,8 @@ class UpgradeExecutorTest {
         @SuppressWarnings("unchecked")
         void dispatchApiCalls() throws Exception {
             verifyDispatchUpdate("httpcalls", "ai.labs.httpcalls",
-                    ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration.class,
-                    ai.labs.eddi.configs.apicalls.IRestApiCallsStore.class);
+                    ApiCallsConfiguration.class,
+                    IRestApiCallsStore.class);
         }
 
         @Test
@@ -939,8 +958,8 @@ class UpgradeExecutorTest {
         @SuppressWarnings("unchecked")
         void dispatchPropertySetter() throws Exception {
             verifyDispatchUpdate("property", "ai.labs.property",
-                    ai.labs.eddi.configs.propertysetter.model.PropertySetterConfiguration.class,
-                    ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore.class);
+                    PropertySetterConfiguration.class,
+                    IRestPropertySetterStore.class);
         }
 
         @Test
@@ -948,8 +967,8 @@ class UpgradeExecutorTest {
         @SuppressWarnings("unchecked")
         void dispatchOutput() throws Exception {
             verifyDispatchUpdate("output", "ai.labs.output",
-                    ai.labs.eddi.configs.output.model.OutputConfigurationSet.class,
-                    ai.labs.eddi.configs.output.IRestOutputStore.class);
+                    OutputConfigurationSet.class,
+                    IRestOutputStore.class);
         }
 
         @Test
@@ -957,8 +976,8 @@ class UpgradeExecutorTest {
         @SuppressWarnings("unchecked")
         void dispatchMcpCalls() throws Exception {
             verifyDispatchUpdate("mcpcalls", "ai.labs.mcpcalls",
-                    ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration.class,
-                    ai.labs.eddi.configs.mcpcalls.IRestMcpCallsStore.class);
+                    McpCallsConfiguration.class,
+                    IRestMcpCallsStore.class);
         }
 
         @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/ai/labs/eddi/backup/impl/ZipResourceSourceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/ZipResourceSourceExtendedTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.backup.impl;
 
 import ai.labs.eddi.backup.IResourceSource.*;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
@@ -72,9 +73,9 @@ class ZipResourceSourceExtendedTest {
             config.setWorkflows(new ArrayList<>());
             when(jsonSerialization.deserialize("{agent config}", AgentConfiguration.class))
                     .thenReturn(config);
-            var descriptor = new ai.labs.eddi.configs.descriptors.model.DocumentDescriptor();
+            var descriptor = new DocumentDescriptor();
             descriptor.setName("My Agent");
-            when(jsonSerialization.deserialize("{\"name\": \"My Agent\"}", ai.labs.eddi.configs.descriptors.model.DocumentDescriptor.class))
+            when(jsonSerialization.deserialize("{\"name\": \"My Agent\"}", DocumentDescriptor.class))
                     .thenReturn(descriptor);
 
             var source = new ZipResourceSource(tempDir, jsonSerialization);

--- a/src/test/java/ai/labs/eddi/backup/impl/ZipResourceSourceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/ZipResourceSourceTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.backup.IResourceSource.SnippetSourceData;
 import ai.labs.eddi.backup.IResourceSource.WorkflowSourceData;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import org.junit.jupiter.api.*;
@@ -141,11 +142,11 @@ class ZipResourceSourceTest {
             Files.writeString(snippetsDir.resolve("snp1.snippet.json"),
                     "{\"name\":\"greeting\",\"content\":\"Hi!\"}", StandardCharsets.UTF_8);
 
-            var snippet = new ai.labs.eddi.configs.snippets.model.PromptSnippet();
+            var snippet = new PromptSnippet();
             snippet.setName("greeting");
             snippet.setContent("Hi!");
             when(jsonSerialization.deserialize(anyString(),
-                    eq(ai.labs.eddi.configs.snippets.model.PromptSnippet.class)))
+                    eq(PromptSnippet.class)))
                     .thenReturn(snippet);
 
             try (var source = new ZipResourceSource(tempDir, jsonSerialization)) {
@@ -168,10 +169,10 @@ class ZipResourceSourceTest {
             Files.writeString(snippetsDir.resolve("snp2.snippet.json"),
                     "{\"name\":\"persona\"}", StandardCharsets.UTF_8);
 
-            var snippet = new ai.labs.eddi.configs.snippets.model.PromptSnippet();
+            var snippet = new PromptSnippet();
             snippet.setName("persona");
             when(jsonSerialization.deserialize(anyString(),
-                    eq(ai.labs.eddi.configs.snippets.model.PromptSnippet.class)))
+                    eq(PromptSnippet.class)))
                     .thenReturn(snippet);
 
             try (var source = new ZipResourceSource(tempDir, jsonSerialization)) {

--- a/src/test/java/ai/labs/eddi/backup/model/BackupModelsTest.java
+++ b/src/test/java/ai/labs/eddi/backup/model/BackupModelsTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -100,7 +101,7 @@ class BackupModelsTest {
     @Test
     void syncRequest_allFieldsAccessible() {
         var request = new SyncRequest("srcAgent", 2, "tgtAgent",
-                java.util.Set.of("res1", "res2"), List.of("wf1", "wf2"));
+                Set.of("res1", "res2"), List.of("wf1", "wf2"));
 
         assertEquals("srcAgent", request.sourceAgentId());
         assertEquals(2, request.sourceAgentVersion());

--- a/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminTest.java
+++ b/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.admin.rest;
 
 import ai.labs.eddi.configs.admin.model.OrphanReport;
 import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
@@ -91,7 +92,7 @@ class RestOrphanAdminTest {
             agentDesc.setResource(URI.create("eddi://ai.labs.agent/agents/agent1?version=1"));
 
             // Agent config references a workflow
-            var agentConfig = new ai.labs.eddi.configs.agents.model.AgentConfiguration();
+            var agentConfig = new AgentConfiguration();
             agentConfig.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflows/wf1?version=1")));
             when(agentStore.read("agent1", 1)).thenReturn(agentConfig);
 

--- a/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.agents;
 
 import ai.labs.eddi.configs.agents.crypto.SignedEnvelope;
 import ai.labs.eddi.secrets.ISecretProvider;
+import ai.labs.eddi.secrets.model.SecretMetadata;
 import ai.labs.eddi.secrets.model.SecretReference;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -309,12 +310,12 @@ class AgentSigningServiceTest {
         }
 
         @Override
-        public ai.labs.eddi.secrets.model.SecretMetadata getMetadata(SecretReference reference) {
+        public SecretMetadata getMetadata(SecretReference reference) {
             return null;
         }
 
         @Override
-        public List<ai.labs.eddi.secrets.model.SecretMetadata> listKeys(String tenantId) {
+        public List<SecretMetadata> listKeys(String tenantId) {
             return List.of();
         }
 

--- a/src/test/java/ai/labs/eddi/configs/agents/CapabilityRegistryServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/CapabilityRegistryServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -256,7 +257,7 @@ class CapabilityRegistryServiceTest {
         assertEquals(2, matches.size());
 
         // Verify both agents are present regardless of order
-        Set<String> agentIds = matches.stream().map(CapabilityMatch::agentId).collect(java.util.stream.Collectors.toSet());
+        Set<String> agentIds = matches.stream().map(CapabilityMatch::agentId).collect(Collectors.toSet());
         assertTrue(agentIds.contains("agent-1"));
         assertTrue(agentIds.contains("agent-2"));
     }

--- a/src/test/java/ai/labs/eddi/configs/agents/model/AgentConfigurationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/model/AgentConfigurationTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.agents.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -221,7 +222,7 @@ class AgentConfigurationTest {
             umc.setMaxEntriesPerUser(1000);
             umc.setOnCapReached("reject");
             umc.setRecallOrder("most_relevant");
-            umc.setAutoRecallCategories(java.util.List.of("preference"));
+            umc.setAutoRecallCategories(List.of("preference"));
             umc.setGuardrails(new AgentConfiguration.Guardrails());
             umc.setDream(new AgentConfiguration.DreamConfig());
             assertEquals("global", umc.getDefaultVisibility());
@@ -248,7 +249,7 @@ class AgentConfigurationTest {
             g.setMaxKeyLength(50);
             g.setMaxValueLength(500);
             g.setMaxWritesPerTurn(5);
-            g.setAllowedCategories(java.util.List.of("fact"));
+            g.setAllowedCategories(List.of("fact"));
             assertEquals(50, g.getMaxKeyLength());
             assertEquals(500, g.getMaxValueLength());
             assertEquals(5, g.getMaxWritesPerTurn());

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
@@ -271,7 +272,7 @@ class RestAgentStoreExpandedTest {
             config.setWorkflows(new ArrayList<>(List.of(
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG_ID + "?version=1"))));
             var hitl = new AgentConfiguration.HitlConfig();
-            var toolApprovals = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var toolApprovals = new ToolApprovalsConfig();
             toolApprovals.setRequireApproval(List.of("http.post:*", "http.put:*", "http.delete:*"));
             toolApprovals.setExempt(List.of("http.get:*"));
             hitl.setToolApprovals(toolApprovals);

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.agents.rest;
 
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
+import ai.labs.eddi.configs.agents.crypto.AgentPublicKey;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
@@ -326,7 +327,7 @@ class RestAgentStoreTest {
             var identity = new AgentConfiguration.AgentIdentity();
             // No legacy publicKey, but rotated keys list is populated
             identity.setKeys(List.of(
-                    ai.labs.eddi.configs.agents.crypto.AgentPublicKey.createCurrent(1, "base64key==")));
+                    AgentPublicKey.createCurrent(1, "base64key==")));
             config.setIdentity(identity);
 
             when(AgentStore.create(any())).thenReturn(new IResourceStore.IResourceId() {

--- a/src/test/java/ai/labs/eddi/configs/groups/model/SharedTaskListTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/model/SharedTaskListTest.java
@@ -8,8 +8,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -450,9 +456,9 @@ class SharedTaskListTest {
 
         // Concurrently assign + start + complete from multiple threads
         var tasks = list.all();
-        var futures = new java.util.ArrayList<java.util.concurrent.CompletableFuture<Void>>();
+        var futures = new ArrayList<CompletableFuture<Void>>();
         for (var task : tasks) {
-            futures.add(java.util.concurrent.CompletableFuture.runAsync(() -> {
+            futures.add(CompletableFuture.runAsync(() -> {
                 try {
                     list.assignTask(task.id(), "agent-" + task.priority(), "Agent " + task.priority());
                     list.startTask(task.id());
@@ -463,8 +469,8 @@ class SharedTaskListTest {
             }));
         }
 
-        java.util.concurrent.CompletableFuture.allOf(futures.toArray(new java.util.concurrent.CompletableFuture[0])).get(10,
-                java.util.concurrent.TimeUnit.SECONDS);
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(10,
+                TimeUnit.SECONDS);
 
         // No corruption: all tasks should still be accessible
         assertEquals(100, list.size(), "All 100 tasks should survive concurrent access");
@@ -663,8 +669,8 @@ class SharedTaskListTest {
 
         // If reentrant locking fails, this would deadlock.
         // Use a timeout to detect deadlock rather than hanging forever.
-        var future = java.util.concurrent.CompletableFuture.supplyAsync(() -> list.findExecutableTasks());
-        var result = future.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        var future = CompletableFuture.supplyAsync(() -> list.findExecutableTasks());
+        var result = future.get(5, TimeUnit.SECONDS);
 
         // task1 has no deps → executable; task2 depends on uncompleted task1 → not
         // executable
@@ -687,8 +693,8 @@ class SharedTaskListTest {
                 List.of(task1.id()), null, null, false, 0, Instant.now(), null);
         list.addTask(task2);
 
-        var future = java.util.concurrent.CompletableFuture.supplyAsync(() -> list.detectCycles());
-        var result = future.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        var future = CompletableFuture.supplyAsync(() -> list.detectCycles());
+        var result = future.get(5, TimeUnit.SECONDS);
         assertTrue(result.isEmpty(), "No cycles expected");
     }
 
@@ -699,12 +705,12 @@ class SharedTaskListTest {
     @Test
     void parallelLifecycleTransitions_noDeadlockOrCorruption() throws Exception {
         int taskCount = 50;
-        var latch = new java.util.concurrent.CountDownLatch(1);
-        var errors = new java.util.concurrent.CopyOnWriteArrayList<Throwable>();
-        var threads = new java.util.ArrayList<Thread>();
+        var latch = new CountDownLatch(1);
+        var errors = new CopyOnWriteArrayList<Throwable>();
+        var threads = new ArrayList<Thread>();
 
         // Pre-populate tasks
-        var taskIds = new java.util.ArrayList<String>();
+        var taskIds = new ArrayList<String>();
         for (int i = 0; i < taskCount; i++) {
             var task = list.addTask(new SharedTaskList.TaskItem("Task " + i, "desc " + i, i));
             taskIds.add(task.id());
@@ -749,11 +755,11 @@ class SharedTaskListTest {
      */
     @Test
     void concurrentReadWriteInterleaving_noDeadlock() throws Exception {
-        var latch = new java.util.concurrent.CountDownLatch(1);
-        var errors = new java.util.concurrent.CopyOnWriteArrayList<Throwable>();
+        var latch = new CountDownLatch(1);
+        var errors = new CopyOnWriteArrayList<Throwable>();
         int writerCount = 20;
         int readerCount = 20;
-        var threads = new java.util.ArrayList<Thread>();
+        var threads = new ArrayList<Thread>();
 
         // Writers: add tasks and transition them
         for (int i = 0; i < writerCount; i++) {
@@ -806,10 +812,10 @@ class SharedTaskListTest {
     @Test
     void raceCondition_doubleAssign_exactlyOneWins() throws Exception {
         var task = list.addTask(new SharedTaskList.TaskItem("Contested Task", "desc", 0));
-        var latch = new java.util.concurrent.CountDownLatch(1);
-        var successes = new java.util.concurrent.atomic.AtomicInteger(0);
-        var expectedFailures = new java.util.concurrent.atomic.AtomicInteger(0);
-        var unexpectedErrors = new java.util.concurrent.CopyOnWriteArrayList<Throwable>();
+        var latch = new CountDownLatch(1);
+        var successes = new AtomicInteger(0);
+        var expectedFailures = new AtomicInteger(0);
+        var unexpectedErrors = new CopyOnWriteArrayList<Throwable>();
 
         var t1 = Thread.ofVirtual().start(() -> {
             try {
@@ -875,7 +881,7 @@ class SharedTaskListTest {
     @Test
     void realisticContention_lifecycleWithDependencyQueries() throws Exception {
         // Create a realistic task graph: 5 root tasks, 5 dependent tasks
-        var rootIds = new java.util.ArrayList<String>();
+        var rootIds = new ArrayList<String>();
         for (int i = 0; i < 5; i++) {
             var task = list.addTask(new SharedTaskList.TaskItem("Root " + i, "desc", 0));
             rootIds.add(task.id());
@@ -888,9 +894,9 @@ class SharedTaskListTest {
             list.addTask(depTask);
         }
 
-        var latch = new java.util.concurrent.CountDownLatch(1);
-        var errors = new java.util.concurrent.CopyOnWriteArrayList<Throwable>();
-        var threads = new java.util.ArrayList<Thread>();
+        var latch = new CountDownLatch(1);
+        var errors = new CopyOnWriteArrayList<Throwable>();
+        var threads = new ArrayList<Thread>();
 
         // 5 threads drive root tasks through lifecycle
         for (String rootId : rootIds) {

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.groups.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
 import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.model.GroupWorkspace;
@@ -254,7 +255,7 @@ class RestAgentGroupStoreTest {
 
             // Capture the descriptor that was created
             var descriptorCaptor = org.mockito.ArgumentCaptor.forClass(
-                    ai.labs.eddi.configs.descriptors.model.DocumentDescriptor.class);
+                    DocumentDescriptor.class);
             verify(documentDescriptorStore).createDescriptor(eq(newId), eq(newVersion), descriptorCaptor.capture());
 
             var descriptor = descriptorCaptor.getValue();

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupTemplatesTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupTemplatesTest.java
@@ -17,6 +17,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,7 +61,7 @@ class RestGroupTemplatesTest {
         var response = rest.listTemplates();
 
         assertEquals(200, response.getStatus());
-        assertEquals(5, ((java.util.List<?>) response.getEntity()).size());
+        assertEquals(5, ((List<?>) response.getEntity()).size());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/hitl/HitlConfigValidationWiringTest.java
+++ b/src/test/java/ai/labs/eddi/configs/hitl/HitlConfigValidationWiringTest.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.datastore.IResourceStorage;
 import ai.labs.eddi.datastore.IResourceStorageFactory;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.datastore.serialization.JsonSerialization;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -173,7 +174,7 @@ class HitlConfigValidationWiringTest {
                     + "\"approvalTimeout\":\"30 minutes\"}}";
 
             // Deserialize via the SAME serializer the import service uses.
-            IJsonSerialization jsonSerialization = new ai.labs.eddi.datastore.serialization.JsonSerialization(
+            IJsonSerialization jsonSerialization = new JsonSerialization(
                     new com.fasterxml.jackson.databind.ObjectMapper());
             AgentConfiguration imported = jsonSerialization.deserialize(agentJson, AgentConfiguration.class);
 
@@ -186,7 +187,7 @@ class HitlConfigValidationWiringTest {
         @Test
         @DisplayName("an imported agent config with NO hitlConfig imports cleanly (backward compat)")
         void importAcceptsMissingHitl() throws Exception {
-            IJsonSerialization jsonSerialization = new ai.labs.eddi.datastore.serialization.JsonSerialization(
+            IJsonSerialization jsonSerialization = new JsonSerialization(
                     new com.fasterxml.jackson.databind.ObjectMapper());
             AgentConfiguration imported = jsonSerialization.deserialize("{}", AgentConfiguration.class);
 

--- a/src/test/java/ai/labs/eddi/configs/migration/MigrationManagerTest.java
+++ b/src/test/java/ai/labs/eddi/configs/migration/MigrationManagerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.util.*;
+import java.util.ArrayList;
 
 import static ai.labs.eddi.configs.migration.MigrationManager.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -1004,7 +1005,7 @@ class MigrationManagerTest {
         @DisplayName("should handle output with empty valueAlternatives")
         void emptyValueAlternatives() {
             var output = new HashMap<String, Object>();
-            output.put("valueAlternatives", new java.util.ArrayList<>());
+            output.put("valueAlternatives", new ArrayList<>());
 
             var outputContainer = new HashMap<String, Object>();
             outputContainer.put("outputs", List.of(output));

--- a/src/test/java/ai/labs/eddi/configs/migration/V6QuteMigrationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/migration/V6QuteMigrationTest.java
@@ -9,6 +9,7 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import java.util.ArrayList;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -132,12 +133,12 @@ class V6QuteMigrationTest {
         when(migrator.containsThymeleafSyntax("{deep}")).thenReturn(false);
 
         var innerDoc = new Document("deepKey", "[[${deep}]]");
-        var list = new java.util.ArrayList<Object>();
+        var list = new ArrayList<Object>();
         list.add("[[${item}]]");
         list.add("safe");
         list.add(innerDoc);
         // Add nested list
-        var nestedList = new java.util.ArrayList<Object>();
+        var nestedList = new ArrayList<Object>();
         nestedList.add("[[${item}]]");
         list.add(nestedList);
 

--- a/src/test/java/ai/labs/eddi/configs/migration/V6RenameMigrationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/migration/V6RenameMigrationTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -186,7 +187,7 @@ class V6RenameMigrationTest {
         void renamesAllCollections() {
             when(migrationLogStore.readMigrationLog(anyString())).thenReturn(null);
 
-            var oldNames = java.util.Set.of("bots", "bots.history", "packages", "packages.history", "behaviorrulesets", "behaviorrulesets.history",
+            var oldNames = Set.of("bots", "bots.history", "packages", "packages.history", "behaviorrulesets", "behaviorrulesets.history",
                     "httpcalls", "httpcalls.history", "langchain", "langchain.history", "regulardictionaries", "regulardictionaries.history");
 
             // Use thenAnswer to return non-empty for old names, empty for everything else
@@ -204,7 +205,7 @@ class V6RenameMigrationTest {
             when(database.getName()).thenReturn("eddi");
 
             // Track all rename calls across all mock collections
-            java.util.List<String> renamedTo = new java.util.ArrayList<>();
+            List<String> renamedTo = new ArrayList<>();
             // Re-wire: capture renameCollection calls
             when(database.getCollection(anyString())).thenAnswer(invocation -> {
                 String name = invocation.getArgument(0);
@@ -785,7 +786,7 @@ class V6RenameMigrationTest {
             when(migrationLogStore.readMigrationLog(anyString())).thenReturn(null);
 
             // Agent document with old field name 'packages'
-            var agentDoc = new Document("packages", java.util.List.of("workflow-ref"))
+            var agentDoc = new Document("packages", List.of("workflow-ref"))
                     .append("_id", new org.bson.types.ObjectId());
 
             MongoCollection<Document> agentCol = mock(MongoCollection.class);

--- a/src/test/java/ai/labs/eddi/configs/snippets/mongo/PromptSnippetStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/snippets/mongo/PromptSnippetStoreTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,7 +29,7 @@ class PromptSnippetStoreTest {
      * Regex pattern duplicated from PromptSnippetStore for validation testing. In
      * production, the store enforces this on create/update.
      */
-    private static final java.util.regex.Pattern NAME_PATTERN = java.util.regex.Pattern.compile("[a-z0-9_]+");
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-z0-9_]+");
 
     // ==================== Name Validation ====================
 

--- a/src/test/java/ai/labs/eddi/datastore/DataStoreProducersBranchTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/DataStoreProducersBranchTest.java
@@ -14,6 +14,7 @@ import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.mongo.MongoUserMemoryStore;
 import ai.labs.eddi.configs.variables.IGlobalVariableStore;
 import ai.labs.eddi.configs.variables.mongo.GlobalVariableStore;
+import ai.labs.eddi.datastore.mongo.GridFsAttachmentStore;
 import ai.labs.eddi.datastore.mongo.MongoResourceStorageFactory;
 import ai.labs.eddi.datastore.postgres.*;
 import ai.labs.eddi.engine.audit.AuditStore;
@@ -22,10 +23,13 @@ import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.memory.ConversationMemoryStore;
 import ai.labs.eddi.engine.memory.IConversationCheckpointStore;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
+import ai.labs.eddi.engine.memory.MongoConversationCheckpointStore;
 import ai.labs.eddi.engine.runtime.DatabaseLogs;
 import ai.labs.eddi.engine.runtime.IDatabaseLogs;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.mongo.MongoScheduleStore;
+import ai.labs.eddi.engine.tenancy.MongoTenantQuotaStore;
+import ai.labs.eddi.engine.tenancy.PostgresTenantQuotaStore;
 import ai.labs.eddi.engine.triggermanagement.IAgentTriggerStore;
 import ai.labs.eddi.engine.triggermanagement.IUserConversationStore;
 import ai.labs.eddi.engine.triggermanagement.mongo.AgentTriggerStore;
@@ -400,9 +404,9 @@ class DataStoreProducersBranchTest {
     @DisplayName("conversationCheckpointStore — mongo")
     void conversationCheckpointStore_mongo() throws Exception {
         producers.datastoreType = "mongodb";
-        Instance<ai.labs.eddi.engine.memory.MongoConversationCheckpointStore> mongo = mock(Instance.class);
+        Instance<MongoConversationCheckpointStore> mongo = mock(Instance.class);
         Instance<PostgresConversationCheckpointStore> pg = mock(Instance.class);
-        var mongoStore = mock(ai.labs.eddi.engine.memory.MongoConversationCheckpointStore.class);
+        var mongoStore = mock(MongoConversationCheckpointStore.class);
         when(mongo.get()).thenReturn(mongoStore);
 
         IConversationCheckpointStore result = producers.conversationCheckpointStore(mongo, pg);
@@ -413,7 +417,7 @@ class DataStoreProducersBranchTest {
     @DisplayName("conversationCheckpointStore — postgres")
     void conversationCheckpointStore_postgres() throws Exception {
         producers.datastoreType = "postgres";
-        Instance<ai.labs.eddi.engine.memory.MongoConversationCheckpointStore> mongo = mock(Instance.class);
+        Instance<MongoConversationCheckpointStore> mongo = mock(Instance.class);
         Instance<PostgresConversationCheckpointStore> pg = mock(Instance.class);
         var pgStore = mock(PostgresConversationCheckpointStore.class);
         when(pg.get()).thenReturn(pgStore);
@@ -428,9 +432,9 @@ class DataStoreProducersBranchTest {
     @DisplayName("attachmentStore — mongo")
     void attachmentStore_mongo() throws Exception {
         producers.datastoreType = "mongodb";
-        Instance<ai.labs.eddi.datastore.mongo.GridFsAttachmentStore> mongo = mock(Instance.class);
+        Instance<GridFsAttachmentStore> mongo = mock(Instance.class);
         Instance<PostgresAttachmentStore> pg = mock(Instance.class);
-        var mongoStore = mock(ai.labs.eddi.datastore.mongo.GridFsAttachmentStore.class);
+        var mongoStore = mock(GridFsAttachmentStore.class);
         when(mongo.get()).thenReturn(mongoStore);
 
         IAttachmentStore result = producers.attachmentStore(mongo, pg);
@@ -441,7 +445,7 @@ class DataStoreProducersBranchTest {
     @DisplayName("attachmentStore — postgres")
     void attachmentStore_postgres() throws Exception {
         producers.datastoreType = "postgres";
-        Instance<ai.labs.eddi.datastore.mongo.GridFsAttachmentStore> mongo = mock(Instance.class);
+        Instance<GridFsAttachmentStore> mongo = mock(Instance.class);
         Instance<PostgresAttachmentStore> pg = mock(Instance.class);
         var pgStore = mock(PostgresAttachmentStore.class);
         when(pg.get()).thenReturn(pgStore);
@@ -456,9 +460,9 @@ class DataStoreProducersBranchTest {
     @DisplayName("tenantQuotaStore — mongo")
     void tenantQuotaStore_mongo() throws Exception {
         producers.datastoreType = "mongodb";
-        Instance<ai.labs.eddi.engine.tenancy.MongoTenantQuotaStore> mongo = mock(Instance.class);
-        Instance<ai.labs.eddi.engine.tenancy.PostgresTenantQuotaStore> pg = mock(Instance.class);
-        var mongoStore = mock(ai.labs.eddi.engine.tenancy.MongoTenantQuotaStore.class);
+        Instance<MongoTenantQuotaStore> mongo = mock(Instance.class);
+        Instance<PostgresTenantQuotaStore> pg = mock(Instance.class);
+        var mongoStore = mock(MongoTenantQuotaStore.class);
         when(mongo.get()).thenReturn(mongoStore);
 
         var result = producers.tenantQuotaStore(mongo, pg);
@@ -469,9 +473,9 @@ class DataStoreProducersBranchTest {
     @DisplayName("tenantQuotaStore — postgres")
     void tenantQuotaStore_postgres() throws Exception {
         producers.datastoreType = "postgres";
-        Instance<ai.labs.eddi.engine.tenancy.MongoTenantQuotaStore> mongo = mock(Instance.class);
-        Instance<ai.labs.eddi.engine.tenancy.PostgresTenantQuotaStore> pg = mock(Instance.class);
-        var pgStore = mock(ai.labs.eddi.engine.tenancy.PostgresTenantQuotaStore.class);
+        Instance<MongoTenantQuotaStore> mongo = mock(Instance.class);
+        Instance<PostgresTenantQuotaStore> pg = mock(Instance.class);
+        var pgStore = mock(PostgresTenantQuotaStore.class);
         when(pg.get()).thenReturn(pgStore);
 
         var result = producers.tenantQuotaStore(mongo, pg);

--- a/src/test/java/ai/labs/eddi/datastore/mongo/GridFsAttachmentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/GridFsAttachmentStoreTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -138,7 +139,7 @@ class GridFsAttachmentStoreTest {
 
         assertNotNull(result);
         // storageRef is a random UUID, not the ObjectId hex
-        assertDoesNotThrow(() -> java.util.UUID.fromString(result.storageRef()));
+        assertDoesNotThrow(() -> UUID.fromString(result.storageRef()));
         assertEquals("test.txt", result.filename());
         assertEquals("application/octet-stream", result.mimeType());
         assertEquals(data.length, result.sizeBytes());

--- a/src/test/java/ai/labs/eddi/datastore/mongo/MongoConversationMemoryStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/MongoConversationMemoryStoreTest.java
@@ -23,6 +23,8 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import de.undercouch.bson4jackson.BsonFactory;
 import de.undercouch.bson4jackson.BsonParser;
+import java.time.Instant;
+import java.util.LinkedHashMap;
 import org.bson.codecs.*;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.junit.jupiter.api.*;
@@ -31,6 +33,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.bson.codecs.configuration.CodecRegistries.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -399,7 +402,7 @@ class MongoConversationMemoryStoreTest {
         @DisplayName("findPendingApprovalSummaries projects the bookmark incl. approvalTimeout and honors the limit")
         void findPendingApprovalSummaries() throws IResourceStore.ResourceStoreException {
             var paused = createSnapshot(null, "agent1", 1, "user1", ConversationState.AWAITING_HUMAN);
-            paused.setHitlPausedAt(java.time.Instant.now());
+            paused.setHitlPausedAt(Instant.now());
             paused.setHitlPauseReason("needs review");
             paused.setHitlTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
             paused.setHitlApprovalTimeout("PT30M");
@@ -472,7 +475,7 @@ class MongoConversationMemoryStoreTest {
             // plain JSON to BSON.
             var snapshot = createSnapshot(null, "agent1", 1, "user1", ConversationState.AWAITING_HUMAN);
             snapshot.setHitlPauseType("TOOL_CALL");
-            snapshot.setHitlPausedAt(java.time.Instant.now());
+            snapshot.setHitlPausedAt(Instant.now());
             snapshot.setHitlPauseReason("gated tool calls awaiting review");
             snapshot.setHitlTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
             snapshot.setHitlApprovalTimeout("PT30M");
@@ -513,16 +516,16 @@ class MongoConversationMemoryStoreTest {
             // traceSoFar: a nested Map<String,Object> — the field most likely to lose
             // fidelity across a BSON round-trip (numeric widening, boolean/string
             // coercion, nested structures).
-            var nested = new java.util.LinkedHashMap<String, Object>();
+            var nested = new LinkedHashMap<String, Object>();
             nested.put("stringField", "value");
             nested.put("intField", 42);
             nested.put("boolField", true);
             nested.put("nestedList", List.of("a", "b", "c"));
-            var traceEntry1 = new java.util.LinkedHashMap<String, Object>();
+            var traceEntry1 = new LinkedHashMap<String, Object>();
             traceEntry1.put("type", "tool_call");
             traceEntry1.put("tool", "readOnlyLookup");
             traceEntry1.put("detail", nested);
-            var traceEntry2 = new java.util.LinkedHashMap<String, Object>();
+            var traceEntry2 = new LinkedHashMap<String, Object>();
             traceEntry2.put("type", "hitl_gate_tripped");
             traceEntry2.put("gatedCount", 2);
             batch.setTraceSoFar(List.of(traceEntry1, traceEntry2));
@@ -572,7 +575,7 @@ class MongoConversationMemoryStoreTest {
             assertEquals("tool_call", loadedTrace1.get("type"));
             assertEquals("readOnlyLookup", loadedTrace1.get("tool"));
             @SuppressWarnings("unchecked")
-            var loadedNested = (java.util.Map<String, Object>) loadedTrace1.get("detail");
+            var loadedNested = (Map<String, Object>) loadedTrace1.get("detail");
             assertNotNull(loadedNested, "the nested Map<String,Object> inside traceSoFar must survive");
             assertEquals("value", loadedNested.get("stringField"));
             assertEquals(42, ((Number) loadedNested.get("intField")).intValue());
@@ -608,7 +611,7 @@ class MongoConversationMemoryStoreTest {
         @DisplayName("clearHitlBookmark removes the bookmark fields but keeps the conversation")
         void clearHitlBookmark() throws IResourceStore.ResourceStoreException {
             var snapshot = createSnapshot(null, "agent1", 1, "user1", ConversationState.AWAITING_HUMAN);
-            snapshot.setHitlPausedAt(java.time.Instant.now());
+            snapshot.setHitlPausedAt(Instant.now());
             snapshot.setHitlPauseReason("needs review");
             snapshot.setHitlTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
             snapshot.setHitlApprovalTimeout("PT30M");

--- a/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageBranchTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageBranchTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -100,10 +101,10 @@ class MongoResourceStorageBranchTest {
             when(historyCollection.find(any(Document.class))).thenReturn(iterable);
 
             doAnswer(inv -> {
-                java.util.function.Consumer<Document> consumer = inv.getArgument(0);
+                Consumer<Document> consumer = inv.getArgument(0);
                 consumer.accept(doc);
                 return null;
-            }).when(iterable).forEach(any(java.util.function.Consumer.class));
+            }).when(iterable).forEach(any(Consumer.class));
 
             List<IResourceStore.IResourceId> result = storage.findHistoryResourceIdsContaining("path", "value");
             assertEquals(1, result.size());
@@ -121,10 +122,10 @@ class MongoResourceStorageBranchTest {
             when(historyCollection.find(any(Document.class))).thenReturn(iterable);
 
             doAnswer(inv -> {
-                java.util.function.Consumer<Document> consumer = inv.getArgument(0);
+                Consumer<Document> consumer = inv.getArgument(0);
                 consumer.accept(doc);
                 return null;
-            }).when(iterable).forEach(any(java.util.function.Consumer.class));
+            }).when(iterable).forEach(any(Consumer.class));
 
             List<IResourceStore.IResourceId> result = storage.findHistoryResourceIdsContaining("path", "value");
             assertEquals(0, result.size());
@@ -156,10 +157,10 @@ class MongoResourceStorageBranchTest {
             when(iterable.skip(anyInt())).thenReturn(iterable);
 
             doAnswer(inv -> {
-                java.util.function.Consumer<Document> consumer = inv.getArgument(0);
+                Consumer<Document> consumer = inv.getArgument(0);
                 consumer.accept(doc);
                 return null;
-            }).when(iterable).forEach(any(java.util.function.Consumer.class));
+            }).when(iterable).forEach(any(Consumer.class));
 
             List<IResourceStore.IResourceId> result = storage.findResources(
                     new IResourceFilter.QueryFilters[]{qfs}, "name", 0, 10);
@@ -184,7 +185,7 @@ class MongoResourceStorageBranchTest {
             when(iterable.sort(any(Document.class))).thenReturn(iterable);
             when(iterable.limit(anyInt())).thenReturn(iterable);
             when(iterable.skip(anyInt())).thenReturn(iterable);
-            doNothing().when(iterable).forEach(any(java.util.function.Consumer.class));
+            doNothing().when(iterable).forEach(any(Consumer.class));
 
             List<IResourceStore.IResourceId> result = storage.findResources(
                     new IResourceFilter.QueryFilters[]{qfs}, null, -1, 0);
@@ -208,7 +209,7 @@ class MongoResourceStorageBranchTest {
             when(iterable.sort(any(Document.class))).thenReturn(iterable);
             when(iterable.limit(anyInt())).thenReturn(iterable);
             when(iterable.skip(anyInt())).thenReturn(iterable);
-            doNothing().when(iterable).forEach(any(java.util.function.Consumer.class));
+            doNothing().when(iterable).forEach(any(Consumer.class));
 
             // sortField=null, skip=0, limit=0 → "no caller limit" → the ceiling
             List<IResourceStore.IResourceId> result = storage.findResources(

--- a/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageTest.java
@@ -23,6 +23,7 @@ import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -295,12 +296,12 @@ class MongoResourceStorageTest {
         FindIterable<Document> iterable = mock(FindIterable.class);
         when(currentCollection.find(any(Bson.class))).thenReturn(iterable);
         doAnswer(inv -> {
-            java.util.function.Consumer<Document> consumer = inv.getArgument(0);
+            Consumer<Document> consumer = inv.getArgument(0);
             // Cursor order deliberately differs from the requested order.
             consumer.accept(first);
             consumer.accept(second);
             return null;
-        }).when(iterable).forEach(any(java.util.function.Consumer.class));
+        }).when(iterable).forEach(any(Consumer.class));
 
         var results = storage.readMany(List.of(resourceId(otherId, 1), resourceId(VALID_ID, 1)));
 
@@ -405,10 +406,10 @@ class MongoResourceStorageTest {
         when(currentCollection.find(any(Document.class))).thenReturn(iterable);
 
         doAnswer(inv -> {
-            java.util.function.Consumer<Document> consumer = inv.getArgument(0);
+            Consumer<Document> consumer = inv.getArgument(0);
             consumer.accept(doc);
             return null;
-        }).when(iterable).forEach(any(java.util.function.Consumer.class));
+        }).when(iterable).forEach(any(Consumer.class));
 
         List<IResourceStore.IResourceId> result = storage.findResourceIdsContaining("field.path", "value");
         assertEquals(1, result.size());

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAgentTriggerStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAgentTriggerStoreTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.datastore.postgres;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.datastore.serialization.JsonSerialization;
+import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
 import ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
@@ -33,7 +34,7 @@ class PostgresAgentTriggerStoreTest extends PostgresTestBase {
         var dsInstance = createDataSourceInstance();
         ds = dsInstance.get();
         IJsonSerialization json = new JsonSerialization(
-                ai.labs.eddi.datastore.serialization.SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
+                SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
         store = new PostgresAgentTriggerStore(dsInstance, json);
     }
 

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.datastore.postgres;
 
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.datastore.serialization.JsonSerialization;
+import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
@@ -36,7 +37,7 @@ class PostgresAuditStoreTest extends PostgresTestBase {
         var dsInstance = createDataSourceInstance();
         ds = dsInstance.get();
         IJsonSerialization json = new JsonSerialization(
-                ai.labs.eddi.datastore.serialization.SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
+                SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
         store = new PostgresAuditStore(dsInstance, json);
     }
 

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresConversationMemoryStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresConversationMemoryStoreTest.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.datastore.serialization.JsonSerialization;
+import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
@@ -18,7 +19,10 @@ import org.junit.jupiter.api.*;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,7 +46,7 @@ class PostgresConversationMemoryStoreTest extends PostgresTestBase {
         var dsInstance = createDataSourceInstance();
         ds = dsInstance.get();
         IJsonSerialization json = new JsonSerialization(
-                ai.labs.eddi.datastore.serialization.SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
+                SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
         store = new PostgresConversationMemoryStore(dsInstance, json);
     }
 
@@ -374,7 +378,7 @@ class PostgresConversationMemoryStoreTest extends PostgresTestBase {
         @DisplayName("findPendingApprovalSummaries projects the bookmark incl. approvalTimeout and honors the limit")
         void findPendingApprovalSummaries() throws Exception {
             var pausedSnapshot = createSnapshot(null, "agent1", 1, "user1", ConversationState.AWAITING_HUMAN);
-            pausedSnapshot.setHitlPausedAt(java.time.Instant.now());
+            pausedSnapshot.setHitlPausedAt(Instant.now());
             pausedSnapshot.setHitlPauseReason("needs review");
             pausedSnapshot.setHitlTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
             pausedSnapshot.setHitlApprovalTimeout("PT30M");
@@ -448,7 +452,7 @@ class PostgresConversationMemoryStoreTest extends PostgresTestBase {
             // real JSON<->JSONB round-trip.
             var snapshot = createSnapshot(null, "agent1", 1, "user1", ConversationState.AWAITING_HUMAN);
             snapshot.setHitlPauseType("TOOL_CALL");
-            snapshot.setHitlPausedAt(java.time.Instant.now());
+            snapshot.setHitlPausedAt(Instant.now());
             snapshot.setHitlPauseReason("gated tool calls awaiting review");
             snapshot.setHitlTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
             snapshot.setHitlApprovalTimeout("PT30M");
@@ -489,16 +493,16 @@ class PostgresConversationMemoryStoreTest extends PostgresTestBase {
             // traceSoFar: a nested Map<String,Object> — the field most likely to lose
             // fidelity across a real JSON round-trip (numeric widening, boolean/string
             // coercion, nested structures).
-            var nested = new java.util.LinkedHashMap<String, Object>();
+            var nested = new LinkedHashMap<String, Object>();
             nested.put("stringField", "value");
             nested.put("intField", 42);
             nested.put("boolField", true);
             nested.put("nestedList", List.of("a", "b", "c"));
-            var traceEntry1 = new java.util.LinkedHashMap<String, Object>();
+            var traceEntry1 = new LinkedHashMap<String, Object>();
             traceEntry1.put("type", "tool_call");
             traceEntry1.put("tool", "readOnlyLookup");
             traceEntry1.put("detail", nested);
-            var traceEntry2 = new java.util.LinkedHashMap<String, Object>();
+            var traceEntry2 = new LinkedHashMap<String, Object>();
             traceEntry2.put("type", "hitl_gate_tripped");
             traceEntry2.put("gatedCount", 2);
             batch.setTraceSoFar(List.of(traceEntry1, traceEntry2));
@@ -548,7 +552,7 @@ class PostgresConversationMemoryStoreTest extends PostgresTestBase {
             assertEquals("tool_call", loadedTrace1.get("type"));
             assertEquals("readOnlyLookup", loadedTrace1.get("tool"));
             @SuppressWarnings("unchecked")
-            var loadedNested = (java.util.Map<String, Object>) loadedTrace1.get("detail");
+            var loadedNested = (Map<String, Object>) loadedTrace1.get("detail");
             assertNotNull(loadedNested, "the nested Map<String,Object> inside traceSoFar must survive");
             assertEquals("value", loadedNested.get("stringField"));
             assertEquals(42, ((Number) loadedNested.get("intField")).intValue());
@@ -564,7 +568,7 @@ class PostgresConversationMemoryStoreTest extends PostgresTestBase {
         @DisplayName("clearHitlBookmark removes the bookmark fields but keeps the conversation")
         void clearHitlBookmark() throws Exception {
             var snapshot = createSnapshot(null, "agent1", 1, "user1", ConversationState.AWAITING_HUMAN);
-            snapshot.setHitlPausedAt(java.time.Instant.now());
+            snapshot.setHitlPausedAt(Instant.now());
             snapshot.setHitlPauseReason("needs review");
             snapshot.setHitlTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
             snapshot.setHitlApprovalTimeout("PT30M");

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresJournalExtraCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresJournalExtraCoverageTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.datastore.postgres;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
 
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService;
@@ -37,6 +38,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -215,7 +217,7 @@ class PostgresJournalExtraCoverageTest {
         void listScopedGroup_approverSeesAll() throws Exception {
             when(ownershipValidator.isAdmin(identity)).thenReturn(false);
             when(ownershipValidator.isApprover(identity)).thenReturn(true);
-            when(groupConversationService.listGroupPendingApprovals(null, 10)).thenReturn(java.util.List.of());
+            when(groupConversationService.listGroupPendingApprovals(null, 10)).thenReturn(List.of());
 
             assertTrue(guard.listScopedGroupPendingApprovals(null, 10).isEmpty());
         }
@@ -228,7 +230,7 @@ class PostgresJournalExtraCoverageTest {
             Principal p = mock(Principal.class);
             when(p.getName()).thenReturn(""); // blank → isBlank() branch
             when(identity.getPrincipal()).thenReturn(p);
-            when(groupConversationService.listGroupPendingApprovals("g1", 10)).thenReturn(java.util.List.of());
+            when(groupConversationService.listGroupPendingApprovals("g1", 10)).thenReturn(List.of());
 
             assertTrue(guard.listScopedGroupPendingApprovals("g1", 10).isEmpty());
         }
@@ -246,7 +248,7 @@ class PostgresJournalExtraCoverageTest {
         @Test
         @DisplayName("requireGroupConversationHitlAccess: null groupId skips the group-match check")
         void requireGroup_nullGroupId_skipsMatch() throws Exception {
-            ai.labs.eddi.configs.groups.model.GroupConversation gc = mock(ai.labs.eddi.configs.groups.model.GroupConversation.class);
+            GroupConversation gc = mock(GroupConversation.class);
             when(gc.getUserId()).thenReturn("owner1");
             when(groupConversationService.readGroupConversation("gc1")).thenReturn(gc);
 

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorageContainerTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorageContainerTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.datastore.postgres;
 
 import ai.labs.eddi.datastore.serialization.JsonSerialization;
+import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 
@@ -12,6 +13,7 @@ import javax.sql.DataSource;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -35,7 +37,7 @@ class PostgresResourceStorageContainerTest extends PostgresTestBase {
     @BeforeEach
     void initStorage() throws SQLException {
         var json = new JsonSerialization(
-                ai.labs.eddi.datastore.serialization.SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
+                SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
         @SuppressWarnings("unchecked")
         Class<Map<String, Object>> type = (Class<Map<String, Object>>) (Class<?>) Map.class;
         storage = new PostgresResourceStorage<>(ds, COLLECTION, json, type);
@@ -73,7 +75,7 @@ class PostgresResourceStorageContainerTest extends PostgresTestBase {
         @Test
         @DisplayName("newResource with explicit id and version")
         void storeWithExplicitId() throws IOException {
-            var id = java.util.UUID.randomUUID().toString();
+            var id = UUID.randomUUID().toString();
             var resource = storage.newResource(id, 3, Map.of("key", "value"));
             storage.store(resource);
 
@@ -86,7 +88,7 @@ class PostgresResourceStorageContainerTest extends PostgresTestBase {
         @Test
         @DisplayName("read non-existent — returns null")
         void readNonExistent() {
-            var id = java.util.UUID.randomUUID().toString();
+            var id = UUID.randomUUID().toString();
             assertNull(storage.read(id, 1));
         }
 
@@ -188,7 +190,7 @@ class PostgresResourceStorageContainerTest extends PostgresTestBase {
         @Test
         @DisplayName("readHistoryLatest returns highest version")
         void readHistoryLatest() throws IOException {
-            var id = java.util.UUID.randomUUID().toString();
+            var id = UUID.randomUUID().toString();
 
             var v1 = storage.newResource(id, 1, Map.of("v", 1));
             var h1 = storage.newHistoryResourceFor(v1, false);
@@ -235,7 +237,7 @@ class PostgresResourceStorageContainerTest extends PostgresTestBase {
         @Test
         @DisplayName("returns -1 for non-existent resource")
         void nonExistent() {
-            assertEquals(-1, storage.getCurrentVersion(java.util.UUID.randomUUID().toString()));
+            assertEquals(-1, storage.getCurrentVersion(UUID.randomUUID().toString()));
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorageTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresResourceStorageTest.java
@@ -802,12 +802,12 @@ class PostgresResourceStorageTest {
         when(resultSet.getString("id")).thenReturn("id1");
         when(resultSet.getInt("version")).thenReturn(1);
 
-        var filter = new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("name", "test.*");
-        var queryFilters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(
-                java.util.List.of(filter));
+        var filter = new IResourceFilter.QueryFilter("name", "test.*");
+        var queryFilters = new IResourceFilter.QueryFilters(
+                List.of(filter));
 
         var results = storage.findResources(
-                new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{queryFilters},
+                new IResourceFilter.QueryFilters[]{queryFilters},
                 "name", 0, 10);
 
         assertEquals(1, results.size());
@@ -817,12 +817,12 @@ class PostgresResourceStorageTest {
     void findResources_zeroLimit_meansUnlimitedUpToCeiling() throws Exception {
         when(resultSet.next()).thenReturn(false);
 
-        var filter = new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("name", "test.*");
-        var queryFilters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(
-                java.util.List.of(filter));
+        var filter = new IResourceFilter.QueryFilter("name", "test.*");
+        var queryFilters = new IResourceFilter.QueryFilters(
+                List.of(filter));
 
         storage.findResources(
-                new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{queryFilters},
+                new IResourceFilter.QueryFilters[]{queryFilters},
                 "name", 0, 0);
 
         var sql = ArgumentCaptor.forClass(String.class);
@@ -836,12 +836,12 @@ class PostgresResourceStorageTest {
     void findResources_oversizedLimit_clampedToCeiling() throws Exception {
         when(resultSet.next()).thenReturn(false);
 
-        var filter = new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("name", "test.*");
-        var queryFilters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(
-                java.util.List.of(filter));
+        var filter = new IResourceFilter.QueryFilter("name", "test.*");
+        var queryFilters = new IResourceFilter.QueryFilters(
+                List.of(filter));
 
         storage.findResources(
-                new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{queryFilters},
+                new IResourceFilter.QueryFilters[]{queryFilters},
                 "name", 0, IResourceStorage.MAX_RESULT_LIMIT * 2);
 
         var sql = ArgumentCaptor.forClass(String.class);
@@ -854,12 +854,12 @@ class PostgresResourceStorageTest {
     void findResources_withBooleanFilter() throws Exception {
         when(resultSet.next()).thenReturn(false);
 
-        var filter = new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("enabled", true);
-        var queryFilters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(
-                java.util.List.of(filter));
+        var filter = new IResourceFilter.QueryFilter("enabled", true);
+        var queryFilters = new IResourceFilter.QueryFilters(
+                List.of(filter));
 
         var results = storage.findResources(
-                new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{queryFilters},
+                new IResourceFilter.QueryFilters[]{queryFilters},
                 null, 0, 5);
 
         assertTrue(results.isEmpty());
@@ -870,12 +870,12 @@ class PostgresResourceStorageTest {
         when(resultSet.next()).thenReturn(false);
 
         // Integer filter — goes through the else branch (toString)
-        var filter = new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("count", 42);
-        var queryFilters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(
-                java.util.List.of(filter));
+        var filter = new IResourceFilter.QueryFilter("count", 42);
+        var queryFilters = new IResourceFilter.QueryFilters(
+                List.of(filter));
 
         var results = storage.findResources(
-                new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{queryFilters},
+                new IResourceFilter.QueryFilters[]{queryFilters},
                 null, 0, 0); // limit < 1 should default to 20
 
         assertTrue(results.isEmpty());
@@ -885,14 +885,14 @@ class PostgresResourceStorageTest {
     void findResources_withOrConnector() throws Exception {
         when(resultSet.next()).thenReturn(false);
 
-        var filter1 = new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("name", "a");
-        var filter2 = new ai.labs.eddi.datastore.IResourceFilter.QueryFilter("name", "b");
-        var queryFilters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(
-                ai.labs.eddi.datastore.IResourceFilter.QueryFilters.ConnectingType.OR,
-                java.util.List.of(filter1, filter2));
+        var filter1 = new IResourceFilter.QueryFilter("name", "a");
+        var filter2 = new IResourceFilter.QueryFilter("name", "b");
+        var queryFilters = new IResourceFilter.QueryFilters(
+                IResourceFilter.QueryFilters.ConnectingType.OR,
+                List.of(filter1, filter2));
 
         var results = storage.findResources(
-                new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{queryFilters},
+                new IResourceFilter.QueryFilters[]{queryFilters},
                 "name", 5, 10);
 
         assertTrue(results.isEmpty());
@@ -902,11 +902,11 @@ class PostgresResourceStorageTest {
     void findResources_sqlException_throwsRuntimeException() throws Exception {
         when(preparedStatement.executeQuery()).thenThrow(new SQLException("DB error"));
 
-        var queryFilters = new ai.labs.eddi.datastore.IResourceFilter.QueryFilters(java.util.List.of());
+        var queryFilters = new IResourceFilter.QueryFilters(List.of());
 
         assertThrows(RuntimeException.class,
                 () -> storage.findResources(
-                        new ai.labs.eddi.datastore.IResourceFilter.QueryFilters[]{queryFilters},
+                        new IResourceFilter.QueryFilters[]{queryFilters},
                         null, 0, 10));
     }
 

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresScheduleStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresScheduleStoreTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.datastore.postgres;
 
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.JsonSerialization;
+import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration.FireStatus;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration.TriggerType;
@@ -43,7 +44,7 @@ class PostgresScheduleStoreTest extends PostgresTestBase {
         var dsInstance = createDataSourceInstance();
         ds = dsInstance.get();
         store = new PostgresScheduleStore(dsInstance,
-                new JsonSerialization(ai.labs.eddi.datastore.serialization.SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false)),
+                new JsonSerialization(SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false)),
                 100);
     }
 

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresTestBase.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresTestBase.java
@@ -10,6 +10,8 @@ import javax.sql.DataSource;
 import jakarta.enterprise.inject.Instance;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Shared Testcontainers base for PostgreSQL adapter integration tests.
@@ -127,8 +129,8 @@ public abstract class PostgresTestBase {
             throw new UnsupportedOperationException();
         }
         @Override
-        public java.util.Iterator<DataSource> iterator() {
-            return java.util.List.of(ds).iterator();
+        public Iterator<DataSource> iterator() {
+            return List.of(ds).iterator();
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserConversationStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserConversationStoreTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.datastore.postgres;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.datastore.serialization.JsonSerialization;
+import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
 import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
@@ -34,7 +35,7 @@ class PostgresUserConversationStoreTest extends PostgresTestBase {
         var dsInstance = createDataSourceInstance();
         ds = dsInstance.get();
         IJsonSerialization json = new JsonSerialization(
-                ai.labs.eddi.datastore.serialization.SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
+                SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
         store = new PostgresUserConversationStore(dsInstance, json);
     }
 

--- a/src/test/java/ai/labs/eddi/engine/api/OperatorMetricsServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/api/OperatorMetricsServiceTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.api;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ class OperatorMetricsServiceTest {
 
         var timer = registry.find("eddi.operator.canary.duration").timer();
         assertEquals(1, timer.count());
-        assertEquals(250.0, timer.totalTime(java.util.concurrent.TimeUnit.MILLISECONDS), 0.001);
+        assertEquals(250.0, timer.totalTime(TimeUnit.MILLISECONDS), 0.001);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTest.java
@@ -21,6 +21,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -75,7 +76,7 @@ class AuditHmacTest {
         @DisplayName("different master keys produce different HMAC keys")
         void differentKeys() {
             byte[] key2 = AuditHmac.deriveHmacKey("different-master-key");
-            assertFalse(java.util.Arrays.equals(hmacKey, key2));
+            assertFalse(Arrays.equals(hmacKey, key2));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.gdpr;
 import ai.labs.eddi.configs.groups.ISharedArtifactStore;
 import ai.labs.eddi.configs.groups.mongo.GroupConversationStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
+import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
 import ai.labs.eddi.engine.audit.AuditLedgerService;
 import ai.labs.eddi.engine.audit.IAuditStore;
@@ -26,12 +27,15 @@ import ai.labs.eddi.engine.model.Deployment;
 import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
 import ai.labs.eddi.engine.triggermanagement.rest.RestUserConversationStore;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.audit.model.AuditEntry;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.inject.Instance;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -459,13 +463,13 @@ class GdprComplianceServiceTest {
         when(userConversationStore.getAllForUser(USER_ID))
                 .thenReturn(List.of());
 
-        var auditEntry = new ai.labs.eddi.engine.audit.model.AuditEntry(
+        var auditEntry = new AuditEntry(
                 "ae-1", "conv-1", "agent-1", 1, USER_ID, "unrestricted",
                 0, "ai.labs.llm", "llm", 0, 150L,
-                java.util.Map.of(), java.util.Map.of(),
-                java.util.Map.of("model", "gpt-4"), null,
+                Map.of(), Map.of(),
+                Map.of("model", "gpt-4"), null,
                 List.of("chat_complete"), 0.003,
-                java.time.Instant.now(), null, null);
+                Instant.now(), null, null);
         when(auditStore.getEntriesByUserId(eq(USER_ID), eq(0), eq(10_000)))
                 .thenReturn(List.of(auditEntry));
 
@@ -537,9 +541,9 @@ class GdprComplianceServiceTest {
         // Given — restriction exists
         var entry = new UserMemoryEntry(
                 "entry-id", USER_ID, "_gdpr_processing_restricted", "true",
-                "gdpr", ai.labs.eddi.configs.properties.model.Property.Visibility.global,
+                "gdpr", Property.Visibility.global,
                 null, List.of(), null, false, 0,
-                java.time.Instant.now(), java.time.Instant.now());
+                Instant.now(), Instant.now());
         when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
                 .thenReturn(Optional.of(entry));
 
@@ -579,9 +583,9 @@ class GdprComplianceServiceTest {
         // Given
         var entry = new UserMemoryEntry(
                 "entry-id", USER_ID, "_gdpr_processing_restricted", "true",
-                "gdpr", ai.labs.eddi.configs.properties.model.Property.Visibility.global,
+                "gdpr", Property.Visibility.global,
                 null, List.of(), null, false, 0,
-                java.time.Instant.now(), java.time.Instant.now());
+                Instant.now(), Instant.now());
         when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
                 .thenReturn(Optional.of(entry));
 
@@ -604,9 +608,9 @@ class GdprComplianceServiceTest {
         // Given — value stored as Boolean true instead of String "true"
         var entry = new UserMemoryEntry(
                 "entry-id", USER_ID, "_gdpr_processing_restricted", Boolean.TRUE,
-                "gdpr", ai.labs.eddi.configs.properties.model.Property.Visibility.global,
+                "gdpr", Property.Visibility.global,
                 null, List.of(), null, false, 0,
-                java.time.Instant.now(), java.time.Instant.now());
+                Instant.now(), Instant.now());
         when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
                 .thenReturn(Optional.of(entry));
 
@@ -629,9 +633,9 @@ class GdprComplianceServiceTest {
         // Given — value is "false" not "true"
         var entry = new UserMemoryEntry(
                 "entry-id", USER_ID, "_gdpr_processing_restricted", "false",
-                "gdpr", ai.labs.eddi.configs.properties.model.Property.Visibility.global,
+                "gdpr", Property.Visibility.global,
                 null, List.of(), null, false, 0,
-                java.time.Instant.now(), java.time.Instant.now());
+                Instant.now(), Instant.now());
         when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
                 .thenReturn(Optional.of(entry));
 

--- a/src/test/java/ai/labs/eddi/engine/hitl/HitlAccessGuardTest.java
+++ b/src/test/java/ai/labs/eddi/engine/hitl/HitlAccessGuardTest.java
@@ -296,7 +296,7 @@ class HitlAccessGuardTest {
     void readAccess_pendingMemberMayReadTheStatusOfTheirTurn() throws Exception {
         var gc = humanPausedGc();
         gc.setPendingHumanInput(new GroupConversation.PendingHumanInput("hannah", "Hannah", 0, 0, 1,
-                "OPINION", "the prompt", "SKIP_TURN", java.time.Instant.now()));
+                "OPINION", "the prompt", "SKIP_TURN", Instant.now()));
         callerNamed("hannah");
         // Not owner, not admin, not approver — the strict guard would refuse.
         doThrow(new ForbiddenException("no"))
@@ -309,7 +309,7 @@ class HitlAccessGuardTest {
     void readAccess_strangerStillRefused_andWrongGroup404s() throws Exception {
         var gc = humanPausedGc();
         gc.setPendingHumanInput(new GroupConversation.PendingHumanInput("hannah", "Hannah", 0, 0, 1,
-                "OPINION", "the prompt", "SKIP_TURN", java.time.Instant.now()));
+                "OPINION", "the prompt", "SKIP_TURN", Instant.now()));
         callerNamed("mallory");
         doThrow(new ForbiddenException("no"))
                 .when(ownershipValidator).requireOwnerAdminOrApprover(any(), any(), any());

--- a/src/test/java/ai/labs/eddi/engine/hitl/HitlCrashRecoveryObserverTest.java
+++ b/src/test/java/ai/labs/eddi/engine/hitl/HitlCrashRecoveryObserverTest.java
@@ -14,6 +14,7 @@ import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
@@ -192,7 +193,7 @@ class HitlCrashRecoveryObserverTest {
 
             var captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
             verify(scheduleStore).createSchedule(captor.capture());
-            Instant expectedDue = pausedAt.plus(java.time.Duration.parse("PT72H"));
+            Instant expectedDue = pausedAt.plus(Duration.parse("PT72H"));
             assertEquals(expectedDue, captor.getValue().getNextFire());
         }
 
@@ -329,9 +330,9 @@ class HitlCrashRecoveryObserverTest {
             // AgentOrchestratorResumeToolLoopTest#journalExecutedReplays.)
             var snapshot = pausedSnapshot("WAIT_INDEFINITELY", null, Instant.now().minus(1, ChronoUnit.HOURS));
             snapshot.setHitlPauseType("TOOL_CALL");
-            var batch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
+            var batch = new PendingToolCallBatch();
             batch.setPauseEpoch("epoch-crash-1");
-            var call = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+            var call = new PendingToolCallBatch.PendingToolCall();
             call.setCallId("call-1");
             call.setToolName("chargeCard");
             batch.setCalls(List.of(call));
@@ -416,7 +417,7 @@ class HitlCrashRecoveryObserverTest {
             // EXECUTION_INTERRUPTED; it must also clear the stray batch.
             var snapshot = new ConversationMemorySnapshot();
             snapshot.setAgentId("agent-1"); // no hitlPausedAt — the "unknown interrupted" branch
-            var orphanBatch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
+            var orphanBatch = new PendingToolCallBatch();
             orphanBatch.setPauseEpoch("orphan-epoch");
             snapshot.setHitlPendingToolCalls(orphanBatch);
             when(memStore.findConversationIdsByState(ConversationState.IN_PROGRESS))

--- a/src/test/java/ai/labs/eddi/engine/hitl/tools/ChatTranscriptCodecTest.java
+++ b/src/test/java/ai/labs/eddi/engine/hitl/tools/ChatTranscriptCodecTest.java
@@ -9,6 +9,7 @@ import dev.langchain4j.data.message.*;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 import static ai.labs.eddi.engine.memory.model.PendingToolCallBatch.TRANSCRIPT_MAX_BYTES_DEFAULT;
@@ -93,7 +94,7 @@ class ChatTranscriptCodecTest {
         // legally: ...AiMessage(with requests) -> results for every request id.
         var codec = new ChatTranscriptCodec();
         var result = codec.serialize(fullConversation(), 2_000_000);
-        List<ChatMessage> restored = new java.util.ArrayList<>(codec.deserialize(result.json()));
+        List<ChatMessage> restored = new ArrayList<>(codec.deserialize(result.json()));
         AiMessage pending = (AiMessage) restored.get(2);
         // simulate resume: answer the still-unanswered request (call_abc)
         restored.add(3 + 1, ToolExecutionResultMessage.from(pending.toolExecutionRequests().get(0),

--- a/src/test/java/ai/labs/eddi/engine/hitl/tools/HitlJournalCodecCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/hitl/tools/HitlJournalCodecCoverageTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.hitl.tools;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore.JournalEntry;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore.Status;
@@ -28,7 +29,9 @@ import org.mockito.Mock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -294,8 +297,8 @@ class HitlJournalCodecCoverageTest {
             return dev.langchain4j.agent.tool.ToolExecutionRequest.builder().id(id).name(name).arguments("{}").build();
         }
 
-        private static ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig cfg(List<String> require, List<String> exempt) {
-            var c = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+        private static ToolApprovalsConfig cfg(List<String> require, List<String> exempt) {
+            var c = new ToolApprovalsConfig();
             c.setRequireApproval(require);
             c.setExempt(exempt);
             return c;
@@ -306,9 +309,9 @@ class HitlJournalCodecCoverageTest {
         void exemptPrecedenceAllows() {
             var gate = new ToolApprovalGate();
             var batch = List.of(req("1", "read_file"));
-            var sources = java.util.Map.of("read_file", "mcp");
+            var sources = Map.of("read_file", "mcp");
             var result = gate.classify(batch, sources,
-                    cfg(List.of("mcp:*"), List.of("mcp:read_*")), java.util.Set.of());
+                    cfg(List.of("mcp:*"), List.of("mcp:read_*")), Set.of());
             assertTrue(result.gated().isEmpty(), "exempt must beat require");
             assertEquals(1, result.allowed().size());
         }
@@ -318,8 +321,8 @@ class HitlJournalCodecCoverageTest {
         void clearedCallIdAllowed() {
             var gate = new ToolApprovalGate();
             var batch = List.of(req("1", "delete_account"));
-            var result = gate.classify(batch, java.util.Map.of("delete_account", "http"),
-                    cfg(List.of("delete_*"), null), java.util.Set.of("1"));
+            var result = gate.classify(batch, Map.of("delete_account", "http"),
+                    cfg(List.of("delete_*"), null), Set.of("1"));
             assertTrue(result.gated().isEmpty());
             assertEquals(1, result.allowed().size());
         }
@@ -329,8 +332,8 @@ class HitlJournalCodecCoverageTest {
         void gatedNonNullIdRecordsReason() {
             var gate = new ToolApprovalGate();
             var batch = List.of(req("call-9", "delete_account"));
-            var result = gate.classify(batch, java.util.Map.of("delete_account", "http"),
-                    cfg(List.of("delete_*"), null), java.util.Set.of());
+            var result = gate.classify(batch, Map.of("delete_account", "http"),
+                    cfg(List.of("delete_*"), null), Set.of());
             assertEquals(1, result.gated().size());
             assertEquals("delete_*", result.gateReasonByCallId().get("call-9"),
                     "the matched require-pattern must be recorded as the gate reason");

--- a/src/test/java/ai/labs/eddi/engine/httpclient/SafeHttpClientTest.java
+++ b/src/test/java/ai/labs/eddi/engine/httpclient/SafeHttpClientTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.httpclient;
+import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
 
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.*;
@@ -212,7 +213,7 @@ class SafeHttpClientTest {
         // file:// URIs are rejected by both Java's HttpRequest.Builder AND
         // UrlValidationUtils. We test the validation layer directly here.
         assertThrows(IllegalArgumentException.class,
-                () -> ai.labs.eddi.modules.llm.tools.UrlValidationUtils.validateUrl("file:///etc/passwd"),
+                () -> UrlValidationUtils.validateUrl("file:///etc/passwd"),
                 "file:// scheme should be blocked by URL validation");
     }
 

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceCoverageTest.java
@@ -33,6 +33,7 @@ import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -129,7 +130,7 @@ class ConversationServiceCoverageTest {
     private ConversationMemorySnapshot createSnapshotWithSteps(int stepCount) {
         var snapshot = createSnapshot();
         var steps = new ArrayList<ConversationStepSnapshot>();
-        var outputs = new ArrayList<ai.labs.eddi.engine.memory.model.ConversationOutput>();
+        var outputs = new ArrayList<ConversationOutput>();
         for (int i = 0; i < stepCount; i++) {
             var step = new ConversationStepSnapshot();
             var workflowRun = new WorkflowRunSnapshot();
@@ -137,7 +138,7 @@ class ConversationServiceCoverageTest {
             workflowRun.setLifecycleTasks(List.of(result));
             step.setWorkflows(List.of(workflowRun));
             steps.add(step);
-            outputs.add(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            outputs.add(new ConversationOutput());
         }
         snapshot.setConversationSteps(steps);
         snapshot.setConversationOutputs(outputs);

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceDeepBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceDeepBranchTest.java
@@ -36,6 +36,7 @@ import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.engine.memory.model.ConversationProperties;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -44,6 +45,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.util.*;
+import java.util.HashSet;
+import java.util.Stack;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -343,13 +346,13 @@ class ConversationServiceDeepBranchTest {
             when(conversationMemory.getUserId()).thenReturn(USER_ID);
             when(conversationMemory.getAgentId()).thenReturn(AGENT_ID);
             when(conversationMemory.getAgentVersion()).thenReturn(1);
-            when(conversationMemory.getRedoCache()).thenReturn(new java.util.Stack<>());
+            when(conversationMemory.getRedoCache()).thenReturn(new Stack<>());
             var stepStack = mock(IConversationMemory.IConversationStepStack.class);
             when(stepStack.size()).thenReturn(0);
             when(conversationMemory.getAllSteps()).thenReturn(stepStack);
             when(conversationMemory.getConversationOutputs()).thenReturn(new ArrayList<>());
-            var conversationProperties = mock(ai.labs.eddi.engine.memory.model.ConversationProperties.class);
-            doReturn(new java.util.HashSet<>()).when(conversationProperties).entrySet();
+            var conversationProperties = mock(ConversationProperties.class);
+            doReturn(new HashSet<>()).when(conversationProperties).entrySet();
             when(conversationMemory.getConversationProperties()).thenReturn(conversationProperties);
             when(mockAgent.startConversation(any(), any(), any(), any())).thenReturn(conversation);
             when(conversationMemoryStore.storeConversationMemorySnapshot(any()))

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceExtendedTest.java
@@ -31,6 +31,9 @@ import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.runtime.IConversationSetup;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -229,7 +232,7 @@ class ConversationServiceExtendedTest {
         @Test
         @DisplayName("with memoryConfig — stores config correctly")
         void withMemoryConfig() {
-            var config = new ai.labs.eddi.configs.agents.model.AgentConfiguration.UserMemoryConfig();
+            var config = new AgentConfiguration.UserMemoryConfig();
             config.setMaxRecallEntries(100);
 
             var handler = conversationService.createPropertiesHandler(USER_ID, config);
@@ -265,7 +268,7 @@ class ConversationServiceExtendedTest {
             when(mockAgent.startConversation(anyString(), anyMap(), any(), any()))
                     .thenThrow(new InstantiationException("Agent init failed"));
 
-            assertThrows(ai.labs.eddi.datastore.IResourceStore.ResourceStoreException.class,
+            assertThrows(IResourceStore.ResourceStoreException.class,
                     () -> conversationService.startConversation(ENV, AGENT_ID, USER_ID, new LinkedHashMap<>()));
         }
     }
@@ -330,8 +333,8 @@ class ConversationServiceExtendedTest {
             step.setWorkflows(new ArrayList<>());
             snapshot.setConversationSteps(new ArrayList<>(List.of(step, step)));
             snapshot.setConversationOutputs(new ArrayList<>(List.of(
-                    new ai.labs.eddi.engine.memory.model.ConversationOutput(),
-                    new ai.labs.eddi.engine.memory.model.ConversationOutput())));
+                    new ConversationOutput(),
+                    new ConversationOutput())));
             when(conversationMemoryStore.loadConversationMemorySnapshot(CONVERSATION_ID)).thenReturn(snapshot);
 
             Boolean result = conversationService.isUndoAvailable(ENV, AGENT_ID, CONVERSATION_ID);

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceHitlCoverage2Test.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceHitlCoverage2Test.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -292,7 +293,7 @@ class ConversationServiceHitlCoverage2Test {
             // The coordinator rejects the resume submission (e.g. saturation) → the inner
             // catch removes the in-flight entry, restores the pause with rearm=true, and
             // wraps the failure.
-            doThrow(new java.util.concurrent.RejectedExecutionException("coordinator full"))
+            doThrow(new RejectedExecutionException("coordinator full"))
                     .when(conversationCoordinator).submitInOrder(eq(CONVERSATION_ID), any());
             doReturn(true).when(conversationMemoryStore).compareAndSetState(
                     CONVERSATION_ID, ConversationState.IN_PROGRESS, ConversationState.AWAITING_HUMAN);
@@ -326,7 +327,7 @@ class ConversationServiceHitlCoverage2Test {
             doReturn(agent).when(agentFactory).getAgent(ENV, AGENT_ID, AGENT_VERSION);
             doReturn(conversation).when(agent).continueConversation(any(IConversationMemory.class), any(), any());
 
-            doThrow(new java.util.concurrent.RejectedExecutionException("coordinator full"))
+            doThrow(new RejectedExecutionException("coordinator full"))
                     .when(conversationCoordinator).submitInOrder(eq(CONVERSATION_ID), any());
             // A concurrent end/cancel already moved the persisted state off IN_PROGRESS →
             // the restore CAS misses, so the pause is NOT restored and nothing is re-armed.

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceHitlCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceHitlCoverageTest.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.engine.security.CallerIdentityContext;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
@@ -51,8 +52,10 @@ import org.mockito.MockitoAnnotations;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -117,7 +120,7 @@ class ConversationServiceHitlCoverageTest {
     void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
         doReturn(conversationStateCache).when(cacheFactory).getCache("conversationState");
-        lenient().doReturn(new java.util.HashMap<String, String>()).when(contextLogger)
+        lenient().doReturn(new HashMap<String, String>()).when(contextLogger)
                 .createLoggingContext(any(), any(), any(), any());
         meterRegistry = new SimpleMeterRegistry();
         conversationService = new ConversationService(
@@ -136,10 +139,10 @@ class ConversationServiceHitlCoverageTest {
                     try {
                         Object result = callable.call();
                         listener.onComplete(result);
-                        return java.util.concurrent.CompletableFuture.completedFuture(result);
+                        return CompletableFuture.completedFuture(result);
                     } catch (Exception e) {
                         listener.onFailure(e);
-                        return java.util.concurrent.CompletableFuture.failedFuture(e);
+                        return CompletableFuture.failedFuture(e);
                     }
                 });
         lenient().when(conversationMemoryStore.storeConversationMemorySnapshotIfState(any(), any()))
@@ -546,7 +549,7 @@ class ConversationServiceHitlCoverageTest {
         void presentToolApprovals_populatesCarrier() throws Exception {
             var agentConfig = new AgentConfiguration();
             var hitl = new AgentConfiguration.HitlConfig();
-            var toolApprovals = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var toolApprovals = new ToolApprovalsConfig();
             hitl.setToolApprovals(toolApprovals);
             agentConfig.setHitlConfig(hitl);
             doReturn(agentConfig).when(agentStore).read(AGENT_ID, AGENT_VERSION);
@@ -561,7 +564,7 @@ class ConversationServiceHitlCoverageTest {
         void pinnedReadThrows_fallsBackToCurrent() throws Exception {
             var agentConfig = new AgentConfiguration();
             var hitl = new AgentConfiguration.HitlConfig();
-            hitl.setToolApprovals(new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig());
+            hitl.setToolApprovals(new ToolApprovalsConfig());
             agentConfig.setHitlConfig(hitl);
             // pinned read throws → fallback path
             doThrow(new ResourceStoreException("pinned gone")).when(agentStore).read(AGENT_ID, AGENT_VERSION);

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceHitlTest.java
@@ -32,6 +32,8 @@ import ai.labs.eddi.engine.runtime.IRuntime;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.engine.audit.model.AuditEntry;
+import ai.labs.eddi.engine.events.HitlResumeCompletedEvent;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -96,7 +98,7 @@ class ConversationServiceHitlTest {
     private ConversationService conversationService;
     // Held reference (not the shared no-op fixture) so the cancel-path HITL event
     // firing (G5) can be verified.
-    private jakarta.enterprise.event.Event<ai.labs.eddi.engine.events.HitlResumeCompletedEvent> hitlResumeCompletedEvent;
+    private jakarta.enterprise.event.Event<HitlResumeCompletedEvent> hitlResumeCompletedEvent;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -185,16 +187,16 @@ class ConversationServiceHitlTest {
 
             // G4-parity audit: the cancel is attributed to the actor with a CANCELLED
             // verdict.
-            ArgumentCaptor<ai.labs.eddi.engine.audit.model.AuditEntry> auditCaptor = ArgumentCaptor
-                    .forClass(ai.labs.eddi.engine.audit.model.AuditEntry.class);
+            ArgumentCaptor<AuditEntry> auditCaptor = ArgumentCaptor
+                    .forClass(AuditEntry.class);
             verify(auditLedgerService).submit(auditCaptor.capture());
             assertEquals("alice", auditCaptor.getValue().output().get("decidedBy"));
             assertEquals("CANCELLED", auditCaptor.getValue().output().get("verdict"));
 
             // G5: the terminal resume-completed event fires with a null verdict and the
             // actor.
-            ArgumentCaptor<ai.labs.eddi.engine.events.HitlResumeCompletedEvent> eventCaptor = ArgumentCaptor
-                    .forClass(ai.labs.eddi.engine.events.HitlResumeCompletedEvent.class);
+            ArgumentCaptor<HitlResumeCompletedEvent> eventCaptor = ArgumentCaptor
+                    .forClass(HitlResumeCompletedEvent.class);
             verify(hitlResumeCompletedEvent).fireAsync(eventCaptor.capture());
             assertNull(eventCaptor.getValue().verdict());
             assertEquals("alice", eventCaptor.getValue().decidedBy());

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceResumeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceResumeTest.java
@@ -31,6 +31,7 @@ import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot.ResultSnapsho
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot.WorkflowRunSnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
@@ -53,8 +54,10 @@ import org.mockito.MockitoAnnotations;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -141,10 +144,10 @@ class ConversationServiceResumeTest {
                     try {
                         Object result = callable.call();
                         listener.onComplete(result);
-                        return java.util.concurrent.CompletableFuture.completedFuture(result);
+                        return CompletableFuture.completedFuture(result);
                     } catch (Exception e) {
                         listener.onFailure(e);
-                        return java.util.concurrent.CompletableFuture.failedFuture(e);
+                        return CompletableFuture.failedFuture(e);
                     }
                 });
 
@@ -623,14 +626,14 @@ class ConversationServiceResumeTest {
 
             var snapshot = createResumeSnapshot();
             snapshot.setHitlPauseType("TOOL_CALL");
-            var batch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
+            var batch = new PendingToolCallBatch();
             batch.setPauseEpoch("epoch-undeploy-1");
-            var call = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+            var call = new PendingToolCallBatch.PendingToolCall();
             call.setCallId("call-1");
             call.setToolName("chargeCard");
             call.setSource("mcp");
             call.setArgumentsRaw("{}");
-            batch.setCalls(java.util.List.of(call));
+            batch.setCalls(List.of(call));
             snapshot.setHitlPendingToolCalls(batch);
             doReturn(snapshot).when(conversationMemoryStore).loadConversationMemorySnapshot(CONVERSATION_ID);
 

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceSayHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceSayHitlTest.java
@@ -35,6 +35,7 @@ import ai.labs.eddi.engine.runtime.IConversationCoordinator;
 import ai.labs.eddi.engine.runtime.IConversationSetup;
 import ai.labs.eddi.engine.runtime.IRuntime;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -51,6 +52,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -363,7 +366,7 @@ class ConversationServiceSayHitlTest {
             IConversation conversation = mock(IConversation.class);
             doReturn(agent).when(agentFactory).getAgent(ENV, AGENT_ID, AGENT_VERSION);
             doReturn(false).when(conversation).isEnded();
-            var memoryRef = new java.util.concurrent.atomic.AtomicReference<IConversationMemory>();
+            var memoryRef = new AtomicReference<IConversationMemory>();
             doAnswer(inv -> {
                 memoryRef.set(inv.getArgument(0));
                 return conversation;
@@ -429,7 +432,7 @@ class ConversationServiceSayHitlTest {
             doReturn(false).when(conversation).isEnded();
             // Capture the real live memory handed to continueConversation so we can
             // simulate the divergent-backend condition on it.
-            var memoryRef = new java.util.concurrent.atomic.AtomicReference<IConversationMemory>();
+            var memoryRef = new AtomicReference<IConversationMemory>();
             doAnswer(inv -> {
                 memoryRef.set(inv.getArgument(0));
                 return conversation;
@@ -485,7 +488,7 @@ class ConversationServiceSayHitlTest {
             IConversation conversation = mock(IConversation.class);
             doReturn(agent).when(agentFactory).getAgent(ENV, AGENT_ID, AGENT_VERSION);
             doReturn(false).when(conversation).isEnded();
-            var memoryRef = new java.util.concurrent.atomic.AtomicReference<IConversationMemory>();
+            var memoryRef = new AtomicReference<IConversationMemory>();
             doAnswer(inv -> {
                 memoryRef.set(inv.getArgument(0));
                 return conversation;
@@ -521,8 +524,8 @@ class ConversationServiceSayHitlTest {
             // never used on the fresh-pause commit path.
             verify(conversationMemoryStore).storeConversationMemorySnapshotIfState(any(), eq(ConversationState.READY));
             verify(conversationMemoryStore, never()).storeConversationMemorySnapshot(any());
-            ArgumentCaptor<ai.labs.eddi.engine.schedule.model.ScheduleConfiguration> schedCaptor = ArgumentCaptor
-                    .forClass(ai.labs.eddi.engine.schedule.model.ScheduleConfiguration.class);
+            ArgumentCaptor<ScheduleConfiguration> schedCaptor = ArgumentCaptor
+                    .forClass(ScheduleConfiguration.class);
             verify(scheduleStore).createSchedule(schedCaptor.capture());
             var schedule = schedCaptor.getValue();
             assertEquals("hitl-timeout-" + CONVERSATION_ID, schedule.getName());
@@ -571,7 +574,7 @@ class ConversationServiceSayHitlTest {
             IConversation conversation = mock(IConversation.class);
             doReturn(agent).when(agentFactory).getAgent(ENV, AGENT_ID, AGENT_VERSION);
             doReturn(false).when(conversation).isEnded();
-            var memoryRef = new java.util.concurrent.atomic.AtomicReference<IConversationMemory>();
+            var memoryRef = new AtomicReference<IConversationMemory>();
             doAnswer(inv -> {
                 memoryRef.set(inv.getArgument(0));
                 return conversation;
@@ -649,10 +652,10 @@ class ConversationServiceSayHitlTest {
             try {
                 Object result = callable.call();
                 listener.onComplete(result);
-                return java.util.concurrent.CompletableFuture.completedFuture(result);
+                return CompletableFuture.completedFuture(result);
             } catch (Exception e) {
                 listener.onFailure(e);
-                return java.util.concurrent.CompletableFuture.failedFuture(e);
+                return CompletableFuture.failedFuture(e);
             }
         }).when(runtime).submitCallable(any(Callable.class), any(IRuntime.IFinishedExecution.class), any());
     }

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceTest.java
@@ -43,6 +43,11 @@ import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.engine.audit.model.AuditEntry;
+import ai.labs.eddi.engine.events.HitlResumeCompletedEvent;
+import ai.labs.eddi.engine.memory.model.ConversationProperties;
+import ai.labs.eddi.engine.model.InputData;
+import ai.labs.eddi.engine.runtime.service.ServiceException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -53,6 +58,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.*;
+import java.util.Stack;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -105,7 +111,7 @@ class ConversationServiceTest {
     private ConversationService conversationService;
     // Held reference (not the shared no-op fixture) so HITL event-firing paths
     // (G5) can be verified.
-    private jakarta.enterprise.event.Event<ai.labs.eddi.engine.events.HitlResumeCompletedEvent> hitlResumeCompletedEvent;
+    private jakarta.enterprise.event.Event<HitlResumeCompletedEvent> hitlResumeCompletedEvent;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -161,9 +167,9 @@ class ConversationServiceTest {
             doReturn(conversation).when(agent).startConversation(eq(USER_ID), anyMap(), any(), isNull());
             doReturn(memory).when(conversation).getConversationMemory();
             doReturn(ConversationState.READY).when(memory).getConversationState();
-            doReturn(new java.util.Stack<>()).when(memory).getRedoCache();
+            doReturn(new Stack<>()).when(memory).getRedoCache();
             doReturn(mock(IConversationMemory.IConversationStepStack.class)).when(memory).getAllSteps();
-            doReturn(new ai.labs.eddi.engine.memory.model.ConversationProperties(memory)).when(memory).getConversationProperties();
+            doReturn(new ConversationProperties(memory)).when(memory).getConversationProperties();
             doReturn(CONVERSATION_ID).when(conversationMemoryStore).storeConversationMemorySnapshot(any());
 
             // Act — null context should NOT throw
@@ -226,9 +232,9 @@ class ConversationServiceTest {
             doReturn(conversation).when(agent).startConversation(eq(USER_ID), eq(context), any(), isNull());
             doReturn(memory).when(conversation).getConversationMemory();
             doReturn(ConversationState.READY).when(memory).getConversationState();
-            doReturn(new java.util.Stack<>()).when(memory).getRedoCache();
+            doReturn(new Stack<>()).when(memory).getRedoCache();
             doReturn(mock(IConversationMemory.IConversationStepStack.class)).when(memory).getAllSteps();
-            doReturn(new ai.labs.eddi.engine.memory.model.ConversationProperties(memory)).when(memory).getConversationProperties();
+            doReturn(new ConversationProperties(memory)).when(memory).getConversationProperties();
             doReturn(CONVERSATION_ID).when(conversationMemoryStore).storeConversationMemorySnapshot(any());
 
             ConversationResult result = conversationService.startConversation(ENV, AGENT_ID, USER_ID, context);
@@ -292,8 +298,8 @@ class ConversationServiceTest {
             verify(conversationMemoryStore).clearHitlBookmark(CONVERSATION_ID);
 
             // G4: an hitl.approval cancellation is audited attributed to the actor.
-            ArgumentCaptor<ai.labs.eddi.engine.audit.model.AuditEntry> auditCaptor = ArgumentCaptor
-                    .forClass(ai.labs.eddi.engine.audit.model.AuditEntry.class);
+            ArgumentCaptor<AuditEntry> auditCaptor = ArgumentCaptor
+                    .forClass(AuditEntry.class);
             verify(auditLedgerService).submit(auditCaptor.capture());
             var detail = auditCaptor.getValue().output(); // hitl.approval detail is carried in the 'output' map
             assertEquals("alice", detail.get("decidedBy"));
@@ -301,8 +307,8 @@ class ConversationServiceTest {
 
             // G5: the terminal resume-completed event fires with a null verdict and
             // the actor so channel observers (Slack) can render the outcome.
-            ArgumentCaptor<ai.labs.eddi.engine.events.HitlResumeCompletedEvent> eventCaptor = ArgumentCaptor
-                    .forClass(ai.labs.eddi.engine.events.HitlResumeCompletedEvent.class);
+            ArgumentCaptor<HitlResumeCompletedEvent> eventCaptor = ArgumentCaptor
+                    .forClass(HitlResumeCompletedEvent.class);
             verify(hitlResumeCompletedEvent).fireAsync(eventCaptor.capture());
             assertNull(eventCaptor.getValue().verdict(), "cancel/end fires a null verdict");
             assertEquals("alice", eventCaptor.getValue().decidedBy());
@@ -318,8 +324,8 @@ class ConversationServiceTest {
 
             conversationService.endConversation(CONVERSATION_ID);
 
-            ArgumentCaptor<ai.labs.eddi.engine.audit.model.AuditEntry> auditCaptor = ArgumentCaptor
-                    .forClass(ai.labs.eddi.engine.audit.model.AuditEntry.class);
+            ArgumentCaptor<AuditEntry> auditCaptor = ArgumentCaptor
+                    .forClass(AuditEntry.class);
             verify(auditLedgerService).submit(auditCaptor.capture());
             assertEquals("system:end", auditCaptor.getValue().output().get("decidedBy"));
         }
@@ -695,7 +701,7 @@ class ConversationServiceTest {
             snapshot.setEnvironment(ENV);
             doReturn(snapshot).when(conversationMemoryStore).loadConversationMemorySnapshot(CONVERSATION_ID);
 
-            var inputData = new ai.labs.eddi.engine.model.InputData("hello", new LinkedHashMap<>());
+            var inputData = new InputData("hello", new LinkedHashMap<>());
 
             // The env-based say will fail because no agent is deployed.
             // We just verify the snapshot was loaded by the single-arg overload.
@@ -718,7 +724,7 @@ class ConversationServiceTest {
             snapshot.setEnvironment(ENV);
             doReturn(snapshot).when(conversationMemoryStore).loadConversationMemorySnapshot(CONVERSATION_ID);
 
-            var inputData = new ai.labs.eddi.engine.model.InputData("hello", new LinkedHashMap<>());
+            var inputData = new InputData("hello", new LinkedHashMap<>());
 
             assertThrows(IConversationService.AgentNotReadyException.class,
                     () -> conversationService.sayStreaming(CONVERSATION_ID, false, false, null, inputData, null));
@@ -869,7 +875,7 @@ class ConversationServiceTest {
             doReturn(USER_ID).when(conversationSetup).computeAnonymousUserIdIfEmpty(eq(USER_ID), isNull());
             doReturn(false).when(gdprComplianceService).isProcessingRestricted(USER_ID);
             doReturn(new HashMap<>()).when(contextLogger).createLoggingContext(any(), any(), any(), any());
-            doThrow(new ai.labs.eddi.engine.runtime.service.ServiceException("agent factory boom"))
+            doThrow(new ServiceException("agent factory boom"))
                     .when(agentFactory).getLatestReadyAgent(ENV, AGENT_ID);
 
             var ex = assertThrows(ResourceStoreException.class,

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceToolTimeoutTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceToolTimeoutTest.java
@@ -53,7 +53,9 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -154,10 +156,10 @@ class ConversationServiceToolTimeoutTest {
                     try {
                         Object result = callable.call();
                         listener.onComplete(result);
-                        return java.util.concurrent.CompletableFuture.completedFuture(result);
+                        return CompletableFuture.completedFuture(result);
                     } catch (Exception e) {
                         listener.onFailure(e);
-                        return java.util.concurrent.CompletableFuture.failedFuture(e);
+                        return CompletableFuture.failedFuture(e);
                     }
                 });
 
@@ -406,7 +408,7 @@ class ConversationServiceToolTimeoutTest {
             Object toolDecisionsObj = approval.output().get("toolDecisions");
             assertInstanceOf(List.class, toolDecisionsObj, "toolDecisions summary must be present");
             @SuppressWarnings("unchecked")
-            List<java.util.Map<String, Object>> toolDecisions = (List<java.util.Map<String, Object>>) toolDecisionsObj;
+            List<Map<String, Object>> toolDecisions = (List<Map<String, Object>>) toolDecisionsObj;
             assertFalse(toolDecisions.isEmpty());
 
             var first = toolDecisions.get(0);

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceAbstentionTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceAbstentionTest.java
@@ -26,6 +26,7 @@ import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
@@ -41,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -133,7 +135,7 @@ class GroupConversationServiceAbstentionTest {
 
     /** Routes each agent's reply through {@code responder}, keyed by agent id. */
     private void stubTurns(Function<String, String> responder) throws Exception {
-        doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class)).when(agentFactory).getLatestReadyAgent(any(), anyString());
+        doReturn(mock(IAgent.class)).when(agentFactory).getLatestReadyAgent(any(), anyString());
         doReturn(new IConversationService.ConversationResult("member-conv", null))
                 .when(conversationService).startConversation(any(), any(), any(), any());
         doAnswer(inv -> {
@@ -164,7 +166,7 @@ class GroupConversationServiceAbstentionTest {
 
         var byAgent = gc.getTranscript().stream()
                 .filter(e -> e.speakerAgentId() != null)
-                .collect(java.util.stream.Collectors.toMap(e -> e.speakerAgentId(), e -> e, (a, b) -> a));
+                .collect(Collectors.toMap(e -> e.speakerAgentId(), e -> e, (a, b) -> a));
         assertEquals(TranscriptEntryType.ABSTAINED, byAgent.get(AGENT_A).type());
         assertNull(byAgent.get(AGENT_A).content(),
                 "recording 'PASS' as content would put a non-answer into the record that peers and the synthesizer read as a position");

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceBranchCoverageTest.java
@@ -24,6 +24,7 @@ import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResponseHandler;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
@@ -864,7 +865,7 @@ class GroupConversationServiceBranchCoverageTest {
                     .thenReturn(null);
 
             var listener = mock(
-                    ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener.class);
+                    IGroupConversationService.GroupDiscussionEventListener.class);
 
             var gc = serviceWithSigning.startAndDiscussAsync(GROUP_ID, QUESTION, USER_ID, listener);
             assertNotNull(gc);

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceConvergenceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceConvergenceTest.java
@@ -21,6 +21,7 @@ import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ProtocolConfig.
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ProtocolConfig.MemberUnavailablePolicy;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TurnOrder;
 import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
@@ -28,6 +29,7 @@ import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventLis
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
@@ -134,7 +136,7 @@ class GroupConversationServiceConvergenceTest {
      * turn returns the verdict JSON.
      */
     private void stubTurns(String memberResponse, String judgeVerdictJson) throws Exception {
-        doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class)).when(agentFactory).getLatestReadyAgent(any(), anyString());
+        doReturn(mock(IAgent.class)).when(agentFactory).getLatestReadyAgent(any(), anyString());
         doReturn(new IConversationService.ConversationResult("member-conv", null))
                 .when(conversationService).startConversation(any(), any(), any(), any());
         doAnswer(inv -> {
@@ -226,7 +228,7 @@ class GroupConversationServiceConvergenceTest {
                 .filter(e -> AGENT_A.equals(e.speakerAgentId()))
                 .count();
         assertEquals(3, memberTurns, "an unreadable verdict must leave the discussion exactly as it would have been");
-        assertNotEquals(ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState.FAILED, gc.getState(),
+        assertNotEquals(GroupConversation.GroupConversationState.FAILED, gc.getState(),
                 "a convergence check is an optimization — it must never be why a discussion dies");
     }
 

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceCostCeilingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceCostCeilingTest.java
@@ -31,6 +31,7 @@ import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot.ConversationStepData;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot.SimpleConversationStep;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
+import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
@@ -45,6 +46,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -142,10 +144,10 @@ class GroupConversationServiceCostCeilingTest {
         // Without a deployed agent every member turn short-circuits to a SKIPPED
         // "Agent not deployed" entry and never reaches say() — so no cost would ever
         // accumulate and the ceiling could never trip.
-        doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class)).when(agentFactory).getLatestReadyAgent(any(), anyString());
+        doReturn(mock(IAgent.class)).when(agentFactory).getLatestReadyAgent(any(), anyString());
         doReturn(new IConversationService.ConversationResult("member-conv", null))
                 .when(conversationService).startConversation(any(), any(), any(), any());
-        var counter = new java.util.concurrent.atomic.AtomicInteger();
+        var counter = new AtomicInteger();
         doAnswer(inv -> {
             IConversationService.ConversationResponseHandler handler = inv.getArgument(8);
             if (handler != null) {

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceExtendedTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.internal;
+import ai.labs.eddi.configs.agents.IAgentStore;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
@@ -19,6 +20,7 @@ import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResponseHandler;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
@@ -29,6 +31,7 @@ import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,6 +41,7 @@ import org.mockito.ArgumentCaptor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -60,7 +64,7 @@ class GroupConversationServiceExtendedTest {
     private IJsonSerialization jsonSerialization;
     private GroupConversationService service;
 
-    private ai.labs.eddi.configs.agents.IAgentStore agentStore;
+    private IAgentStore agentStore;
 
     private static final String GROUP_ID = "test-group";
     private static final String USER_ID = "test-user";
@@ -75,7 +79,7 @@ class GroupConversationServiceExtendedTest {
         templatingEngine = mock(ITemplatingEngine.class);
         jsonSerialization = mock(IJsonSerialization.class);
 
-        agentStore = mock(ai.labs.eddi.configs.agents.IAgentStore.class);
+        agentStore = mock(IAgentStore.class);
         service = new GroupConversationService(groupStore, conversationStore,
                 conversationService, agentFactory, templatingEngine,
                 jsonSerialization, new SimpleMeterRegistry(),
@@ -589,7 +593,7 @@ class GroupConversationServiceExtendedTest {
             // proves nothing about what a crashed-and-recovered pod would see
             // (review finding: a captor would hold the same mutable instance, so
             // the value is recorded AT persist time instead).
-            var basesAtPersistTime = new java.util.ArrayList<Integer>();
+            var basesAtPersistTime = new ArrayList<Integer>();
             doAnswer(inv -> {
                 basesAtPersistTime.add(((GroupConversation) inv.getArgument(0)).getPausedRepeatSliceBase());
                 return null;
@@ -622,9 +626,9 @@ class GroupConversationServiceExtendedTest {
             gc.setState(GroupConversationState.IN_PROGRESS);
             gc.setOriginalQuestion(QUESTION);
             gc.getTranscript().add(new TranscriptEntry("a1", "Alice", "Opinion A", 0, "Discuss",
-                    TranscriptEntryType.OPINION, java.time.Instant.now(), null, null));
+                    TranscriptEntryType.OPINION, Instant.now(), null, null));
             gc.getTranscript().add(new TranscriptEntry("h1", "Hannah", "Human view", 0, "Discuss",
-                    TranscriptEntryType.OPINION, java.time.Instant.now(), null, null));
+                    TranscriptEntryType.OPINION, Instant.now(), null, null));
             gc.setResumePoint(new GroupConversation.ResumePoint(0, 0, 2, GroupConversation.RESUME_KIND_HUMAN_TURN));
             gc.setPausedRepeatSliceBase(0);
 
@@ -685,7 +689,7 @@ class GroupConversationServiceExtendedTest {
 
             // Gate the first agent response so the async thread blocks until we release it.
             // This guarantees the state is still IN_PROGRESS when we assert.
-            var gate = new java.util.concurrent.CountDownLatch(1);
+            var gate = new CountDownLatch(1);
 
             when(agentFactory.getLatestReadyAgent(any(Environment.class), eq("a1")))
                     .thenReturn(mock(IAgent.class));
@@ -1111,7 +1115,7 @@ class GroupConversationServiceExtendedTest {
             // executeDiscussion must surface an execution failure as
             // GroupExecutionException
             // (which REST maps to 5xx), not a bare GroupDiscussionException (409).
-            assertThrows(ai.labs.eddi.engine.api.IGroupConversationService.GroupExecutionException.class,
+            assertThrows(IGroupConversationService.GroupExecutionException.class,
                     () -> service.discuss(GROUP_ID, QUESTION, USER_ID, 0));
         }
 
@@ -1127,7 +1131,7 @@ class GroupConversationServiceExtendedTest {
             when(agentFactory.getLatestReadyAgent(any(Environment.class), eq("a1")))
                     .thenThrow(new RuntimeException("Agent check failed"));
 
-            assertThrows(ai.labs.eddi.engine.api.IGroupConversationService.GroupExecutionException.class,
+            assertThrows(IGroupConversationService.GroupExecutionException.class,
                     () -> service.discuss(GROUP_ID, QUESTION, USER_ID, 0));
         }
 
@@ -1203,7 +1207,7 @@ class GroupConversationServiceExtendedTest {
             // to
             // 504 (not the 502 an ordinary execution failure gets). executeDiscussion's
             // re-wrap preserves the subtype.
-            assertThrows(ai.labs.eddi.engine.api.IGroupConversationService.GroupTimeoutException.class,
+            assertThrows(IGroupConversationService.GroupTimeoutException.class,
                     () -> service.discuss(GROUP_ID, QUESTION, USER_ID, 0));
         }
     }
@@ -1236,7 +1240,7 @@ class GroupConversationServiceExtendedTest {
             setupStore(cfg);
 
             assertThrows(
-                    ai.labs.eddi.engine.api.IGroupConversationService.GroupDepthExceededException.class,
+                    IGroupConversationService.GroupDepthExceededException.class,
                     () -> service.discuss(GROUP_ID, QUESTION, USER_ID, 4));
         }
     }

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceHitlCoverage2Test.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceHitlCoverage2Test.java
@@ -30,8 +30,10 @@ import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.audit.AuditLedgerService;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
+import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
@@ -47,6 +49,7 @@ import org.mockito.MockitoAnnotations;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -162,9 +165,9 @@ class GroupConversationServiceHitlCoverage2Test {
     private SimpleConversationMemorySnapshot snapshot(ConversationState state, String text) {
         var snap = new SimpleConversationMemorySnapshot();
         snap.setConversationState(state);
-        var output = new ai.labs.eddi.engine.memory.model.ConversationOutput();
+        var output = new ConversationOutput();
         output.put("output", List.of(text));
-        snap.setConversationOutputs(new java.util.ArrayList<>(List.of(output)));
+        snap.setConversationOutputs(new ArrayList<>(List.of(output)));
         return snap;
     }
 
@@ -305,7 +308,7 @@ class GroupConversationServiceHitlCoverage2Test {
         // placeholder
         var errSnap = new SimpleConversationMemorySnapshot();
         errSnap.setConversationState(ConversationState.ERROR);
-        errSnap.setConversationOutputs(new java.util.ArrayList<>());
+        errSnap.setConversationOutputs(new ArrayList<>());
         doAnswer(inv -> {
             IConversationService.ConversationResponseHandler h = inv.getArgument(2);
             h.onComplete(errSnap);
@@ -959,7 +962,7 @@ class GroupConversationServiceHitlCoverage2Test {
     void propagateEmptySteps() {
         var gc = pausedPhaseGc("gc-prop-empty");
         var snap = new SimpleConversationMemorySnapshot();
-        snap.setConversationSteps(new java.util.ArrayList<>());
+        snap.setConversationSteps(new ArrayList<>());
         GroupConversationService.propagateDynamicAgentTracking(snap, gc);
         assertTrue(gc.getCreatedAgentIds().isEmpty());
     }
@@ -998,7 +1001,7 @@ class GroupConversationServiceHitlCoverage2Test {
                 AgentGroupConfiguration.ProtocolConfig.MemberFailurePolicy.ABORT, 2,
                 AgentGroupConfiguration.ProtocolConfig.MemberUnavailablePolicy.SKIP);
 
-        assertThrows(ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException.class,
+        assertThrows(IGroupConversationService.GroupDiscussionException.class,
                 () -> invoke(m, member(), 0, phase(PhaseType.OPINION), protocol,
                         new RuntimeException("fail"), "Agent failed", null));
     }

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceHitlCoverage3Test.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceHitlCoverage3Test.java
@@ -32,6 +32,8 @@ import ai.labs.eddi.engine.internal.groups.TaskForceEngine;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
+import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
+import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
@@ -45,8 +47,12 @@ import org.mockito.MockitoAnnotations;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -339,7 +345,7 @@ class GroupConversationServiceHitlCoverage3Test {
     @Test
     @DisplayName("filterByScope: ANONYMOUS scope → speaker attribution stripped to 'Anonymous'")
     void filterByScopeAnonymous() throws Exception {
-        var result = (List<java.util.Map<String, Object>>) filterByScope(ContextScope.ANONYMOUS,
+        var result = (List<Map<String, Object>>) filterByScope(ContextScope.ANONYMOUS,
                 List.of(entry(AGENT_A, "Agent A", "secret", TranscriptEntryType.OPINION, null)), 1, member());
         assertEquals(1, result.size());
         assertEquals("Anonymous", result.get(0).get("speaker"));
@@ -561,11 +567,11 @@ class GroupConversationServiceHitlCoverage3Test {
         var g = gc("gc-taskphase-default");
         var m = method("executeTaskPhase", GroupConversation.class, AgentGroupConfiguration.class,
                 List.class, DiscussionPhase.class, ProtocolConfig.class, String.class, int.class,
-                GroupDiscussionEventListener.class, java.util.concurrent.atomic.AtomicInteger.class, int.class);
+                GroupDiscussionEventListener.class, AtomicInteger.class, int.class);
         // OPINION is not a task phase — routed to default arm which just logs
         assertDoesNotThrow(() -> invoke(m, g, buildConfig(List.of()), List.of(member()),
                 phase(PhaseType.OPINION), defaultProtocol(), "Q?", 0, null,
-                new java.util.concurrent.atomic.AtomicInteger(0), 50));
+                new AtomicInteger(0), 50));
     }
 
     // =================================================================
@@ -579,10 +585,10 @@ class GroupConversationServiceHitlCoverage3Test {
         g.setTaskList(null);
         var m = method("executeTaskExecutionPhase", GroupConversation.class, AgentGroupConfiguration.class,
                 List.class, DiscussionPhase.class, ProtocolConfig.class, String.class, int.class,
-                GroupDiscussionEventListener.class, java.util.concurrent.atomic.AtomicInteger.class, int.class);
+                GroupDiscussionEventListener.class, AtomicInteger.class, int.class);
         assertDoesNotThrow(() -> invoke(m, g, buildConfig(List.of()), List.of(member()),
                 phase(PhaseType.EXECUTE), defaultProtocol(), "Q?", 0, null,
-                new java.util.concurrent.atomic.AtomicInteger(0), 50));
+                new AtomicInteger(0), 50));
     }
 
     @Test
@@ -592,10 +598,10 @@ class GroupConversationServiceHitlCoverage3Test {
         g.setTaskList(new SharedTaskList());
         var m = method("executeTaskExecutionPhase", GroupConversation.class, AgentGroupConfiguration.class,
                 List.class, DiscussionPhase.class, ProtocolConfig.class, String.class, int.class,
-                GroupDiscussionEventListener.class, java.util.concurrent.atomic.AtomicInteger.class, int.class);
+                GroupDiscussionEventListener.class, AtomicInteger.class, int.class);
         assertDoesNotThrow(() -> invoke(m, g, buildConfig(List.of()), List.of(member()),
                 phase(PhaseType.EXECUTE), defaultProtocol(), "Q?", 0, null,
-                new java.util.concurrent.atomic.AtomicInteger(0), 50));
+                new AtomicInteger(0), 50));
     }
 
     // =================================================================
@@ -605,7 +611,7 @@ class GroupConversationServiceHitlCoverage3Test {
     private Method verifyPhaseMethod() throws NoSuchMethodException {
         return method("executeTaskVerificationPhase", GroupConversation.class, AgentGroupConfiguration.class,
                 List.class, DiscussionPhase.class, ProtocolConfig.class, String.class, int.class,
-                GroupDiscussionEventListener.class, java.util.concurrent.atomic.AtomicInteger.class, int.class);
+                GroupDiscussionEventListener.class, AtomicInteger.class, int.class);
     }
 
     @Test
@@ -615,7 +621,7 @@ class GroupConversationServiceHitlCoverage3Test {
         g.setTaskList(null);
         assertDoesNotThrow(() -> invoke(verifyPhaseMethod(), g, buildConfig(List.of()), List.of(member()),
                 phase(PhaseType.VERIFY), defaultProtocol(), "Q?", 0, null,
-                new java.util.concurrent.atomic.AtomicInteger(0), 50));
+                new AtomicInteger(0), 50));
     }
 
     @Test
@@ -627,7 +633,7 @@ class GroupConversationServiceHitlCoverage3Test {
         g.setTaskList(taskList);
         invoke(verifyPhaseMethod(), g, buildConfig(List.of()), List.of(member()),
                 phase(PhaseType.VERIFY), defaultProtocol(), "Q?", 0, null,
-                new java.util.concurrent.atomic.AtomicInteger(0), 50);
+                new AtomicInteger(0), 50);
         assertTrue(g.getTranscript().stream()
                 .anyMatch(e -> e.type() == TranscriptEntryType.VERIFICATION),
                 "a VERIFICATION 'no completed tasks' note is recorded");
@@ -647,7 +653,7 @@ class GroupConversationServiceHitlCoverage3Test {
         // empty speakers → no verifier
         assertDoesNotThrow(() -> invoke(verifyPhaseMethod(), g, buildConfig(List.of()), List.of(),
                 phase(PhaseType.VERIFY), defaultProtocol(), "Q?", 0, null,
-                new java.util.concurrent.atomic.AtomicInteger(0), 50));
+                new AtomicInteger(0), 50));
     }
 
     // =================================================================
@@ -686,7 +692,7 @@ class GroupConversationServiceHitlCoverage3Test {
     void parseVerificationJsonPassed() throws Exception {
         var g = gcWithCompletedTask("gc-verif-json");
         var completed = g.getTaskList().all();
-        doReturn(List.of(java.util.Map.of("subject", "Build", "passed", true, "feedback", "ok")))
+        doReturn(List.of(Map.of("subject", "Build", "passed", true, "feedback", "ok")))
                 .when(jsonSerialization).deserialize(anyString(), eq(List.class));
         invoke(parseVerificationMethod(), g, completed, "[{\"subject\":\"Build\",\"passed\":true}]", null);
         assertEquals(TaskStatus.VERIFIED, g.getTaskList().all().get(0).status());
@@ -697,7 +703,7 @@ class GroupConversationServiceHitlCoverage3Test {
     void parseVerificationJsonFailed() throws Exception {
         var g = gcWithCompletedTask("gc-verif-json-fail");
         var completed = g.getTaskList().all();
-        doReturn(List.of(java.util.Map.of("subject", "Build", "passed", false)))
+        doReturn(List.of(Map.of("subject", "Build", "passed", false)))
                 .when(jsonSerialization).deserialize(anyString(), eq(List.class));
         invoke(parseVerificationMethod(), g, completed, "[{\"subject\":\"Build\",\"passed\":false}]", null);
         assertEquals(TaskStatus.FAILED, g.getTaskList().all().get(0).status());
@@ -801,7 +807,7 @@ class GroupConversationServiceHitlCoverage3Test {
         g.setTaskList(taskList);
         var task = g.getTaskList().all().get(0);
 
-        var errors = java.util.Collections.synchronizedList(new java.util.ArrayList<GroupDiscussionException>());
+        var errors = Collections.synchronizedList(new ArrayList<GroupDiscussionException>());
         // handleTaskFailure was split so the SSE listener callback is not made while
         // holding the task-list monitor; recordTaskFailure is the document-mutating
         // half these tests actually assert on.
@@ -829,7 +835,7 @@ class GroupConversationServiceHitlCoverage3Test {
         g.setTaskList(taskList);
         var task = g.getTaskList().all().get(0);
 
-        var errors = java.util.Collections.synchronizedList(new java.util.ArrayList<GroupDiscussionException>());
+        var errors = Collections.synchronizedList(new ArrayList<GroupDiscussionException>());
         // handleTaskFailure was split so the SSE listener callback is not made while
         // holding the task-list monitor; recordTaskFailure is the document-mutating
         // half these tests actually assert on.
@@ -993,9 +999,9 @@ class GroupConversationServiceHitlCoverage3Test {
     @Test
     @DisplayName("extractResponse: metadata-only snapshot (no outputs) → empty string, never null")
     void extractResponseEmpty() throws Exception {
-        var snap = new ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot();
+        var snap = new SimpleConversationMemorySnapshot();
         var m = method("extractResponse",
-                ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot.class);
+                SimpleConversationMemorySnapshot.class);
         Object result = invoke(m, snap);
         assertEquals("", result, "null extraction is coerced to empty string for GCS callers");
     }
@@ -1111,7 +1117,7 @@ class GroupConversationServiceHitlCoverage3Test {
                 .when(conversationStore).read("gc-cancel-missing");
         assertThrows(IResourceStore.ResourceNotFoundException.class,
                 () -> service.cancelDiscussion("gc-cancel-missing",
-                        ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL));
+                        ControlSignal.CANCEL_GRACEFUL));
     }
 
     // =================================================================

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceHitlCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceHitlCoverageTest.java
@@ -27,15 +27,19 @@ import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDepthExceededException;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.audit.AuditLedgerService;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.lifecycle.model.DiscussionControlToken;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict;
+import ai.labs.eddi.engine.memory.model.ConversationOutput;
+import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,7 +47,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -141,12 +148,12 @@ class GroupConversationServiceHitlCoverageTest {
     }
 
     @SuppressWarnings("unchecked")
-    private java.util.concurrent.ConcurrentHashMap<String, DiscussionControlToken> activeTokens(
-                                                                                                GroupConversationService svc)
+    private ConcurrentHashMap<String, DiscussionControlToken> activeTokens(
+                                                                           GroupConversationService svc)
             throws Exception {
         var field = GroupConversationService.class.getDeclaredField("activeTokens");
         field.setAccessible(true);
-        return (java.util.concurrent.ConcurrentHashMap<String, DiscussionControlToken>) field.get(svc);
+        return (ConcurrentHashMap<String, DiscussionControlToken>) field.get(svc);
     }
 
     private GroupApprovalRequest approvedRequest() {
@@ -228,7 +235,7 @@ class GroupConversationServiceHitlCoverageTest {
         doReturn(gc).when(conversationStore).read("gc-phase-with-taskapprovals");
 
         var request = approvedRequest();
-        request.setTaskApprovals(java.util.Map.of("whatever", "APPROVED"));
+        request.setTaskApprovals(Map.of("whatever", "APPROVED"));
 
         var ex = assertThrows(IllegalArgumentException.class,
                 () -> service.resumeDiscussion("gc-phase-with-taskapprovals", request, null));
@@ -245,7 +252,7 @@ class GroupConversationServiceHitlCoverageTest {
         doReturn(gc).when(conversationStore).read("gc-no-tasklist");
 
         var request = approvedRequest();
-        request.setTaskApprovals(java.util.Map.of("whatever", "APPROVED"));
+        request.setTaskApprovals(Map.of("whatever", "APPROVED"));
 
         var ex = assertThrows(IllegalArgumentException.class,
                 () -> service.resumeDiscussion("gc-no-tasklist", request, null));
@@ -363,10 +370,10 @@ class GroupConversationServiceHitlCoverageTest {
     }
 
     private void stubAgentSay() throws Exception {
-        var snapshot = new ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot();
-        var output = new ai.labs.eddi.engine.memory.model.ConversationOutput();
+        var snapshot = new SimpleConversationMemorySnapshot();
+        var output = new ConversationOutput();
         output.put("output", List.of("Test response"));
-        snapshot.setConversationOutputs(new java.util.ArrayList<>(List.of(output)));
+        snapshot.setConversationOutputs(new ArrayList<>(List.of(output)));
         doAnswer(inv -> {
             IConversationService.ConversationResponseHandler handler = inv.getArgument(8);
             if (handler != null) {
@@ -451,7 +458,7 @@ class GroupConversationServiceHitlCoverageTest {
         var gc = pausedPhaseGc("gc-past-due");
         gc.setHitlTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
         gc.setHitlApprovalTimeout("PT1M");
-        gc.setPausedAt(Instant.now().minus(java.time.Duration.ofHours(2))); // long past due
+        gc.setPausedAt(Instant.now().minus(Duration.ofHours(2))); // long past due
 
         var m = GroupConversationService.class.getDeclaredMethod(
                 "scheduleGroupHitlTimeout", GroupConversation.class);
@@ -477,7 +484,7 @@ class GroupConversationServiceHitlCoverageTest {
 
     /** The listener parameter type used by the private convert overload. */
     private Class<?> IGroupConversationServiceListenerType() {
-        return ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener.class;
+        return IGroupConversationService.GroupDiscussionEventListener.class;
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceHitlTest.java
@@ -29,10 +29,17 @@ import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
+import ai.labs.eddi.engine.api.IGroupConversationService;
+import ai.labs.eddi.engine.audit.AuditLedgerService;
+import ai.labs.eddi.engine.audit.model.AuditEntry;
+import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
+import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
+import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -47,9 +54,18 @@ import org.mockito.MockitoAnnotations;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -286,9 +302,9 @@ class GroupConversationServiceHitlTest {
             // the returned object would race the async resumed leg, which mutates the
             // shared gc (and flips it to COMPLETED) — the CAS point is where the
             // clear-pause block deterministically runs.
-            var casState = new java.util.concurrent.atomic.AtomicReference<GroupConversationState>();
-            var casPhaseIndex = new java.util.concurrent.atomic.AtomicInteger(Integer.MIN_VALUE);
-            var casPausedAtWasNull = new java.util.concurrent.atomic.AtomicBoolean(false);
+            var casState = new AtomicReference<GroupConversationState>();
+            var casPhaseIndex = new AtomicInteger(Integer.MIN_VALUE);
+            var casPausedAtWasNull = new AtomicBoolean(false);
             doAnswer(inv -> {
                 GroupConversation g = inv.getArgument(0);
                 if (casState.compareAndSet(null, g.getState())) {
@@ -465,7 +481,7 @@ class GroupConversationServiceHitlTest {
             // executeDiscussion can seed turnCounter from it (M3). Capturing here (not
             // on the live gc after return) removes the race with the async discussion
             // completing and resetting pausedTurnCount to 0.
-            var capturedTurnCount = new java.util.concurrent.atomic.AtomicInteger(-1);
+            var capturedTurnCount = new AtomicInteger(-1);
             doAnswer(inv -> {
                 GroupConversation g = inv.getArgument(0);
                 capturedTurnCount.compareAndSet(-1, g.getPausedTurnCount());
@@ -675,14 +691,14 @@ class GroupConversationServiceHitlTest {
             var field = GroupConversationService.class.getDeclaredField("activeTokens");
             field.setAccessible(true);
             @SuppressWarnings("unchecked")
-            var activeTokens = (java.util.concurrent.ConcurrentHashMap<String, ?>) field.get(service);
+            var activeTokens = (ConcurrentHashMap<String, ?>) field.get(service);
             assertFalse(activeTokens.containsKey("gc-real-pause"),
                     "NEW-2: activeTokens MUST be empty after pause (finally block removes token)");
 
             // Step 3: Cancel. With no token, cancelDiscussion takes the DB-write branch.
             doReturn(gc).when(conversationStore).read("gc-real-pause");
             service.cancelDiscussion("gc-real-pause",
-                    ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL);
+                    ControlSignal.CANCEL_GRACEFUL);
 
             assertEquals(GroupConversationState.CANCELLED, gc.getState(),
                     "Paused GC should be CANCELLED via DB write");
@@ -725,7 +741,7 @@ class GroupConversationServiceHitlTest {
 
             // Agent factory must return a non-null agent so executeAgentTurn
             // doesn't skip with SKIPPED entry
-            doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class))
+            doReturn(mock(IAgent.class))
                     .when(agentFactory).getLatestReadyAgent(any(), eq(AGENT_A));
 
             // startConversation must return a result with a conversation ID
@@ -733,12 +749,12 @@ class GroupConversationServiceHitlTest {
             doReturn(convResult).when(conversationService).startConversation(any(), any(), any(), any());
 
             // Latch: agent say blocks until cancel fires
-            var agentBlocked = new java.util.concurrent.CountDownLatch(1);
-            var cancelFired = new java.util.concurrent.CountDownLatch(1);
+            var agentBlocked = new CountDownLatch(1);
+            var cancelFired = new CountDownLatch(1);
 
             doAnswer(inv -> {
                 agentBlocked.countDown(); // signal: agent is running
-                cancelFired.await(5, java.util.concurrent.TimeUnit.SECONDS); // block until cancel
+                cancelFired.await(5, TimeUnit.SECONDS); // block until cancel
 
                 // Return a minimal response
                 var snapshot = new SimpleConversationMemorySnapshot();
@@ -754,8 +770,8 @@ class GroupConversationServiceHitlTest {
             }).when(conversationService).say(any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any());
 
             // Run discuss on a separate thread
-            var resultHolder = new java.util.concurrent.atomic.AtomicReference<GroupConversation>();
-            var exHolder = new java.util.concurrent.atomic.AtomicReference<Exception>();
+            var resultHolder = new AtomicReference<GroupConversation>();
+            var exHolder = new AtomicReference<Exception>();
 
             Thread discussThread = new Thread(() -> {
                 try {
@@ -769,7 +785,7 @@ class GroupConversationServiceHitlTest {
             discussThread.start();
 
             // Wait for the agent to be in-flight
-            boolean started = agentBlocked.await(5, java.util.concurrent.TimeUnit.SECONDS);
+            boolean started = agentBlocked.await(5, TimeUnit.SECONDS);
 
             if (!started || exHolder.get() != null) {
                 discussThread.join(5_000);
@@ -779,7 +795,7 @@ class GroupConversationServiceHitlTest {
 
             // Fire GRACEFUL cancel
             service.cancelDiscussion("gc-inflight",
-                    ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL);
+                    ControlSignal.CANCEL_GRACEFUL);
 
             // Unblock the agent
             cancelFired.countDown();
@@ -826,7 +842,7 @@ class GroupConversationServiceHitlTest {
                 return "gc-immediate";
             }).when(conversationStore).create(any());
 
-            doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class))
+            doReturn(mock(IAgent.class))
                     .when(agentFactory).getLatestReadyAgent(any(), eq(AGENT_A));
 
             var convResult = new IConversationService.ConversationResult("conv-imm", null);
@@ -836,12 +852,12 @@ class GroupConversationServiceHitlTest {
             // executeTaskExecutionPhase's CompletableFuture.runAsync, so
             // the allOf.get() is blocked, and CANCEL_IMMEDIATE fires
             // cancelActiveFuture() → CancellationException.
-            var agentBlocked = new java.util.concurrent.CountDownLatch(1);
-            var cancelFired = new java.util.concurrent.CountDownLatch(1);
+            var agentBlocked = new CountDownLatch(1);
+            var cancelFired = new CountDownLatch(1);
 
             doAnswer(inv -> {
                 agentBlocked.countDown();
-                cancelFired.await(5, java.util.concurrent.TimeUnit.SECONDS);
+                cancelFired.await(5, TimeUnit.SECONDS);
 
                 var snapshot = new SimpleConversationMemorySnapshot();
                 var output = new ConversationOutput();
@@ -855,8 +871,8 @@ class GroupConversationServiceHitlTest {
                 return null;
             }).when(conversationService).say(any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any());
 
-            var resultHolder = new java.util.concurrent.atomic.AtomicReference<GroupConversation>();
-            var exHolder = new java.util.concurrent.atomic.AtomicReference<Exception>();
+            var resultHolder = new AtomicReference<GroupConversation>();
+            var exHolder = new AtomicReference<Exception>();
 
             Thread discussThread = new Thread(() -> {
                 try {
@@ -868,7 +884,7 @@ class GroupConversationServiceHitlTest {
             });
             discussThread.start();
 
-            boolean started = agentBlocked.await(5, java.util.concurrent.TimeUnit.SECONDS);
+            boolean started = agentBlocked.await(5, TimeUnit.SECONDS);
             if (!started || exHolder.get() != null) {
                 discussThread.join(5_000);
                 fail("discuss() failed before reaching say(): " +
@@ -878,7 +894,7 @@ class GroupConversationServiceHitlTest {
             // Fire IMMEDIATE cancel — triggers cancelActiveFuture() on the allOf
             // future inside executeTaskExecutionPhase, producing CancellationException
             service.cancelDiscussion("gc-immediate",
-                    ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_IMMEDIATE);
+                    ControlSignal.CANCEL_IMMEDIATE);
 
             cancelFired.countDown();
 
@@ -921,18 +937,18 @@ class GroupConversationServiceHitlTest {
                 return "gc-r1";
             }).when(conversationStore).create(any());
 
-            doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class))
+            doReturn(mock(IAgent.class))
                     .when(agentFactory).getLatestReadyAgent(any(), eq(AGENT_A));
 
             var convResult = new IConversationService.ConversationResult("conv-r1", null);
             doReturn(convResult).when(conversationService).startConversation(any(), any(), any(), any());
 
-            var agentBlocked = new java.util.concurrent.CountDownLatch(1);
-            var cancelFired = new java.util.concurrent.CountDownLatch(1);
+            var agentBlocked = new CountDownLatch(1);
+            var cancelFired = new CountDownLatch(1);
 
             doAnswer(inv -> {
                 agentBlocked.countDown();
-                cancelFired.await(5, java.util.concurrent.TimeUnit.SECONDS);
+                cancelFired.await(5, TimeUnit.SECONDS);
 
                 var snapshot = new SimpleConversationMemorySnapshot();
                 var output = new ConversationOutput();
@@ -946,8 +962,8 @@ class GroupConversationServiceHitlTest {
                 return null;
             }).when(conversationService).say(any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any());
 
-            var resultHolder = new java.util.concurrent.atomic.AtomicReference<GroupConversation>();
-            var exHolder = new java.util.concurrent.atomic.AtomicReference<Exception>();
+            var resultHolder = new AtomicReference<GroupConversation>();
+            var exHolder = new AtomicReference<Exception>();
 
             Thread discussThread = new Thread(() -> {
                 try {
@@ -959,7 +975,7 @@ class GroupConversationServiceHitlTest {
             });
             discussThread.start();
 
-            boolean started = agentBlocked.await(5, java.util.concurrent.TimeUnit.SECONDS);
+            boolean started = agentBlocked.await(5, TimeUnit.SECONDS);
             if (!started || exHolder.get() != null) {
                 discussThread.join(5_000);
                 fail("discuss() failed before reaching say(): "
@@ -968,7 +984,7 @@ class GroupConversationServiceHitlTest {
 
             // Cancel lands while the requiresApproval phase is mid-flight
             service.cancelDiscussion("gc-r1",
-                    ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL);
+                    ControlSignal.CANCEL_GRACEFUL);
             cancelFired.countDown();
 
             discussThread.join(10_000);
@@ -1071,7 +1087,7 @@ class GroupConversationServiceHitlTest {
             return gc;
         }
 
-        private GroupApprovalRequest approvedRequest(java.util.Map<String, String> taskApprovals) {
+        private GroupApprovalRequest approvedRequest(Map<String, String> taskApprovals) {
             var request = new GroupApprovalRequest();
             var decision = new HitlDecision();
             decision.setVerdict(HitlVerdict.APPROVED);
@@ -1088,7 +1104,7 @@ class GroupConversationServiceHitlTest {
 
             var ex = assertThrows(IllegalArgumentException.class,
                     () -> service.resumeDiscussion("gc-approvals",
-                            approvedRequest(java.util.Map.of("no-such-task", "APPROVED")), null));
+                            approvedRequest(Map.of("no-such-task", "APPROVED")), null));
             assertTrue(ex.getMessage().contains("no-such-task"), ex.getMessage());
 
             assertTrue(gc.getTaskList().hasAwaitingApproval(), "no task may be mutated on a rejected request");
@@ -1108,7 +1124,7 @@ class GroupConversationServiceHitlTest {
 
             var ex = assertThrows(IllegalArgumentException.class,
                     () -> service.resumeDiscussion("gc-approvals",
-                            approvedRequest(java.util.Map.of(assignedTaskId, "APPROVED")), null));
+                            approvedRequest(Map.of(assignedTaskId, "APPROVED")), null));
             assertTrue(ex.getMessage().contains("not awaiting approval"), ex.getMessage());
             verify(conversationStore, never()).updateIfState(any(), any());
         }
@@ -1124,7 +1140,7 @@ class GroupConversationServiceHitlTest {
 
             var ex = assertThrows(IllegalArgumentException.class,
                     () -> service.resumeDiscussion("gc-approvals",
-                            approvedRequest(java.util.Map.of(awaitingTaskId, "MAYBE")), null));
+                            approvedRequest(Map.of(awaitingTaskId, "MAYBE")), null));
             assertTrue(ex.getMessage().contains("APPROVED or REJECTED"), ex.getMessage());
 
             assertTrue(gc.getTaskList().hasAwaitingApproval(), "no task may be mutated on a rejected request");
@@ -1141,7 +1157,7 @@ class GroupConversationServiceHitlTest {
                     .findFirst().orElseThrow().id();
 
             service.resumeDiscussion("gc-approvals",
-                    approvedRequest(java.util.Map.of(awaitingTaskId, "approved")), null);
+                    approvedRequest(Map.of(awaitingTaskId, "approved")), null);
 
             assertFalse(gc.getTaskList().hasAwaitingApproval(), "lowercase 'approved' must be accepted");
         }
@@ -1152,7 +1168,7 @@ class GroupConversationServiceHitlTest {
             var gc = pausedGcWithTasks();
             doReturn(gc).when(conversationStore).read("gc-approvals");
 
-            service.resumeDiscussion("gc-approvals", approvedRequest(java.util.Map.of()), null);
+            service.resumeDiscussion("gc-approvals", approvedRequest(Map.of()), null);
 
             assertFalse(gc.getTaskList().hasAwaitingApproval(),
                     "an explicit {} must auto-approve like an absent map — otherwise the phase instantly re-pauses");
@@ -1167,12 +1183,12 @@ class GroupConversationServiceHitlTest {
     @DisplayName("HITL audit emission")
     class AuditEmission {
 
-        private ai.labs.eddi.engine.audit.AuditLedgerService auditLedger;
+        private AuditLedgerService auditLedger;
         private GroupConversationService auditedService;
 
         @BeforeEach
         void setUpAuditedService() {
-            auditLedger = mock(ai.labs.eddi.engine.audit.AuditLedgerService.class);
+            auditLedger = mock(AuditLedgerService.class);
             when(auditLedger.isEnabled()).thenReturn(true);
             auditedService = new GroupConversationService(
                     groupStore, conversationStore, conversationService,
@@ -1210,7 +1226,7 @@ class GroupConversationServiceHitlTest {
 
             auditedService.resumeDiscussion("gc-audit-resume", request, null);
 
-            var captor = org.mockito.ArgumentCaptor.forClass(ai.labs.eddi.engine.audit.model.AuditEntry.class);
+            var captor = org.mockito.ArgumentCaptor.forClass(AuditEntry.class);
             verify(auditLedger).submit(captor.capture());
             var entry = captor.getValue();
             assertEquals("hitl.approval", entry.taskId(), "audit event type must be hitl.approval");
@@ -1230,10 +1246,10 @@ class GroupConversationServiceHitlTest {
             doReturn(null).when(groupStore).getCurrentResourceId(GROUP_ID);
 
             boolean cancelled = auditedService.cancelDiscussion("gc-audit-cancel",
-                    ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL);
+                    ControlSignal.CANCEL_GRACEFUL);
 
             assertTrue(cancelled);
-            var captor = org.mockito.ArgumentCaptor.forClass(ai.labs.eddi.engine.audit.model.AuditEntry.class);
+            var captor = org.mockito.ArgumentCaptor.forClass(AuditEntry.class);
             verify(auditLedger).submit(captor.capture());
             var entry = captor.getValue();
             assertEquals("hitl.approval", entry.taskId());
@@ -1317,22 +1333,22 @@ class GroupConversationServiceHitlTest {
             request.setDecision(dec);
 
             // Capture phase indices via a listener
-            var observedPhaseIndices = java.util.Collections.synchronizedList(new java.util.ArrayList<Integer>());
-            var resumeDone = new java.util.concurrent.CountDownLatch(1);
+            var observedPhaseIndices = Collections.synchronizedList(new ArrayList<Integer>());
+            var resumeDone = new CountDownLatch(1);
 
-            var listener = new ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener() {
+            var listener = new IGroupConversationService.GroupDiscussionEventListener() {
                 @Override
-                public void onPhaseStart(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.PhaseStartEvent event) {
+                public void onPhaseStart(GroupConversationEventSink.PhaseStartEvent event) {
                     observedPhaseIndices.add(event.phaseIndex());
                 }
 
                 @Override
-                public void onGroupComplete(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupCompleteEvent event) {
+                public void onGroupComplete(GroupConversationEventSink.GroupCompleteEvent event) {
                     resumeDone.countDown();
                 }
 
                 @Override
-                public void onGroupError(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupErrorEvent event) {
+                public void onGroupError(GroupConversationEventSink.GroupErrorEvent event) {
                     resumeDone.countDown();
                 }
             };
@@ -1340,7 +1356,7 @@ class GroupConversationServiceHitlTest {
             service.resumeDiscussion("gc-task-resume", request, listener);
 
             // Wait for async resume to complete
-            assertTrue(resumeDone.await(5, java.util.concurrent.TimeUnit.SECONDS),
+            assertTrue(resumeDone.await(5, TimeUnit.SECONDS),
                     "Async resume should complete within 5s");
 
             // TASK resume: first phase seen must be the PAUSED phase (1), not +1
@@ -1387,29 +1403,29 @@ class GroupConversationServiceHitlTest {
             dec.setVerdict(HitlVerdict.APPROVED);
             request.setDecision(dec);
 
-            var observedPhaseIndices = java.util.Collections.synchronizedList(new java.util.ArrayList<Integer>());
-            var resumeDone = new java.util.concurrent.CountDownLatch(1);
+            var observedPhaseIndices = Collections.synchronizedList(new ArrayList<Integer>());
+            var resumeDone = new CountDownLatch(1);
 
-            var listener = new ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener() {
+            var listener = new IGroupConversationService.GroupDiscussionEventListener() {
                 @Override
-                public void onPhaseStart(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.PhaseStartEvent event) {
+                public void onPhaseStart(GroupConversationEventSink.PhaseStartEvent event) {
                     observedPhaseIndices.add(event.phaseIndex());
                 }
 
                 @Override
-                public void onGroupComplete(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupCompleteEvent event) {
+                public void onGroupComplete(GroupConversationEventSink.GroupCompleteEvent event) {
                     resumeDone.countDown();
                 }
 
                 @Override
-                public void onGroupError(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupErrorEvent event) {
+                public void onGroupError(GroupConversationEventSink.GroupErrorEvent event) {
                     resumeDone.countDown();
                 }
             };
 
             service.resumeDiscussion("gc-phase-resume", request, listener);
 
-            assertTrue(resumeDone.await(5, java.util.concurrent.TimeUnit.SECONDS),
+            assertTrue(resumeDone.await(5, TimeUnit.SECONDS),
                     "Async resume should complete within 5s");
 
             // PHASE resume: first phase seen must be pausedAt + 1 = 2
@@ -1461,24 +1477,24 @@ class GroupConversationServiceHitlTest {
             dec.setVerdict(HitlVerdict.APPROVED);
             request.setDecision(dec);
 
-            var errorMessage = new java.util.concurrent.atomic.AtomicReference<String>();
-            var resumeDone = new java.util.concurrent.CountDownLatch(1);
-            var listener = new ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener() {
+            var errorMessage = new AtomicReference<String>();
+            var resumeDone = new CountDownLatch(1);
+            var listener = new IGroupConversationService.GroupDiscussionEventListener() {
                 @Override
-                public void onGroupError(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupErrorEvent event) {
+                public void onGroupError(GroupConversationEventSink.GroupErrorEvent event) {
                     errorMessage.set(event.error());
                     resumeDone.countDown();
                 }
 
                 @Override
-                public void onGroupComplete(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupCompleteEvent event) {
+                public void onGroupComplete(GroupConversationEventSink.GroupCompleteEvent event) {
                     resumeDone.countDown();
                 }
             };
 
             service.resumeDiscussion("gc-speaker-drift", request, listener);
 
-            assertTrue(resumeDone.await(5, java.util.concurrent.TimeUnit.SECONDS),
+            assertTrue(resumeDone.await(5, TimeUnit.SECONDS),
                     "Async resume should complete within 5s");
 
             assertNotNull(errorMessage.get(), "a roster shrink below the bookmarked speaker index must fire onGroupError");
@@ -1533,31 +1549,31 @@ class GroupConversationServiceHitlTest {
             dec.setVerdict(HitlVerdict.APPROVED);
             request.setDecision(dec);
 
-            var completedSpeakers = java.util.Collections.synchronizedSet(new java.util.HashSet<String>());
-            var resumeDone = new java.util.concurrent.CountDownLatch(1);
-            var listener = new ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener() {
+            var completedSpeakers = Collections.synchronizedSet(new HashSet<String>());
+            var resumeDone = new CountDownLatch(1);
+            var listener = new IGroupConversationService.GroupDiscussionEventListener() {
                 @Override
-                public void onSpeakerComplete(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.SpeakerCompleteEvent event) {
+                public void onSpeakerComplete(GroupConversationEventSink.SpeakerCompleteEvent event) {
                     completedSpeakers.add(event.agentId());
                 }
 
                 @Override
-                public void onGroupComplete(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupCompleteEvent event) {
+                public void onGroupComplete(GroupConversationEventSink.GroupCompleteEvent event) {
                     resumeDone.countDown();
                 }
 
                 @Override
-                public void onGroupError(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupErrorEvent event) {
+                public void onGroupError(GroupConversationEventSink.GroupErrorEvent event) {
                     resumeDone.countDown();
                 }
             };
 
             service.resumeDiscussion("gc-parallel-resume", request, listener);
 
-            assertTrue(resumeDone.await(5, java.util.concurrent.TimeUnit.SECONDS),
+            assertTrue(resumeDone.await(5, TimeUnit.SECONDS),
                     "Async resume should complete within 5s");
 
-            assertEquals(java.util.Set.of(AGENT_A, "agent-b"), completedSpeakers,
+            assertEquals(Set.of(AGENT_A, "agent-b"), completedSpeakers,
                     "a PARALLEL resume must run every speaker — the speaker bookmark is not honored for PARALLEL phases");
             assertNull(gc.getResumePoint(), "the bookmark must be consumed/cleared even though its offset was ignored");
         }
@@ -1640,7 +1656,7 @@ class GroupConversationServiceHitlTest {
             doReturn(config).when(groupStore).read(GROUP_ID, 1);
             doReturn("gc-member-pause").when(conversationStore).create(any());
 
-            doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class))
+            doReturn(mock(IAgent.class))
                     .when(agentFactory).getLatestReadyAgent(any(), eq(AGENT_A));
             var convResult = new IConversationService.ConversationResult("member-conv", null);
             doReturn(convResult).when(conversationService).startConversation(any(), any(), any(), any());
@@ -1650,7 +1666,7 @@ class GroupConversationServiceHitlTest {
             doAnswer(inv -> {
                 var snapshot = new SimpleConversationMemorySnapshot();
                 snapshot.setConversationState(
-                        ai.labs.eddi.engine.memory.model.ConversationState.AWAITING_HUMAN);
+                        ConversationState.AWAITING_HUMAN);
                 IConversationService.ConversationResponseHandler handler = inv.getArgument(8);
                 if (handler != null) {
                     handler.onComplete(snapshot);
@@ -1663,7 +1679,7 @@ class GroupConversationServiceHitlTest {
             // The stranded member pause must have been cancelled, attributed to the
             // group system actor in the audit trail.
             verify(conversationService).cancelConversation(eq("member-conv"),
-                    eq(ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL), eq("system:group"));
+                    eq(ControlSignal.CANCEL_GRACEFUL), eq("system:group"));
 
             // The member turn is recorded SKIPPED with the explanatory note — never
             // as an empty OPINION contribution.
@@ -1704,7 +1720,7 @@ class GroupConversationServiceHitlTest {
             doReturn(config).when(groupStore).read(GROUP_ID, 1);
             doReturn("gc-member-say-throws").when(conversationStore).create(any());
 
-            doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class))
+            doReturn(mock(IAgent.class))
                     .when(agentFactory).getLatestReadyAgent(any(), eq(AGENT_A));
             var convResult = new IConversationService.ConversationResult("member-conv-throws", null);
             doReturn(convResult).when(conversationService).startConversation(any(), any(), any(), any());
@@ -1719,7 +1735,7 @@ class GroupConversationServiceHitlTest {
             // The stranded member pause must have been cancelled (handleMemberPause),
             // attributed to the group system actor — NOT left armed by handleAgentFailure.
             verify(conversationService).cancelConversation(eq("member-conv-throws"),
-                    eq(ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL), eq("system:group"));
+                    eq(ControlSignal.CANCEL_GRACEFUL), eq("system:group"));
 
             // The member turn is recorded SKIPPED with the group-HITL note — NOT FAILURE.
             var memberEntries = gc.getTranscript().stream()
@@ -1794,16 +1810,16 @@ class GroupConversationServiceHitlTest {
             var field = GroupConversationService.class.getDeclaredField("activeTokens");
             field.setAccessible(true);
             @SuppressWarnings("unchecked")
-            var activeTokens = (java.util.concurrent.ConcurrentHashMap<String, ?>) field.get(service);
+            var activeTokens = (ConcurrentHashMap<String, ?>) field.get(service);
 
-            var tokenPresentInWindow = new java.util.concurrent.atomic.AtomicBoolean(false);
-            var cancelReturnedTrue = new java.util.concurrent.atomic.AtomicBoolean(false);
-            var cancelThrew = new java.util.concurrent.atomic.AtomicReference<Throwable>();
-            var resumeDone = new java.util.concurrent.CountDownLatch(1);
+            var tokenPresentInWindow = new AtomicBoolean(false);
+            var cancelReturnedTrue = new AtomicBoolean(false);
+            var cancelThrew = new AtomicReference<Throwable>();
+            var resumeDone = new CountDownLatch(1);
 
-            var listener = new ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener() {
+            var listener = new IGroupConversationService.GroupDiscussionEventListener() {
                 @Override
-                public void onHitlResume(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.HitlResumeEvent event) {
+                public void onHitlResume(GroupConversationEventSink.HitlResumeEvent event) {
                     // We are now in the CAS→submit window, on the resume thread.
                     // O2 guarantees the token is ALREADY registered here.
                     tokenPresentInWindow.set(activeTokens.containsKey("gc-o2-window"));
@@ -1811,26 +1827,26 @@ class GroupConversationServiceHitlTest {
                         // Concurrent cancel: with the token present it must take the
                         // SIGNAL path (setSignal + return true), NOT the DB branch.
                         cancelReturnedTrue.set(service.cancelDiscussion("gc-o2-window",
-                                ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL));
+                                ControlSignal.CANCEL_GRACEFUL));
                     } catch (Throwable t) {
                         cancelThrew.set(t);
                     }
                 }
 
                 @Override
-                public void onCancelled(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.CancelledEvent event) {
+                public void onCancelled(GroupConversationEventSink.CancelledEvent event) {
                     // The resumed leg honoured the in-window cancel signal at its
                     // top-of-phase check → notifyCancelled → onCancelled.
                     resumeDone.countDown();
                 }
 
                 @Override
-                public void onGroupComplete(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupCompleteEvent event) {
+                public void onGroupComplete(GroupConversationEventSink.GroupCompleteEvent event) {
                     resumeDone.countDown();
                 }
 
                 @Override
-                public void onGroupError(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupErrorEvent event) {
+                public void onGroupError(GroupConversationEventSink.GroupErrorEvent event) {
                     resumeDone.countDown();
                 }
             };
@@ -1850,7 +1866,7 @@ class GroupConversationServiceHitlTest {
 
             // The resumed leg observes the cancelled token at its top-of-phase check and
             // stops with CANCELLED — it must NEVER run a member turn or complete normally.
-            assertTrue(resumeDone.await(5, java.util.concurrent.TimeUnit.SECONDS),
+            assertTrue(resumeDone.await(5, TimeUnit.SECONDS),
                     "resumed leg should terminate quickly");
             assertEquals(GroupConversationState.CANCELLED, gc.getState(),
                     "the resumed leg must end CANCELLED, honouring the in-window signal");
@@ -1917,15 +1933,15 @@ class GroupConversationServiceHitlTest {
             gc.setHitlLastPauseFingerprint("phase=0;" + taskId + ":ASSIGNED,");
             doReturn(gc).when(conversationStore).read("gc-noprogress");
 
-            var resumeDone = new java.util.concurrent.CountDownLatch(1);
-            var errored = new java.util.concurrent.atomic.AtomicBoolean(false);
-            var listener = new ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener() {
+            var resumeDone = new CountDownLatch(1);
+            var errored = new AtomicBoolean(false);
+            var listener = new IGroupConversationService.GroupDiscussionEventListener() {
                 @Override
-                public void onGroupComplete(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupCompleteEvent event) {
+                public void onGroupComplete(GroupConversationEventSink.GroupCompleteEvent event) {
                     resumeDone.countDown();
                 }
                 @Override
-                public void onGroupError(ai.labs.eddi.engine.lifecycle.GroupConversationEventSink.GroupErrorEvent event) {
+                public void onGroupError(GroupConversationEventSink.GroupErrorEvent event) {
                     errored.set(true);
                     resumeDone.countDown();
                 }
@@ -1941,7 +1957,7 @@ class GroupConversationServiceHitlTest {
 
             service.resumeDiscussion("gc-noprogress", request, listener);
 
-            assertTrue(resumeDone.await(5, java.util.concurrent.TimeUnit.SECONDS),
+            assertTrue(resumeDone.await(5, TimeUnit.SECONDS),
                     "resumed leg should terminate quickly, not loop");
             assertTrue(errored.get(), "no-progress resume must emit a terminal group_error");
             assertEquals(GroupConversationState.FAILED, gc.getState(),
@@ -1976,7 +1992,7 @@ class GroupConversationServiceHitlTest {
             var dec = new HitlDecision();
             dec.setVerdict(HitlVerdict.APPROVED);
             request.setDecision(dec);
-            request.setTaskApprovals(java.util.Map.of("some-task", "APPROVED"));
+            request.setTaskApprovals(Map.of("some-task", "APPROVED"));
 
             var ex = assertThrows(IllegalArgumentException.class,
                     () -> service.resumeDiscussion("gc-phase-only", request, null),

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTaskForceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTaskForceTest.java
@@ -27,6 +27,7 @@ import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskStatus;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
+import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
@@ -40,6 +41,7 @@ import org.mockito.Mock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -392,10 +394,10 @@ class GroupConversationServiceTaskForceTest {
         @DisplayName("Setter wraps plain HashMap into ConcurrentHashMap")
         void setter_wrapsInConcurrentHashMap() {
             var gc = new GroupConversation();
-            gc.setMemberConversationIds(new java.util.LinkedHashMap<>(
+            gc.setMemberConversationIds(new LinkedHashMap<>(
                     Map.of("agent-1", "conv-1")));
 
-            assertTrue(gc.getMemberConversationIds() instanceof java.util.concurrent.ConcurrentHashMap,
+            assertTrue(gc.getMemberConversationIds() instanceof ConcurrentHashMap,
                     "Must be ConcurrentHashMap after setter");
             assertEquals("conv-1", gc.getMemberConversationIds().get("agent-1"));
         }
@@ -407,7 +409,7 @@ class GroupConversationServiceTaskForceTest {
             gc.setMemberConversationIds(null);
 
             assertNotNull(gc.getMemberConversationIds());
-            assertTrue(gc.getMemberConversationIds() instanceof java.util.concurrent.ConcurrentHashMap);
+            assertTrue(gc.getMemberConversationIds() instanceof ConcurrentHashMap);
             assertTrue(gc.getMemberConversationIds().isEmpty());
         }
     }
@@ -427,7 +429,7 @@ class GroupConversationServiceTaskForceTest {
             var member = new GroupMember("agent-1", "Agent One", 0, "MEMBER");
             var gc = new GroupConversation();
             gc.setTranscript(new ArrayList<>());
-            gc.setMemberConversationIds(new java.util.concurrent.ConcurrentHashMap<>());
+            gc.setMemberConversationIds(new ConcurrentHashMap<>());
 
             var protocol = new AgentGroupConfiguration.ProtocolConfig(
                     60, AgentGroupConfiguration.ProtocolConfig.MemberFailurePolicy.SKIP, 2,
@@ -437,7 +439,7 @@ class GroupConversationServiceTaskForceTest {
                     false, null, 1);
 
             // Agent is available but startConversation throws quota error
-            when(agentFactory.getLatestReadyAgent(any(), eq("agent-1"))).thenReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class));
+            when(agentFactory.getLatestReadyAgent(any(), eq("agent-1"))).thenReturn(mock(IAgent.class));
             when(conversationService.startConversation(any(), eq("agent-1"), any(), any()))
                     .thenThrow(new QuotaExceededException("Conversation limit reached"));
 
@@ -456,7 +458,7 @@ class GroupConversationServiceTaskForceTest {
             var gc = new GroupConversation();
             gc.setTranscript(new ArrayList<>());
             // Pre-set a conversation ID so startConversation is skipped
-            gc.setMemberConversationIds(new java.util.concurrent.ConcurrentHashMap<>(
+            gc.setMemberConversationIds(new ConcurrentHashMap<>(
                     Map.of("agent-1", "existing-conv")));
 
             var protocol = new AgentGroupConfiguration.ProtocolConfig(
@@ -467,7 +469,7 @@ class GroupConversationServiceTaskForceTest {
                     false, null, 1);
 
             // Agent is available
-            when(agentFactory.getLatestReadyAgent(any(), eq("agent-1"))).thenReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class));
+            when(agentFactory.getLatestReadyAgent(any(), eq("agent-1"))).thenReturn(mock(IAgent.class));
             // say() throws quota error
             doThrow(new QuotaExceededException("API call limit reached"))
                     .when(conversationService).say(any(), eq("agent-1"), eq("existing-conv"),
@@ -487,7 +489,7 @@ class GroupConversationServiceTaskForceTest {
             var member = new GroupMember("agent-1", "Agent One", 0, "MEMBER");
             var gc = new GroupConversation();
             gc.setTranscript(new ArrayList<>());
-            gc.setMemberConversationIds(new java.util.concurrent.ConcurrentHashMap<>(
+            gc.setMemberConversationIds(new ConcurrentHashMap<>(
                     Map.of("agent-1", "existing-conv")));
 
             // RETRY policy with 5 retries — quota should still abort immediately
@@ -498,7 +500,7 @@ class GroupConversationServiceTaskForceTest {
                     AgentGroupConfiguration.TurnOrder.PARALLEL, AgentGroupConfiguration.ContextScope.TASK_ONLY,
                     false, null, 1);
 
-            when(agentFactory.getLatestReadyAgent(any(), eq("agent-1"))).thenReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class));
+            when(agentFactory.getLatestReadyAgent(any(), eq("agent-1"))).thenReturn(mock(IAgent.class));
             doThrow(new QuotaExceededException("API call limit reached"))
                     .when(conversationService).say(any(), eq("agent-1"), eq("existing-conv"),
                             any(), any(), any(), any(), anyBoolean(), any());

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTest.java
@@ -26,6 +26,7 @@ import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDepthExceededException;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
@@ -45,6 +46,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -836,10 +838,10 @@ class GroupConversationServiceTest {
 
     /** Reflectively access the private per-conversation concurrency guard set. */
     @SuppressWarnings("unchecked")
-    private java.util.Set<String> operationsInProgress() throws Exception {
+    private Set<String> operationsInProgress() throws Exception {
         var field = GroupConversationService.class.getDeclaredField("operationsInProgress");
         field.setAccessible(true);
-        return (java.util.Set<String>) field.get(service);
+        return (Set<String>) field.get(service);
     }
 
     @Nested
@@ -901,7 +903,7 @@ class GroupConversationServiceTest {
 
             // Specific subtype so REST can map an unknown member to 404 (not a 409
             // conflict).
-            assertThrows(ai.labs.eddi.engine.api.IGroupConversationService.GroupMemberNotFoundException.class,
+            assertThrows(IGroupConversationService.GroupMemberNotFoundException.class,
                     () -> service.followUpWithMember("gc-1", "ghost", "hello"));
             verify(conversationService, never())
                     .say(any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any());
@@ -918,7 +920,7 @@ class GroupConversationServiceTest {
             doThrow(new RuntimeException("provider 500")).when(conversationService)
                     .say(any(), eq("agentA"), any(), any(), any(), any(), any(), anyBoolean(), any());
 
-            assertThrows(ai.labs.eddi.engine.api.IGroupConversationService.GroupExecutionException.class,
+            assertThrows(IGroupConversationService.GroupExecutionException.class,
                     () -> service.followUpWithMember("gc-1", "agentA", "hello"));
         }
 
@@ -1007,7 +1009,7 @@ class GroupConversationServiceTest {
             // must NOT be able to reach "unanimous agreement" on it.
             inProgress.negotiationState().addProposal(new GroupConversation.Proposal(
                     "p1", "a1", 0, "round 1 terms", GroupConversation.PROPOSAL_OPEN,
-                    java.util.List.of("a1"), java.util.Map.of("a1", 3)));
+                    List.of("a1"), Map.of("a1", 3)));
             when(conversationStore.read("gc-1")).thenReturn(gc, inProgress);
             when(conversationStore.compareAndSetState("gc-1",
                     GroupConversationState.COMPLETED, GroupConversationState.IN_PROGRESS)).thenReturn(true);

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceToolPauseTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceToolPauseTest.java
@@ -22,12 +22,15 @@ import ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationStat
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +41,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -75,7 +79,7 @@ class GroupConversationServiceToolPauseTest {
     @Mock
     private NonceCacheService nonceCacheService;
     @Mock
-    private ai.labs.eddi.engine.schedule.IScheduleStore scheduleStore;
+    private IScheduleStore scheduleStore;
 
     private GroupConversationService service;
 
@@ -161,7 +165,7 @@ class GroupConversationServiceToolPauseTest {
         doReturn(config).when(groupStore).read(GROUP_ID, 1);
         doReturn("gc-tool-graceful").when(conversationStore).create(any());
 
-        doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class))
+        doReturn(mock(IAgent.class))
                 .when(agentFactory).getLatestReadyAgent(any(), eq(AGENT_A));
         doReturn(new IConversationService.ConversationResult("member-conv", null))
                 .when(conversationService).startConversation(any(), any(), any(), any());
@@ -175,7 +179,7 @@ class GroupConversationServiceToolPauseTest {
 
         // The graceful system:group REJECTED resume completes synchronously with a
         // coherent tool-less answer that becomes the member's contribution.
-        var rejectDecision = new java.util.concurrent.atomic.AtomicReference<HitlDecision>();
+        var rejectDecision = new AtomicReference<HitlDecision>();
         doAnswer(inv -> {
             rejectDecision.set(inv.getArgument(1));
             IConversationService.ConversationResponseHandler handler = inv.getArgument(2);
@@ -220,7 +224,7 @@ class GroupConversationServiceToolPauseTest {
         doReturn(config).when(groupStore).read(GROUP_ID, 1);
         doReturn("gc-tool-repause").when(conversationStore).create(any());
 
-        doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class))
+        doReturn(mock(IAgent.class))
                 .when(agentFactory).getLatestReadyAgent(any(), eq(AGENT_A));
         doReturn(new IConversationService.ConversationResult("member-conv", null))
                 .when(conversationService).startConversation(any(), any(), any(), any());
@@ -245,7 +249,7 @@ class GroupConversationServiceToolPauseTest {
         // Fallback path: the stranded pause is cancelled (audited system:group) and the
         // turn is recorded SKIPPED with the explanatory note.
         verify(conversationService).cancelConversation(eq("member-conv"),
-                eq(ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL), eq("system:group"));
+                eq(ControlSignal.CANCEL_GRACEFUL), eq("system:group"));
         assertEquals(1.0, skippedCount(), "the fallback must count exactly one member-pause skip");
 
         var memberEntries = gc.getTranscript().stream()
@@ -268,7 +272,7 @@ class GroupConversationServiceToolPauseTest {
         doReturn(config).when(groupStore).read(GROUP_ID, 1);
         doReturn("gc-rule-pause").when(conversationStore).create(any());
 
-        doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class))
+        doReturn(mock(IAgent.class))
                 .when(agentFactory).getLatestReadyAgent(any(), eq(AGENT_A));
         doReturn(new IConversationService.ConversationResult("member-conv", null))
                 .when(conversationService).startConversation(any(), any(), any(), any());
@@ -289,7 +293,7 @@ class GroupConversationServiceToolPauseTest {
         // rejection resume. It stays exactly as before: SKIP + cancel + skip metric.
         verify(conversationService, never()).resumeConversation(any(), any(), any());
         verify(conversationService).cancelConversation(eq("member-conv"),
-                eq(ai.labs.eddi.engine.lifecycle.model.ControlSignal.CANCEL_GRACEFUL), eq("system:group"));
+                eq(ControlSignal.CANCEL_GRACEFUL), eq("system:group"));
         assertEquals(1.0, skippedCount(), "a RULE member pause still counts a skip");
 
         var memberEntries = gc.getTranscript().stream()

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceUncoveredBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceUncoveredBranchTest.java
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.internal;
+import ai.labs.eddi.configs.agents.AgentSigningService;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.crypto.NonceCacheService;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
@@ -93,11 +96,11 @@ class GroupConversationServiceUncoveredBranchTest {
     @Mock
     private IJsonSerialization jsonSerialization;
     @Mock
-    private ai.labs.eddi.configs.agents.AgentSigningService agentSigningService;
+    private AgentSigningService agentSigningService;
     @Mock
-    private ai.labs.eddi.configs.agents.IAgentStore agentStore;
+    private IAgentStore agentStore;
     @Mock
-    private ai.labs.eddi.configs.agents.crypto.NonceCacheService nonceCacheService;
+    private NonceCacheService nonceCacheService;
     @Mock
     private io.micrometer.core.instrument.MeterRegistry meterRegistry;
     @Mock

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceVerdictTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceVerdictTest.java
@@ -28,6 +28,7 @@ import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.model.InputData;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.engine.runtime.IAgent;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
@@ -148,7 +149,7 @@ class GroupConversationServiceVerdictTest {
     }
 
     private void stubTurns(Function<String, String> responder) throws Exception {
-        doReturn(mock(ai.labs.eddi.engine.runtime.IAgent.class)).when(agentFactory).getLatestReadyAgent(any(), anyString());
+        doReturn(mock(IAgent.class)).when(agentFactory).getLatestReadyAgent(any(), anyString());
         doReturn(new IConversationService.ConversationResult("member-conv", null))
                 .when(conversationService).startConversation(any(), any(), any(), any());
         doAnswer(inv -> {

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationExtendedTest.java
@@ -32,6 +32,7 @@ import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -384,7 +385,7 @@ class RestAgentAdministrationExtendedTest {
 
             assertEquals(200, response.getStatus());
             @SuppressWarnings("unchecked")
-            var body = (java.util.Map<String, Object>) response.getEntity();
+            var body = (Map<String, Object>) response.getEntity();
             assertEquals("Deployment was interrupted", body.get("error"));
 
             // Verify thread interrupt flag was set

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.engine.internal;
 
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
 import ai.labs.eddi.engine.memory.rest.IRestConversationStore;
 import ai.labs.eddi.engine.model.Deployment;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
+import java.util.Date;
 
 import java.util.List;
 import java.util.concurrent.*;
@@ -233,8 +235,8 @@ class RestAgentAdministrationTest {
             when(agent1.getAgentVersion()).thenReturn(1);
             when(agent1.getDeploymentStatus()).thenReturn(Deployment.Status.READY);
 
-            var desc1 = new ai.labs.eddi.configs.descriptors.model.DocumentDescriptor();
-            desc1.setLastModifiedOn(new java.util.Date(1000));
+            var desc1 = new DocumentDescriptor();
+            desc1.setLastModifiedOn(new Date(1000));
             when(documentDescriptorStore.readDescriptor("agent-1", 1)).thenReturn(desc1);
 
             when(agentFactory.getAllLatestAgents(any())).thenReturn(List.of(agent1));

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineHitlTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.internal;
 import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
 import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
 import ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore;
@@ -17,6 +18,7 @@ import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict;
 import ai.labs.eddi.engine.hitl.HitlAccessGuard;
+import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.security.ConversationAccessGuard;
 import ai.labs.eddi.engine.security.OwnershipValidator;
 import io.quarkus.security.ForbiddenException;
@@ -32,6 +34,7 @@ import org.mockito.MockitoAnnotations;
 import java.security.Principal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -57,7 +60,7 @@ class RestAgentEngineHitlTest {
     @Mock
     private Principal principal;
     @Mock
-    private ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore hitlToolJournalStore;
+    private IHitlToolJournalStore hitlToolJournalStore;
 
     private RestAgentEngine restAgentEngine;
 
@@ -80,7 +83,7 @@ class RestAgentEngineHitlTest {
         // that logic end-to-end through the delegating REST endpoint.
         var hitlAccessGuard = new HitlAccessGuard(
                 identity, ownershipValidator, conversationDescriptorStore, conversationService,
-                mock(ai.labs.eddi.engine.api.IGroupConversationService.class));
+                mock(IGroupConversationService.class));
         var conversationAccessGuard = new ConversationAccessGuard(
                 identity, ownershipValidator, conversationDescriptorStore);
         restAgentEngine = new RestAgentEngine(
@@ -226,8 +229,8 @@ class RestAgentEngineHitlTest {
         @Test
         @DisplayName("decision note longer than 4096 chars → 400, service never called")
         void oversizedNoteRejected() throws Exception {
-            var decision = new ai.labs.eddi.engine.lifecycle.model.HitlDecision();
-            decision.setVerdict(ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict.APPROVED);
+            var decision = new HitlDecision();
+            decision.setVerdict(HitlDecision.HitlVerdict.APPROVED);
             decision.setNote("x".repeat(4097));
 
             Response response = restAgentEngine.resumeConversation(CONVERSATION_ID, decision);
@@ -239,8 +242,8 @@ class RestAgentEngineHitlTest {
         @Test
         @DisplayName("note of exactly 4096 chars is accepted")
         void maxLengthNoteAccepted() throws Exception {
-            var decision = new ai.labs.eddi.engine.lifecycle.model.HitlDecision();
-            decision.setVerdict(ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict.APPROVED);
+            var decision = new HitlDecision();
+            decision.setVerdict(HitlDecision.HitlVerdict.APPROVED);
             decision.setNote("x".repeat(4096));
 
             Response response = restAgentEngine.resumeConversation(CONVERSATION_ID, decision);
@@ -252,7 +255,7 @@ class RestAgentEngineHitlTest {
         @Test
         @DisplayName("missing verdict → 400, service never called")
         void missingVerdictRejected() throws Exception {
-            var decision = new ai.labs.eddi.engine.lifecycle.model.HitlDecision();
+            var decision = new HitlDecision();
 
             Response response = restAgentEngine.resumeConversation(CONVERSATION_ID, decision);
 
@@ -334,7 +337,7 @@ class RestAgentEngineHitlTest {
 
             assertEquals(200, response.getStatus());
             @SuppressWarnings("unchecked")
-            var summary = (java.util.Map<String, Object>) response.getEntity();
+            var summary = (Map<String, Object>) response.getEntity();
             assertEquals("", summary.get("pauseReason"), "Stale pause fields must be suppressed");
         }
     }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
@@ -7,10 +7,12 @@ package ai.labs.eddi.engine.internal;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
+import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.model.InputData;
 import ai.labs.eddi.engine.security.ConversationAccessGuard;
+import ai.labs.eddi.utils.LogSanitizer;
 import io.quarkus.security.ForbiddenException;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.Sse;
@@ -54,10 +56,10 @@ class RestAgentEngineStreamingTest {
         @Test
         @DisplayName("should replace newlines, carriage returns, and tabs")
         void replacesControlChars() {
-            assertEquals("hello_world", ai.labs.eddi.utils.LogSanitizer.sanitize("hello\nworld"));
-            assertEquals("hello_world", ai.labs.eddi.utils.LogSanitizer.sanitize("hello\rworld"));
-            assertEquals("hello_world", ai.labs.eddi.utils.LogSanitizer.sanitize("hello\tworld"));
-            assertEquals("null", ai.labs.eddi.utils.LogSanitizer.sanitize(null));
+            assertEquals("hello_world", LogSanitizer.sanitize("hello\nworld"));
+            assertEquals("hello_world", LogSanitizer.sanitize("hello\rworld"));
+            assertEquals("hello_world", LogSanitizer.sanitize("hello\tworld"));
+            assertEquals("null", LogSanitizer.sanitize(null));
         }
     }
 
@@ -115,7 +117,7 @@ class RestAgentEngineStreamingTest {
             method.setAccessible(true);
 
             var snapshot = new SimpleConversationMemorySnapshot();
-            snapshot.setConversationState(ai.labs.eddi.engine.memory.model.ConversationState.READY);
+            snapshot.setConversationState(ConversationState.READY);
 
             String json = (String) method.invoke(streaming, snapshot);
 
@@ -129,8 +131,8 @@ class RestAgentEngineStreamingTest {
             method.setAccessible(true);
 
             var snapshot = new SimpleConversationMemorySnapshot();
-            snapshot.setConversationState(ai.labs.eddi.engine.memory.model.ConversationState.READY);
-            var output = new ai.labs.eddi.engine.memory.model.ConversationOutput();
+            snapshot.setConversationState(ConversationState.READY);
+            var output = new ConversationOutput();
             output.put("output", List.of("Hello!"));
             snapshot.setConversationOutputs(List.of(output));
 

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
@@ -8,8 +8,11 @@ import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
 import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.*;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.gdpr.ProcessingRestrictedException;
 import ai.labs.eddi.engine.hitl.HitlAccessGuard;
+import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
+import ai.labs.eddi.engine.memory.IConversationMemoryStore;
 import ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore;
 import ai.labs.eddi.engine.memory.descriptor.model.ConversationDescriptor;
 import ai.labs.eddi.engine.memory.model.ConversationState;
@@ -34,6 +37,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -59,11 +63,11 @@ class RestAgentEngineTest {
         // Default: descriptor not found → ownership check skipped gracefully
         when(descriptorStore.readDescriptor(anyString(), anyInt()))
                 .thenThrow(new ResourceNotFoundException("test default"));
-        var conversationMemoryStore = mock(ai.labs.eddi.engine.memory.IConversationMemoryStore.class);
+        var conversationMemoryStore = mock(IConversationMemoryStore.class);
         var hitlAccessGuard = new HitlAccessGuard(identity, ownershipValidator, descriptorStore, conversationService,
-                mock(ai.labs.eddi.engine.api.IGroupConversationService.class));
+                mock(IGroupConversationService.class));
         var conversationAccessGuard = new ConversationAccessGuard(identity, ownershipValidator, descriptorStore);
-        var hitlToolJournalStore = mock(ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore.class);
+        var hitlToolJournalStore = mock(IHitlToolJournalStore.class);
         restAgentEngine = new RestAgentEngine(conversationService, conversationMemoryStore, identity, ownershipValidator,
                 conversationAccessGuard, hitlAccessGuard, hitlToolJournalStore, 30);
     }
@@ -271,7 +275,7 @@ class RestAgentEngineTest {
             restAgentEngine.sayWithinContext("conv-1", false, false,
                     List.of(), inputData, asyncResponse);
 
-            verify(asyncResponse).setTimeout(30, java.util.concurrent.TimeUnit.SECONDS);
+            verify(asyncResponse).setTimeout(30, TimeUnit.SECONDS);
             verify(conversationService).say(eq("conv-1"), eq(false), eq(false),
                     eq(List.of()), eq(inputData), eq(false), any());
         }
@@ -458,7 +462,7 @@ class RestAgentEngineTest {
 
             restAgentEngine.say("conv-1", false, false, List.of(), "Hello world", asyncResponse);
 
-            verify(asyncResponse).setTimeout(30, java.util.concurrent.TimeUnit.SECONDS);
+            verify(asyncResponse).setTimeout(30, TimeUnit.SECONDS);
             verify(conversationService).say(eq("conv-1"), eq(false), eq(false),
                     eq(List.of()), any(InputData.class), eq(false), any());
         }
@@ -476,7 +480,7 @@ class RestAgentEngineTest {
             restAgentEngine.rerunLastConversationStep("conv-1", "en", false, false,
                     List.of(), asyncResponse);
 
-            verify(asyncResponse).setTimeout(30, java.util.concurrent.TimeUnit.SECONDS);
+            verify(asyncResponse).setTimeout(30, TimeUnit.SECONDS);
             var captor = ArgumentCaptor.forClass(InputData.class);
             verify(conversationService).say(eq("conv-1"), eq(false), eq(false),
                     eq(List.of()), captor.capture(), eq(true), any());

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineToolPauseDetailsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineToolPauseDetailsTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.internal;
 
 import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.hitl.HitlAccessGuard;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
@@ -74,7 +75,7 @@ class RestAgentEngineToolPauseDetailsTest {
 
         var hitlAccessGuard = new HitlAccessGuard(
                 identity, ownershipValidator, conversationDescriptorStore, conversationService,
-                mock(ai.labs.eddi.engine.api.IGroupConversationService.class));
+                mock(IGroupConversationService.class));
         var conversationAccessGuard = new ConversationAccessGuard(
                 identity, ownershipValidator, conversationDescriptorStore);
         restAgentEngine = new RestAgentEngine(

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentManagementTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentManagementTest.java
@@ -15,6 +15,7 @@ import ai.labs.eddi.engine.triggermanagement.IRestAgentTriggerStore;
 import ai.labs.eddi.engine.triggermanagement.IUserConversationStore;
 import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.model.Deployment;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.core.Response;
@@ -68,7 +69,7 @@ class RestAgentManagementTest {
         @DisplayName("should return 200 and end conversation when found")
         void endsConversation() throws Exception {
             var userConv = new UserConversation("intent-1", "user-1",
-                    ai.labs.eddi.engine.model.Deployment.Environment.production, "agent-1", "conv-1");
+                    Deployment.Environment.production, "agent-1", "conv-1");
             when(userConversationStore.readUserConversation("intent-1", "user-1"))
                     .thenReturn(userConv);
 
@@ -363,6 +364,6 @@ class RestAgentManagementTest {
 
     private UserConversation createUserConversation() {
         return new UserConversation("intent-1", "user-1",
-                ai.labs.eddi.engine.model.Deployment.Environment.production, "agent-1", "conv-1");
+                Deployment.Environment.production, "agent-1", "conv-1");
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestCoordinatorAdminTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestCoordinatorAdminTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -39,7 +40,7 @@ class RestCoordinatorAdminTest {
         @Test
         @DisplayName("should delegate to coordinator")
         void delegatesToCoordinator() {
-            var status = new CoordinatorStatus("in-memory", true, "OK", 5, 100L, 0L, java.util.Map.of());
+            var status = new CoordinatorStatus("in-memory", true, "OK", 5, 100L, 0L, Map.of());
             when(coordinator.getStatus()).thenReturn(status);
 
             CoordinatorStatus result = restCoordinatorAdmin.getStatus();
@@ -147,7 +148,7 @@ class RestCoordinatorAdminTest {
         @Test
         @DisplayName("should send initial status and register client")
         void sendsInitialStatus() {
-            var status = new CoordinatorStatus("in-memory", true, "OK", 0, 0L, 0L, java.util.Map.of());
+            var status = new CoordinatorStatus("in-memory", true, "OK", 0, 0L, 0L, Map.of());
             when(coordinator.getStatus()).thenReturn(status);
 
             var eventSink = mock(jakarta.ws.rs.sse.SseEventSink.class);

--- a/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationExtendedTest.java
@@ -7,10 +7,14 @@ package ai.labs.eddi.engine.internal;
 import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
 import ai.labs.eddi.engine.api.IRestGroupConversation.DiscussRequest;
+import ai.labs.eddi.engine.api.IRestGroupConversation;
+import ai.labs.eddi.engine.hitl.HitlAccessGuard;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
+import ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore;
 import ai.labs.eddi.engine.security.OwnershipValidator;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -50,10 +54,10 @@ class RestGroupConversationExtendedTest {
         identity = mock(SecurityIdentity.class);
         ownershipValidator = mock(OwnershipValidator.class);
         when(ownershipValidator.validateAndResolveUserId(any(), any())).thenAnswer(inv -> inv.getArgument(1));
-        var hitlAccessGuard = new ai.labs.eddi.engine.hitl.HitlAccessGuard(
+        var hitlAccessGuard = new HitlAccessGuard(
                 identity, ownershipValidator,
-                mock(ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore.class),
-                mock(ai.labs.eddi.engine.api.IConversationService.class),
+                mock(IConversationDescriptorStore.class),
+                mock(IConversationService.class),
                 groupService);
         restGroupConversation = new RestGroupConversation(
                 groupService, jsonSerialization, identity, ownershipValidator, hitlAccessGuard);
@@ -482,7 +486,7 @@ class RestGroupConversationExtendedTest {
 
             restGroupConversation.continueDiscussionStreaming("group-1", "gc-1",
                     new DiscussRequest("q", "user-1",
-                            List.of(new ai.labs.eddi.engine.api.IRestGroupConversation.AttachmentRef(
+                            List.of(new IRestGroupConversation.AttachmentRef(
                                     "image/png", "aGVsbG8=", null, "d.png"))),
                     eventSink, sse);
 

--- a/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationHitlTest.java
@@ -8,9 +8,13 @@ import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService;
+import ai.labs.eddi.engine.hitl.HitlAccessGuard;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict;
+import ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore;
+import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import ai.labs.eddi.engine.security.OwnershipValidator;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -21,6 +25,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.security.Principal;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -57,10 +63,10 @@ class RestGroupConversationHitlTest {
 
         // Real guard wired with the same mocks + real OwnershipValidator, so the group
         // HITL ownership + listing assertions still exercise that logic end-to-end.
-        var hitlAccessGuard = new ai.labs.eddi.engine.hitl.HitlAccessGuard(
+        var hitlAccessGuard = new HitlAccessGuard(
                 identity, ownershipValidator,
-                mock(ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore.class),
-                mock(ai.labs.eddi.engine.api.IConversationService.class),
+                mock(IConversationDescriptorStore.class),
+                mock(IConversationService.class),
                 groupService);
         restGroupConversation = new RestGroupConversation(
                 groupService, jsonSerialization, identity, ownershipValidator, hitlAccessGuard);
@@ -307,9 +313,9 @@ class RestGroupConversationHitlTest {
     @DisplayName("Pending approvals listing")
     class PendingApprovalsListing {
 
-        private ai.labs.eddi.engine.model.PendingApprovalSummary summaryOwnedBy(String gcId, String ownerId) {
-            var summary = new ai.labs.eddi.engine.model.PendingApprovalSummary(
-                    gcId, null, ownerId, java.time.Instant.now(), "needs review", "WAIT_INDEFINITELY");
+        private PendingApprovalSummary summaryOwnedBy(String gcId, String ownerId) {
+            var summary = new PendingApprovalSummary(
+                    gcId, null, ownerId, Instant.now(), "needs review", "WAIT_INDEFINITELY");
             summary.setGroupId(GROUP_ID);
             return summary;
         }
@@ -318,7 +324,7 @@ class RestGroupConversationHitlTest {
         @DisplayName("admin sees all of the group's pending summaries")
         void adminSeesAll() throws Exception {
             asAdmin(ADMIN_ID);
-            when(groupService.listGroupPendingApprovals(eq(GROUP_ID), anyInt())).thenReturn(java.util.List.of(
+            when(groupService.listGroupPendingApprovals(eq(GROUP_ID), anyInt())).thenReturn(List.of(
                     summaryOwnedBy("gc-1", OWNER_ID), summaryOwnedBy("gc-2", "someone-else")));
 
             var result = restGroupConversation.listGroupPendingApprovals(GROUP_ID, 100);
@@ -334,7 +340,7 @@ class RestGroupConversationHitlTest {
             when(identity.getPrincipal()).thenReturn(principal);
             when(identity.hasRole("eddi-admin")).thenReturn(false);
             when(identity.hasRole("eddi-approver")).thenReturn(true);
-            when(groupService.listGroupPendingApprovals(eq(GROUP_ID), anyInt())).thenReturn(java.util.List.of(
+            when(groupService.listGroupPendingApprovals(eq(GROUP_ID), anyInt())).thenReturn(List.of(
                     summaryOwnedBy("gc-1", OWNER_ID), summaryOwnedBy("gc-2", "someone-else")));
 
             var result = restGroupConversation.listGroupPendingApprovals(GROUP_ID, 100);
@@ -346,7 +352,7 @@ class RestGroupConversationHitlTest {
         @DisplayName("regular user sees ONLY their own conversations")
         void ownerSeesOnlyOwn() throws Exception {
             asUser(OWNER_ID);
-            when(groupService.listGroupPendingApprovals(eq(GROUP_ID), anyInt())).thenReturn(java.util.List.of(
+            when(groupService.listGroupPendingApprovals(eq(GROUP_ID), anyInt())).thenReturn(List.of(
                     summaryOwnedBy("gc-mine", OWNER_ID),
                     summaryOwnedBy("gc-theirs", "someone-else"),
                     summaryOwnedBy("gc-unowned", null)));
@@ -362,7 +368,7 @@ class RestGroupConversationHitlTest {
         void anonymousSeesNothing() throws Exception {
             when(identity.getPrincipal()).thenReturn(null);
             when(identity.hasRole(anyString())).thenReturn(false);
-            when(groupService.listGroupPendingApprovals(eq(GROUP_ID), anyInt())).thenReturn(java.util.List.of(
+            when(groupService.listGroupPendingApprovals(eq(GROUP_ID), anyInt())).thenReturn(List.of(
                     summaryOwnedBy("gc-1", OWNER_ID)));
 
             var result = restGroupConversation.listGroupPendingApprovals(GROUP_ID, 100);
@@ -374,7 +380,7 @@ class RestGroupConversationHitlTest {
         @DisplayName("null limit param defaults to 100")
         void nullLimitDefaults() throws Exception {
             asAdmin(ADMIN_ID);
-            when(groupService.listGroupPendingApprovals(GROUP_ID, 100)).thenReturn(java.util.List.of());
+            when(groupService.listGroupPendingApprovals(GROUP_ID, 100)).thenReturn(List.of());
 
             restGroupConversation.listGroupPendingApprovals(GROUP_ID, null);
 

--- a/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationTest.java
@@ -7,11 +7,14 @@ package ai.labs.eddi.engine.internal;
 import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.api.IRestGroupConversation;
 import ai.labs.eddi.engine.api.IRestGroupConversation.AttachmentRef;
 import ai.labs.eddi.engine.api.IRestGroupConversation.DiscussRequest;
 import ai.labs.eddi.engine.api.IRestGroupConversation.FollowUpRequest;
+import ai.labs.eddi.engine.hitl.HitlAccessGuard;
+import ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore;
 import ai.labs.eddi.engine.memory.model.Attachment;
 import ai.labs.eddi.engine.security.OwnershipValidator;
 import io.quarkus.security.ForbiddenException;
@@ -25,6 +28,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -47,10 +51,10 @@ class RestGroupConversationTest {
         identity = mock(SecurityIdentity.class);
         ownershipValidator = mock(OwnershipValidator.class);
         when(ownershipValidator.validateAndResolveUserId(any(), any())).thenAnswer(inv -> inv.getArgument(1));
-        var hitlAccessGuard = new ai.labs.eddi.engine.hitl.HitlAccessGuard(
+        var hitlAccessGuard = new HitlAccessGuard(
                 identity, ownershipValidator,
-                mock(ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore.class),
-                mock(ai.labs.eddi.engine.api.IConversationService.class),
+                mock(IConversationDescriptorStore.class),
+                mock(IConversationService.class),
                 groupService);
         restGroupConversation = new RestGroupConversation(
                 groupService, jsonSerialization, identity, ownershipValidator, hitlAccessGuard);
@@ -437,7 +441,7 @@ class RestGroupConversationTest {
             when(groupService.readGroupConversation("gc-1")).thenReturn(gcInGroup("group-1"));
             when(groupService.followUpWithMember("gc-1", "agentA", "q"))
                     .thenThrow(new IGroupConversationService.GroupTimeoutException(
-                            "Follow-up timed out for agent 'agentA'", new java.util.concurrent.TimeoutException()));
+                            "Follow-up timed out for agent 'agentA'", new TimeoutException()));
 
             Response response = restGroupConversation.followUpWithMember("group-1", "gc-1",
                     new FollowUpRequest("q", "agentA", "user-1"));
@@ -502,7 +506,7 @@ class RestGroupConversationTest {
             when(groupService.readGroupConversation("gc-1")).thenReturn(gcInGroup("group-1"));
             when(groupService.continueDiscussion("gc-1", "q", null))
                     .thenThrow(new IGroupConversationService.GroupTimeoutException(
-                            "timed out", new java.util.concurrent.TimeoutException()));
+                            "timed out", new TimeoutException()));
 
             Response response = restGroupConversation.continueDiscussion("group-1", "gc-1",
                     new DiscussRequest("q", "user-1"));

--- a/src/test/java/ai/labs/eddi/engine/internal/RestLogAdminTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestLogAdminTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -133,7 +134,7 @@ class RestLogAdminTest {
                     .build())
                     .thenReturn(event);
             when(eventSink.send(any(jakarta.ws.rs.sse.OutboundSseEvent.class)))
-                    .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(null));
+                    .thenReturn(CompletableFuture.completedFuture(null));
             when(eventSink.isClosed()).thenReturn(true); // close immediately to prevent cleanup thread from running long
 
             restLogAdmin.streamLogs("agent-1", null, "INFO", eventSink, sse);

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupAttachmentBinderTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupAttachmentBinderTest.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.memory.model.Attachment;
 import ai.labs.eddi.engine.model.Context;
+import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
@@ -48,7 +49,7 @@ class GroupAttachmentBinderTest {
         var inline = new Attachment();
         inline.setMimeType("image/png");
         inline.setFileName("a.png");
-        inline.setBase64Data(java.util.Base64.getEncoder().encodeToString("png".getBytes()));
+        inline.setBase64Data(Base64.getEncoder().encodeToString("png".getBytes()));
         var gc = gc("gc-1");
 
         binder.materializeAttachments(gc, List.of(inline));

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupContextBuilderTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -234,7 +235,7 @@ class GroupContextBuilderTest {
         // Expected visibility for an entry belonging to the CURRENT
         // (still-running) phase — the strictest case for VOTE/BID, which are
         // only conditionally hidden (see the two dedicated tests below).
-        var expected = new java.util.LinkedHashMap<TranscriptEntryType, Boolean>();
+        var expected = new LinkedHashMap<TranscriptEntryType, Boolean>();
         expected.put(TranscriptEntryType.QUESTION, false);
         expected.put(TranscriptEntryType.OPINION, true);
         expected.put(TranscriptEntryType.CRITIQUE, true);

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/GroupHitlCoordinatorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/GroupHitlCoordinatorTest.java
@@ -24,12 +24,15 @@ import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
 import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
+import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.audit.AuditLedgerService;
 import ai.labs.eddi.engine.hitl.HitlSchedules;
+import ai.labs.eddi.engine.internal.GroupApprovalRequest;
 import ai.labs.eddi.engine.internal.GroupConversationService;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
 import ai.labs.eddi.engine.lifecycle.model.DiscussionControlToken;
+import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
@@ -42,6 +45,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -225,7 +229,7 @@ class GroupHitlCoordinatorTest {
         var gc = gc(GroupConversationState.AWAITING_APPROVAL);
         gc.setHitlApprovalTimeout("PT10M");
         gc.setHitlTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
-        gc.setPausedAt(java.time.Instant.now());
+        gc.setPausedAt(Instant.now());
 
         coordinator().scheduleGroupHitlTimeout(gc);
 
@@ -237,7 +241,7 @@ class GroupHitlCoordinatorTest {
         var gc = gc(GroupConversationState.AWAITING_APPROVAL);
         gc.setHitlApprovalTimeout("PT10M");
         gc.setHitlTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
-        gc.setPausedAt(java.time.Instant.now());
+        gc.setPausedAt(Instant.now());
         var coordinator = coordinator();
         doThrow(new RuntimeException("store down")).when(scheduleStore).createSchedule(any());
 
@@ -430,7 +434,7 @@ class GroupHitlCoordinatorTest {
         var coordinator = coordinator();
         when(conversationStore.read(GC_ID)).thenReturn(gc(GroupConversationState.COMPLETED));
 
-        assertThrows(ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException.class,
+        assertThrows(IGroupConversationService.GroupDiscussionException.class,
                 () -> coordinator.submitHumanInput(GC_ID, "h-1", "text", "h-1", null));
     }
 
@@ -460,7 +464,7 @@ class GroupHitlCoordinatorTest {
         when(groupStore.read(GROUP_ID, 1)).thenReturn(config);
         when(groupConversationService.effectivePhases(any(), eq(config))).thenReturn(List.of(opinionPhase()));
 
-        assertThrows(ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException.class,
+        assertThrows(IGroupConversationService.GroupDiscussionException.class,
                 () -> coordinator.submitHumanInput(GC_ID, "h-1", "text", "h-1", null));
 
         assertTrue(gc.getTranscript().isEmpty(), "drift refuses BEFORE any mutation — no rollback needed");
@@ -622,17 +626,17 @@ class GroupHitlCoordinatorTest {
         gc.setPausedAtPhaseIndex(0);
         gc.setPausedPhaseName("Phase 1");
         gc.setHitlPauseType(GroupConversation.HitlPauseType.PHASE);
-        gc.setPausedAt(java.time.Instant.now());
+        gc.setPausedAt(Instant.now());
         when(conversationStore.read(GC_ID)).thenReturn(gc);
         when(executorService.submit(any(Runnable.class))).thenAnswer(invocation -> {
             // The racing cancel: lands after the fresh token was registered but
             // before the rollback runs — exactly the dropped window.
             activeTokens.get(GC_ID).setSignal(ControlSignal.CANCEL_GRACEFUL);
-            throw new java.util.concurrent.RejectedExecutionException("saturated");
+            throw new RejectedExecutionException("saturated");
         });
-        var decision = new ai.labs.eddi.engine.lifecycle.model.HitlDecision();
-        decision.setVerdict(ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict.APPROVED);
-        var request = new ai.labs.eddi.engine.internal.GroupApprovalRequest();
+        var decision = new HitlDecision();
+        decision.setVerdict(HitlDecision.HitlVerdict.APPROVED);
+        var request = new GroupApprovalRequest();
         request.setDecision(decision);
 
         assertThrows(IResourceStore.ResourceStoreException.class,

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/NegotiationEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/NegotiationEngineTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TurnOrder;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionType;
 import ai.labs.eddi.configs.groups.model.GroupConversation.Proposal;
@@ -345,7 +346,7 @@ class NegotiationEngineTest {
     void agreement_groupMemberNotRequired() {
         var gc = gc();
         var nestedGroup = new GroupMember("g1", "Sub Team", 3, null,
-                ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.MemberType.GROUP);
+                AgentGroupConfiguration.MemberType.GROUP);
         NegotiationEngine.applyRepeat(gc, List.of(proposal("a1", "50/50")), 0, 0);
         NegotiationEngine.applyRepeat(gc, List.of(bargain("a2", "{\"accept\": \"p1\"}")), 1, 1);
 

--- a/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngineTest.java
@@ -28,7 +28,9 @@ import ai.labs.eddi.engine.security.CallerIdentityContext;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -632,7 +634,7 @@ class PhaseExecutionEngineTest {
                 ContextScope.FULL, true, null, 1, false, null, true);
 
         // 9 abstentions is what the loop actually produces; the exit must fire on it.
-        var entries = new java.util.ArrayList<TranscriptEntry>();
+        var entries = new ArrayList<TranscriptEntry>();
         for (int i = 0; i < 9; i++) {
             entries.add(new TranscriptEntry("a", "a", null, 0, "P", TranscriptEntryType.ABSTAINED, Instant.now(), null, null));
         }
@@ -649,7 +651,7 @@ class PhaseExecutionEngineTest {
 
     private DiscussionPhase votePhase() {
         var voteConfig = new VoteConfig(VoteMethod.MAJORITY, OptionsSource.EXPLICIT,
-                List.of("Adopt PostgreSQL", "Stay on MongoDB"), 0.5, java.util.Map.of(), false, TiePolicy.MODERATOR_DECIDES);
+                List.of("Adopt PostgreSQL", "Stay on MongoDB"), 0.5, Map.of(), false, TiePolicy.MODERATOR_DECIDES);
         return new DiscussionPhase("Ballot", PhaseType.VOTE, "ALL", TurnOrder.PARALLEL, ContextScope.NONE,
                 false, null, 1, false, null, false, voteConfig);
     }

--- a/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerHitlTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static ai.labs.eddi.engine.memory.MemoryKeys.ACTIONS;
 import static org.junit.jupiter.api.Assertions.*;
@@ -155,7 +156,7 @@ class LifecycleManagerHitlTest {
             when(pauseActionData.getResult()).thenReturn(List.of(IConversation.PAUSE_CONVERSATION));
 
             // Track which task was last executed to determine what getLatestData returns
-            java.util.concurrent.atomic.AtomicInteger lastExecutedTask = new java.util.concurrent.atomic.AtomicInteger(-1);
+            AtomicInteger lastExecutedTask = new AtomicInteger(-1);
             doAnswer(inv -> {
                 lastExecutedTask.set(0);
                 return null;

--- a/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerTest.java
+++ b/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerTest.java
@@ -19,6 +19,7 @@ import ai.labs.eddi.engine.memory.ConversationMemory;
 import ai.labs.eddi.engine.memory.ConversationStep;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IData;
+import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.Data;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +30,8 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -36,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.Map;
+import java.util.Set;
 
 import static ai.labs.eddi.engine.memory.MemoryKeys.ACTIONS;
 import static org.junit.jupiter.api.Assertions.*;
@@ -311,9 +315,9 @@ class LifecycleManagerTest {
 
             // Pre-execution snapshot
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.HashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new HashSet<>());
             when(currentStep.getAllElements()).thenReturn(new LinkedList<>());
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             when(componentCache.getComponentMap(anyString())).thenReturn(new HashMap<>());
 
@@ -351,9 +355,9 @@ class LifecycleManagerTest {
             when(memory.getMemoryPolicy()).thenReturn(memoryPolicy);
 
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.HashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new HashSet<>());
             when(currentStep.getAllElements()).thenReturn(new LinkedList<>());
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             when(componentCache.getComponentMap(anyString())).thenReturn(new HashMap<>());
 
@@ -767,13 +771,13 @@ class LifecycleManagerTest {
             when(task.getId()).thenReturn(new TaskId("llm_task"));
             when(task.getType()).thenReturn("langchain");
 
-            var conversationOutput = new ai.labs.eddi.engine.memory.model.ConversationOutput();
+            var conversationOutput = new ConversationOutput();
             // Pre-existing key that should survive rollback
             conversationOutput.put("existingKey", "existingValue");
 
             var currentStep = mock(ConversationStep.class);
             // Snapshot before: only "existingKey"
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.LinkedHashSet<>(java.util.Set.of("existingKey")));
+            when(currentStep.snapshotOutputKeys()).thenReturn(new LinkedHashSet<>(Set.of("existingKey")));
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
             when(currentStep.getAllElements()).thenReturn(new LinkedList<>());
             when(currentStep.getConversationOutput()).thenReturn(conversationOutput);
@@ -836,10 +840,10 @@ class LifecycleManagerTest {
 
             var currentStep = mock(ConversationStep.class);
             when(currentStep.snapshotDataIdentities()).thenReturn(beforeSnapshot);
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.LinkedHashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new LinkedHashSet<>());
             // After failure: step contains the overwritten entry
-            when(currentStep.getAllElements()).thenReturn(new java.util.LinkedList<>(List.of(overwrittenData)));
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getAllElements()).thenReturn(new LinkedList<>(List.of(overwrittenData)));
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             doThrow(new LifecycleException("fail"))
                     .when(task).execute(any(), any());
@@ -898,9 +902,9 @@ class LifecycleManagerTest {
             when(memory.getMemoryPolicy()).thenReturn(memoryPolicy);
 
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.LinkedHashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new LinkedHashSet<>());
             when(currentStep.getAllElements()).thenReturn(new LinkedList<>());
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             when(componentCache.getComponentMap(anyString())).thenReturn(new HashMap<>());
 
@@ -939,9 +943,9 @@ class LifecycleManagerTest {
             when(memory.getMemoryPolicy()).thenReturn(memoryPolicy);
 
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.LinkedHashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new LinkedHashSet<>());
             when(currentStep.getAllElements()).thenReturn(new LinkedList<>());
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             when(componentCache.getComponentMap(anyString())).thenReturn(new HashMap<>());
 
@@ -981,9 +985,9 @@ class LifecycleManagerTest {
             when(memory.getMemoryPolicy()).thenReturn(memoryPolicy);
 
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.LinkedHashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new LinkedHashSet<>());
             when(currentStep.getAllElements()).thenReturn(new LinkedList<>());
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             when(componentCache.getComponentMap(anyString())).thenReturn(new HashMap<>());
 
@@ -1027,9 +1031,9 @@ class LifecycleManagerTest {
             when(memory.getMemoryPolicy()).thenReturn(memoryPolicy);
 
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.LinkedHashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new LinkedHashSet<>());
             when(currentStep.getAllElements()).thenReturn(new LinkedList<>());
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             when(componentCache.getComponentMap(anyString())).thenReturn(new HashMap<>());
 
@@ -1077,9 +1081,9 @@ class LifecycleManagerTest {
             when(memory.getMemoryPolicy()).thenReturn(memoryPolicy);
 
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.LinkedHashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new LinkedHashSet<>());
             when(currentStep.getAllElements()).thenReturn(new LinkedList<>());
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             when(componentCache.getComponentMap(anyString())).thenReturn(new HashMap<>());
 
@@ -1682,9 +1686,9 @@ class LifecycleManagerTest {
             when(memory.getMemoryPolicy()).thenReturn(memoryPolicy);
 
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.LinkedHashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new LinkedHashSet<>());
             when(currentStep.getAllElements()).thenReturn(new LinkedList<>());
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             when(componentCache.getComponentMap(anyString())).thenReturn(new HashMap<>());
 
@@ -1714,10 +1718,10 @@ class LifecycleManagerTest {
             var currentStep = mock(ConversationStep.class);
             // Before snapshot: empty (no pre-existing keys)
             when(currentStep.snapshotDataIdentities()).thenReturn(new HashMap<>());
-            when(currentStep.snapshotOutputKeys()).thenReturn(new java.util.LinkedHashSet<>());
+            when(currentStep.snapshotOutputKeys()).thenReturn(new LinkedHashSet<>());
             // After failure: step contains the new entry
-            when(currentStep.getAllElements()).thenReturn(new java.util.LinkedList<>(List.of(newData)));
-            when(currentStep.getConversationOutput()).thenReturn(new ai.labs.eddi.engine.memory.model.ConversationOutput());
+            when(currentStep.getAllElements()).thenReturn(new LinkedList<>(List.of(newData)));
+            when(currentStep.getConversationOutput()).thenReturn(new ConversationOutput());
 
             doThrow(new LifecycleException("timeout"))
                     .when(task).execute(any(), any());

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsExtendedTest.java
@@ -35,6 +35,7 @@ import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.engine.schedule.model.ScheduleFireLog;
 import ai.labs.eddi.engine.triggermanagement.IRestAgentTriggerStore;
+import ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -1438,9 +1439,9 @@ class McpAdminToolsExtendedTest {
 
     @Test
     void createAgentTrigger_missingIntentInConfig_returnsError() throws IOException {
-        var config = new ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration();
+        var config = new AgentTriggerConfiguration();
         config.setIntent(null);
-        when(jsonSerialization.deserialize(anyString(), eq(ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration.class)))
+        when(jsonSerialization.deserialize(anyString(), eq(AgentTriggerConfiguration.class)))
                 .thenReturn(config);
 
         String result = tools.createAgentTrigger("{\"agentDeployments\":[]}");
@@ -1451,7 +1452,7 @@ class McpAdminToolsExtendedTest {
 
     @Test
     void createAgentTrigger_handlesException() throws IOException {
-        when(jsonSerialization.deserialize(anyString(), eq(ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration.class)))
+        when(jsonSerialization.deserialize(anyString(), eq(AgentTriggerConfiguration.class)))
                 .thenThrow(new RuntimeException("parse error"));
 
         String result = tools.createAgentTrigger("{\"bad json\"}");
@@ -1484,7 +1485,7 @@ class McpAdminToolsExtendedTest {
 
     @Test
     void updateAgentTrigger_handlesException() throws IOException {
-        when(jsonSerialization.deserialize(anyString(), eq(ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration.class)))
+        when(jsonSerialization.deserialize(anyString(), eq(AgentTriggerConfiguration.class)))
                 .thenThrow(new RuntimeException("update error"));
 
         String result = tools.updateAgentTrigger("support", "{}");

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsSwitchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsSwitchCoverageTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mock;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -782,7 +783,7 @@ class McpAdminToolsSwitchCoverageTest {
 
             var step = new WorkflowConfiguration.WorkflowStep();
             step.setType(URI.create("ai.labs.rules"));
-            step.setConfig(new java.util.HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1")));
+            step.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1")));
             var wfConfig = new WorkflowConfiguration();
             wfConfig.setWorkflowSteps(List.of(step));
             when(workflowStore.readWorkflow("wf1", 1)).thenReturn(wfConfig);
@@ -847,7 +848,7 @@ class McpAdminToolsSwitchCoverageTest {
 
             var step = new WorkflowConfiguration.WorkflowStep();
             step.setType(null);
-            step.setConfig(new java.util.HashMap<>());
+            step.setConfig(new HashMap<>());
             var wfConfig = new WorkflowConfiguration();
             wfConfig.setWorkflowSteps(List.of(step));
             when(workflowStore.readWorkflow("wf1", 1)).thenReturn(wfConfig);
@@ -1019,7 +1020,7 @@ class McpAdminToolsSwitchCoverageTest {
         @Test
         @DisplayName("workflow modified → agent updated with new workflow URIs")
         void workflowModified() throws Exception {
-            var mapping = new java.util.HashMap<String, String>();
+            var mapping = new HashMap<String, String>();
             mapping.put("oldUri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1");
             mapping.put("newUri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=2");
             when(jsonSerialization.deserialize(anyString(), eq(List.class))).thenReturn(List.of(mapping));
@@ -1030,7 +1031,7 @@ class McpAdminToolsSwitchCoverageTest {
             when(restAgentStore.readAgent("agent1", 1)).thenReturn(agent);
 
             var step = new WorkflowConfiguration.WorkflowStep();
-            step.setConfig(new java.util.HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1")));
+            step.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1")));
             var wfConfig = new WorkflowConfiguration();
             wfConfig.setWorkflowSteps(List.of(step));
             when(workflowStore.readWorkflow("wf1", 1)).thenReturn(wfConfig);
@@ -1053,7 +1054,7 @@ class McpAdminToolsSwitchCoverageTest {
         @Test
         @DisplayName("redeploy=true after cascade")
         void redeployAfterCascade() throws Exception {
-            var mapping = new java.util.HashMap<String, String>();
+            var mapping = new HashMap<String, String>();
             mapping.put("oldUri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1");
             mapping.put("newUri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=2");
             when(jsonSerialization.deserialize(anyString(), eq(List.class))).thenReturn(List.of(mapping));
@@ -1064,7 +1065,7 @@ class McpAdminToolsSwitchCoverageTest {
             when(restAgentStore.readAgent("agent1", 1)).thenReturn(agent);
 
             var step = new WorkflowConfiguration.WorkflowStep();
-            step.setConfig(new java.util.HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1")));
+            step.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1")));
             var wfConfig = new WorkflowConfiguration();
             wfConfig.setWorkflowSteps(List.of(step));
             when(workflowStore.readWorkflow("wf1", 1)).thenReturn(wfConfig);
@@ -1090,7 +1091,7 @@ class McpAdminToolsSwitchCoverageTest {
         @Test
         @DisplayName("redeploy exception → deployError in result")
         void redeployException() throws Exception {
-            var mapping = new java.util.HashMap<String, String>();
+            var mapping = new HashMap<String, String>();
             mapping.put("oldUri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1");
             mapping.put("newUri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=2");
             when(jsonSerialization.deserialize(anyString(), eq(List.class))).thenReturn(List.of(mapping));
@@ -1101,7 +1102,7 @@ class McpAdminToolsSwitchCoverageTest {
             when(restAgentStore.readAgent("agent1", 1)).thenReturn(agent);
 
             var step = new WorkflowConfiguration.WorkflowStep();
-            step.setConfig(new java.util.HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1")));
+            step.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/rs1?version=1")));
             var wfConfig = new WorkflowConfiguration();
             wfConfig.setWorkflowSteps(List.of(step));
             when(workflowStore.readWorkflow("wf1", 1)).thenReturn(wfConfig);
@@ -1125,7 +1126,7 @@ class McpAdminToolsSwitchCoverageTest {
         @Test
         @DisplayName("workflow config null → keep URI as-is")
         void workflowConfigNull() throws Exception {
-            var mapping = new java.util.HashMap<String, String>();
+            var mapping = new HashMap<String, String>();
             mapping.put("oldUri", "old");
             mapping.put("newUri", "new");
             when(jsonSerialization.deserialize(anyString(), eq(List.class))).thenReturn(List.of(mapping));

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpApiToolBuilderTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpApiToolBuilderTest.java
@@ -5,11 +5,13 @@
 package ai.labs.eddi.engine.mcp;
 
 import ai.labs.eddi.configs.apicalls.model.ApiCall;
+import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -253,7 +255,7 @@ class McpApiToolBuilderTest {
 
         assertEquals("A path id", call.getParameters().get("requestBody"), "the path parameter keeps the name");
         // Every variable the body template references must still be declared.
-        var matcher = java.util.regex.Pattern.compile("\\{([A-Za-z0-9_]+)}").matcher(call.getRequest().getBody());
+        var matcher = Pattern.compile("\\{([A-Za-z0-9_]+)}").matcher(call.getRequest().getBody());
         assertTrue(matcher.find());
         assertTrue(call.getParameters().containsKey(matcher.group(1)),
                 "the body variable was renamed to " + matcher.group(1) + " and must be declared");
@@ -334,7 +336,7 @@ class McpApiToolBuilderTest {
         assertNotNull(createPet.getParameters(), "a call with a body must declare parameters");
         // Every variable the template references must be declared — that is the
         // invariant, whatever shape the template takes.
-        var matcher = java.util.regex.Pattern.compile("\\{([A-Za-z0-9_]+)}").matcher(createPet.getRequest().getBody());
+        var matcher = Pattern.compile("\\{([A-Za-z0-9_]+)}").matcher(createPet.getRequest().getBody());
         int found = 0;
         while (matcher.find()) {
             found++;
@@ -501,8 +503,8 @@ class McpApiToolBuilderTest {
         // (internal OpenAPI discovery must keep working). The scheme gate accepts
         // them — only a subsequent fetch/parse can fail, never the URL check itself.
         assertTrue(McpApiToolBuilder.looksLikeInlineSpec("http://10.0.0.5/openapi.json") == false);
-        assertTrue(ai.labs.eddi.modules.llm.tools.UrlValidationUtils.isValidHttpUrl("http://169.254.169.254/latest/meta-data/"));
-        assertTrue(ai.labs.eddi.modules.llm.tools.UrlValidationUtils.isValidHttpUrl("http://internal-svc.cluster.local/spec.json"));
+        assertTrue(UrlValidationUtils.isValidHttpUrl("http://169.254.169.254/latest/meta-data/"));
+        assertTrue(UrlValidationUtils.isValidHttpUrl("http://internal-svc.cluster.local/spec.json"));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsExtendedTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResponseHandler;
@@ -638,7 +639,7 @@ class McpConversationToolsExtendedTest {
     @Test
     void chatManaged_emptyDeployments_returnsError() throws Exception {
         when(userConversationStore.readUserConversation("support", "user1"))
-                .thenThrow(new ai.labs.eddi.datastore.IResourceStore.ResourceStoreException("not found"));
+                .thenThrow(new IResourceStore.ResourceStoreException("not found"));
 
         var trigger = new AgentTriggerConfiguration();
         trigger.setIntent("support");
@@ -654,7 +655,7 @@ class McpConversationToolsExtendedTest {
     @Test
     void chatManaged_nullTrigger_returnsError() throws Exception {
         when(userConversationStore.readUserConversation("support", "user1"))
-                .thenThrow(new ai.labs.eddi.datastore.IResourceStore.ResourceStoreException("not found"));
+                .thenThrow(new IResourceStore.ResourceStoreException("not found"));
 
         when(agentTriggerStore.readAgentTrigger("support")).thenReturn(null);
 

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsHitlTest.java
@@ -3,20 +3,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.mcp;
+import ai.labs.eddi.configs.agents.IRestAgentStore;
 
 import ai.labs.eddi.datastore.serialization.JsonSerialization;
+import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResponseHandler;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResult;
+import ai.labs.eddi.engine.api.IRestAgentAdministration;
 import ai.labs.eddi.engine.api.IRestAgentEngine;
+import ai.labs.eddi.engine.audit.rest.IRestAuditStore;
 import ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.model.Deployment;
+import ai.labs.eddi.engine.runtime.BoundedLogStore;
+import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
 import ai.labs.eddi.engine.security.ConversationAccessGuard;
 import ai.labs.eddi.engine.security.OwnershipValidator;
 import ai.labs.eddi.engine.triggermanagement.IRestAgentTriggerStore;
 import ai.labs.eddi.engine.triggermanagement.IUserConversationStore;
+import ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration;
 import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -24,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -59,12 +68,12 @@ class McpConversationToolsHitlTest {
                 mock(IConversationDescriptorStore.class));
 
         tools = new McpConversationTools(
-                conversationService, mock(ai.labs.eddi.engine.api.IRestAgentAdministration.class),
-                mock(ai.labs.eddi.configs.agents.IRestAgentStore.class),
-                mock(ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory.class),
-                new JsonSerialization(ai.labs.eddi.datastore.serialization.SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false)),
-                mock(ai.labs.eddi.engine.runtime.BoundedLogStore.class),
-                mock(ai.labs.eddi.engine.audit.rest.IRestAuditStore.class),
+                conversationService, mock(IRestAgentAdministration.class),
+                mock(IRestAgentStore.class),
+                mock(IRestInterfaceFactory.class),
+                new JsonSerialization(SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false)),
+                mock(BoundedLogStore.class),
+                mock(IRestAuditStore.class),
                 agentTriggerStore, userConversationStore, restAgentEngine,
                 identity, conversationAccessGuard, false);
     }
@@ -76,7 +85,7 @@ class McpConversationToolsHitlTest {
         when(userConversationStore.readUserConversation("customer_support", "U1")).thenReturn(existing);
         // Trigger still exists (no exception), conversation not ENDED → existing reused
         when(agentTriggerStore.readAgentTrigger("customer_support"))
-                .thenReturn(mock(ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration.class));
+                .thenReturn(mock(AgentTriggerConfiguration.class));
         when(restAgentEngine.getConversationState("conv-1")).thenReturn(ConversationState.AWAITING_HUMAN);
         // say throws — conversation already paused
         doThrow(new IConversationService.ConversationAwaitingApprovalException("paused"))
@@ -102,7 +111,7 @@ class McpConversationToolsHitlTest {
                 Deployment.Environment.production, "agent-1", "conv-1");
         when(userConversationStore.readUserConversation("customer_support", "U1")).thenReturn(existing);
         when(agentTriggerStore.readAgentTrigger("customer_support"))
-                .thenReturn(mock(ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration.class));
+                .thenReturn(mock(AgentTriggerConfiguration.class));
         when(restAgentEngine.getConversationState("conv-1")).thenReturn(ConversationState.READY);
 
         // say completes with an AWAITING_HUMAN snapshot (this turn paused)
@@ -126,7 +135,7 @@ class McpConversationToolsHitlTest {
                 Deployment.Environment.production, "agent-1", "conv-1");
         when(userConversationStore.readUserConversation("customer_support", "U1")).thenReturn(existing);
         when(agentTriggerStore.readAgentTrigger("customer_support"))
-                .thenReturn(mock(ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration.class));
+                .thenReturn(mock(AgentTriggerConfiguration.class));
         when(restAgentEngine.getConversationState("conv-1")).thenReturn(ConversationState.READY);
 
         // H7: say skips the queued turn (IN_PROGRESS busy) — must NOT be reported as
@@ -152,7 +161,7 @@ class McpConversationToolsHitlTest {
                 Deployment.Environment.production, "agent-1", "conv-1");
         when(userConversationStore.readUserConversation("customer_support", "U1")).thenReturn(existing);
         when(agentTriggerStore.readAgentTrigger("customer_support"))
-                .thenReturn(mock(ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration.class));
+                .thenReturn(mock(AgentTriggerConfiguration.class));
         when(restAgentEngine.getConversationState("conv-1")).thenReturn(ConversationState.AWAITING_HUMAN);
 
         // H7: a skip whose state is AWAITING_HUMAN → pending approval, not busy.
@@ -228,13 +237,13 @@ class McpConversationToolsHitlTest {
         // Task 13: a TOOL_CALL pause must additively include pauseType + tool NAMES
         // (names only) in the PAUSED_FOR_APPROVAL envelope, without breaking the
         // existing fields (suggestNextTool, conversationState, /resume).
-        var batch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
-        var call1 = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+        var batch = new PendingToolCallBatch();
+        var call1 = new PendingToolCallBatch.PendingToolCall();
         call1.setToolName("delete_production_db");
         call1.setArgumentsRaw("{\"token\":\"topsecret\"}");
-        var call2 = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+        var call2 = new PendingToolCallBatch.PendingToolCall();
         call2.setToolName("wire_transfer");
-        batch.setCalls(java.util.List.of(call1, call2));
+        batch.setCalls(List.of(call1, call2));
 
         var snapshot = new SimpleConversationMemorySnapshot();
         snapshot.setConversationState(ConversationState.AWAITING_HUMAN);

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.engine.triggermanagement.IUserConversationStore;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResponseHandler;
@@ -18,6 +19,7 @@ import ai.labs.eddi.engine.api.IRestAgentEngine;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
 import ai.labs.eddi.engine.audit.rest.IRestAuditStore;
 import ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore;
+import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.model.*;
 import ai.labs.eddi.engine.security.ConversationAccessGuard;
@@ -27,6 +29,7 @@ import ai.labs.eddi.engine.model.Deployment;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.runtime.BoundedLogStore;
 import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
+import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
 import java.util.LinkedHashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -535,7 +538,7 @@ class McpConversationToolsTest {
     @Test
     void chatManaged_noTriggerConfigured_returnsError() throws Exception {
         when(userConversationStore.readUserConversation("no_trigger", "user1"))
-                .thenThrow(new ai.labs.eddi.datastore.IResourceStore.ResourceStoreException("not found"));
+                .thenThrow(new IResourceStore.ResourceStoreException("not found"));
         when(AgentTriggerStore.readAgentTrigger("no_trigger")).thenReturn(null);
 
         String result = tools.chatManaged("no_trigger", "user1", "hello", "production");
@@ -547,7 +550,7 @@ class McpConversationToolsTest {
     void chatManaged_happyPath_createsConversationAndSendsMessage() throws Exception {
         // No existing UserConversation
         when(userConversationStore.readUserConversation("support", "user1"))
-                .thenThrow(new ai.labs.eddi.datastore.IResourceStore.ResourceStoreException("not found"));
+                .thenThrow(new IResourceStore.ResourceStoreException("not found"));
 
         // Trigger exists with a deployment
         var trigger = new AgentTriggerConfiguration();
@@ -585,7 +588,7 @@ class McpConversationToolsTest {
     @Test
     void chatManaged_existingConversation_reusesIt() throws Exception {
         // Existing UserConversation found
-        var existing = new ai.labs.eddi.engine.triggermanagement.model.UserConversation(
+        var existing = new UserConversation(
                 "support", "user1", Environment.production, AGENT_ID, CONV_ID);
         when(userConversationStore.readUserConversation("support", "user1")).thenReturn(existing);
 
@@ -596,7 +599,7 @@ class McpConversationToolsTest {
 
         // Conversation state is READY (not ended)
         when(RestAgentEngine.getConversationState(CONV_ID))
-                .thenReturn(ai.labs.eddi.engine.memory.model.ConversationState.READY);
+                .thenReturn(ConversationState.READY);
 
         // Mock say
         doAnswer(invocation -> {
@@ -618,7 +621,7 @@ class McpConversationToolsTest {
     @Test
     void chatManaged_staleConversation_recreatesFresh() throws Exception {
         // Existing UserConversation references a deleted conversation
-        var existing = new ai.labs.eddi.engine.triggermanagement.model.UserConversation(
+        var existing = new UserConversation(
                 "support", "user1", Environment.production, AGENT_ID, "deleted-conv-id");
         when(userConversationStore.readUserConversation("support", "user1")).thenReturn(existing);
 
@@ -661,7 +664,7 @@ class McpConversationToolsTest {
     @Test
     void chatManaged_endedConversation_recreatesFresh() throws Exception {
         // Existing UserConversation references an ended conversation
-        var existing = new ai.labs.eddi.engine.triggermanagement.model.UserConversation(
+        var existing = new UserConversation(
                 "support", "user1", Environment.production, AGENT_ID, "ended-conv-id");
         when(userConversationStore.readUserConversation("support", "user1")).thenReturn(existing);
 
@@ -677,7 +680,7 @@ class McpConversationToolsTest {
 
         // getConversationState returns ENDED
         when(RestAgentEngine.getConversationState("ended-conv-id"))
-                .thenReturn(ai.labs.eddi.engine.memory.model.ConversationState.ENDED);
+                .thenReturn(ConversationState.ENDED);
 
         // New conversation creation succeeds
         when(conversationService.startConversation(eq(Environment.production), eq(AGENT_ID), eq("user1"), anyMap()))
@@ -704,7 +707,7 @@ class McpConversationToolsTest {
     @Test
     void chatManaged_transientStateError_doesNotRecreate() throws Exception {
         // Existing UserConversation is valid
-        var existing = new ai.labs.eddi.engine.triggermanagement.model.UserConversation(
+        var existing = new UserConversation(
                 "support", "user1", Environment.production, AGENT_ID, CONV_ID);
         when(userConversationStore.readUserConversation("support", "user1")).thenReturn(existing);
 
@@ -730,7 +733,7 @@ class McpConversationToolsTest {
     @Test
     void chatManaged_triggerDeleted_returnsError() throws Exception {
         // Existing UserConversation found
-        var existing = new ai.labs.eddi.engine.triggermanagement.model.UserConversation(
+        var existing = new UserConversation(
                 "deleted_intent", "user1", Environment.production, AGENT_ID, CONV_ID);
         when(userConversationStore.readUserConversation("deleted_intent", "user1")).thenReturn(existing);
 
@@ -753,7 +756,7 @@ class McpConversationToolsTest {
     void chatManaged_conversationCreationFails_returnsError() throws Exception {
         // No existing UserConversation
         when(userConversationStore.readUserConversation("support", "user1"))
-                .thenThrow(new ai.labs.eddi.datastore.IResourceStore.ResourceStoreException("not found"));
+                .thenThrow(new IResourceStore.ResourceStoreException("not found"));
 
         // Trigger exists
         var trigger = new AgentTriggerConfiguration();

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.configs.groups.model.SharedTaskList;
 import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.groups.templates.GroupTemplateService;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.security.OwnershipValidator;
@@ -24,6 +25,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -41,8 +43,8 @@ class McpGroupToolsTest {
     private IGroupWorkspaceStore workspaceStore;
     private McpGroupTools tools;
 
-    private static ai.labs.eddi.configs.groups.templates.GroupTemplateService templateService() {
-        var service = new ai.labs.eddi.configs.groups.templates.GroupTemplateService(
+    private static GroupTemplateService templateService() {
+        var service = new GroupTemplateService(
                 new com.fasterxml.jackson.databind.ObjectMapper());
         service.loadTemplates();
         return service;
@@ -361,7 +363,7 @@ class McpGroupToolsTest {
         gc.setId("gc-async-1");
         gc.setState(GroupConversation.GroupConversationState.IN_PROGRESS);
         when(groupConversationService.startAndDiscussAsync("g1", "Build it", "user1", null)).thenReturn(gc);
-        when(jsonSerialization.serialize(any(java.util.Map.class))).thenReturn(
+        when(jsonSerialization.serialize(any(Map.class))).thenReturn(
                 "{\"groupConversationId\":\"gc-async-1\",\"state\":\"IN_PROGRESS\",\"message\":\"Discussion started.\"}");
 
         String result = tools.start_group_discussion("g1", "Build it", "user1");
@@ -372,7 +374,7 @@ class McpGroupToolsTest {
 
         // Verify the Map passed to serialize contains the right keys
         @SuppressWarnings("unchecked")
-        ArgumentCaptor<java.util.Map<String, Object>> captor = ArgumentCaptor.forClass(java.util.Map.class);
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
         verify(jsonSerialization).serialize(captor.capture());
         var map = captor.getValue();
         assertEquals("gc-async-1", map.get("groupConversationId"));

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpHitlToolsCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpHitlToolsCoverageTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.security.Principal;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,7 +89,7 @@ class McpHitlToolsCoverageTest {
 
     @Test
     void listPendingApprovals_nullLimit_usesDefaultAndSucceeds() throws Exception {
-        when(guard.listScopedPendingApprovals(anyInt())).thenReturn(java.util.List.of());
+        when(guard.listScopedPendingApprovals(anyInt())).thenReturn(List.of());
         when(json.serialize(any())).thenReturn("[]");
         String out = tools.listPendingApprovals(null);
         assertTrue(out.equals("[]"), out);
@@ -273,7 +275,7 @@ class McpHitlToolsCoverageTest {
 
     @Test
     void listGroupPending_happyPath_serializes() throws Exception {
-        when(guard.listScopedGroupPendingApprovals(eq("g1"), anyInt())).thenReturn(java.util.List.of());
+        when(guard.listScopedGroupPendingApprovals(eq("g1"), anyInt())).thenReturn(List.of());
         when(json.serialize(any())).thenReturn("[]");
         String out = tools.listGroupPendingApprovals("g1", "100");
         assertTrue(out.equals("[]"), out);
@@ -380,7 +382,7 @@ class McpHitlToolsCoverageTest {
         // deserialize returns a map whose value is not a String => value-type
         // validation fails
         when(json.deserialize(eq("{\"t1\":5}"), eq(Map.class)))
-                .thenReturn(new java.util.LinkedHashMap<>(Map.of("t1", 5)));
+                .thenReturn(new LinkedHashMap<>(Map.of("t1", 5)));
         String out = tools.approveGroupPhase("g1", "gc1", "APPROVED", null, "{\"t1\":5}");
         assertTrue(out.contains("\"errorCode\":\"BAD_REQUEST\""), out);
         verifyNoInteractions(groupConversationService);
@@ -389,7 +391,7 @@ class McpHitlToolsCoverageTest {
     @Test
     void approveGroup_blankTaskApprovalValue_returnsBadRequest() throws Exception {
         when(json.deserialize(eq("{\"t1\":\"\"}"), eq(Map.class)))
-                .thenReturn(new java.util.LinkedHashMap<>(Map.of("t1", "")));
+                .thenReturn(new LinkedHashMap<>(Map.of("t1", "")));
         String out = tools.approveGroupPhase("g1", "gc1", "APPROVED", null, "{\"t1\":\"\"}");
         assertTrue(out.contains("\"errorCode\":\"BAD_REQUEST\""), out);
         verifyNoInteractions(groupConversationService);
@@ -462,7 +464,7 @@ class McpHitlToolsCoverageTest {
     @Test
     void approveGroup_validTaskApprovals_delegatesAndSucceeds() throws Exception {
         when(json.deserialize(eq("{\"t1\":\"APPROVED\"}"), eq(Map.class)))
-                .thenReturn(new java.util.LinkedHashMap<>(Map.of("t1", "APPROVED")));
+                .thenReturn(new LinkedHashMap<>(Map.of("t1", "APPROVED")));
         when(groupConversationService.resumeDiscussion(eq("gc1"), any(), isNull()))
                 .thenReturn(mock(GroupConversation.class));
         when(json.serialize(any())).thenReturn("{\"ok\":true}");

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpHitlToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpHitlToolsTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -151,7 +153,7 @@ class McpHitlToolsTest {
 
     @Test
     void listPendingApprovals_delegatesToGuard() throws Exception {
-        when(guard.listScopedPendingApprovals(anyInt())).thenReturn(java.util.List.of());
+        when(guard.listScopedPendingApprovals(anyInt())).thenReturn(List.of());
         when(json.serialize(any())).thenReturn("[]");
         String out = tools.listPendingApprovals("50");
         assertEquals("[]", out);
@@ -189,7 +191,7 @@ class McpHitlToolsTest {
 
     @Test
     void approveGroup_malformedTaskApprovals_returnsBadRequest() throws Exception {
-        when(json.deserialize(eq("{bad"), eq(java.util.Map.class))).thenThrow(new java.io.IOException("parse"));
+        when(json.deserialize(eq("{bad"), eq(Map.class))).thenThrow(new java.io.IOException("parse"));
         String out = tools.approveGroupPhase("g1", "gc1", "APPROVED", null, "{bad");
         assertTrue(out.contains("\"errorCode\":\"BAD_REQUEST\""), out);
         verifyNoInteractions(groupConversationService);
@@ -208,7 +210,7 @@ class McpHitlToolsTest {
 
     @Test
     void listAllGroupPendingApprovals_delegatesToGuardWithNullGroup() throws Exception {
-        when(guard.listScopedGroupPendingApprovals(isNull(), anyInt())).thenReturn(java.util.List.of());
+        when(guard.listScopedGroupPendingApprovals(isNull(), anyInt())).thenReturn(List.of());
         when(json.serialize(any())).thenReturn("[]");
         String out = tools.listAllGroupPendingApprovals("100");
         assertEquals("[]", out);

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpMemoryToolsBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpMemoryToolsBranchCoverageTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.security.OwnershipValidator;
 import io.quarkus.security.identity.SecurityIdentity;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -83,7 +84,7 @@ class McpMemoryToolsBranchCoverageTest {
                     mock(UserMemoryEntry.class),
                     mock(UserMemoryEntry.class),
                     mock(UserMemoryEntry.class));
-            when(userMemoryStore.getAllEntries("user1")).thenReturn(new java.util.ArrayList<>(entries));
+            when(userMemoryStore.getAllEntries("user1")).thenReturn(new ArrayList<>(entries));
             when(jsonSerialization.serialize(any())).thenReturn("{\"count\":2}");
 
             String result = tools.listUserMemories("user1", 2);

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpSetupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpSetupToolsTest.java
@@ -25,6 +25,7 @@ import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
 import ai.labs.eddi.engine.setup.AgentSetupService;
 import ai.labs.eddi.secrets.ISecretProvider;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.secrets.model.SecretReference;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -272,7 +273,7 @@ class McpSetupToolsTest {
                 null, null, null, null, false, null);
 
         // Verify the API key was stored in the vault
-        var refCaptor = ArgumentCaptor.forClass(ai.labs.eddi.secrets.model.SecretReference.class);
+        var refCaptor = ArgumentCaptor.forClass(SecretReference.class);
         verify(vaultProvider).store(refCaptor.capture(), eq("sk-live-secret"), contains("Vault Agent"), any());
         assertTrue(refCaptor.getValue().keyName().startsWith("setup.vault-agent."),
                 "Vault key should start with 'setup.<sanitized-name>.'");
@@ -401,7 +402,7 @@ class McpSetupToolsTest {
 
         var task = config.tasks().get(0);
         assertTrue(task.getEnableBuiltInTools());
-        assertEquals(java.util.List.of("calculator", "websearch"), task.getBuiltInToolsWhitelist());
+        assertEquals(List.of("calculator", "websearch"), task.getBuiltInToolsWhitelist());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpToolSchemaValidationTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpToolSchemaValidationTest.java
@@ -3,6 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.mcp;
+import ai.labs.eddi.modules.llm.tools.EddiToolBridge;
+import ai.labs.eddi.modules.llm.tools.impl.CalculatorTool;
+import ai.labs.eddi.modules.llm.tools.impl.DataFormatterTool;
+import ai.labs.eddi.modules.llm.tools.impl.DateTimeTool;
+import ai.labs.eddi.modules.llm.tools.impl.PdfReaderTool;
+import ai.labs.eddi.modules.llm.tools.impl.TextSummarizerTool;
+import ai.labs.eddi.modules.llm.tools.impl.WeatherTool;
+import ai.labs.eddi.modules.llm.tools.impl.WebScraperTool;
+import ai.labs.eddi.modules.llm.tools.impl.WebSearchTool;
 
 import dev.langchain4j.agent.tool.P;
 import org.junit.jupiter.api.Test;
@@ -49,11 +58,11 @@ class McpToolSchemaValidationTest {
      */
     private static final Class<?>[] TOOL_CLASSES = {
             // Built-in langchain4j tools (use @P for parameter names)
-            ai.labs.eddi.modules.llm.tools.impl.CalculatorTool.class, ai.labs.eddi.modules.llm.tools.impl.DataFormatterTool.class,
-            ai.labs.eddi.modules.llm.tools.impl.DateTimeTool.class, ai.labs.eddi.modules.llm.tools.impl.PdfReaderTool.class,
-            ai.labs.eddi.modules.llm.tools.impl.TextSummarizerTool.class, ai.labs.eddi.modules.llm.tools.impl.WeatherTool.class,
-            ai.labs.eddi.modules.llm.tools.impl.WebScraperTool.class, ai.labs.eddi.modules.llm.tools.impl.WebSearchTool.class,
-            ai.labs.eddi.modules.llm.tools.EddiToolBridge.class,
+            CalculatorTool.class, DataFormatterTool.class,
+            DateTimeTool.class, PdfReaderTool.class,
+            TextSummarizerTool.class, WeatherTool.class,
+            WebScraperTool.class, WebSearchTool.class,
+            EddiToolBridge.class,
 
             // MCP tools (use @ToolArg — Java parameter names become keys)
             McpConversationTools.class, McpAdminTools.class, McpSetupTools.class,};

--- a/src/test/java/ai/labs/eddi/engine/memory/AttachmentContextExtractorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/AttachmentContextExtractorTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.memory;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.memory.model.Attachment;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
+import ai.labs.eddi.engine.memory.model.Data;
 import ai.labs.eddi.engine.model.Context;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -499,7 +500,7 @@ class AttachmentContextExtractorTest {
             ConversationMemory memory = new ConversationMemory("conv-1", "agent-1", 1, "user-1");
             Attachment pdf = new Attachment("application/pdf", "report.pdf", 1234L, "ref-1");
             memory.getCurrentStep().storeData(
-                    new ai.labs.eddi.engine.memory.model.Data<>(MemoryKeys.ATTACHMENTS.key(), List.of(pdf)));
+                    new Data<>(MemoryKeys.ATTACHMENTS.key(), List.of(pdf)));
             memory.startNextStep(); // the follow-up turn, carrying no file of its own
 
             // Persist and reload the way both stores do: Jackson to JSON and back

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationLogGeneratorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationLogGeneratorTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -502,9 +503,9 @@ class ConversationLogGeneratorTest {
             var outputs = new ArrayList<ConversationOutput>();
             var output = new ConversationOutput();
             output.put("input", "hello");
-            Map<String, Object> mapWithNull = new java.util.HashMap<>();
+            Map<String, Object> mapWithNull = new HashMap<>();
             mapWithNull.put("text", null);
-            Map<String, Object> mapWithText = new java.util.HashMap<>();
+            Map<String, Object> mapWithText = new HashMap<>();
             mapWithText.put("text", "valid");
             output.put("output", List.of(mapWithNull, mapWithText));
             outputs.add(output);

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryStoreResilienceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryStoreResilienceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -86,7 +87,7 @@ class ConversationMemoryStoreResilienceTest {
     @Test
     @DisplayName("G11 — a context entry without a 'type' does not fail the whole conversation load")
     void contextWithoutTypeDoesNotFailTheLoad() throws Exception {
-        assertLoadsWith(new LinkedHashMap<>(java.util.Map.of("value", "de")));
+        assertLoadsWith(new LinkedHashMap<>(Map.of("value", "de")));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesHitlTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.memory;
 
 import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot.ConversationStepSnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot.ResultSnapshot;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -227,12 +229,12 @@ class ConversationMemoryUtilitiesHitlTest {
             batch.setPauseEpoch("epoch-1");
             batch.setLlmTaskId("task-a");
             batch.setChatTranscriptJson(CANARY_TRANSCRIPT);
-            batch.setTraceSoFar(List.of(java.util.Map.of("args", CANARY_ARGS)));
+            batch.setTraceSoFar(List.of(Map.of("args", CANARY_ARGS)));
             batch.setFingerprint("sha256-" + CANARY_SECRET);
             batch.setCalls(List.of(call));
             // Fix #1: the batch carries the effective tool-approval config — it must NOT
             // enter the fix-#4 names-only projection (config, not user data).
-            var effective = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var effective = new ToolApprovalsConfig();
             effective.setPendingMessage("Awaiting review for {toolNames}");
             batch.setEffectiveToolApprovals(effective);
             snapshot.setHitlPendingToolCalls(batch);

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationStepTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationStepTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -257,12 +258,12 @@ public class ConversationStepTest {
 
     @Test
     public void testAddConversationOutputMap() {
-        conversationStep.addConversationOutputMap("data", java.util.Map.of("k1", "v1"));
-        conversationStep.addConversationOutputMap("data", java.util.Map.of("k2", "v2"));
+        conversationStep.addConversationOutputMap("data", Map.of("k1", "v1"));
+        conversationStep.addConversationOutputMap("data", Map.of("k2", "v2"));
 
         var output = conversationStep.getConversationOutput();
         @SuppressWarnings("unchecked")
-        var data = (java.util.Map<String, Object>) output.get("data");
+        var data = (Map<String, Object>) output.get("data");
         Assertions.assertEquals("v1", data.get("k1"));
         Assertions.assertEquals("v2", data.get("k2"));
     }

--- a/src/test/java/ai/labs/eddi/engine/memory/model/MemoryCheckpointTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/model/MemoryCheckpointTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -111,7 +112,7 @@ class MemoryCheckpointTest {
         @DisplayName("Should deep-copy properties (original mutation doesn't affect checkpoint)")
         void testCreateDeepCopiesProperties() {
             Property mutableProp = new Property("name", "original", Scope.conversation);
-            Map<String, Property> properties = new java.util.LinkedHashMap<>();
+            Map<String, Property> properties = new LinkedHashMap<>();
             properties.put("name", mutableProp);
 
             MemoryCheckpoint checkpoint = MemoryCheckpoint.create(

--- a/src/test/java/ai/labs/eddi/engine/memory/model/PendingToolCallBatchSnapshotTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/model/PendingToolCallBatchSnapshotTest.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.memory.model;
+import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 
 import ai.labs.eddi.engine.lifecycle.exceptions.ConversationPauseException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -70,17 +72,17 @@ class PendingToolCallBatchSnapshotTest {
         batch.setAutoApproveCount(1);
         batch.setPauseCountThisTurn(2);
 
-        var effective = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+        var effective = new ToolApprovalsConfig();
         effective.setRequireApproval(List.of("delete_*", "mcp:*"));
-        effective.setTimeoutPolicy(ai.labs.eddi.configs.hitl.HitlTimeoutPolicy.AUTO_REJECT);
+        effective.setTimeoutPolicy(HitlTimeoutPolicy.AUTO_REJECT);
         effective.setApprovalTimeout("PT1H");
         effective.setOnNoProgress("AUTO_REJECT");
         effective.setPendingMessage("Awaiting review for {toolNames}");
         batch.setEffectiveToolApprovals(effective);
 
-        var rule = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig.ApprovalRule();
+        var rule = new ToolApprovalsConfig.ApprovalRule();
         rule.setMatch("mcp:delete_*");
-        rule.setTimeoutPolicy(ai.labs.eddi.configs.hitl.HitlTimeoutPolicy.WAIT_INDEFINITELY);
+        rule.setTimeoutPolicy(HitlTimeoutPolicy.WAIT_INDEFINITELY);
         rule.setPauseReason("Deleting a record — check the id");
         rule.setPendingMessage("Waiting on a reviewer for {toolNames}");
         batch.setEffectiveRule(rule);
@@ -116,7 +118,7 @@ class PendingToolCallBatchSnapshotTest {
         // Fix #1: the effective tool-approval config round-trips on the batch.
         assertNotNull(batch.getEffectiveToolApprovals());
         assertEquals(List.of("delete_*", "mcp:*"), batch.getEffectiveToolApprovals().getRequireApproval());
-        assertEquals(ai.labs.eddi.configs.hitl.HitlTimeoutPolicy.AUTO_REJECT,
+        assertEquals(HitlTimeoutPolicy.AUTO_REJECT,
                 batch.getEffectiveToolApprovals().getTimeoutPolicy());
         assertEquals("PT1H", batch.getEffectiveToolApprovals().getApprovalTimeout());
         assertEquals("AUTO_REJECT", batch.getEffectiveToolApprovals().getOnNoProgress());
@@ -131,7 +133,7 @@ class PendingToolCallBatchSnapshotTest {
         // dropPendingApprovalPlaceholder removes it by recomputing that exact string.
         assertNotNull(batch.getEffectiveRule());
         assertEquals("mcp:delete_*", batch.getEffectiveRule().getMatch());
-        assertEquals(ai.labs.eddi.configs.hitl.HitlTimeoutPolicy.WAIT_INDEFINITELY,
+        assertEquals(HitlTimeoutPolicy.WAIT_INDEFINITELY,
                 batch.getEffectiveRule().getTimeoutPolicy());
         assertEquals("Deleting a record — check the id", batch.getEffectiveRule().getPauseReason());
         assertEquals("Waiting on a reviewer for {toolNames}", batch.getEffectiveRule().getPendingMessage());

--- a/src/test/java/ai/labs/eddi/engine/model/EngineModelsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/model/EngineModelsTest.java
@@ -132,7 +132,7 @@ class EngineModelsTest {
     @Test
     void coordinatorStatus_record() {
         var status = new CoordinatorStatus(
-                "in-memory", true, "ok", 5, 100L, 2L, java.util.Map.of("c1", 3));
+                "in-memory", true, "ok", 5, 100L, 2L, Map.of("c1", 3));
         assertEquals("in-memory", status.coordinatorType());
         assertTrue(status.connected());
         assertEquals(5, status.activeConversations());

--- a/src/test/java/ai/labs/eddi/engine/runtime/BoundedLogStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/BoundedLogStoreTest.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -323,7 +325,7 @@ class BoundedLogStoreTest {
 
         @Test
         void captureWithEmptyMessage_shouldBeNoOp() {
-            var record = new java.util.logging.LogRecord(java.util.logging.Level.INFO, "");
+            var record = new LogRecord(Level.INFO, "");
             record.setLoggerName("test.Logger");
 
             store.capture(record);
@@ -332,7 +334,7 @@ class BoundedLogStoreTest {
 
         @Test
         void captureWithNullMessage_shouldBeNoOp() {
-            var record = new java.util.logging.LogRecord(java.util.logging.Level.INFO, null);
+            var record = new LogRecord(Level.INFO, null);
             record.setLoggerName("test.Logger");
 
             store.capture(record);
@@ -341,7 +343,7 @@ class BoundedLogStoreTest {
 
         @Test
         void captureFromBoundedLogStoreLogger_shouldSkipToPreventRecursion() {
-            var record = new java.util.logging.LogRecord(java.util.logging.Level.INFO, "This is a real message");
+            var record = new LogRecord(Level.INFO, "This is a real message");
             record.setLoggerName("ai.labs.eddi.engine.runtime.BoundedLogStore");
 
             store.capture(record);
@@ -351,7 +353,7 @@ class BoundedLogStoreTest {
 
         @Test
         void captureFromBoundedLogStoreSubLogger_shouldSkipToPreventRecursion() {
-            var record = new java.util.logging.LogRecord(java.util.logging.Level.WARNING, "Sub-logger message");
+            var record = new LogRecord(Level.WARNING, "Sub-logger message");
             record.setLoggerName("ai.labs.eddi.engine.runtime.BoundedLogStore.internal");
 
             store.capture(record);
@@ -363,7 +365,7 @@ class BoundedLogStoreTest {
         void captureWithRegularLogRecord_shouldFallbackToSlf4jMdc() {
             // Use a plain JUL LogRecord (not ExtLogRecord) — capture should
             // fall through to the SLF4J MDC branch
-            var record = new java.util.logging.LogRecord(java.util.logging.Level.WARNING, "SLF4J fallback test");
+            var record = new LogRecord(Level.WARNING, "SLF4J fallback test");
             record.setLoggerName("com.example.MyService");
 
             // Set SLF4J MDC values before capture
@@ -395,7 +397,7 @@ class BoundedLogStoreTest {
 
         @Test
         void captureWithInvalidAgentVersionMdc_shouldHandleGracefully() {
-            var record = new java.util.logging.LogRecord(java.util.logging.Level.INFO, "Invalid version test");
+            var record = new LogRecord(Level.INFO, "Invalid version test");
             record.setLoggerName("com.example.MyService");
 
             org.slf4j.MDC.put("agentVersion", "not-a-number");
@@ -413,7 +415,7 @@ class BoundedLogStoreTest {
         @Test
         void captureWithExtLogRecordAndMdc_shouldExtractMdcFields() {
             var extRecord = new org.jboss.logmanager.ExtLogRecord(
-                    java.util.logging.Level.SEVERE, "ExtLogRecord test",
+                    Level.SEVERE, "ExtLogRecord test",
                     "com.example.ExtService");
             extRecord.setLoggerName("com.example.ExtService");
 
@@ -442,7 +444,7 @@ class BoundedLogStoreTest {
         @Test
         void captureWithExtLogRecord_invalidAgentVersion_shouldHandleGracefully() {
             var extRecord = new org.jboss.logmanager.ExtLogRecord(
-                    java.util.logging.Level.INFO, "Invalid ext version",
+                    Level.INFO, "Invalid ext version",
                     "com.example.ExtService");
             extRecord.setLoggerName("com.example.ExtService");
             extRecord.putMdc("agentVersion", "abc");
@@ -456,7 +458,7 @@ class BoundedLogStoreTest {
 
         @Test
         void captureWithPrintfFormatPattern_shouldFormatCorrectly() {
-            var record = new java.util.logging.LogRecord(java.util.logging.Level.WARNING, "%s, line %d in %s");
+            var record = new LogRecord(Level.WARNING, "%s, line %d in %s");
             record.setLoggerName("com.example.ScriptEngine");
             record.setParameters(new Object[]{"hitlConfig is configured but nothing in this agent can trigger a pause", 42, "rules.js"});
 
@@ -470,7 +472,7 @@ class BoundedLogStoreTest {
         @Test
         void captureWithExtLogRecordPrintfPattern_shouldFormatCorrectly() {
             var extRecord = new org.jboss.logmanager.ExtLogRecord(
-                    java.util.logging.Level.WARNING, "%s, line %d in %s",
+                    Level.WARNING, "%s, line %d in %s",
                     "com.example.ScriptEngine");
             extRecord.setLoggerName("com.example.ScriptEngine");
             extRecord.setParameters(new Object[]{"Syntax error", 10, "agent.js"});
@@ -492,8 +494,8 @@ class BoundedLogStoreTest {
         void captureWithIndexedPrintfSpecifiers_shouldFormatCorrectly() {
             // Neither "%1$s" nor "%2$d" contains the literal "%s"/"%d" the old check
             // looked for, so this reached the viewer as the raw pattern.
-            var record = new java.util.logging.LogRecord(
-                    java.util.logging.Level.WARNING, "agent %1$s failed after %2$d attempts");
+            var record = new LogRecord(
+                    Level.WARNING, "agent %1$s failed after %2$d attempts");
             record.setLoggerName("com.example.Retry");
             record.setParameters(new Object[]{"support-bot", 7});
 
@@ -507,8 +509,8 @@ class BoundedLogStoreTest {
         @Test
         void captureWithPaddedPrintfSpecifier_shouldFormatCorrectly() {
             // "%03d" likewise does not contain "%d".
-            var record = new java.util.logging.LogRecord(
-                    java.util.logging.Level.INFO, "retrying in %03d ms");
+            var record = new LogRecord(
+                    Level.INFO, "retrying in %03d ms");
             record.setLoggerName("com.example.Retry");
             record.setParameters(new Object[]{5});
 
@@ -522,8 +524,8 @@ class BoundedLogStoreTest {
         void captureWithMessageFormatPatternContainingPercent_shouldStillUseMessageFormat() {
             // A literal percent must not drag a MessageFormat pattern down the printf
             // path: String.format rejects "% f", so it falls through as intended.
-            var record = new java.util.logging.LogRecord(
-                    java.util.logging.Level.INFO, "progress 50% for {0}");
+            var record = new LogRecord(
+                    Level.INFO, "progress 50% for {0}");
             record.setLoggerName("com.example.Progress");
             record.setParameters(new Object[]{"batch-1"});
 

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementBranchTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 
 import static ai.labs.eddi.configs.deployment.model.DeploymentInfo.DeploymentStatus.deployed;
@@ -75,7 +76,7 @@ class AgentDeploymentManagementBranchTest {
     @BeforeEach
     void setUp() {
         openMocks(this);
-        var scheduledExecutorService = mock(java.util.concurrent.ScheduledExecutorService.class);
+        var scheduledExecutorService = mock(ScheduledExecutorService.class);
         when(runtime.getScheduledExecutorService()).thenReturn(scheduledExecutorService);
 
         management = new AgentDeploymentManagement(

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.ChannelConnectorMigration;
 import ai.labs.eddi.configs.migration.V6QuteMigration;
@@ -20,7 +21,11 @@ import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.lifecycle.IConversation;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
+import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.runtime.IRuntime;
 import ai.labs.eddi.engine.runtime.internal.readiness.IAgentsReadiness;
@@ -32,6 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -298,7 +304,7 @@ class AgentDeploymentManagementTest {
         private WorkflowConfiguration behaviorWorkflow(URI ruleSetUri) {
             var step = new WorkflowConfiguration.WorkflowStep();
             step.setType(URI.create("eddi://ai.labs.behavior"));
-            step.setConfig(java.util.Map.of("uri", ruleSetUri.toString()));
+            step.setConfig(Map.of("uri", ruleSetUri.toString()));
 
             var workflowConfiguration = new WorkflowConfiguration();
             workflowConfiguration.setWorkflowSteps(List.of(step));
@@ -361,7 +367,7 @@ class AgentDeploymentManagementTest {
             when(agentStore.read("agent1", 1)).thenReturn(agentConfiguration);
             when(workflowStore.read("aaaaaaaaaaaaaaaaaaaaaaaa", 1)).thenReturn(behaviorWorkflow(ruleSetUri));
             when(ruleSetStore.read("bbbbbbbbbbbbbbbbbbbbbbbb", 1))
-                    .thenReturn(ruleSetWithActions(ai.labs.eddi.engine.lifecycle.IConversation.PAUSE_CONVERSATION));
+                    .thenReturn(ruleSetWithActions(IConversation.PAUSE_CONVERSATION));
 
             management.checkDeployments();
 
@@ -373,7 +379,7 @@ class AgentDeploymentManagementTest {
         @DisplayName("hitlConfig set with requireApproval configured -> no ruleset lookup needed to avoid the warning, deploy proceeds")
         void requireApprovalConfiguredStillDeploys() throws Exception {
             stubDeploymentOf("agent1", 1);
-            var toolApprovals = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var toolApprovals = new ToolApprovalsConfig();
             toolApprovals.setRequireApproval(List.of("mcp:*"));
             var hitlConfig = new AgentConfiguration.HitlConfig();
             hitlConfig.setToolApprovals(toolApprovals);
@@ -429,7 +435,7 @@ class AgentDeploymentManagementTest {
         @Test
         @DisplayName("skips AWAITING_HUMAN conversations (no raw ENDED write)")
         void skipsPausedConversations() throws Exception {
-            var paused = snapshot("conv-paused", ai.labs.eddi.engine.memory.model.ConversationState.AWAITING_HUMAN);
+            var paused = snapshot("conv-paused", ConversationState.AWAITING_HUMAN);
 
             when(conversationMemoryStore.loadActiveConversationMemorySnapshot("agent1", 1))
                     .thenReturn(List.of(paused));
@@ -447,9 +453,9 @@ class AgentDeploymentManagementTest {
         @DisplayName("Task 14/3: skips a PENDING TOOL_CALL pause identically — the spare check only reads "
                 + "ConversationState, never hitlPauseType, so undeploy is allowed the same way for both pause flavors")
         void skipsPausedToolCallConversation() throws Exception {
-            var toolPaused = snapshot("conv-tool-paused", ai.labs.eddi.engine.memory.model.ConversationState.AWAITING_HUMAN);
+            var toolPaused = snapshot("conv-tool-paused", ConversationState.AWAITING_HUMAN);
             toolPaused.setHitlPauseType("TOOL_CALL");
-            var batch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
+            var batch = new PendingToolCallBatch();
             batch.setPauseEpoch("epoch-undeploy-sweep");
             toolPaused.setHitlPendingToolCalls(batch);
 
@@ -467,10 +473,10 @@ class AgentDeploymentManagementTest {
         }
     }
 
-    private static ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot snapshot(
-                                                                                        String id,
-                                                                                        ai.labs.eddi.engine.memory.model.ConversationState state) {
-        var s = new ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot();
+    private static ConversationMemorySnapshot snapshot(
+                                                       String id,
+                                                       ConversationState state) {
+        var s = new ConversationMemorySnapshot();
         s.setId(id);
         s.setAgentId("agent1");
         s.setAgentVersion(1);

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationHitlTest.java
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.runtime.internal;
+import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
+import ai.labs.eddi.configs.properties.model.Property;
 
 import ai.labs.eddi.engine.lifecycle.IConversation;
 import ai.labs.eddi.engine.lifecycle.IConversation.ConversationNotReadyException;
@@ -14,8 +17,12 @@ import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict;
 import ai.labs.eddi.engine.memory.ConversationMemory;
 import ai.labs.eddi.engine.memory.IPropertiesHandler;
+import ai.labs.eddi.engine.memory.MemoryKeys;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.Data;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.runtime.IExecutableWorkflow;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -126,8 +133,8 @@ class ConversationHitlTest {
             memory.setConversationState(ConversationState.READY);
             // A step-scoped property that postConversationLifecycleTasks would purge
             memory.getConversationProperties().put("stepProp",
-                    new ai.labs.eddi.configs.properties.model.Property("stepProp", "value",
-                            ai.labs.eddi.configs.properties.model.Property.Scope.step));
+                    new Property("stepProp", "value",
+                            Property.Scope.step));
 
             doThrow(new ConversationPauseException("wf1", 1, "human review"))
                     .when(lifecycleManager).executeLifecycle(any(), any());
@@ -148,18 +155,18 @@ class ConversationHitlTest {
             memory.setConversationState(ConversationState.READY);
 
             // Agent-level default present on memory (what the pre-fix path read only).
-            var agentLevel = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var agentLevel = new ToolApprovalsConfig();
             agentLevel.setPendingMessage("AGENT default for {toolNames}");
             memory.setAgentToolApprovalsConfig(agentLevel);
 
             // The batch carries the task-scoped override that actually gated the call.
-            var taskOverride = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var taskOverride = new ToolApprovalsConfig();
             taskOverride.setPendingMessage("TASK review pending for {toolNames}");
 
             doAnswer(inv -> {
-                var call = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+                var call = new PendingToolCallBatch.PendingToolCall();
                 call.setToolName("delete_record");
-                var batch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
+                var batch = new PendingToolCallBatch();
                 batch.setCalls(List.of(call));
                 batch.setEffectiveToolApprovals(taskOverride);
                 memory.setHitlPendingToolCalls(batch);
@@ -171,7 +178,7 @@ class ConversationHitlTest {
             conv.say("delete it", Map.of());
 
             var output = memory.getCurrentStep().getConversationOutput();
-            String rendered = output.get(ai.labs.eddi.engine.memory.MemoryKeys.OUTPUT_PREFIX).toString();
+            String rendered = output.get(MemoryKeys.OUTPUT_PREFIX).toString();
             assertTrue(rendered.contains("TASK review pending for delete_record"),
                     "the batch's task-scoped pendingMessage must win over the agent-level default; got: " + rendered);
             assertFalse(rendered.contains("AGENT default"),
@@ -183,14 +190,14 @@ class ConversationHitlTest {
         void toolPauseLegacyBatchFallsBackToAgentLevel() throws Exception {
             memory.setConversationState(ConversationState.READY);
 
-            var agentLevel = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var agentLevel = new ToolApprovalsConfig();
             agentLevel.setPendingMessage("AGENT default for {toolNames}");
             memory.setAgentToolApprovalsConfig(agentLevel);
 
             doAnswer(inv -> {
-                var call = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+                var call = new PendingToolCallBatch.PendingToolCall();
                 call.setToolName("delete_record");
-                var batch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
+                var batch = new PendingToolCallBatch();
                 batch.setCalls(List.of(call));
                 // No effectiveToolApprovals — legacy batch.
                 memory.setHitlPendingToolCalls(batch);
@@ -202,7 +209,7 @@ class ConversationHitlTest {
             conv.say("delete it", Map.of());
 
             var output = memory.getCurrentStep().getConversationOutput();
-            String rendered = output.get(ai.labs.eddi.engine.memory.MemoryKeys.OUTPUT_PREFIX).toString();
+            String rendered = output.get(MemoryKeys.OUTPUT_PREFIX).toString();
             assertTrue(rendered.contains("AGENT default for delete_record"),
                     "a legacy batch must fall back to the agent-level pendingMessage; got: " + rendered);
         }
@@ -215,21 +222,21 @@ class ConversationHitlTest {
             // the end user actually sees the endpoint-specific wording.
             memory.setConversationState(ConversationState.READY);
 
-            var agentLevel = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var agentLevel = new ToolApprovalsConfig();
             agentLevel.setPendingMessage("AGENT default for {toolNames}");
             memory.setAgentToolApprovalsConfig(agentLevel);
 
-            var taskOverride = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var taskOverride = new ToolApprovalsConfig();
             taskOverride.setPendingMessage("TASK review pending for {toolNames}");
 
-            var rule = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig.ApprovalRule();
+            var rule = new ToolApprovalsConfig.ApprovalRule();
             rule.setMatch("http.post:/agentstore/agents");
             rule.setPendingMessage("RULE creating an agent via {toolNames}");
 
             doAnswer(inv -> {
-                var call = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+                var call = new PendingToolCallBatch.PendingToolCall();
                 call.setToolName("createAgent");
-                var batch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
+                var batch = new PendingToolCallBatch();
                 batch.setCalls(List.of(call));
                 batch.setEffectiveToolApprovals(taskOverride);
                 batch.setEffectiveRule(rule);
@@ -242,7 +249,7 @@ class ConversationHitlTest {
             conv.say("create an agent", Map.of());
 
             var output = memory.getCurrentStep().getConversationOutput();
-            String rendered = output.get(ai.labs.eddi.engine.memory.MemoryKeys.OUTPUT_PREFIX).toString();
+            String rendered = output.get(MemoryKeys.OUTPUT_PREFIX).toString();
             assertTrue(rendered.contains("RULE creating an agent via createAgent"),
                     "the governing rule's pendingMessage must win over both scalar levels; got: " + rendered);
             assertFalse(rendered.contains("TASK review pending"),
@@ -256,17 +263,17 @@ class ConversationHitlTest {
             // not blank out the message the designer wrote at the level above.
             memory.setConversationState(ConversationState.READY);
 
-            var taskOverride = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var taskOverride = new ToolApprovalsConfig();
             taskOverride.setPendingMessage("TASK review pending for {toolNames}");
 
-            var rule = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig.ApprovalRule();
+            var rule = new ToolApprovalsConfig.ApprovalRule();
             rule.setMatch("http.delete:*");
-            rule.setTimeoutPolicy(ai.labs.eddi.configs.hitl.HitlTimeoutPolicy.WAIT_INDEFINITELY);
+            rule.setTimeoutPolicy(HitlTimeoutPolicy.WAIT_INDEFINITELY);
 
             doAnswer(inv -> {
-                var call = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+                var call = new PendingToolCallBatch.PendingToolCall();
                 call.setToolName("deleteAgent");
-                var batch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
+                var batch = new PendingToolCallBatch();
                 batch.setCalls(List.of(call));
                 batch.setEffectiveToolApprovals(taskOverride);
                 batch.setEffectiveRule(rule);
@@ -279,7 +286,7 @@ class ConversationHitlTest {
             conv.say("delete it", Map.of());
 
             var output = memory.getCurrentStep().getConversationOutput();
-            String rendered = output.get(ai.labs.eddi.engine.memory.MemoryKeys.OUTPUT_PREFIX).toString();
+            String rendered = output.get(MemoryKeys.OUTPUT_PREFIX).toString();
             assertTrue(rendered.contains("TASK review pending for deleteAgent"),
                     "a rule silent on pendingMessage must inherit the scalar; got: " + rendered);
         }
@@ -289,8 +296,8 @@ class ConversationHitlTest {
         void normalTurnPurgesStepProperties() throws Exception {
             memory.setConversationState(ConversationState.READY);
             memory.getConversationProperties().put("stepProp",
-                    new ai.labs.eddi.configs.properties.model.Property("stepProp", "value",
-                            ai.labs.eddi.configs.properties.model.Property.Scope.step));
+                    new Property("stepProp", "value",
+                            Property.Scope.step));
 
             var conv = createConversation();
             conv.say("normal turn", Map.of());
@@ -346,7 +353,7 @@ class ConversationHitlTest {
             memory.setHitlPausedAbsoluteTaskIndex(1);
             // The paused turn's actions (incl. PAUSE_CONVERSATION) are restored
             // into the current step on resume — they must not survive re-entry.
-            memory.getCurrentStep().storeData(new ai.labs.eddi.engine.memory.model.Data<>(
+            memory.getCurrentStep().storeData(new Data<>(
                     "actions", List.of("delete_account", IConversation.PAUSE_CONVERSATION)));
 
             var conv = createConversation();
@@ -398,7 +405,7 @@ class ConversationHitlTest {
             memory.setConversationState(ConversationState.AWAITING_HUMAN);
             memory.setHitlPausedWorkflowId("wf1");
             memory.setHitlPausedAbsoluteTaskIndex(2);
-            memory.setHitlPausedAt(java.time.Instant.now());
+            memory.setHitlPausedAt(Instant.now());
             memory.setHitlPauseReason("some reason");
 
             var conv = createConversation();
@@ -507,7 +514,7 @@ class ConversationHitlTest {
             memory.setHitlPausedAbsoluteTaskIndex(1);
             // The paused turn's ACTIONS (incl. PAUSE_CONVERSATION) are restored on
             // resume — the REJECTED branch must strip the gate action just like APPROVED.
-            memory.getCurrentStep().storeData(new ai.labs.eddi.engine.memory.model.Data<>(
+            memory.getCurrentStep().storeData(new Data<>(
                     "actions", List.of("delete_account", IConversation.PAUSE_CONVERSATION)));
 
             var conv = createConversation();
@@ -518,7 +525,7 @@ class ConversationHitlTest {
             var output = memory.getCurrentStep().getConversationOutput();
             @SuppressWarnings("unchecked")
             var outputList = (List<Object>) output.get(
-                    ai.labs.eddi.engine.memory.MemoryKeys.OUTPUT_PREFIX);
+                    MemoryKeys.OUTPUT_PREFIX);
             assertNotNull(outputList, "REJECTED must publish an output entry");
             assertTrue(outputList.stream().anyMatch(o -> o.toString().contains("rejected by a human reviewer")),
                     "output must carry the rejection message, got: " + outputList);

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationTest.java
@@ -14,6 +14,7 @@ import ai.labs.eddi.engine.memory.IConversationMemory.IConversationProperties;
 import ai.labs.eddi.engine.memory.IConversationMemory.IWritableConversationStep;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.runtime.IExecutableWorkflow;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -123,7 +124,7 @@ class ConversationTest {
 
             var entry = new UserMemoryEntry(null, "user1", "language", "en",
                     "fact", Property.Visibility.self, "agent1", List.of(), "conv1",
-                    false, 0, java.time.Instant.now(), java.time.Instant.now());
+                    false, 0, Instant.now(), Instant.now());
             when(store.getVisibleEntries(eq("user1"), eq("agent1"), anyList(), anyString(), anyInt()))
                     .thenReturn(List.of(entry));
 

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/CronDescriberExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/CronDescriberExtendedTest.java
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.runtime.internal;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -175,11 +178,11 @@ class CronDescriberExtendedTest {
         @Test
         @DisplayName("should fall back to String.valueOf for negative value in single-element set")
         void negativeValueSingleElement() throws Exception {
-            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", java.util.Set.class, String[].class);
+            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
             formatSet.setAccessible(true);
 
             String[] labels = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-            java.util.Set<Integer> negativeSet = java.util.Set.of(-1);
+            Set<Integer> negativeSet = Set.of(-1);
 
             // Before fix: ArrayIndexOutOfBoundsException
             // After fix: returns "-1" (String.valueOf)
@@ -190,11 +193,11 @@ class CronDescriberExtendedTest {
         @Test
         @DisplayName("should fall back to String.valueOf for negative values in multi-element set")
         void negativeValueMultiElement() throws Exception {
-            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", java.util.Set.class, String[].class);
+            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
             formatSet.setAccessible(true);
 
             String[] labels = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-            java.util.Set<Integer> mixedSet = new java.util.TreeSet<>(java.util.List.of(-1, 0, 99));
+            Set<Integer> mixedSet = new TreeSet<>(List.of(-1, 0, 99));
 
             String result = (String) formatSet.invoke(null, mixedSet, labels);
             assertTrue(result.contains("-1"), "negative value should be rendered as string");
@@ -205,23 +208,23 @@ class CronDescriberExtendedTest {
         @Test
         @DisplayName("should handle value equal to labels.length (out of bounds)")
         void valueAtBoundary() throws Exception {
-            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", java.util.Set.class, String[].class);
+            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
             formatSet.setAccessible(true);
 
             String[] labels = {"A", "B", "C"};
             // v=3 is exactly labels.length, should fall back to String.valueOf
-            String result = (String) formatSet.invoke(null, java.util.Set.of(3), labels);
+            String result = (String) formatSet.invoke(null, Set.of(3), labels);
             assertEquals("3", result);
         }
 
         @Test
         @DisplayName("should handle valid value at max index")
         void validMaxIndex() throws Exception {
-            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", java.util.Set.class, String[].class);
+            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
             formatSet.setAccessible(true);
 
             String[] labels = {"A", "B", "C"};
-            String result = (String) formatSet.invoke(null, java.util.Set.of(2), labels);
+            String result = (String) formatSet.invoke(null, Set.of(2), labels);
             assertEquals("C", result);
         }
     }

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/CronParserTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/CronParserTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.runtime.internal;
+import java.time.DayOfWeek;
 
 import org.junit.jupiter.api.Test;
 
@@ -114,7 +115,7 @@ class CronParserTest {
         assertEquals(9, nextZdt.getHour());
         assertEquals(0, nextZdt.getMinute());
         // Should be Monday
-        assertEquals(java.time.DayOfWeek.MONDAY, nextZdt.getDayOfWeek());
+        assertEquals(DayOfWeek.MONDAY, nextZdt.getDayOfWeek());
     }
 
     @Test
@@ -174,7 +175,7 @@ class CronParserTest {
         // 2024-01-06 is a Saturday; the next Sunday is 2024-01-07.
         Instant saturday = ZonedDateTime.of(2024, 1, 6, 12, 0, 0, 0, UTC).toInstant();
         Instant next = CronParser.computeNextFire("0 0 * * 7", saturday, UTC);
-        assertEquals(java.time.DayOfWeek.SUNDAY, next.atZone(UTC).getDayOfWeek());
+        assertEquals(DayOfWeek.SUNDAY, next.atZone(UTC).getDayOfWeek());
     }
 
     @Test
@@ -216,7 +217,7 @@ class CronParserTest {
         Instant next = CronParser.computeNextFire("0 0 13 * 5", base, UTC);
         ZonedDateTime z = next.atZone(UTC);
         assertEquals(13, z.getDayOfMonth());
-        assertEquals(java.time.DayOfWeek.SATURDAY, z.getDayOfWeek());
+        assertEquals(DayOfWeek.SATURDAY, z.getDayOfWeek());
     }
 
     @Test
@@ -226,7 +227,7 @@ class CronParserTest {
         Instant base = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, UTC).toInstant();
         Instant next = CronParser.computeNextFire("0 0 13 * 5", base, UTC);
         ZonedDateTime z = next.atZone(UTC);
-        assertEquals(java.time.DayOfWeek.FRIDAY, z.getDayOfWeek());
+        assertEquals(DayOfWeek.FRIDAY, z.getDayOfWeek());
         assertEquals(5, z.getDayOfMonth());
     }
 

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/DreamServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/DreamServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -130,7 +131,7 @@ class DreamServiceTest {
 
     @Test
     void process_shouldHandleStoreException() throws Exception {
-        when(store.getAllEntries("user-1")).thenThrow(new ai.labs.eddi.datastore.IResourceStore.ResourceStoreException("DB down"));
+        when(store.getAllEntries("user-1")).thenThrow(new IResourceStore.ResourceStoreException("DB down"));
 
         var result = dreamService.process("user-1", "agent-1", dreamConfig);
 
@@ -176,7 +177,7 @@ class DreamServiceTest {
 
     private List<UserMemoryEntry> makeEntries(int count, String category, String agentId) {
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < count; i++) {
             entries.add(new UserMemoryEntry("id-" + i, "user-1", "key-" + i, "value-" + i,
                     category, Visibility.self, agentId, List.of(), "conv-1", false, 0, now, now));
@@ -345,7 +346,7 @@ class DreamServiceTest {
 
         Instant now = Instant.now();
         // Two categories with 5+ entries each
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 6; i++) {
             entries.add(new UserMemoryEntry("f-" + i, "user-1", "fk-" + i, "fv-" + i,
                     "fact", Visibility.self, "agent-1", List.of(), "conv-1", false, 0, now, now));
@@ -381,7 +382,7 @@ class DreamServiceTest {
         dreamConfig.setSummarizeGroupBy("category");
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int category = 0; category < 12; category++) { // 12 groups > default ceiling of 10
             for (int i = 0; i < 6; i++) {
                 entries.add(new UserMemoryEntry("c" + category + "-" + i, "user-1", "k" + category + "-" + i, "v",
@@ -426,7 +427,7 @@ class DreamServiceTest {
         dreamConfig.setSummarizeGroupBy("all");
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 3; i++) {
             entries.add(new UserMemoryEntry("f-" + i, "user-1", "fk-" + i, "fv",
                     "fact", Visibility.self, "agent-1", List.of(), "conv-1", false, 0, now, now));
@@ -457,7 +458,7 @@ class DreamServiceTest {
         dreamConfig.setCrossAgentMaintenance(true); // sub-grouping is only observable across agents
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         // 3 entries from agent-1 (fact)
         for (int i = 0; i < 3; i++) {
             entries.add(new UserMemoryEntry("a1-" + i, "user-1", "k-a1-" + i, "v",
@@ -503,7 +504,7 @@ class DreamServiceTest {
         enableSummarization();
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         // Mix of self and global visibility
         for (int i = 0; i < 3; i++) {
             entries.add(new UserMemoryEntry("s-" + i, "user-1", "sk-" + i, "sv",
@@ -713,7 +714,7 @@ class DreamServiceTest {
         dreamConfig.setSummarizeGroupBy("category");
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 6; i++) {
             entries.add(new UserMemoryEntry("f-" + i, "user-1", "fk-" + i, "fv-" + i,
                     "fact", Visibility.self, "agent-1", List.of(), "conv-1", false, 0, now, now));
@@ -744,7 +745,7 @@ class DreamServiceTest {
         dreamConfig.setSummarizeGroupBy("category");
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 6; i++) {
             entries.add(new UserMemoryEntry("f-" + i, "user-1", "fk-" + i, "fv-" + i,
                     "fact", Visibility.self, "agent-1", List.of(), "conv-1", false, 0, now, now));
@@ -848,7 +849,7 @@ class DreamServiceTest {
         Instant fresh = Instant.now();
         // First call returns stale + fresh entries; second call (after prune) returns
         // only fresh
-        var initialEntries = new java.util.ArrayList<UserMemoryEntry>();
+        var initialEntries = new ArrayList<UserMemoryEntry>();
         initialEntries.add(new UserMemoryEntry("stale-1", "user-1", "old", "v", "fact", Visibility.self, "agent-1", List.of(), "conv-1", false, 0,
                 stale, stale));
         for (int i = 0; i < 6; i++) {
@@ -925,7 +926,7 @@ class DreamServiceTest {
         dreamConfig.setSummarizeGroupBy("category");
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 6; i++) {
             entries.add(new UserMemoryEntry("f-" + i, "user-1", "fk-" + i, "fv-" + i,
                     "fact", Visibility.self, "agent-1", List.of(), "conv-1", false, 0, now, now));
@@ -967,7 +968,7 @@ class DreamServiceTest {
         dreamConfig.setCrossAgentMaintenance(true); // opt-in whole-set maintenance is what puts two agents in one group
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 3; i++) {
             entries.add(new UserMemoryEntry("a1-" + i, "user-1", "k1-" + i, "secret of agent-1",
                     "fact", Visibility.self, "agent-1", List.of(), "conv-1", false, 0, now, now));
@@ -1009,7 +1010,7 @@ class DreamServiceTest {
         dreamConfig.setCrossAgentMaintenance(true); // opt-in whole-set maintenance is what puts two agents in one group
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 2; i++) {
             entries.add(new UserMemoryEntry("priv-" + i, "user-1", "pk-" + i, "private",
                     "fact", Visibility.self, "agent-1", List.of(), "conv-1", false, 0, now, now));
@@ -1039,7 +1040,7 @@ class DreamServiceTest {
         enableSummarization();
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 6; i++) {
             entries.add(new UserMemoryEntry("id-" + i, "user-1", "k-" + i, "v-" + i,
                     "fact", Visibility.group, "agent-1",
@@ -1066,7 +1067,7 @@ class DreamServiceTest {
         dreamConfig.setSummarizeMinEntries(3);
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 3; i++) {
             entries.add(new UserMemoryEntry("id-" + i, "user-1", "k-" + i, "v-" + i,
                     null, Visibility.self, "agent-1", List.of(), "conv-1", false, 0, now, now));
@@ -1224,7 +1225,7 @@ class DreamServiceTest {
         dreamConfig.setSummarizeMinEntries(2);
 
         Instant now = Instant.now();
-        var entries = new java.util.ArrayList<UserMemoryEntry>();
+        var entries = new ArrayList<UserMemoryEntry>();
         for (int i = 0; i < 3; i++) {
             entries.add(new UserMemoryEntry("a1-" + i, "user-1", "k1-" + i, "owned-by-agent-1",
                     "fact", Visibility.self, "agent-1", List.of(), "conv-1", false, 0, now, now));

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/InMemoryConversationCoordinatorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/InMemoryConversationCoordinatorTest.java
@@ -385,7 +385,7 @@ class InMemoryConversationCoordinatorTest {
         smallCoordinator.submitInOrder("conv-2", task2);
 
         // Third NEW conversation should be rejected
-        assertThrows(java.util.concurrent.RejectedExecutionException.class,
+        assertThrows(RejectedExecutionException.class,
                 () -> smallCoordinator.submitInOrder("conv-3", task3));
     }
 

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorBranchTest.java
@@ -23,6 +23,7 @@ import org.mockito.ArgumentCaptor;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 
@@ -197,7 +198,7 @@ class NatsConversationCoordinatorBranchTest {
 
         // The queue for conv-1 should have 2 entries
         var method = NatsConversationCoordinator.class
-                .getDeclaredMethod("computeTotalQueueDepth", java.util.Map.class);
+                .getDeclaredMethod("computeTotalQueueDepth", Map.class);
         method.setAccessible(true);
 
         var queuesField = NatsConversationCoordinator.class.getDeclaredField("conversationQueues");

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorExtendedTest.java
@@ -424,7 +424,7 @@ class NatsConversationCoordinatorExtendedTest {
 
         // Consume metrics should be recorded even on failure
         verify(consumeCount).increment();
-        verify(consumeDuration).record(any(java.time.Duration.class));
+        verify(consumeDuration).record(any(Duration.class));
     }
 
     // ==================== Extract JSON helpers ====================

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorIT.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorIT.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -235,12 +236,12 @@ class NatsConversationCoordinatorIT {
         }
 
         @Override
-        public <T> Future<T> submitCallable(Callable<T> callable, java.util.Map<Object, Object> threadBindings) {
+        public <T> Future<T> submitCallable(Callable<T> callable, Map<Object, Object> threadBindings) {
             return executor.submit(callable);
         }
 
         @Override
-        public <T> Future<T> submitCallable(Callable<T> callable, IFinishedExecution<T> callback, java.util.Map<Object, Object> threadBindings) {
+        public <T> Future<T> submitCallable(Callable<T> callable, IFinishedExecution<T> callback, Map<Object, Object> threadBindings) {
             return executor.submit(() -> {
                 try {
                     T result = callable.call();

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -322,7 +323,7 @@ class NatsConversationCoordinatorTest {
 
         // Publish metrics should be recorded
         verify(publishCount).increment();
-        verify(publishDuration).record(any(java.time.Duration.class));
+        verify(publishDuration).record(any(Duration.class));
     }
 
     @Test
@@ -339,6 +340,6 @@ class NatsConversationCoordinatorTest {
         callbackCaptor.getValue().onComplete(null);
 
         verify(consumeCount).increment();
-        verify(consumeDuration).record(any(java.time.Duration.class));
+        verify(consumeDuration).record(any(Duration.class));
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ScheduleFireExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ScheduleFireExecutorTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration.FireStatus;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration.TriggerType;
 import ai.labs.eddi.engine.schedule.model.ScheduleFireLog;
 import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.internal.HitlTimeoutHandler;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.model.InputData;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -32,7 +34,7 @@ class ScheduleFireExecutorTest {
 
     private IConversationService conversationService;
     private IScheduleStore scheduleStore;
-    private ai.labs.eddi.engine.internal.HitlTimeoutHandler hitlTimeoutHandler;
+    private HitlTimeoutHandler hitlTimeoutHandler;
     private DreamService dreamService;
     private TeamCadenceService teamCadenceService;
     private ScheduleFireExecutor executor;
@@ -41,7 +43,7 @@ class ScheduleFireExecutorTest {
     void setUp() {
         conversationService = mock(IConversationService.class);
         scheduleStore = mock(IScheduleStore.class);
-        hitlTimeoutHandler = mock(ai.labs.eddi.engine.internal.HitlTimeoutHandler.class);
+        hitlTimeoutHandler = mock(HitlTimeoutHandler.class);
         dreamService = mock(DreamService.class);
         teamCadenceService = mock(TeamCadenceService.class);
 
@@ -167,7 +169,7 @@ class ScheduleFireExecutorTest {
         var ctx = inputCaptor.getValue().getContext();
         var scheduleCtx = ctx.get("schedule");
         assertNotNull(scheduleCtx);
-        var data = (java.util.Map<?, ?>) scheduleCtx.getValue();
+        var data = (Map<?, ?>) scheduleCtx.getValue();
         assertEquals("heartbeat", data.get("trigger"));
         assertEquals("HEARTBEAT", data.get("triggerType"));
     }
@@ -354,7 +356,7 @@ class ScheduleFireExecutorTest {
         // The metadata key ('hitlType') and value ('hitl_timeout') route into the
         // handler — a rename on either side would break this and the timeout would
         // silently never fire.
-        var mdCaptor = ArgumentCaptor.forClass(java.util.Map.class);
+        var mdCaptor = ArgumentCaptor.forClass(Map.class);
         verify(hitlTimeoutHandler).handleTimeout(mdCaptor.capture());
         assertEquals("hitl_timeout", mdCaptor.getValue().get("hitlType"));
         assertEquals("conv-paused", mdCaptor.getValue().get("conversationId"));
@@ -542,7 +544,7 @@ class ScheduleFireExecutorTest {
         s.setTimeZone("UTC");
         s.setFireStatus(FireStatus.CLAIMED);
         s.setNextFire(Instant.now().minusSeconds(1));
-        s.setMetadata(java.util.Map.of(
+        s.setMetadata(Map.of(
                 TeamCadenceService.METADATA_TYPE_KEY, TeamCadenceService.METADATA_TYPE_CADENCE,
                 TeamCadenceService.METADATA_GROUP_ID_KEY, "group-1",
                 TeamCadenceService.METADATA_CADENCE_ID_KEY, "cadence-1"));
@@ -596,7 +598,7 @@ class ScheduleFireExecutorTest {
         s.setUserId(userId);
         s.setFireStatus(FireStatus.CLAIMED);
         s.setNextFire(Instant.now().minusSeconds(1));
-        s.setMetadata(java.util.Map.of(
+        s.setMetadata(Map.of(
                 DreamService.METADATA_TYPE_KEY, DreamService.METADATA_TYPE_CONSOLIDATION));
         return s;
     }
@@ -611,7 +613,7 @@ class ScheduleFireExecutorTest {
         s.setNextFire(Instant.now().minusSeconds(1));
         // The producer (ConversationService.scheduleHitlTimeout) sets exactly these
         // keys.
-        s.setMetadata(java.util.Map.of(
+        s.setMetadata(Map.of(
                 "hitlType", "hitl_timeout",
                 "policy", policy,
                 "surface", "regular",

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/SchedulePollerServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/SchedulePollerServiceTest.java
@@ -17,6 +17,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -223,8 +226,8 @@ class SchedulePollerServiceTest {
         when(scheduleStore.findDueSchedules(any(), any(), anyInt())).thenReturn(List.of(schedule));
         when(scheduleStore.tryClaim(any(), any(), any(), any())).thenReturn(true);
 
-        var release = new java.util.concurrent.CountDownLatch(1);
-        var entered = new java.util.concurrent.CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var entered = new CountDownLatch(1);
         when(fireExecutor.fire(any(), any(), anyInt())).thenAnswer(inv -> {
             entered.countDown();
             // Block until released, ignoring interruption entirely — the poll cycle
@@ -232,7 +235,7 @@ class SchedulePollerServiceTest {
             boolean released = false;
             while (!released) {
                 try {
-                    released = release.await(30, java.util.concurrent.TimeUnit.SECONDS);
+                    released = release.await(30, TimeUnit.SECONDS);
                 } catch (InterruptedException ignored) {
                     // swallow — this is the non-interruptible case under test
                 }
@@ -315,7 +318,7 @@ class SchedulePollerServiceTest {
         });
 
         // markFailed behaves like the sync Mongo driver: refuses to run interrupted.
-        var markFailedCompleted = new java.util.concurrent.atomic.AtomicBoolean(false);
+        var markFailedCompleted = new AtomicBoolean(false);
         doAnswer(inv -> {
             if (Thread.currentThread().isInterrupted()) {
                 throw new IllegalStateException("interrupted during connection checkout");

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/TeamCadenceServiceTest.java
@@ -14,6 +14,7 @@ import ai.labs.eddi.configs.groups.model.GroupWorkspace.Cadence;
 import ai.labs.eddi.configs.groups.model.SharedTaskList;
 import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
 import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskStatus;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.internal.GroupConversationService;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -352,7 +353,7 @@ class TeamCadenceServiceTest {
         workspace.setRunningDiscussionId("gone-gc");
         workspace.setPulledTaskIds(List.of(taskA.id()));
         when(conversationStore.read("gone-gc")).thenThrow(
-                new ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException("gone"));
+                new IResourceStore.ResourceNotFoundException("gone"));
 
         assertTrue(service.reconcile(workspace));
 

--- a/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreExpandedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreExpandedTest.java
@@ -12,6 +12,7 @@ import ai.labs.eddi.engine.schedule.model.ScheduleFireLog;
 import ai.labs.eddi.engine.runtime.internal.ScheduleFireExecutor;
 import ai.labs.eddi.engine.runtime.internal.SchedulePollerService;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.security.OwnershipValidator;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -38,7 +40,7 @@ class RestScheduleStoreExpandedTest {
     private IScheduleStore scheduleStore;
     private ScheduleFireExecutor fireExecutor;
     private SchedulePollerService pollerService;
-    private ai.labs.eddi.engine.security.OwnershipValidator ownershipValidator;
+    private OwnershipValidator ownershipValidator;
     private RestScheduleStore sut;
 
     @BeforeEach
@@ -46,7 +48,7 @@ class RestScheduleStoreExpandedTest {
         scheduleStore = mock(IScheduleStore.class);
         fireExecutor = mock(ScheduleFireExecutor.class);
         pollerService = mock(SchedulePollerService.class);
-        ownershipValidator = mock(ai.labs.eddi.engine.security.OwnershipValidator.class);
+        ownershipValidator = mock(OwnershipValidator.class);
         // admin by default: the HITL redaction/guards are tested in
         // RestScheduleStoreTest — these tests exercise the general surface
         doReturn(true).when(ownershipValidator).isAdmin(any());
@@ -90,7 +92,7 @@ class RestScheduleStoreExpandedTest {
     private static ScheduleConfiguration hitlSchedule(String id) {
         var s = makeCronSchedule(id);
         s.setName("hitl-timeout-conv-" + id);
-        s.setMetadata(java.util.Map.of("hitlType", "hitl_timeout", "policy", "AUTO_REJECT",
+        s.setMetadata(Map.of("hitlType", "hitl_timeout", "policy", "AUTO_REJECT",
                 "surface", "regular", "conversationId", "conv-" + id));
         return s;
     }

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceBranchCoverageTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
 import ai.labs.eddi.engine.runtime.client.factory.RestInterfaceFactory;
 import ai.labs.eddi.secrets.ISecretProvider;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -594,7 +595,7 @@ class AgentSetupServiceBranchCoverageTest {
         @Test
         @DisplayName("tool URIs set tools list")
         void toolUris() {
-            var uris = java.util.List.of("/httpcalls/loc1", "/httpcalls/loc2");
+            var uris = List.of("/httpcalls/loc1", "/httpcalls/loc2");
             var config = service.createLlmConfig("anthropic", "claude-3", "key", "prompt",
                     false, null, null, null, false, false, uris);
             var task = config.tasks().get(0);
@@ -647,8 +648,8 @@ class AgentSetupServiceBranchCoverageTest {
         void fullPipeline() {
             var config = service.createWorkflowConfig(
                     "/parser/loc", "/behavior/loc",
-                    java.util.List.of("/http1", "/http2"),
-                    java.util.List.of("/mcp1"),
+                    List.of("/http1", "/http2"),
+                    List.of("/mcp1"),
                     "/langchain/loc", "/output/loc");
             // parser + behavior + 2 httpcalls + 1 mcpcalls + langchain + output = 7
             assertEquals(7, config.getWorkflowSteps().size());

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceTest.java
@@ -3,11 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.setup;
+import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore;
+import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
+import ai.labs.eddi.configs.llm.IRestLlmStore;
 
 import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
 import ai.labs.eddi.configs.output.model.OutputConfigurationSet;
+import ai.labs.eddi.configs.parser.IRestParserStore;
 import ai.labs.eddi.configs.parser.model.ParserConfiguration;
+import ai.labs.eddi.configs.rules.IRestRuleSetStore;
 import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.engine.model.Deployment;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
@@ -46,9 +54,9 @@ class AgentSetupServiceTest {
     @BeforeEach
     void setUp() {
         service = new AgentSetupService(
-                mock(ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory.class),
-                mock(ai.labs.eddi.engine.api.IRestAgentAdministration.class),
-                mock(ai.labs.eddi.secrets.ISecretProvider.class),
+                mock(IRestInterfaceFactory.class),
+                mock(IRestAgentAdministration.class),
+                mock(ISecretProvider.class),
                 "http://localhost:11434");
     }
 
@@ -617,8 +625,8 @@ class AgentSetupServiceTest {
             var guardedService = new AgentSetupService(restInterfaceFactory,
                     mock(IRestAgentAdministration.class), mock(ISecretProvider.class), "http://localhost:11434");
 
-            var hitl = new ai.labs.eddi.configs.agents.model.AgentConfiguration.HitlConfig();
-            var toolApprovals = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var hitl = new AgentConfiguration.HitlConfig();
+            var toolApprovals = new ToolApprovalsConfig();
             toolApprovals.setRequireApproval(List.of("mcp:/agentstore/agents"));
             hitl.setToolApprovals(toolApprovals);
 
@@ -640,8 +648,8 @@ class AgentSetupServiceTest {
             var guardedService = new AgentSetupService(restInterfaceFactory,
                     mock(IRestAgentAdministration.class), mock(ISecretProvider.class), "http://localhost:11434");
 
-            var hitl = new ai.labs.eddi.configs.agents.model.AgentConfiguration.HitlConfig();
-            var toolApprovals = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var hitl = new AgentConfiguration.HitlConfig();
+            var toolApprovals = new ToolApprovalsConfig();
             toolApprovals.setRequireApproval(List.of("http.post:*", "http.put:*", "http.delete:*"));
             toolApprovals.setExempt(List.of("http.get:*"));
             hitl.setToolApprovals(toolApprovals);
@@ -679,7 +687,7 @@ class AgentSetupServiceTest {
         }
 
         private IRestInterfaceFactory wireMinimalHappyPath(
-                                                           org.mockito.ArgumentCaptor<ai.labs.eddi.configs.agents.model.AgentConfiguration> agentCaptor)
+                                                           org.mockito.ArgumentCaptor<AgentConfiguration> agentCaptor)
                 throws Exception {
             var factory = mock(IRestInterfaceFactory.class);
 
@@ -690,34 +698,34 @@ class AgentSetupServiceTest {
             // leaves BOTH unfinished (UnfinishedStubbingException) — not a
             // compile error, only a test-time one, so this is worth spelling out.
             var parserResponse = located("/parserstore/parsers/000000000000000000000001?version=1");
-            var parserStore = mock(ai.labs.eddi.configs.parser.IRestParserStore.class);
+            var parserStore = mock(IRestParserStore.class);
             when(parserStore.createParser(any())).thenReturn(parserResponse);
-            when(factory.get(ai.labs.eddi.configs.parser.IRestParserStore.class)).thenReturn(parserStore);
+            when(factory.get(IRestParserStore.class)).thenReturn(parserStore);
 
             var ruleSetResponse = located("/rulestore/rulesets/000000000000000000000002?version=1");
-            var ruleSetStore = mock(ai.labs.eddi.configs.rules.IRestRuleSetStore.class);
+            var ruleSetStore = mock(IRestRuleSetStore.class);
             when(ruleSetStore.createRuleSet(any())).thenReturn(ruleSetResponse);
-            when(factory.get(ai.labs.eddi.configs.rules.IRestRuleSetStore.class)).thenReturn(ruleSetStore);
+            when(factory.get(IRestRuleSetStore.class)).thenReturn(ruleSetStore);
 
             var llmResponse = located("/llmstore/llms/000000000000000000000003?version=1");
-            var llmStore = mock(ai.labs.eddi.configs.llm.IRestLlmStore.class);
+            var llmStore = mock(IRestLlmStore.class);
             when(llmStore.createLlm(any())).thenReturn(llmResponse);
-            when(factory.get(ai.labs.eddi.configs.llm.IRestLlmStore.class)).thenReturn(llmStore);
+            when(factory.get(IRestLlmStore.class)).thenReturn(llmStore);
 
             var workflowResponse = located("/workflowstore/workflows/000000000000000000000004?version=1");
-            var workflowStore = mock(ai.labs.eddi.configs.workflows.IRestWorkflowStore.class);
+            var workflowStore = mock(IRestWorkflowStore.class);
             when(workflowStore.createWorkflow(any())).thenReturn(workflowResponse);
-            when(factory.get(ai.labs.eddi.configs.workflows.IRestWorkflowStore.class)).thenReturn(workflowStore);
+            when(factory.get(IRestWorkflowStore.class)).thenReturn(workflowStore);
 
             var agentResponse = located("/agentstore/agents/000000000000000000000005?version=1");
-            var agentStore = mock(ai.labs.eddi.configs.agents.IRestAgentStore.class);
+            var agentStore = mock(IRestAgentStore.class);
             when(agentStore.createAgent(agentCaptor.capture())).thenReturn(agentResponse);
-            when(factory.get(ai.labs.eddi.configs.agents.IRestAgentStore.class)).thenReturn(agentStore);
+            when(factory.get(IRestAgentStore.class)).thenReturn(agentStore);
 
             // patchDescriptor fires after every creation; an unstubbed mock returning
             // null for it is fine, but factory.get(...) still has to resolve the class.
-            when(factory.get(ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore.class))
-                    .thenReturn(mock(ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore.class));
+            when(factory.get(IRestDocumentDescriptorStore.class))
+                    .thenReturn(mock(IRestDocumentDescriptorStore.class));
 
             return factory;
         }
@@ -725,13 +733,13 @@ class AgentSetupServiceTest {
         @Test
         @DisplayName("a configured hitlConfig is set on the AgentConfiguration handed to createAgent")
         void hitlConfigReachesTheCreatedAgentConfiguration() throws Exception {
-            var agentCaptor = org.mockito.ArgumentCaptor.forClass(ai.labs.eddi.configs.agents.model.AgentConfiguration.class);
+            var agentCaptor = org.mockito.ArgumentCaptor.forClass(AgentConfiguration.class);
             var factory = wireMinimalHappyPath(agentCaptor);
             var wiredService = new AgentSetupService(factory, mock(IRestAgentAdministration.class), mock(ISecretProvider.class),
                     "http://localhost:11434");
 
-            var hitl = new ai.labs.eddi.configs.agents.model.AgentConfiguration.HitlConfig();
-            var toolApprovals = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var hitl = new AgentConfiguration.HitlConfig();
+            var toolApprovals = new ToolApprovalsConfig();
             toolApprovals.setRequireApproval(List.of("http.post:*", "http.put:*", "http.delete:*"));
             toolApprovals.setExempt(List.of("http.get:*"));
             hitl.setToolApprovals(toolApprovals);
@@ -754,7 +762,7 @@ class AgentSetupServiceTest {
             // The mirror of the test above: this field is opt-in. A caller that
             // supplies none must not have one silently invented for them — that
             // would be a correctness bug in the other direction.
-            var agentCaptor = org.mockito.ArgumentCaptor.forClass(ai.labs.eddi.configs.agents.model.AgentConfiguration.class);
+            var agentCaptor = org.mockito.ArgumentCaptor.forClass(AgentConfiguration.class);
             var factory = wireMinimalHappyPath(agentCaptor);
             var wiredService = new AgentSetupService(factory, mock(IRestAgentAdministration.class), mock(ISecretProvider.class),
                     "http://localhost:11434");
@@ -829,8 +837,8 @@ class AgentSetupServiceTest {
             var guardedService = new AgentSetupService(restInterfaceFactory,
                     mock(IRestAgentAdministration.class), mock(ISecretProvider.class), "http://localhost:11434");
 
-            var hitl = new ai.labs.eddi.configs.agents.model.AgentConfiguration.HitlConfig();
-            var toolApprovals = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var hitl = new AgentConfiguration.HitlConfig();
+            var toolApprovals = new ToolApprovalsConfig();
             // 'mcp' tools carry no endpoint, so this pattern can never match — it would
             // save as a gate that gates nothing.
             toolApprovals.setRequireApproval(List.of("mcp:/agentstore/agents"));
@@ -897,8 +905,8 @@ class AgentSetupServiceTest {
             var guardedService = new AgentSetupService(restInterfaceFactory,
                     mock(IRestAgentAdministration.class), mock(ISecretProvider.class), "http://localhost:11434");
 
-            var hitl = new ai.labs.eddi.configs.agents.model.AgentConfiguration.HitlConfig();
-            var toolApprovals = new ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig();
+            var hitl = new AgentConfiguration.HitlConfig();
+            var toolApprovals = new ToolApprovalsConfig();
             toolApprovals.setRequireApproval(List.of("http.post:*", "http.put:*", "http.delete:*"));
             toolApprovals.setExempt(List.of("http.get:*"));
             hitl.setToolApprovals(toolApprovals);

--- a/src/test/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuotaTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuotaTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.tenancy.rest;
 
 import ai.labs.eddi.engine.tenancy.InMemoryTenantQuotaStore;
+import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.TenantQuota;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -107,7 +108,7 @@ class RestTenantQuotaTest {
     @Test
     void shouldReturnExceptionMapperResponse() {
         var mapper = new QuotaExceededExceptionMapper();
-        var exception = new ai.labs.eddi.engine.tenancy.QuotaExceededException("Test limit exceeded");
+        var exception = new QuotaExceededException("Test limit exceeded");
 
         try (Response response = mapper.toResponse(exception)) {
             assertEquals(429, response.getStatus());

--- a/src/test/java/ai/labs/eddi/integration/AgentConfigurationIT.java
+++ b/src/test/java/ai/labs/eddi/integration/AgentConfigurationIT.java
@@ -8,6 +8,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.*;
 
 import static io.restassured.RestAssured.given;
@@ -25,7 +27,7 @@ import static org.hamcrest.Matchers.*;
 public class AgentConfigurationIT extends BaseIntegrationIT {
 
     private static final String AGENT_STORE = "/agentstore/agents/";
-    private static final java.util.List<ResourceId> createdAgents = new java.util.ArrayList<>();
+    private static final List<ResourceId> createdAgents = new ArrayList<>();
 
     @AfterAll
     static void cleanup() {

--- a/src/test/java/ai/labs/eddi/integration/AgentDeploymentComponentIT.java
+++ b/src/test/java/ai/labs/eddi/integration/AgentDeploymentComponentIT.java
@@ -8,6 +8,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.*;
 
 import static io.restassured.RestAssured.given;
@@ -23,7 +25,7 @@ import static org.hamcrest.Matchers.*;
 @TestProfile(IntegrationTestProfile.class)
 public class AgentDeploymentComponentIT extends BaseIntegrationIT {
 
-    private static final java.util.List<ResourceId> createdAgents = new java.util.ArrayList<>();
+    private static final List<ResourceId> createdAgents = new ArrayList<>();
 
     @AfterAll
     static void cleanup() {

--- a/src/test/java/ai/labs/eddi/integration/ApiContractIT.java
+++ b/src/test/java/ai/labs/eddi/integration/ApiContractIT.java
@@ -8,6 +8,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.*;
 
 import static io.restassured.RestAssured.given;
@@ -24,7 +26,7 @@ import static org.hamcrest.Matchers.*;
 public class ApiContractIT extends BaseIntegrationIT {
 
     // Track resources for cleanup
-    private static final java.util.List<String[]> createdResources = new java.util.ArrayList<>();
+    private static final List<String[]> createdResources = new ArrayList<>();
 
     @AfterAll
     static void cleanup() {

--- a/src/test/java/ai/labs/eddi/integration/AuditAndSecurityIT.java
+++ b/src/test/java/ai/labs/eddi/integration/AuditAndSecurityIT.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.integration;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
+import java.util.List;
 import org.junit.jupiter.api.*;
 
 import static io.restassured.RestAssured.given;
@@ -45,7 +46,7 @@ public class AuditAndSecurityIT extends BaseIntegrationIT {
                 .then().assertThat()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .body("$", instanceOf(java.util.List.class));
+                .body("$", instanceOf(List.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/integration/GlobalVariableCrudIT.java
+++ b/src/test/java/ai/labs/eddi/integration/GlobalVariableCrudIT.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.integration;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
+import java.util.List;
 import org.junit.jupiter.api.*;
 
 import static io.restassured.RestAssured.given;
@@ -44,7 +45,7 @@ public class GlobalVariableCrudIT extends BaseIntegrationIT {
                 .then().assertThat()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .body("$", instanceOf(java.util.List.class));
+                .body("$", instanceOf(List.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/integration/LogAdminIT.java
+++ b/src/test/java/ai/labs/eddi/integration/LogAdminIT.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.integration;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
+import java.util.List;
 import org.junit.jupiter.api.*;
 
 import static io.restassured.RestAssured.given;
@@ -50,7 +51,7 @@ public class LogAdminIT {
     @DisplayName("GET /administration/logs should return recent log entries from ring buffer")
     void getRecentLogs_returnsEntries() {
         // By the time this test runs, Quarkus boot has already generated log entries
-        given().get(BASE).then().assertThat().statusCode(200).contentType(ContentType.JSON).body("$", instanceOf(java.util.List.class));
+        given().get(BASE).then().assertThat().statusCode(200).contentType(ContentType.JSON).body("$", instanceOf(List.class));
     }
 
     @Test
@@ -83,7 +84,7 @@ public class LogAdminIT {
     @Order(6)
     @DisplayName("GET /administration/logs/history should return list (may be empty if DB logging is off)")
     void getHistoryLogs_returnsListOrEmpty() {
-        given().get(BASE + "/history").then().assertThat().statusCode(200).contentType(ContentType.JSON).body("$", instanceOf(java.util.List.class));
+        given().get(BASE + "/history").then().assertThat().statusCode(200).contentType(ContentType.JSON).body("$", instanceOf(List.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterDeepBranchTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterDeepBranchTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -179,7 +180,7 @@ class ChannelTargetRouterDeepBranchTest {
         @Test
         @DisplayName("colon, trigger is null in list → skip that trigger")
         void nullTriggerInList() {
-            var triggerList = new java.util.ArrayList<String>();
+            var triggerList = new ArrayList<String>();
             triggerList.add(null);
             triggerList.add("gpt4");
             var target = createTarget("gpt4", triggerList);

--- a/src/test/java/ai/labs/eddi/integrations/openai/OpenAiAuthFilterTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/openai/OpenAiAuthFilterTest.java
@@ -9,6 +9,8 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -16,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -108,9 +111,9 @@ class OpenAiAuthFilterTest {
         // application.properties, which shadows the production one and declares
         // none of these keys — a classpath lookup would assert nothing about the
         // file the justification actually depends on.
-        var productionConfig = java.nio.file.Path.of("src", "main", "resources", "application.properties");
-        var properties = new java.util.Properties();
-        try (var in = java.nio.file.Files.newInputStream(productionConfig)) {
+        var productionConfig = Path.of("src", "main", "resources", "application.properties");
+        var properties = new Properties();
+        try (var in = Files.newInputStream(productionConfig)) {
             properties.load(in);
         }
 

--- a/src/test/java/ai/labs/eddi/integrations/openai/OpenAiConversationBridgeTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/openai/OpenAiConversationBridgeTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.engine.memory.MemoryKeys;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.triggermanagement.IUserConversationStore;
 import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
@@ -26,6 +27,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static ai.labs.eddi.integrations.openai.OpenAiTestFixtures.AGENT_ID_SUPPORT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -122,7 +124,7 @@ class OpenAiConversationBridgeTest {
     }
 
     /** Drive sayStreaming's handler with the given script. */
-    private void givenStreamingEmits(java.util.function.Consumer<IConversationService.StreamingResponseHandler> script)
+    private void givenStreamingEmits(Consumer<IConversationService.StreamingResponseHandler> script)
             throws Exception {
         doAnswer(invocation -> {
             script.accept(invocation.getArgument(5));
@@ -690,7 +692,7 @@ class OpenAiConversationBridgeTest {
 
         bridge.prepare(statefulModel, simpleRequest(), headers("chat-a"), USER_ID);
 
-        ArgumentCaptor<Map<String, ai.labs.eddi.engine.model.Context>> captor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Map<String, Context>> captor = ArgumentCaptor.forClass(Map.class);
         verify(conversationService).startConversation(any(), any(), any(), captor.capture());
         assertTrue(captor.getValue().containsKey(OpenAiConversationBridge.CONTEXT_CHANNEL_INTENT));
     }

--- a/src/test/java/ai/labs/eddi/integrations/openai/OpenAiTestFixtures.java
+++ b/src/test/java/ai/labs/eddi/integrations/openai/OpenAiTestFixtures.java
@@ -5,6 +5,8 @@
 package ai.labs.eddi.integrations.openai;
 
 import ai.labs.eddi.engine.model.Deployment.Environment;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * Shared fixtures for the OpenAI adapter tests.
@@ -28,7 +30,7 @@ final class OpenAiTestFixtures {
         });
     }
 
-    static OpenAiCompatConfig config(java.util.function.Consumer<ConfigBuilder> customizer) {
+    static OpenAiCompatConfig config(Consumer<ConfigBuilder> customizer) {
         ConfigBuilder builder = new ConfigBuilder();
         customizer.accept(builder);
         return builder.build();
@@ -49,7 +51,7 @@ final class OpenAiTestFixtures {
         boolean exposeStatelessVariants = true;
 
         OpenAiCompatConfig build() {
-            return new OpenAiCompatConfig(enabled, java.util.Optional.ofNullable(apiKey), httpPolicy,
+            return new OpenAiCompatConfig(enabled, Optional.ofNullable(apiKey), httpPolicy,
                     trustUserHeaders, allowAnonymous, defaultUser, environment, requestTimeoutSeconds,
                     maxConcurrentRequests, modelCacheSeconds, exposeStatelessVariants);
         }

--- a/src/test/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListenerTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/slack/SlackGroupDiscussionListenerTest.java
@@ -7,7 +7,9 @@ package ai.labs.eddi.integrations.slack;
 import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionRecord;
 import ai.labs.eddi.configs.groups.model.GroupConversation.DecisionType;
 import ai.labs.eddi.configs.groups.model.GroupConversation.Dissent;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -289,7 +291,7 @@ class SlackGroupDiscussionListenerTest {
     void awaitCompletion_returnsTrueAfterGroupComplete() {
         initExpanded();
         listener.onGroupComplete(new GroupConversationEventSink.GroupCompleteEvent(
-                ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState.COMPLETED, null));
+                GroupConversation.GroupConversationState.COMPLETED, null));
 
         assertTrue(listener.awaitCompletion(1, TimeUnit.SECONDS));
     }
@@ -317,7 +319,7 @@ class SlackGroupDiscussionListenerTest {
                 .thenReturn("ts-synth");
 
         listener.onGroupComplete(new GroupConversationEventSink.GroupCompleteEvent(
-                ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState.COMPLETED,
+                GroupConversation.GroupConversationState.COMPLETED,
                 "Final synthesis answer"));
 
         verify(slackApi).postMessage(eq(AUTH_TOKEN), eq(CHANNEL), isNull(), contains("Synthesis"));
@@ -334,7 +336,7 @@ class SlackGroupDiscussionListenerTest {
 
         // Now onGroupComplete also has a synthesis — should NOT post again
         listener.onGroupComplete(new GroupConversationEventSink.GroupCompleteEvent(
-                ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState.COMPLETED,
+                GroupConversation.GroupConversationState.COMPLETED,
                 "Duplicate synthesis"));
 
         // Only one synthesis header posted
@@ -349,7 +351,7 @@ class SlackGroupDiscussionListenerTest {
     }
 
     private GroupConversationEventSink.GroupStartEvent groupStart(String style, int memberCount) {
-        List<String> ids = new java.util.ArrayList<>();
+        List<String> ids = new ArrayList<>();
         for (int i = 0; i < memberCount; i++)
             ids.add("a" + i);
         return new GroupConversationEventSink.GroupStartEvent(
@@ -396,13 +398,13 @@ class SlackGroupDiscussionListenerTest {
 
         withHitl.onHitlPause(new GroupConversationEventSink.HitlPauseEvent(0, "Phase 1", "sign-off", "phase"));
 
-        var blocksCaptor = org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+        var blocksCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
         verify(slackApi).postBlocksMessage(eq(AUTH_TOKEN), eq("C_APPROVAL"), isNull(), blocksCaptor.capture(), anyString());
         @SuppressWarnings("unchecked")
-        var blocks = (java.util.List<java.util.Map<String, Object>>) blocksCaptor.getValue();
+        var blocks = (List<Map<String, Object>>) blocksCaptor.getValue();
         var actions = blocks.stream().filter(b -> "actions".equals(b.get("type"))).findFirst().orElseThrow();
         @SuppressWarnings("unchecked")
-        var elements = (java.util.List<java.util.Map<String, Object>>) actions.get("elements");
+        var elements = (List<Map<String, Object>>) actions.get("elements");
         String value = (String) elements.get(0).get("value");
         var parsed = SlackHitlSupport.parseActionValue(value);
         assertEquals("acme-int", parsed.integrationName());

--- a/src/test/java/ai/labs/eddi/integrations/slack/SlackHitlResumeObserverTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/slack/SlackHitlResumeObserverTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.integrations.slack;
+import ai.labs.eddi.datastore.IResourceStore;
 
 import ai.labs.eddi.engine.events.HitlResumeCompletedEvent;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict;
@@ -166,7 +167,7 @@ class SlackHitlResumeObserverTest {
     @Test
     void onResumeCompleted_storeError_swallowed() throws Exception {
         when(userConversationStore.readUserConversationByConversationId(any()))
-                .thenThrow(new ai.labs.eddi.datastore.IResourceStore.ResourceStoreException("boom"));
+                .thenThrow(new IResourceStore.ResourceStoreException("boom"));
 
         // Must not throw — observer failures are best-effort.
         assertDoesNotThrow(() -> observer.onResumeCompleted(new HitlResumeCompletedEvent(

--- a/src/test/java/ai/labs/eddi/integrations/slack/SlackInteractivityHandlerTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/slack/SlackInteractivityHandlerTest.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.engine.internal.GroupApprovalRequest;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.integrations.channels.ChannelTargetRouter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -53,7 +54,7 @@ class SlackInteractivityHandlerTest {
         var cfg = new ChannelIntegrationConfiguration();
         cfg.setName(name);
         cfg.setChannelType("slack");
-        var pc = new java.util.HashMap<String, String>();
+        var pc = new HashMap<String, String>();
         pc.put("channelId", "C_MAIN");
         pc.put("botToken", "xoxb-token");
         pc.put("signingSecret", signingSecret);

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorBranchCoverageTest.java
@@ -25,6 +25,10 @@ import org.mockito.Mock;
 
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -716,20 +720,20 @@ class ApiCallExecutorBranchCoverageTest {
             call.setPreRequest(preRequest);
             setupSuccessResponse(200, "ok", "text/plain");
 
-            var scheduledExecutorService = mock(java.util.concurrent.ScheduledExecutorService.class);
+            var scheduledExecutorService = mock(ScheduledExecutorService.class);
             when(runtime.getScheduledExecutorService()).thenReturn(scheduledExecutorService);
 
             @SuppressWarnings("unchecked")
-            java.util.concurrent.ScheduledFuture<IResponse> future = mock(java.util.concurrent.ScheduledFuture.class);
+            ScheduledFuture<IResponse> future = mock(ScheduledFuture.class);
             when(future.get()).thenReturn(mockResponse);
-            when(scheduledExecutorService.schedule(any(java.util.concurrent.Callable.class), eq(500L),
-                    eq(java.util.concurrent.TimeUnit.MILLISECONDS)))
+            when(scheduledExecutorService.schedule(any(Callable.class), eq(500L),
+                    eq(TimeUnit.MILLISECONDS)))
                     .thenReturn(future);
 
             Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
 
-            verify(scheduledExecutorService).schedule(any(java.util.concurrent.Callable.class), eq(500L),
-                    eq(java.util.concurrent.TimeUnit.MILLISECONDS));
+            verify(scheduledExecutorService).schedule(any(Callable.class), eq(500L),
+                    eq(TimeUnit.MILLISECONDS));
             assertNotNull(result);
         }
     }

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorTest.java
@@ -26,6 +26,12 @@ import org.mockito.ArgumentCaptor;
 
 import java.net.URI;
 import java.util.*;
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -421,7 +427,7 @@ class ApiCallExecutorTest {
         // while execute() sent a request with every {arg} rendered empty.
         ApiCall call = createSimpleApiCall("empty-instructions-call", false);
         var preRequest = new HttpPreRequest();
-        preRequest.setPropertyInstructions(new java.util.ArrayList<>());
+        preRequest.setPropertyInstructions(new ArrayList<>());
         call.setPreRequest(preRequest);
         stubRequestMap();
 
@@ -973,11 +979,11 @@ class ApiCallExecutorTest {
         preRequest.setDelayBeforeExecutingInMillis(100);
         call.setPreRequest(preRequest);
 
-        var scheduledExecutor = mock(java.util.concurrent.ScheduledExecutorService.class);
+        var scheduledExecutor = mock(ScheduledExecutorService.class);
         @SuppressWarnings("unchecked")
-        var future = mock(java.util.concurrent.ScheduledFuture.class);
+        var future = mock(ScheduledFuture.class);
         when(future.get()).thenReturn(mockResponse);
-        when(scheduledExecutor.schedule(any(java.util.concurrent.Callable.class), eq(100L), eq(java.util.concurrent.TimeUnit.MILLISECONDS)))
+        when(scheduledExecutor.schedule(any(Callable.class), eq(100L), eq(TimeUnit.MILLISECONDS)))
                 .thenReturn(future);
         when(runtime.getScheduledExecutorService()).thenReturn(scheduledExecutor);
 
@@ -985,7 +991,7 @@ class ApiCallExecutorTest {
 
         executor.execute(call, memory, new HashMap<>(), "http://example.com");
 
-        verify(scheduledExecutor).schedule(any(java.util.concurrent.Callable.class), eq(100L), eq(java.util.concurrent.TimeUnit.MILLISECONDS));
+        verify(scheduledExecutor).schedule(any(Callable.class), eq(100L), eq(TimeUnit.MILLISECONDS));
     }
 
     // ==================== Retry with Exponential Backoff Tests
@@ -1002,13 +1008,13 @@ class ApiCallExecutorTest {
         postResponse.setRetryApiCallInstruction(retryInstruction);
         call.setPostResponse(postResponse);
 
-        var scheduledExecutor = mock(java.util.concurrent.ScheduledExecutorService.class);
+        var scheduledExecutor = mock(ScheduledExecutorService.class);
         @SuppressWarnings("unchecked")
-        var future = mock(java.util.concurrent.ScheduledFuture.class);
+        var future = mock(ScheduledFuture.class);
         when(runtime.getScheduledExecutorService()).thenReturn(scheduledExecutor);
 
         // Use a flag to switch from 503 to 200; toggled when the scheduler is invoked.
-        var retried = new java.util.concurrent.atomic.AtomicBoolean(false);
+        var retried = new AtomicBoolean(false);
         when(mockResponse.getHttpCode()).thenAnswer(inv -> retried.get() ? 200 : 503);
         when(mockResponse.getContentAsString()).thenAnswer(inv -> retried.get() ? "ok" : "retry");
         when(mockResponse.getHttpCodeMessage()).thenAnswer(inv -> retried.get() ? "OK" : "Service Unavailable");
@@ -1019,17 +1025,17 @@ class ApiCallExecutorTest {
         doAnswer(inv -> {
             retried.set(true);
             @SuppressWarnings("unchecked")
-            java.util.concurrent.Callable<IResponse> callable = inv.getArgument(0);
+            Callable<IResponse> callable = inv.getArgument(0);
             IResponse result = callable.call();
             when(future.get()).thenReturn(result);
             return future;
-        }).when(scheduledExecutor).schedule(any(java.util.concurrent.Callable.class), anyLong(), any());
+        }).when(scheduledExecutor).schedule(any(Callable.class), anyLong(), any());
 
         executor.execute(call, memory, new HashMap<>(), "http://example.com");
 
         verify(scheduledExecutor, times(1)).schedule(
-                any(java.util.concurrent.Callable.class), eq(50L),
-                eq(java.util.concurrent.TimeUnit.MILLISECONDS));
+                any(Callable.class), eq(50L),
+                eq(TimeUnit.MILLISECONDS));
     }
 
     // ==================== Null PostResponse RetryInstruction Tests
@@ -1060,7 +1066,7 @@ class ApiCallExecutorTest {
 
         executor.execute(call, memory, new HashMap<>(), "http://example.com");
 
-        verify(mockRequest).setTimeout(DEFAULT_TIMEOUT_MILLIS, java.util.concurrent.TimeUnit.MILLISECONDS);
+        verify(mockRequest).setTimeout(DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         verify(mockRequest).setMaxResponseSize(ApiCallExecutor.MAX_TRANSPORT_RESPONSE_SIZE_BYTES);
     }
 
@@ -1073,7 +1079,7 @@ class ApiCallExecutorTest {
 
         executor.execute(call, memory, new HashMap<>(), "http://example.com");
 
-        verify(mockRequest).setTimeout(1_500L, java.util.concurrent.TimeUnit.MILLISECONDS);
+        verify(mockRequest).setTimeout(1_500L, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -1137,9 +1143,9 @@ class ApiCallExecutorTest {
     @Test
     void execute_requestSendThrowsException_wrapsInLifecycleException() throws Exception {
         ApiCall call = createSimpleApiCall("err-call", false);
-        when(mockRequest.send()).thenThrow(new ai.labs.eddi.engine.httpclient.IRequest.HttpRequestException("Connection refused"));
+        when(mockRequest.send()).thenThrow(new IRequest.HttpRequestException("Connection refused"));
 
-        assertThrows(ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException.class,
+        assertThrows(LifecycleException.class,
                 () -> executor.execute(call, memory, new HashMap<>(), "http://example.com"));
     }
 }

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/PrePostUtilsTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/PrePostUtilsTest.java
@@ -273,13 +273,13 @@ class PrePostUtilsTest {
     class PropertyTypeTests {
 
         private IConversationMemory memory;
-        private ai.labs.eddi.engine.memory.model.ConversationProperties conversationProperties;
+        private ConversationProperties conversationProperties;
         private Map<String, Object> templateData;
 
         @BeforeEach
         void setupMemory() throws Exception {
             memory = mock(IConversationMemory.class);
-            conversationProperties = mock(ai.labs.eddi.engine.memory.model.ConversationProperties.class);
+            conversationProperties = mock(ConversationProperties.class);
             when(memory.getConversationProperties()).thenReturn(conversationProperties);
             when(conversationProperties.toMap()).thenReturn(new HashMap<>());
             templateData = new HashMap<>();

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/A2AToolProviderManagerExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/A2AToolProviderManagerExtendedTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -217,7 +218,7 @@ class A2AToolProviderManagerExtendedTest {
         @DisplayName("CachedAgentInfo stores card and timestamp")
         void cachedAgentInfo() {
             var info = new A2AToolProviderManager.CachedAgentInfo(
-                    java.util.Map.of("name", "agent"), 123456L);
+                    Map.of("name", "agent"), 123456L);
             assertEquals("agent", info.agentCard().get("name"));
             assertEquals(123456L, info.timestamp());
         }
@@ -234,7 +235,7 @@ class A2AToolProviderManagerExtendedTest {
         @DisplayName("A2AToolsResult stores specs and executors")
         void a2aToolsResult() {
             var result = new A2AToolProviderManager.A2AToolsResult(
-                    List.of(), java.util.Map.of());
+                    List.of(), Map.of());
             assertTrue(result.toolSpecs().isEmpty());
             assertTrue(result.executors().isEmpty());
         }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorBranchTest.java
@@ -11,11 +11,13 @@ import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
+import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IData;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
 import ai.labs.eddi.engine.memory.MemoryKeys;
 import ai.labs.eddi.engine.memory.MemorySnapshotService;
+import ai.labs.eddi.engine.memory.model.Attachment;
 import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.modules.apicalls.impl.IApiCallExecutor;
@@ -105,7 +107,7 @@ class AgentOrchestratorBranchTest {
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,
                 null, null, null, null, null,
-                mock(ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
+                mock(IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
     }
 
     // =========================================================
@@ -165,7 +167,7 @@ class AgentOrchestratorBranchTest {
                 // A real Attachment, not a placeholder Object: the gate counts
                 // coerced attachments, so a stand-in would not represent a turn
                 // that actually carries a file.
-                var attachment = new ai.labs.eddi.engine.memory.model.Attachment();
+                var attachment = new Attachment();
                 attachment.setStorageRef("ref-current");
                 attachment.setFileName("current.pdf");
                 attachment.setMimeType("application/pdf");
@@ -187,7 +189,7 @@ class AgentOrchestratorBranchTest {
         @SuppressWarnings({"rawtypes", "unchecked"})
         private void withAttachmentsOnAnEarlierTurnOnly() {
             withAttachments(false);
-            var attachment = new ai.labs.eddi.engine.memory.model.Attachment();
+            var attachment = new Attachment();
             attachment.setStorageRef("ref-1");
             attachment.setFileName("report.pdf");
             attachment.setMimeType("application/pdf");
@@ -342,11 +344,11 @@ class AgentOrchestratorBranchTest {
             when(memory.getCurrentStep()).thenReturn(step);
             when(memory.getConversationId()).thenReturn("conv-1");
 
-            var inline = new ai.labs.eddi.engine.memory.model.Attachment();
+            var inline = new Attachment();
             inline.setMimeType("application/pdf");
             inline.setFileName("inline.pdf");
             inline.setBase64Data("JVBERi0=");
-            var byUrl = new ai.labs.eddi.engine.memory.model.Attachment();
+            var byUrl = new Attachment();
             byUrl.setMimeType("image/png");
             byUrl.setUrl("https://example.com/a.png");
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverage2Test.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverage2Test.java
@@ -12,7 +12,9 @@ import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
+import ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException;
 import ai.labs.eddi.engine.memory.IConversationMemory;
+import ai.labs.eddi.engine.memory.IData;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
 import ai.labs.eddi.engine.memory.MemorySnapshotService;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
@@ -397,7 +399,7 @@ class AgentOrchestratorCoverage2Test {
         var gatedReq = ToolExecutionRequest.builder().id("c1").name("calculate").arguments("{\"expression\":\"6*7\"}").build();
         when(chatModel.chat(any(ChatRequest.class))).thenReturn(toolBatch(gatedReq));
 
-        assertThrows(ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException.class,
+        assertThrows(ToolApprovalRequiredException.class,
                 () -> orchestrator.executeIfToolsEnabled(chatModel, "sys", List.of(UserMessage.from("hi")),
                         task, memory, gateCalculate(), 0));
 
@@ -412,7 +414,7 @@ class AgentOrchestratorCoverage2Test {
         // takes the null-result arm -> count 0 -> pauses.
         var task = twoToolTask();
         @SuppressWarnings("unchecked")
-        ai.labs.eddi.engine.memory.IData<Integer> data = mock(ai.labs.eddi.engine.memory.IData.class);
+        IData<Integer> data = mock(IData.class);
         when(data.getResult()).thenReturn(null);
         doReturn(data).when(currentStep).getLatestData("hitl:tool_pause_count");
 
@@ -420,7 +422,7 @@ class AgentOrchestratorCoverage2Test {
         var gatedReq = ToolExecutionRequest.builder().id("c1").name("calculate").arguments("{\"expression\":\"6*7\"}").build();
         when(chatModel.chat(any(ChatRequest.class))).thenReturn(toolBatch(gatedReq));
 
-        assertThrows(ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException.class,
+        assertThrows(ToolApprovalRequiredException.class,
                 () -> orchestrator.executeIfToolsEnabled(chatModel, "sys", List.of(UserMessage.from("hi")),
                         task, memory, gateCalculate(), 0));
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverageTest.java
@@ -28,10 +28,12 @@ import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
+import ai.labs.eddi.engine.memory.IData;
 import ai.labs.eddi.modules.apicalls.impl.IApiCallExecutor;
 import ai.labs.eddi.modules.apicalls.impl.RequestRedactor;
 import ai.labs.eddi.modules.apicalls.impl.ResolvedRequest;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.modules.llm.tools.ToolCostTracker;
 import ai.labs.eddi.modules.llm.tools.ToolExecutionService;
 import ai.labs.eddi.modules.llm.tools.ToolInvocation;
 import ai.labs.eddi.modules.llm.tools.impl.*;
@@ -269,8 +271,8 @@ class AgentOrchestratorCoverageTest {
     }
 
     @SuppressWarnings("unchecked")
-    private ai.labs.eddi.engine.memory.IData<Integer> dataOfInt(int v) {
-        var d = mock(ai.labs.eddi.engine.memory.IData.class);
+    private IData<Integer> dataOfInt(int v) {
+        var d = mock(IData.class);
         lenient().when(d.getResult()).thenReturn(v);
         return d;
     }
@@ -378,14 +380,14 @@ class AgentOrchestratorCoverageTest {
      * {@code isWithinBudget}, not from accumulated cost. That the budget can be
      * reached by real spend at all is proved by
      * {@code AgentOrchestratorToolCostTest}, which drives the same loop against a
-     * REAL {@link ai.labs.eddi.modules.llm.tools.ToolCostTracker}.
+     * REAL {@link ToolCostTracker}.
      */
     @Test
     void toolCall_perConversationBudgetExceeded_returnsBudgetError() throws Exception {
         var task = calcOnlyTask();
         task.setMaxBudgetPerConversation(1.0);
         task.setEnforceBudget(true);
-        var costTracker = mock(ai.labs.eddi.modules.llm.tools.ToolCostTracker.class);
+        var costTracker = mock(ToolCostTracker.class);
         when(toolExecutionService.getCostTracker()).thenReturn(costTracker);
         when(costTracker.isWithinBudget(eq("conv-1"), eq(1.0))).thenReturn(false);
 
@@ -689,7 +691,7 @@ class AgentOrchestratorCoverageTest {
         var task = calcOnlyTask();
         task.setMaxBudgetPerConversation(1.0);
         task.setEnforceBudget(false);
-        var costTracker = mock(ai.labs.eddi.modules.llm.tools.ToolCostTracker.class);
+        var costTracker = mock(ToolCostTracker.class);
         lenient().when(toolExecutionService.getCostTracker()).thenReturn(costTracker);
         lenient().when(costTracker.isWithinBudget(anyString(), anyDouble())).thenReturn(false);
 
@@ -731,7 +733,7 @@ class AgentOrchestratorCoverageTest {
         var task = calcOnlyTask();
         task.setMaxBudgetPerConversation(1.0);
         // deliberately no setEnforceBudget(...)
-        var costTracker = mock(ai.labs.eddi.modules.llm.tools.ToolCostTracker.class);
+        var costTracker = mock(ToolCostTracker.class);
         lenient().when(toolExecutionService.getCostTracker()).thenReturn(costTracker);
         lenient().when(costTracker.isWithinBudget(nullable(String.class), anyDouble())).thenReturn(false);
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorExtendedBranchTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
 import ai.labs.eddi.engine.memory.MemorySnapshotService;
@@ -104,7 +105,7 @@ class AgentOrchestratorExtendedBranchTest {
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,
                 null, null, null, null, null,
-                mock(ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
+                mock(IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
     }
 
     // =========================================================
@@ -225,7 +226,7 @@ class AgentOrchestratorExtendedBranchTest {
                     null, // null userMemoryStore
                     toolResponseTruncator, tenantQuotaService, memorySnapshotService,
                     null, null, null, null, null,
-                    mock(ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
+                    mock(IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
 
             var task = new LlmConfiguration.Task();
             task.setEnableBuiltInTools(true);

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorExtendedTest.java
@@ -11,6 +11,7 @@ import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.configs.shared.RetryConfiguration;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
@@ -100,7 +101,7 @@ class AgentOrchestratorExtendedTest {
                 userMemoryStore, mock(ToolResponseTruncator.class),
                 mock(TenantQuotaService.class), memorySnapshotService,
                 null, null, null, null, null,
-                mock(ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
+                mock(IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
 
         mockMemory = mock(IConversationMemory.class);
         when(mockMemory.getUserMemoryConfig()).thenReturn(null);

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorResumeToolLoopTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorResumeToolLoopTest.java
@@ -10,11 +10,13 @@ import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.hitl.tools.ChatTranscriptCodec;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.lifecycle.model.ToolCallDecision;
 import ai.labs.eddi.engine.memory.IConversationMemory;
+import ai.labs.eddi.engine.memory.IData;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
 import ai.labs.eddi.engine.memory.MemorySnapshotService;
 import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
@@ -22,6 +24,7 @@ import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.modules.apicalls.impl.IApiCallExecutor;
+import ai.labs.eddi.modules.apicalls.impl.ResolvedRequest;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import ai.labs.eddi.modules.llm.tools.ToolCostTracker;
 import ai.labs.eddi.modules.llm.tools.ToolExecutionService;
@@ -35,6 +38,7 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -201,7 +205,7 @@ class AgentOrchestratorResumeToolLoopTest {
         List<ChatMessage> transcript = new ArrayList<>();
         transcript.add(UserMessage.from("do the thing"));
         transcript.add(AiMessage.from(aiRequests));
-        var codec = new ai.labs.eddi.engine.hitl.tools.ChatTranscriptCodec();
+        var codec = new ChatTranscriptCodec();
         var res = codec.serialize(transcript, PendingToolCallBatch.TRANSCRIPT_MAX_BYTES_DEFAULT);
         batch.setChatTranscriptJson(res.json());
         batch.setTranscriptOmitted(res.omitted());
@@ -232,8 +236,8 @@ class AgentOrchestratorResumeToolLoopTest {
     }
 
     @SuppressWarnings("unchecked")
-    private ai.labs.eddi.engine.memory.IData<Integer> dataOfInt(int v) {
-        var d = mock(ai.labs.eddi.engine.memory.IData.class);
+    private IData<Integer> dataOfInt(int v) {
+        var d = mock(IData.class);
         when(d.getResult()).thenReturn(v);
         return d;
     }
@@ -355,7 +359,7 @@ class AgentOrchestratorResumeToolLoopTest {
         var batch = batchWith(0, List.of(gated), List.of(r1));
 
         // Re-resolution now yields a DIFFERENT fingerprint — the tamper case.
-        ToolRequestResolver movedResolver = req -> ai.labs.eddi.modules.apicalls.impl.ResolvedRequest.of("POST",
+        ToolRequestResolver movedResolver = req -> ResolvedRequest.of("POST",
                 "https://eddi.example/agentstore/agents/attacker-choice", Map.of(), Map.of(), "{}", true);
         var spied = spy(orchestrator);
         doAnswer(invocation -> {
@@ -393,7 +397,7 @@ class AgentOrchestratorResumeToolLoopTest {
         var r1 = ToolExecutionRequest.builder().id("c1").name("calculate").arguments("{\"expression\":\"6*7\"}").build();
         var gated = gatedCall("c1", "calculate", "{\"expression\":\"6*7\"}");
 
-        ToolRequestResolver stableResolver = req -> ai.labs.eddi.modules.apicalls.impl.ResolvedRequest.of("POST",
+        ToolRequestResolver stableResolver = req -> ResolvedRequest.of("POST",
                 "https://eddi.example/agentstore/agents/a1", Map.of(), Map.of(), "{}", true);
         // Pin it to whatever that resolver actually produces, so gate time and
         // resume time genuinely agree.
@@ -503,7 +507,7 @@ class AgentOrchestratorResumeToolLoopTest {
         when(journalStore.tryClaim(anyString(), anyString(), eq("c1"), anyString(), anyString())).thenReturn(false);
         when(journalStore.find("conv-1", "epoch-1", "c1")).thenReturn(Optional.of(
                 new IHitlToolJournalStore.JournalEntry("conv-1", "epoch-1", "c1", "calculate",
-                        IHitlToolJournalStore.Status.EXECUTED, "42", java.time.Instant.now(), "reviewer-1")));
+                        IHitlToolJournalStore.Status.EXECUTED, "42", Instant.now(), "reviewer-1")));
 
         ChatModel chatModel = mock(ChatModel.class);
         var captor = ArgumentCaptor.forClass(ChatRequest.class);

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
 import ai.labs.eddi.engine.memory.MemorySnapshotService;
@@ -113,7 +114,7 @@ class AgentOrchestratorTest {
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,
                 null, null, null, null, null,
-                mock(ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
+                mock(IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -524,7 +525,7 @@ class AgentOrchestratorTest {
                 null, // null userMemoryStore
                 toolResponseTruncator, tenantQuotaService, memorySnapshotService,
                 null, null, null, null, null,
-                mock(ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
+                mock(IHitlToolJournalStore.class), new ConversationHistoryBuilder(), new TokenCounterFactory());
 
         var task = new LlmConfiguration.Task();
         task.setEnableBuiltInTools(true);

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolPauseTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolPauseTest.java
@@ -20,6 +20,9 @@ import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.modules.apicalls.impl.IApiCallExecutor;
 import ai.labs.eddi.configs.shared.RetryConfiguration;
+import ai.labs.eddi.engine.audit.model.AuditEntry;
+import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
+import ai.labs.eddi.engine.memory.IData;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import ai.labs.eddi.modules.llm.tools.ToolExecutionService;
 import ai.labs.eddi.modules.llm.tools.ToolInvocation;
@@ -30,6 +33,7 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -106,7 +110,7 @@ class AgentOrchestratorToolPauseTest {
     @Mock
     private IConversationMemory.IWritableConversationStep currentStep;
     @Mock
-    private ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore journalStore;
+    private IHitlToolJournalStore journalStore;
 
     private AgentOrchestrator orchestrator;
 
@@ -319,7 +323,7 @@ class AgentOrchestratorToolPauseTest {
         doReturn(dataOfInt(1)).when(currentStep).getLatestData("hitl:tool_pause_count");
 
         // Audit context present — Task 10 records the guard through the collector.
-        var collected = new java.util.ArrayList<ai.labs.eddi.engine.audit.model.AuditEntry>();
+        var collected = new ArrayList<AuditEntry>();
         when(memory.getUserId()).thenReturn("user-1");
         when(memory.getAuditCollector()).thenReturn(collected::add);
 
@@ -329,7 +333,7 @@ class AgentOrchestratorToolPauseTest {
                 .filter(e -> "hitl.tool.pause_cap".equals(e.taskId()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("expected a hitl.tool.pause_cap guard audit entry, got: "
-                        + collected.stream().map(ai.labs.eddi.engine.audit.model.AuditEntry::taskId).toList()));
+                        + collected.stream().map(AuditEntry::taskId).toList()));
         assertEquals("pause_cap", guard.output().get("guard"));
         assertNotNull(guard.output().get("fingerprint"), "guard audit carries the gated fingerprint");
         assertEquals(true, guard.output().get("automated"));
@@ -377,8 +381,8 @@ class AgentOrchestratorToolPauseTest {
     }
 
     @SuppressWarnings("unchecked")
-    private ai.labs.eddi.engine.memory.IData<Integer> dataOfInt(int v) {
-        var d = mock(ai.labs.eddi.engine.memory.IData.class);
+    private IData<Integer> dataOfInt(int v) {
+        var d = mock(IData.class);
         when(d.getResult()).thenReturn(v);
         return d;
     }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AttachmentForwarderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AttachmentForwarderTest.java
@@ -6,10 +6,13 @@ package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.httpclient.SafeHttpClient;
+import ai.labs.eddi.engine.memory.ConversationMemory;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IConversationMemory.IWritableConversationStep;
 import ai.labs.eddi.engine.memory.IData;
+import ai.labs.eddi.engine.memory.MemoryKeys;
 import ai.labs.eddi.engine.memory.model.Attachment;
+import ai.labs.eddi.engine.memory.model.Data;
 import ai.labs.eddi.modules.llm.capability.ModelCapabilityService;
 import ai.labs.eddi.modules.llm.tools.impl.AttachmentTextExtractor;
 import dev.langchain4j.data.message.*;
@@ -28,6 +31,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -141,7 +145,7 @@ class AttachmentForwarderTest {
             when(store.load(eq("ref-1"), any())).thenReturn(pdf);
 
             // The map form Jackson hands back for a persisted Attachment.
-            Map<String, Object> persisted = new java.util.HashMap<>();
+            Map<String, Object> persisted = new HashMap<>();
             persisted.put("storageRef", "ref-1");
             persisted.put("fileName", "report.pdf");
             persisted.put("mimeType", "application/pdf");
@@ -545,18 +549,18 @@ class AttachmentForwarderTest {
         // attachments:extracts / attachments:errors keys. A prefix read of
         // "attachments" would return one of those List<String> entries and forward
         // nothing; the exact-match read must still find the List<Attachment>.
-        var realMemory = new ai.labs.eddi.engine.memory.ConversationMemory("agent-1", 1, "user-1");
+        var realMemory = new ConversationMemory("agent-1", 1, "user-1");
         var step = realMemory.getCurrentStep();
         Attachment att = new Attachment();
         att.setMimeType("image/png");
         att.setBase64Data(Base64.getEncoder().encodeToString("png".getBytes()));
-        step.storeData(new ai.labs.eddi.engine.memory.model.Data<>(ATTACHMENTS.key(), List.of(att)));
+        step.storeData(new Data<>(ATTACHMENTS.key(), List.of(att)));
         // Inserted AFTER attachments — this is what a prefix reverse-scan would return
         // first.
-        step.storeData(new ai.labs.eddi.engine.memory.model.Data<>(
-                ai.labs.eddi.engine.memory.MemoryKeys.ATTACHMENT_ERRORS.key(), List.of("earlier error")));
-        step.storeData(new ai.labs.eddi.engine.memory.model.Data<>(
-                ai.labs.eddi.engine.memory.MemoryKeys.ATTACHMENT_EXTRACTS.key(), List.of("doc: earlier extract")));
+        step.storeData(new Data<>(
+                MemoryKeys.ATTACHMENT_ERRORS.key(), List.of("earlier error")));
+        step.storeData(new Data<>(
+                MemoryKeys.ATTACHMENT_EXTRACTS.key(), List.of("doc: earlier extract")));
 
         List<ChatMessage> messages = messages(UserMessage.from("look"));
         forwarder.forward(messages, realMemory, "openai", "gpt-4o");

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskBranchTest.java
@@ -477,7 +477,7 @@ class LlmTaskBranchTest {
             when(templatingEngine.processTemplate(anyString(), anyMap())).thenAnswer(i -> i.getArgument(0));
 
             // ConversationSummarizer.readSummary needs conversationProperties mock
-            var props = mock(ai.labs.eddi.engine.memory.model.ConversationProperties.class);
+            var props = mock(ConversationProperties.class);
             when(memory.getConversationProperties()).thenReturn(props);
             when(props.get(anyString())).thenReturn(null);
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverage2Test.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverage2Test.java
@@ -22,6 +22,7 @@ import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
 import ai.labs.eddi.modules.apicalls.impl.IApiCallExecutor;
 import ai.labs.eddi.modules.apicalls.impl.PrePostUtils;
 import ai.labs.eddi.configs.shared.RetryConfiguration;
+import ai.labs.eddi.engine.audit.IAuditEntryCollector;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration.CascadeStep;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration.ConversationSummaryConfig;
@@ -634,7 +635,7 @@ class LlmTaskCoverage2Test {
     void cascadeEnabled_auditMetadataStored() throws Exception {
         wireStandardMemory(List.of("action1"));
         when(chatModel.chat(anyList())).thenReturn(chatResponse("cascade answer"));
-        when(memory.getAuditCollector()).thenReturn(mock(ai.labs.eddi.engine.audit.IAuditEntryCollector.class));
+        when(memory.getAuditCollector()).thenReturn(mock(IAuditEntryCollector.class));
 
         var cascade = new ModelCascadeConfig();
         cascade.setEnabled(true);
@@ -815,7 +816,7 @@ class LlmTaskCoverage2Test {
         // non-empty tokenUsage map, which the cascade result then surfaces.
         when(chatModel.chat(anyList())).thenReturn(ChatResponse.builder().aiMessage(aiMessage("cascade answer"))
                 .metadata(ChatResponseMetadata.builder().tokenUsage(new TokenUsage(120, 30)).build()).build());
-        when(memory.getAuditCollector()).thenReturn(mock(ai.labs.eddi.engine.audit.IAuditEntryCollector.class));
+        when(memory.getAuditCollector()).thenReturn(mock(IAuditEntryCollector.class));
         var templateData = new HashMap<String, Object>();
         when(memoryItemConverter.convert(memory)).thenReturn(templateData);
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverageTest.java
@@ -10,8 +10,10 @@ import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.audit.IAuditEntryCollector;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
+import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict;
 import ai.labs.eddi.engine.memory.*;
@@ -707,7 +709,7 @@ class LlmTaskCoverageTest {
     void auditCollectorPresent_storesAuditKeys() throws Exception {
         wireStandardMemory(List.of("action1"));
         agentReturns("audited answer");
-        when(memory.getAuditCollector()).thenReturn(mock(ai.labs.eddi.engine.audit.IAuditEntryCollector.class));
+        when(memory.getAuditCollector()).thenReturn(mock(IAuditEntryCollector.class));
 
         var t = task("taskA", List.of("action1"), null);
         llmTask.execute(memory, new LlmConfiguration(List.of(t)));
@@ -795,7 +797,7 @@ class LlmTaskCoverageTest {
     void resume_auditKeysStored() throws Exception {
         var b = batch("taskA", 0);
         wireResumeMemory(List.of("action1"), b, decision(HitlVerdict.APPROVED));
-        when(memory.getAuditCollector()).thenReturn(mock(ai.labs.eddi.engine.audit.IAuditEntryCollector.class));
+        when(memory.getAuditCollector()).thenReturn(mock(IAuditEntryCollector.class));
         when(agentOrchestrator.resumeToolLoop(any(), any(), any(), any(), any(), anyBoolean(), any()))
                 .thenReturn(new AgentOrchestrator.ExecutionResult("resumed answer", new ArrayList<>()));
 
@@ -848,7 +850,7 @@ class LlmTaskCoverageTest {
     @Test
     @DisplayName("configure() with no URI → throws WorkflowConfigurationException")
     void configure_noUri_throws() {
-        assertThrows(ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException.class,
+        assertThrows(WorkflowConfigurationException.class,
                 () -> llmTask.configure(new HashMap<>(), new HashMap<>()));
     }
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskDeepBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskDeepBranchTest.java
@@ -22,6 +22,8 @@ import ai.labs.eddi.modules.llm.tools.impl.*;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import ai.labs.eddi.secrets.SecretResolver;
 import ai.labs.eddi.engine.audit.IAuditEntryCollector;
+import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
+import ai.labs.eddi.engine.runtime.service.ServiceException;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -237,14 +239,14 @@ class LlmTaskDeepBranchTest {
         @Test
         @DisplayName("null URI in configuration throws WorkflowConfigurationException")
         void nullUri() {
-            assertThrows(ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException.class,
+            assertThrows(WorkflowConfigurationException.class,
                     () -> llmTask.configure(Map.of(), Map.of()));
         }
 
         @Test
         @DisplayName("empty URI in configuration throws WorkflowConfigurationException")
         void emptyUri() {
-            assertThrows(ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException.class,
+            assertThrows(WorkflowConfigurationException.class,
                     () -> llmTask.configure(Map.of("uri", ""), Map.of()));
         }
 
@@ -263,9 +265,9 @@ class LlmTaskDeepBranchTest {
         @DisplayName("ServiceException from resource library wraps in WorkflowConfigurationException")
         void serviceException() throws Exception {
             when(resourceClientLibrary.getResource(any(), eq(LlmConfiguration.class)))
-                    .thenThrow(new ai.labs.eddi.engine.runtime.service.ServiceException("fail"));
+                    .thenThrow(new ServiceException("fail"));
 
-            assertThrows(ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException.class,
+            assertThrows(WorkflowConfigurationException.class,
                     () -> llmTask.configure(Map.of("uri", "eddi://ai.labs.llm/llmstore/llmconfigs/abc123?version=1"), Map.of()));
         }
     }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskTest.java
@@ -22,6 +22,7 @@ import ai.labs.eddi.modules.apicalls.impl.PrePostUtils;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration.Task;
 import ai.labs.eddi.modules.llm.tools.impl.*;
+import ai.labs.eddi.modules.output.model.types.TextOutputItem;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -483,7 +484,7 @@ class LlmTaskTest {
                     "Non-blank text should pass the output guard");
 
             // Verify TextOutputItem can be created with valid text
-            var outputItem = new ai.labs.eddi.modules.output.model.types.TextOutputItem("Valid output", 0);
+            var outputItem = new TextOutputItem("Valid output", 0);
             assertEquals("Valid output", outputItem.getText());
         }
 

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/ConverseWithAgentToolHitlTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/ConverseWithAgentToolHitlTest.java
@@ -7,7 +7,9 @@ package ai.labs.eddi.modules.llm.tools;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResponseHandler;
 import ai.labs.eddi.engine.memory.model.ConversationState;
+import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
@@ -59,13 +61,13 @@ class ConverseWithAgentToolHitlTest {
         // Task 13: a nested TOOL_CALL pause must additively surface pauseType and
         // the gated tool NAMES (names only — never arguments) in the delegated-tool
         // text message.
-        var batch = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch();
-        var call1 = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+        var batch = new PendingToolCallBatch();
+        var call1 = new PendingToolCallBatch.PendingToolCall();
         call1.setToolName("delete_production_db");
         call1.setArgumentsRaw("{\"secret\":\"nuke\"}");
-        var call2 = new ai.labs.eddi.engine.memory.model.PendingToolCallBatch.PendingToolCall();
+        var call2 = new PendingToolCallBatch.PendingToolCall();
         call2.setToolName("wire_transfer");
-        batch.setCalls(java.util.List.of(call1, call2));
+        batch.setCalls(List.of(call1, call2));
 
         var snapshot = new SimpleConversationMemorySnapshot();
         snapshot.setConversationState(ConversationState.AWAITING_HUMAN);

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/DynamicAgentToolsTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/DynamicAgentToolsTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DynamicAgentConfig;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResponseHandler;
 import ai.labs.eddi.engine.api.IConversationService.ConversationResult;
@@ -30,6 +31,8 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CompletableFuture;
@@ -485,7 +488,7 @@ class DynamicAgentToolsTest {
         @DisplayName("Fix 3: null entries in allowedProviders list don't cause NPE")
         void createSubAgent_nullEntryInProviderAllowList() {
             // Simulates malformed JSON config with null entries
-            var providers = new java.util.ArrayList<String>();
+            var providers = new ArrayList<String>();
             providers.add(null);
             providers.add("openai");
             config.setAllowedProviders(providers);
@@ -499,7 +502,7 @@ class DynamicAgentToolsTest {
         @DisplayName("Fix 4: null values in allowedModels map don't cause NPE (with provider)")
         void createSubAgent_nullModelListInAllowedModels_withProvider() throws Exception {
             // Map with a provider key mapping to null list
-            var models = new java.util.HashMap<String, List<String>>();
+            var models = new HashMap<String, List<String>>();
             models.put("openai", null); // null list for provider
             config.setAllowedModels(models);
             config.setAllowedProviders(List.of("openai"));
@@ -517,7 +520,7 @@ class DynamicAgentToolsTest {
         @DisplayName("Fix 4: null values in allowedModels map don't cause NPE (without provider)")
         void createSubAgent_nullModelListInAllowedModels_noProvider() {
             // Map with a provider key mapping to null list
-            var models = new java.util.HashMap<String, List<String>>();
+            var models = new HashMap<String, List<String>>();
             models.put("openai", null);
             config.setAllowedModels(models);
 
@@ -531,7 +534,7 @@ class DynamicAgentToolsTest {
         @Test
         @DisplayName("Fix 4: null model entries in allowedModels list don't cause NPE")
         void createSubAgent_nullModelEntryInList() {
-            var modelList = new java.util.ArrayList<String>();
+            var modelList = new ArrayList<String>();
             modelList.add(null);
             modelList.add("gpt-4o");
             config.setAllowedModels(Map.of("openai", modelList));
@@ -690,7 +693,7 @@ class DynamicAgentToolsTest {
             doAnswer(invocation -> {
                 // Don't invoke the handler — but we can't wait 60s.
                 // Instead, let's directly throw to simulate the scenario via the outer catch.
-                throw new java.util.concurrent.TimeoutException("Simulated timeout");
+                throw new TimeoutException("Simulated timeout");
             }).when(conversationService).say(
                     any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(), anyBoolean(), any());
 
@@ -1246,8 +1249,8 @@ class DynamicAgentToolsTest {
 
         @Test
         void addDynamicMember_threadSafe() {
-            var gc = new ai.labs.eddi.configs.groups.model.GroupConversation();
-            var member = new ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember(
+            var gc = new GroupConversation();
+            var member = new AgentGroupConfiguration.GroupMember(
                     "dynamic-1", "Dynamic Agent", 99, "specialist");
 
             gc.addDynamicMember(member);
@@ -1258,7 +1261,7 @@ class DynamicAgentToolsTest {
 
         @Test
         void createdAgentIds_tracking() {
-            var gc = new ai.labs.eddi.configs.groups.model.GroupConversation();
+            var gc = new GroupConversation();
 
             gc.getCreatedAgentIds().add("agent-a");
             gc.getCreatedAgentIds().add("agent-b");
@@ -1269,7 +1272,7 @@ class DynamicAgentToolsTest {
 
         @Test
         void retainedAgentIds_tracking() {
-            var gc = new ai.labs.eddi.configs.groups.model.GroupConversation();
+            var gc = new GroupConversation();
 
             gc.getRetainedAgentIds().add("agent-a");
 
@@ -1279,7 +1282,7 @@ class DynamicAgentToolsTest {
 
         @Test
         void setDynamicMembers_null_safe() {
-            var gc = new ai.labs.eddi.configs.groups.model.GroupConversation();
+            var gc = new GroupConversation();
             gc.setDynamicMembers(null);
             assertNotNull(gc.getDynamicMembers());
             assertTrue(gc.getDynamicMembers().isEmpty());
@@ -1287,7 +1290,7 @@ class DynamicAgentToolsTest {
 
         @Test
         void setCreatedAgentIds_null_safe() {
-            var gc = new ai.labs.eddi.configs.groups.model.GroupConversation();
+            var gc = new GroupConversation();
             gc.setCreatedAgentIds(null);
             assertNotNull(gc.getCreatedAgentIds());
             assertTrue(gc.getCreatedAgentIds().isEmpty());
@@ -1295,7 +1298,7 @@ class DynamicAgentToolsTest {
 
         @Test
         void setRetainedAgentIds_null_safe() {
-            var gc = new ai.labs.eddi.configs.groups.model.GroupConversation();
+            var gc = new GroupConversation();
             gc.setRetainedAgentIds(null);
             assertNotNull(gc.getRetainedAgentIds());
             assertTrue(gc.getRetainedAgentIds().isEmpty());

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/impl/PdfReaderToolTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/impl/PdfReaderToolTest.java
@@ -5,6 +5,13 @@
 package ai.labs.eddi.modules.llm.tools.impl;
 
 import ai.labs.eddi.engine.httpclient.SafeHttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
+import java.util.GregorianCalendar;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -159,7 +166,7 @@ class PdfReaderToolTest {
         @org.junit.jupiter.api.DisplayName("extractTextFromPdf — non-200 status returns error")
         @SuppressWarnings("unchecked")
         void extractText_non200_returnsError() throws Exception {
-            var mockResponse = (java.net.http.HttpResponse<java.nio.file.Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+            var mockResponse = (java.net.http.HttpResponse<Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
             org.mockito.Mockito.when(mockResponse.statusCode()).thenReturn(404);
             org.mockito.Mockito.doReturn(mockResponse).when(mockedHttpClient).send(
                     org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
@@ -175,7 +182,7 @@ class PdfReaderToolTest {
         @org.junit.jupiter.api.DisplayName("extractTextFromPdfPages — non-200 status returns error")
         @SuppressWarnings("unchecked")
         void extractPages_non200_returnsError() throws Exception {
-            var mockResponse = (java.net.http.HttpResponse<java.nio.file.Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+            var mockResponse = (java.net.http.HttpResponse<Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
             org.mockito.Mockito.when(mockResponse.statusCode()).thenReturn(500);
             org.mockito.Mockito.doReturn(mockResponse).when(mockedHttpClient).send(
                     org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
@@ -191,7 +198,7 @@ class PdfReaderToolTest {
         @org.junit.jupiter.api.DisplayName("getPdfInfo — non-200 status returns error")
         @SuppressWarnings("unchecked")
         void pdfInfo_non200_returnsError() throws Exception {
-            var mockResponse = (java.net.http.HttpResponse<java.nio.file.Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+            var mockResponse = (java.net.http.HttpResponse<Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
             org.mockito.Mockito.when(mockResponse.statusCode()).thenReturn(403);
             org.mockito.Mockito.doReturn(mockResponse).when(mockedHttpClient).send(
                     org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
@@ -270,8 +277,8 @@ class PdfReaderToolTest {
             mockedTool = new PdfReaderTool(mockedHttpClient, new AttachmentTextExtractor(10000));
         }
 
-        private java.nio.file.Path createTinyPdf(String text) throws Exception {
-            java.nio.file.Path tempFile = java.nio.file.Files.createTempFile("eddi-test-", ".pdf");
+        private Path createTinyPdf(String text) throws Exception {
+            Path tempFile = Files.createTempFile("eddi-test-", ".pdf");
             try (org.apache.pdfbox.pdmodel.PDDocument doc = new org.apache.pdfbox.pdmodel.PDDocument()) {
                 var page = new org.apache.pdfbox.pdmodel.PDPage();
                 doc.addPage(page);
@@ -288,8 +295,8 @@ class PdfReaderToolTest {
             return tempFile;
         }
 
-        private java.nio.file.Path createMultiPagePdf(String... texts) throws Exception {
-            java.nio.file.Path tempFile = java.nio.file.Files.createTempFile("eddi-test-multi-", ".pdf");
+        private Path createMultiPagePdf(String... texts) throws Exception {
+            Path tempFile = Files.createTempFile("eddi-test-multi-", ".pdf");
             try (org.apache.pdfbox.pdmodel.PDDocument doc = new org.apache.pdfbox.pdmodel.PDDocument()) {
                 for (String text : texts) {
                     var page = new org.apache.pdfbox.pdmodel.PDPage();
@@ -308,10 +315,10 @@ class PdfReaderToolTest {
             return tempFile;
         }
 
-        private java.nio.file.Path createPdfWithMetadata(String title, String author,
-                                                         String subject, String creator)
+        private Path createPdfWithMetadata(String title, String author,
+                                           String subject, String creator)
                 throws Exception {
-            java.nio.file.Path tempFile = java.nio.file.Files.createTempFile("eddi-test-meta-", ".pdf");
+            Path tempFile = Files.createTempFile("eddi-test-meta-", ".pdf");
             try (org.apache.pdfbox.pdmodel.PDDocument doc = new org.apache.pdfbox.pdmodel.PDDocument()) {
                 var page = new org.apache.pdfbox.pdmodel.PDPage();
                 doc.addPage(page);
@@ -328,9 +335,9 @@ class PdfReaderToolTest {
                 info.setAuthor(author);
                 info.setSubject(subject);
                 info.setCreator(creator);
-                info.setCreationDate(java.util.GregorianCalendar.from(
-                        java.time.ZonedDateTime.of(2025, 1, 15, 10, 30, 0, 0,
-                                java.time.ZoneId.of("UTC"))));
+                info.setCreationDate(GregorianCalendar.from(
+                        ZonedDateTime.of(2025, 1, 15, 10, 30, 0, 0,
+                                ZoneId.of("UTC"))));
                 doc.setDocumentInformation(info);
                 doc.save(tempFile.toFile());
             }
@@ -338,27 +345,27 @@ class PdfReaderToolTest {
         }
 
         @SuppressWarnings("unchecked")
-        private void mockHttpToServePdf(java.nio.file.Path sourcePdf) throws Exception {
+        private void mockHttpToServePdf(Path sourcePdf) throws Exception {
             org.mockito.Mockito.doAnswer(invocation -> {
                 // downloadPdf() creates a temp file with prefix "eddi-pdf-" immediately
                 // before calling send(). Find that temp file and copy our PDF into it.
-                java.nio.file.Path tempDir = java.nio.file.Path.of(System.getProperty("java.io.tmpdir"));
-                java.nio.file.Path target = java.nio.file.Files.list(tempDir)
+                Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
+                Path target = Files.list(tempDir)
                         .filter(p -> p.getFileName().toString().startsWith("eddi-pdf-")
                                 && p.getFileName().toString().endsWith(".pdf"))
-                        .max(java.util.Comparator.comparingLong(p -> {
+                        .max(Comparator.comparingLong(p -> {
                             try {
-                                return java.nio.file.Files.getLastModifiedTime(p).toMillis();
+                                return Files.getLastModifiedTime(p).toMillis();
                             } catch (Exception e) {
                                 return 0L;
                             }
                         }))
                         .orElseThrow(() -> new RuntimeException("Could not find eddi-pdf temp file"));
 
-                java.nio.file.Files.copy(sourcePdf, target,
-                        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(sourcePdf, target,
+                        StandardCopyOption.REPLACE_EXISTING);
 
-                var mockResponse = (java.net.http.HttpResponse<java.nio.file.Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+                var mockResponse = (java.net.http.HttpResponse<Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
                 org.mockito.Mockito.when(mockResponse.statusCode()).thenReturn(200);
                 org.mockito.Mockito.when(mockResponse.body()).thenReturn(target);
                 return mockResponse;
@@ -370,7 +377,7 @@ class PdfReaderToolTest {
         @org.junit.jupiter.api.Test
         @org.junit.jupiter.api.DisplayName("extractTextFromPdf — extracts text from a valid small PDF")
         void extractText_validPdf() throws Exception {
-            java.nio.file.Path pdfPath = createTinyPdf("Hello EDDI World");
+            Path pdfPath = createTinyPdf("Hello EDDI World");
             try {
                 mockHttpToServePdf(pdfPath);
                 String result = mockedTool.extractTextFromPdf("https://example.com/test.pdf");
@@ -379,14 +386,14 @@ class PdfReaderToolTest {
                 assertTrue(result.contains("Hello EDDI World"),
                         "Should extract text from PDF. Got: " + result);
             } finally {
-                java.nio.file.Files.deleteIfExists(pdfPath);
+                Files.deleteIfExists(pdfPath);
             }
         }
 
         @org.junit.jupiter.api.Test
         @org.junit.jupiter.api.DisplayName("extractTextFromPdfPages — startPage > totalPages returns error")
         void extractPages_startPageBeyondTotal() throws Exception {
-            java.nio.file.Path pdfPath = createTinyPdf("Only page");
+            Path pdfPath = createTinyPdf("Only page");
             try {
                 mockHttpToServePdf(pdfPath);
                 String result = mockedTool.extractTextFromPdfPages(
@@ -397,14 +404,14 @@ class PdfReaderToolTest {
                 assertTrue(result.contains("out of range") || result.contains("Start page"),
                         "Should mention out of range. Got: " + result);
             } finally {
-                java.nio.file.Files.deleteIfExists(pdfPath);
+                Files.deleteIfExists(pdfPath);
             }
         }
 
         @org.junit.jupiter.api.Test
         @org.junit.jupiter.api.DisplayName("extractTextFromPdfPages — endPage > totalPages clamps to totalPages")
         void extractPages_endPageClamped() throws Exception {
-            java.nio.file.Path pdfPath = createMultiPagePdf("Page one text", "Page two text");
+            Path pdfPath = createMultiPagePdf("Page one text", "Page two text");
             try {
                 mockHttpToServePdf(pdfPath);
                 String result = mockedTool.extractTextFromPdfPages(
@@ -418,14 +425,14 @@ class PdfReaderToolTest {
                 assertTrue(result.contains("Page two text"),
                         "Should contain page 2 text. Got: " + result);
             } finally {
-                java.nio.file.Files.deleteIfExists(pdfPath);
+                Files.deleteIfExists(pdfPath);
             }
         }
 
         @org.junit.jupiter.api.Test
         @org.junit.jupiter.api.DisplayName("getPdfInfo — extracts metadata from PDF")
         void pdfInfo_withMetadata() throws Exception {
-            java.nio.file.Path pdfPath = createPdfWithMetadata(
+            Path pdfPath = createPdfWithMetadata(
                     "EDDI Test Document", "Test Author", "Testing Subject", "PDFBox Creator");
             try {
                 mockHttpToServePdf(pdfPath);
@@ -445,14 +452,14 @@ class PdfReaderToolTest {
                 assertTrue(result.contains("Number of pages: 1"),
                         "Should contain page count. Got: " + result);
             } finally {
-                java.nio.file.Files.deleteIfExists(pdfPath);
+                Files.deleteIfExists(pdfPath);
             }
         }
 
         @org.junit.jupiter.api.Test
         @org.junit.jupiter.api.DisplayName("extractTextFromPdf — text > 10000 chars gets truncation message")
         void extractText_truncation() throws Exception {
-            java.nio.file.Path tempFile = java.nio.file.Files.createTempFile("eddi-test-long-", ".pdf");
+            Path tempFile = Files.createTempFile("eddi-test-long-", ".pdf");
             try {
                 try (org.apache.pdfbox.pdmodel.PDDocument doc = new org.apache.pdfbox.pdmodel.PDDocument()) {
                     var page = new org.apache.pdfbox.pdmodel.PDPage();
@@ -480,14 +487,14 @@ class PdfReaderToolTest {
                 assertTrue(result.contains("[Content truncated"),
                         "Should contain truncation message. Got length: " + result.length());
             } finally {
-                java.nio.file.Files.deleteIfExists(tempFile);
+                Files.deleteIfExists(tempFile);
             }
         }
 
         @org.junit.jupiter.api.Test
         @org.junit.jupiter.api.DisplayName("extractTextFromPdfPages — valid page range extracts correctly")
         void extractPages_validRange() throws Exception {
-            java.nio.file.Path pdfPath = createMultiPagePdf("First page", "Second page", "Third page");
+            Path pdfPath = createMultiPagePdf("First page", "Second page", "Third page");
             try {
                 mockHttpToServePdf(pdfPath);
                 String result = mockedTool.extractTextFromPdfPages(
@@ -502,14 +509,14 @@ class PdfReaderToolTest {
                 assertFalse(result.contains("Third page"),
                         "Should not contain page 3 text");
             } finally {
-                java.nio.file.Files.deleteIfExists(pdfPath);
+                Files.deleteIfExists(pdfPath);
             }
         }
 
         @org.junit.jupiter.api.Test
         @org.junit.jupiter.api.DisplayName("getPdfInfo — PDF without metadata fields still works")
         void pdfInfo_noMetadata() throws Exception {
-            java.nio.file.Path pdfPath = createTinyPdf("bare content");
+            Path pdfPath = createTinyPdf("bare content");
             try {
                 mockHttpToServePdf(pdfPath);
                 String result = mockedTool.getPdfInfo("https://example.com/bare.pdf");
@@ -520,7 +527,7 @@ class PdfReaderToolTest {
                 assertFalse(result.contains("Title:"),
                         "Should not contain title when none set");
             } finally {
-                java.nio.file.Files.deleteIfExists(pdfPath);
+                Files.deleteIfExists(pdfPath);
             }
         }
     }

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/impl/WebSearchToolTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/impl/WebSearchToolTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.modules.llm.tools.impl;
 
 import ai.labs.eddi.engine.httpclient.SafeHttpClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -544,11 +545,11 @@ class WebSearchToolTest {
 
             var apiKeyField = WebSearchTool.class.getDeclaredField("googleApiKey");
             apiKeyField.setAccessible(true);
-            apiKeyField.set(mockedTool, java.util.Optional.of("test-key"));
+            apiKeyField.set(mockedTool, Optional.of("test-key"));
 
             var cxField = WebSearchTool.class.getDeclaredField("googleCx");
             cxField.setAccessible(true);
-            cxField.set(mockedTool, java.util.Optional.of("test-cx"));
+            cxField.set(mockedTool, Optional.of("test-cx"));
 
             var response = (java.net.http.HttpResponse<String>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
             org.mockito.Mockito.when(response.statusCode()).thenReturn(200);

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/spi/ToolAssemblyContextTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/spi/ToolAssemblyContextTest.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DynamicAgentCon
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -86,7 +87,7 @@ class ToolAssemblyContextTest {
 
     @Test
     void toolContribution_fourArgConstructor_defaultsFailuresToEmpty() {
-        var contribution = new ToolContribution(List.of(), java.util.Map.of(), java.util.Map.of(), java.util.Map.of());
+        var contribution = new ToolContribution(List.of(), Map.of(), Map.of(), Map.of());
 
         assertTrue(contribution.failures().isEmpty());
     }

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/spi/ToolSourceProviderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/spi/ToolSourceProviderTest.java
@@ -6,6 +6,9 @@ package ai.labs.eddi.modules.llm.tools.spi;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -144,7 +147,7 @@ class ToolSourceProviderTest {
     @Test
     void nullProviderEntriesAreSkipped() {
         var assembled = ToolSourceRegistry.assemble(
-                java.util.Arrays.asList(null, provider("builtin", "calculator"), null), null);
+                Arrays.asList(null, provider("builtin", "calculator"), null), null);
 
         assertEquals(1, assembled.specs().size());
     }
@@ -374,8 +377,8 @@ class ToolSourceProviderTest {
 
     @Test
     void contributionComponentsAreImmutableRegardlessOfWhatAProviderPassed() {
-        var mutableSpecs = new java.util.ArrayList<ToolSpecification>();
-        var mutableSources = new java.util.HashMap<String, String>();
+        var mutableSpecs = new ArrayList<ToolSpecification>();
+        var mutableSources = new HashMap<String, String>();
         var contribution = new ToolContribution(mutableSpecs, Map.of(), mutableSources, Map.of(), List.of(), Map.of());
 
         assertThrows(UnsupportedOperationException.class,

--- a/src/test/java/ai/labs/eddi/modules/mcpcalls/McpCallsTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/mcpcalls/McpCallsTaskTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.*;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -62,7 +63,7 @@ class McpCallsTaskTest {
         // tests keep asserting on the raw tool result.
         lenient().when(toolExecutionService.executeToolWrapped(anyString(), any(), any(), any(), any(),
                 anyBoolean(), anyBoolean(), anyBoolean(), anyInt()))
-                .thenAnswer(inv -> ((java.util.function.Supplier<String>) inv.getArgument(4)).get());
+                .thenAnswer(inv -> ((Supplier<String>) inv.getArgument(4)).get());
         task = new McpCallsTask(resourceClientLibrary, memoryItemConverter,
                 jsonSerialization, mcpToolProviderManager, prePostUtils, toolExecutionService);
     }

--- a/src/test/java/ai/labs/eddi/modules/mcpcalls/impl/McpCallsTaskBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/modules/mcpcalls/impl/McpCallsTaskBranchCoverageTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -66,7 +67,7 @@ class McpCallsTaskBranchCoverageTest {
         // tests keep asserting on the raw tool result.
         lenient().when(toolExecutionService.executeToolWrapped(anyString(), any(), any(), any(), any(),
                 anyBoolean(), anyBoolean(), anyBoolean(), anyInt()))
-                .thenAnswer(inv -> ((java.util.function.Supplier<String>) inv.getArgument(4)).get());
+                .thenAnswer(inv -> ((Supplier<String>) inv.getArgument(4)).get());
         task = new McpCallsTask(resourceClientLibrary, memoryItemConverter, jsonSerialization,
                 mcpToolProviderManager, prePostUtils, toolExecutionService);
         when(memory.getCurrentStep()).thenReturn(currentStep);

--- a/src/test/java/ai/labs/eddi/modules/mcpcalls/impl/McpCallsTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/mcpcalls/impl/McpCallsTaskTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.*;
 import org.mockito.Mock;
 
 import java.util.*;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -59,7 +60,7 @@ class McpCallsTaskTest {
         // tests keep asserting on the raw tool result.
         lenient().when(toolExecutionService.executeToolWrapped(anyString(), any(), any(), any(), any(),
                 anyBoolean(), anyBoolean(), anyBoolean(), anyInt()))
-                .thenAnswer(inv -> ((java.util.function.Supplier<String>) inv.getArgument(4)).get());
+                .thenAnswer(inv -> ((Supplier<String>) inv.getArgument(4)).get());
 
         task = new McpCallsTask(resourceClientLibrary, memoryItemConverter, jsonSerialization,
                 mcpToolProviderManager, prePostUtils, toolExecutionService);

--- a/src/test/java/ai/labs/eddi/modules/nlp/extensions/dictionaries/NlpDictionariesTest.java
+++ b/src/test/java/ai/labs/eddi/modules/nlp/extensions/dictionaries/NlpDictionariesTest.java
@@ -5,13 +5,16 @@
 package ai.labs.eddi.modules.nlp.extensions.dictionaries;
 
 import ai.labs.eddi.modules.nlp.expressions.Expression;
+import ai.labs.eddi.modules.nlp.expressions.Expressions;
 import ai.labs.eddi.modules.nlp.expressions.utilities.IExpressionProvider;
+import java.util.LinkedList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -412,8 +415,8 @@ class NlpDictionariesTest {
         void lookupIfKnownTrueChecksRegex() {
             var dict = new RegularDictionary();
             dict.setLookupIfKnown(true);
-            dict.addWord("123", new ai.labs.eddi.modules.nlp.expressions.Expressions(new Expression("num")), 0);
-            dict.addRegex("\\d+", new ai.labs.eddi.modules.nlp.expressions.Expressions(new Expression("digit")));
+            dict.addWord("123", new Expressions(new Expression("num")), 0);
+            dict.addRegex("\\d+", new Expressions(new Expression("digit")));
 
             // With lookupIfKnown=true, BOTH the word match AND regex match should be in
             // results
@@ -425,7 +428,7 @@ class NlpDictionariesTest {
         @DisplayName("lookupTerm phrase word exact match vs case-insensitive deduplication")
         void phraseWordDeduplication() {
             var dict = new RegularDictionary();
-            dict.addPhrase("Hello World", new ai.labs.eddi.modules.nlp.expressions.Expressions(new Expression("greeting")));
+            dict.addPhrase("Hello World", new Expressions(new Expression("greeting")));
 
             // "Hello" is an exact match (case-sensitive) of one of the phrase words
             var result = dict.lookupTerm("Hello");
@@ -438,7 +441,7 @@ class NlpDictionariesTest {
         @DisplayName("lookupTerm phrase word case-insensitive match (not exact)")
         void phraseWordCaseInsensitive() {
             var dict = new RegularDictionary();
-            dict.addPhrase("Hello World", new ai.labs.eddi.modules.nlp.expressions.Expressions(new Expression("greeting")));
+            dict.addPhrase("Hello World", new Expressions(new Expression("greeting")));
 
             // "hello" is a case-insensitive match of "Hello" in the phrase
             var result = dict.lookupTerm("hello");
@@ -449,7 +452,7 @@ class NlpDictionariesTest {
         @DisplayName("setWords replaces word map")
         void setWords() {
             var dict = new RegularDictionary();
-            var words = new java.util.TreeMap<String, IDictionary.IWord>(String.CASE_INSENSITIVE_ORDER);
+            var words = new TreeMap<String, IDictionary.IWord>(String.CASE_INSENSITIVE_ORDER);
             dict.setWords(words);
             assertTrue(dict.getWords().isEmpty());
         }
@@ -458,7 +461,7 @@ class NlpDictionariesTest {
         @DisplayName("setPhrases replaces phrase list")
         void setPhrases() {
             var dict = new RegularDictionary();
-            dict.setPhrases(new java.util.LinkedList<>());
+            dict.setPhrases(new LinkedList<>());
             assertTrue(dict.getPhrases().isEmpty());
         }
 
@@ -466,7 +469,7 @@ class NlpDictionariesTest {
         @DisplayName("setRegExs replaces regex list")
         void setRegExs() {
             var dict = new RegularDictionary();
-            dict.setRegExs(new java.util.LinkedList<>());
+            dict.setRegExs(new LinkedList<>());
             assertTrue(dict.getRegExs().isEmpty());
         }
     }

--- a/src/test/java/ai/labs/eddi/modules/output/OutputGenerationTaskBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/output/OutputGenerationTaskBranchTest.java
@@ -5,9 +5,11 @@
 package ai.labs.eddi.modules.output;
 
 import ai.labs.eddi.configs.output.model.OutputConfigurationSet;
+import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.engine.TestMemoryFactory;
 import ai.labs.eddi.engine.TestMemoryFactory.MemoryContext;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
+import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IData;
 import ai.labs.eddi.engine.memory.IDataFactory;
 import ai.labs.eddi.engine.memory.model.Data;
@@ -150,8 +152,8 @@ class OutputGenerationTaskBranchTest {
         void matchingLanguageProcesses() {
             MemoryContext ctx = TestMemoryFactory.createWithActions(List.of("greet"));
             ctx.conversationProperties().put("lang",
-                    new ai.labs.eddi.configs.properties.model.Property("lang", "en",
-                            ai.labs.eddi.configs.properties.model.Property.Scope.longTerm));
+                    new Property("lang", "en",
+                            Property.Scope.longTerm));
 
             IOutputGeneration outputGen = mock(IOutputGeneration.class);
             when(outputGen.getLanguage()).thenReturn("en");
@@ -172,8 +174,8 @@ class OutputGenerationTaskBranchTest {
         void mismatchingLanguageSkips() {
             MemoryContext ctx = TestMemoryFactory.createWithActions(List.of("greet"));
             ctx.conversationProperties().put("lang",
-                    new ai.labs.eddi.configs.properties.model.Property("lang", "de",
-                            ai.labs.eddi.configs.properties.model.Property.Scope.longTerm));
+                    new Property("lang", "de",
+                            Property.Scope.longTerm));
 
             IOutputGeneration outputGen = mock(IOutputGeneration.class);
             when(outputGen.getLanguage()).thenReturn("en");
@@ -214,7 +216,7 @@ class OutputGenerationTaskBranchTest {
         void nullLatestDataInPreviousStep() {
             MemoryContext ctx = TestMemoryFactory.createWithActions(List.of("greet"));
             // Add previous step but with null actions data
-            var prevStep = mock(ai.labs.eddi.engine.memory.IConversationMemory.IConversationStep.class);
+            var prevStep = mock(IConversationMemory.IConversationStep.class);
             when(prevStep.getLatestData(eq("actions"))).thenReturn(null);
             when(ctx.previousSteps().size()).thenReturn(1);
             when(ctx.previousSteps().get(eq(0))).thenReturn(prevStep);

--- a/src/test/java/ai/labs/eddi/modules/output/OutputGenerationTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/output/OutputGenerationTaskTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.modules.output;
 
 import ai.labs.eddi.configs.output.model.OutputConfiguration;
 import ai.labs.eddi.configs.output.model.OutputConfigurationSet;
+import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.engine.TestMemoryFactory;
 import ai.labs.eddi.engine.TestMemoryFactory.MemoryContext;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
@@ -112,8 +113,8 @@ class OutputGenerationTaskTest {
             // Actually, null language in memory means "any" — but output language
             // requires a match. Let's set the conversation property language.
             ctx.conversationProperties().put("language",
-                    new ai.labs.eddi.configs.properties.model.Property("language", "en",
-                            ai.labs.eddi.configs.properties.model.Property.Scope.longTerm));
+                    new Property("language", "en",
+                            Property.Scope.longTerm));
 
             task.execute(ctx.memory(), outputGen);
 

--- a/src/test/java/ai/labs/eddi/modules/output/model/OutputModelsTest.java
+++ b/src/test/java/ai/labs/eddi/modules/output/model/OutputModelsTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.modules.output.model;
 
 import ai.labs.eddi.modules.output.model.types.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -209,7 +210,7 @@ class OutputModelsTest {
         var e2 = new OutputEntry("b", 5, List.of(), List.of());
         var e3 = new OutputEntry("c", 3, List.of(), List.of());
 
-        var sorted = new java.util.ArrayList<>(List.of(e2, e3, e1));
+        var sorted = new ArrayList<>(List.of(e2, e3, e1));
         Collections.sort(sorted);
         assertEquals("a", sorted.get(0).getAction());
         assertEquals("c", sorted.get(1).getAction());

--- a/src/test/java/ai/labs/eddi/modules/properties/PropertySetterTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/properties/PropertySetterTaskTest.java
@@ -22,6 +22,7 @@ import ai.labs.eddi.modules.properties.impl.PropertySetterTask;
 import ai.labs.eddi.modules.properties.model.SetOnActions;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import ai.labs.eddi.configs.properties.model.PropertyInstruction;
+import ai.labs.eddi.secrets.ISecretProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -62,7 +63,7 @@ public class PropertySetterTaskTest {
     private IExpressionProvider expressionProvider;
     private IMemoryItemConverter memoryItemConverter;
     private ITemplatingEngine templateEngine;
-    private ai.labs.eddi.secrets.ISecretProvider secretProvider;
+    private ISecretProvider secretProvider;
     private ConversationProperties conversationProperties;
     private Expressions expressions;
 
@@ -89,7 +90,7 @@ public class PropertySetterTaskTest {
         memoryItemConverter = mock(IMemoryItemConverter.class);
         templateEngine = mock(ITemplatingEngine.class);
         IResourceClientLibrary resourceClientLibrary = mock(IResourceClientLibrary.class);
-        secretProvider = mock(ai.labs.eddi.secrets.ISecretProvider.class);
+        secretProvider = mock(ISecretProvider.class);
 
         conversationProperties = new ConversationProperties(conversationMemory);
         when(conversationMemory.getConversationProperties()).thenReturn(conversationProperties);

--- a/src/test/java/ai/labs/eddi/modules/rules/impl/conditions/CapabilityMatchConditionTest.java
+++ b/src/test/java/ai/labs/eddi/modules/rules/impl/conditions/CapabilityMatchConditionTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.modules.rules.impl.conditions;
 
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService.CapabilityMatch;
+import ai.labs.eddi.engine.audit.IAuditEntryCollector;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
@@ -202,7 +203,7 @@ class CapabilityMatchConditionTest {
     void execute_emitsAuditEventOnSuccess() {
         condition.setConfigs(Map.of("skill", "coding", "strategy", "all"));
 
-        var auditCollector = mock(ai.labs.eddi.engine.audit.IAuditEntryCollector.class);
+        var auditCollector = mock(IAuditEntryCollector.class);
         when(memory.getAuditCollector()).thenReturn(auditCollector);
         when(memory.getConversationId()).thenReturn("conv-123");
         when(memory.getAgentId()).thenReturn("agent-owner");
@@ -258,7 +259,7 @@ class CapabilityMatchConditionTest {
     void execute_auditFailureDoesNotBreakExecution() {
         condition.setConfigs(Map.of("skill", "coding"));
 
-        var auditCollector = mock(ai.labs.eddi.engine.audit.IAuditEntryCollector.class);
+        var auditCollector = mock(IAuditEntryCollector.class);
         when(memory.getAuditCollector()).thenReturn(auditCollector);
         when(memory.getConversationId()).thenReturn("conv-123");
         when(memory.getAgentId()).thenReturn("agent-owner");
@@ -284,7 +285,7 @@ class CapabilityMatchConditionTest {
     void execute_noAuditEventOnFailure() {
         condition.setConfigs(Map.of("skill", "nonexistent"));
 
-        var auditCollector = mock(ai.labs.eddi.engine.audit.IAuditEntryCollector.class);
+        var auditCollector = mock(IAuditEntryCollector.class);
         when(memory.getAuditCollector()).thenReturn(auditCollector);
 
         when(registryService.findBySkill("nonexistent", "highest_confidence"))

--- a/src/test/java/ai/labs/eddi/modules/rules/impl/conditions/ContextMatcherTest.java
+++ b/src/test/java/ai/labs/eddi/modules/rules/impl/conditions/ContextMatcherTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+import java.util.Objects;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -502,12 +503,12 @@ public class ContextMatcherTest {
             if (o == null || getClass() != o.getClass())
                 return false;
             MockData<?> that = (MockData<?>) o;
-            return java.util.Objects.equals(key, that.key) && java.util.Objects.equals(result, that.result);
+            return Objects.equals(key, that.key) && Objects.equals(result, that.result);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(key, result);
+            return Objects.hash(key, result);
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/modules/templating/OutputTemplateTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/templating/OutputTemplateTaskTest.java
@@ -21,8 +21,10 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static ai.labs.eddi.modules.templating.ITemplatingEngine.TemplateMode.HTML;
 import static ai.labs.eddi.modules.templating.ITemplatingEngine.TemplateMode.TEXT;
@@ -230,12 +232,12 @@ public class OutputTemplateTaskTest {
             if (o == null || getClass() != o.getClass())
                 return false;
             MockData<?> that = (MockData<?>) o;
-            return java.util.Objects.equals(key, that.key) && java.util.Objects.equals(result, that.result);
+            return Objects.equals(key, that.key) && Objects.equals(result, that.result);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(key, result);
+            return Objects.hash(key, result);
         }
     }
 
@@ -302,7 +304,7 @@ public class OutputTemplateTaskTest {
     public void executeTask_withMapOutput() throws Exception {
         when(currentStep.getAllData(eq("context"))).thenReturn(null);
 
-        var mapOutput = new java.util.LinkedHashMap<String, Object>();
+        var mapOutput = new LinkedHashMap<String, Object>();
         mapOutput.put("key1", "value with {template}");
         mapOutput.put("key2", 42); // non-string value - should not be templated
 

--- a/src/test/java/ai/labs/eddi/secrets/VaultGrantCheckerTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/VaultGrantCheckerTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.secrets;
+import ai.labs.eddi.configs.agents.IAgentStore;
 
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
@@ -10,6 +11,7 @@ import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
 import ai.labs.eddi.configs.llm.ILlmStore;
 import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
 import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
+import ai.labs.eddi.configs.rag.IRagStore;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
@@ -55,7 +57,7 @@ class VaultGrantCheckerTest {
     private ILlmStore llmStore;
     private IApiCallsStore apiCallsStore;
     private IMcpCallsStore mcpCallsStore;
-    private ai.labs.eddi.configs.agents.IAgentStore agentStore;
+    private IAgentStore agentStore;
     private VaultGrantChecker checker;
 
     @BeforeEach
@@ -68,9 +70,9 @@ class VaultGrantCheckerTest {
         apiCallsStore = mock(IApiCallsStore.class);
         mcpCallsStore = mock(IMcpCallsStore.class);
 
-        agentStore = mock(ai.labs.eddi.configs.agents.IAgentStore.class);
+        agentStore = mock(IAgentStore.class);
         checker = new VaultGrantChecker(secretProvider, agentStore, workflowStore, llmStore, apiCallsStore, mcpCallsStore,
-                mock(ai.labs.eddi.configs.rag.IRagStore.class));
+                mock(IRagStore.class));
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/secrets/VaultGrantGateModeTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/VaultGrantGateModeTest.java
@@ -5,6 +5,8 @@
 package ai.labs.eddi.secrets;
 
 import ai.labs.eddi.secrets.VaultGrantGate.Mode;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -80,10 +82,10 @@ class VaultGrantGateModeTest {
     @Test
     @DisplayName("the bundled application.properties matches the code fallback")
     void bundledPropertyMatchesTheCodeFallback() throws Exception {
-        var shippedProperties = java.nio.file.Path.of("src", "main", "resources", "application.properties");
-        assertTrue(java.nio.file.Files.exists(shippedProperties), "expected the shipped application.properties at " + shippedProperties);
+        var shippedProperties = Path.of("src", "main", "resources", "application.properties");
+        assertTrue(Files.exists(shippedProperties), "expected the shipped application.properties at " + shippedProperties);
 
-        var configured = java.nio.file.Files.readAllLines(shippedProperties).stream()
+        var configured = Files.readAllLines(shippedProperties).stream()
                 .map(String::trim)
                 .filter(line -> line.startsWith("eddi.vault.grant-enforcement="))
                 .map(line -> line.substring(line.indexOf('=') + 1).trim())

--- a/src/test/java/ai/labs/eddi/secrets/crypto/EnvelopeCryptoTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/crypto/EnvelopeCryptoTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.secrets.crypto;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -74,7 +75,7 @@ class EnvelopeCryptoTest {
         byte[] key1 = EnvelopeCrypto.deriveKeyFromString("passphrase-a");
         byte[] key2 = EnvelopeCrypto.deriveKeyFromString("passphrase-b");
 
-        assertFalse(java.util.Arrays.equals(key1, key2));
+        assertFalse(Arrays.equals(key1, key2));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/secrets/impl/SecretVaultIntegrationTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/impl/SecretVaultIntegrationTest.java
@@ -11,6 +11,7 @@ import ai.labs.eddi.secrets.model.EncryptedSecret;
 import ai.labs.eddi.secrets.model.SecretReference;
 import ai.labs.eddi.secrets.persistence.ISecretPersistence;
 import ai.labs.eddi.secrets.crypto.VaultSaltManager;
+import ai.labs.eddi.secrets.persistence.PersistenceException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.runtime.StartupEvent;
 import org.junit.jupiter.api.BeforeEach;
@@ -411,7 +412,7 @@ class SecretVaultIntegrationTest {
         @DisplayName("persistence failure on store throws SecretProviderException")
         void persistenceFailureOnStore() {
             setupDekMocking();
-            doThrow(new ai.labs.eddi.secrets.persistence.PersistenceException("DB down")).when(persistence).upsertSecret(any());
+            doThrow(new PersistenceException("DB down")).when(persistence).upsertSecret(any());
             when(persistence.findSecret(anyString(), anyString())).thenReturn(Optional.empty());
 
             assertThrows(ISecretProvider.SecretProviderException.class,
@@ -421,7 +422,7 @@ class SecretVaultIntegrationTest {
         @Test
         @DisplayName("persistence failure on resolve throws SecretProviderException")
         void persistenceFailureOnResolve() {
-            when(persistence.findSecret(anyString(), anyString())).thenThrow(new ai.labs.eddi.secrets.persistence.PersistenceException("DB down"));
+            when(persistence.findSecret(anyString(), anyString())).thenThrow(new PersistenceException("DB down"));
 
             assertThrows(ISecretProvider.SecretProviderException.class, () -> provider.resolve(new SecretReference(TENANT, KEY_NAME)));
         }

--- a/src/test/java/ai/labs/eddi/secrets/impl/VaultSecretProviderBranchTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/impl/VaultSecretProviderBranchTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.secrets.impl;
 
 import ai.labs.eddi.secrets.ISecretProvider.SecretProviderException;
+import ai.labs.eddi.secrets.ISecretProvider;
 import ai.labs.eddi.secrets.crypto.EnvelopeCrypto;
 import ai.labs.eddi.secrets.crypto.VaultSaltManager;
 import ai.labs.eddi.secrets.model.*;
@@ -304,7 +305,7 @@ class VaultSecretProviderBranchTest {
 
             when(persistence.findSecret(TENANT_ID, KEY_NAME)).thenReturn(Optional.empty());
 
-            assertThrows(ai.labs.eddi.secrets.ISecretProvider.SecretNotFoundException.class,
+            assertThrows(ISecretProvider.SecretNotFoundException.class,
                     () -> provider.resolve(new SecretReference(TENANT_ID, KEY_NAME)));
         }
     }


### PR DESCRIPTION
**Stacked on #677** (`fix/review-defects`) — review that one first; this PR's diff is against it.

Split out of #675 so the substantive fixes there could be reviewed at all: at 302 files both
CodeRabbit (>100) and Copilot (>300) declined. This is the half that does not need line-by-line
reading.

## What

AGENTS.md §4.7 asks for a top-level import and the simple name. These were **not** the permitted
disambiguation case — `PendingApprovalSummary`, `HitlDecision`, `ToolApprovalsConfig`,
`ConversationMemorySnapshot` and `ControlSignal` each resolve to exactly one class, and
`IConversationService` imported `java.util.List` on line 17 while writing `java.util.List<…>`
fully-qualified on line 355.

The two genuine cases — `mongo.HistorizedResourceStore extends datastore.HistorizedResourceStore`
and its `Modifiable` twin — are detected and left alone, and named explicitly in the test's
allowlist so adding to it is a reviewable act rather than silent drift.

## Why the test is in this PR

`ImportStyleTest` is what stops this re-accumulating. They build up precisely because nothing fails
when one is added: the code compiles either way, so the rule was advice a reviewer had to catch by
eye. Writing it also showed the original audit had **under-counted** — its pattern required a
package segment after `java.util`, so `java.util.List` never matched. The real total was 575, not
the 141 first reported.

## Verification

- **Clean** `test-compile`, not incremental — a reused stale class hides exactly this kind of break
  in a caller that was never edited.
- **Every string literal in all changed files compared against `origin/main`: byte-identical.** This
  is the check that matters for a rewrite this broad. A substitution that reached inside a literal —
  a reflective class name, a config key, a log format — would still compile, still pass every test,
  and show up nowhere else.
- Full suite green in CI.