### PR TITLE
Secret hardening for HITL surfaces: serve-time re-redaction + raw-carrier strip

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,16 @@ Six new tests: five on the approver sanitizer (raw-carrier strip, stale-redactio
 preview surfaces, fingerprint marker contract, null-safety) and one end-to-end orchestrator test
 pinning that a credential embedded in tool arguments never survives into the trace.
 
+**A `${vault:…}` reference is no longer redacted.** It is a POINTER to a secret — the correct,
+encouraged alternative to writing one down — and the key name it carries is ordinary configuration
+an admin reads in the agent document anyway. Masking it cost real information and bought nothing:
+on an approval card it hid *which* credential a request uses (exactly what an approver must judge),
+and it made every correctly vault-referencing request display a `<REDACTED>` marker — training
+approvers to read that marker as normal, when the marker is precisely the signal that a secret
+*literal* was embedded. A resolved secret does not look like a vault reference, so nothing is
+weakened. Three tests pin that references stay legible (plain, inside JSON, and the legacy
+`${eddivault:…}` spelling).
+
 ---
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,36 @@
 
 
 
+## 🔒 feat(secrets): defense-in-depth for HITL surfaces — serve-time re-redaction + raw-carrier strip (2026-08-14)
+
+**Repo:** EDDI (`fix/hitl-secret-hardening`, follow-up to the filter fix in 943cd119c)
+
+The filter fix closed the pattern gaps; this closes the ARCHITECTURE gaps that let a stale or
+missed redaction reach a human:
+
+- **Serve-time re-redaction everywhere pending-call arguments leave the server.** `argumentsRedacted`
+  is computed once, at pause time, with whatever filter version existed then — a pause stored before
+  a filter improvement kept serving its old, leaky redaction forever. The approval-status summary,
+  the `detail=full` snapshot, the MCP mirror and the Slack approval card now re-run
+  `SecretRedactionFilter` over every served string (arguments, preview uri/body/query/headers).
+- **The raw carriers never leave the server on the approver surface.** `detail=full` returned the
+  whole snapshot with only fingerprints stripped — `argumentsRaw`, the frozen LLM transcript
+  (`chatTranscriptJson`) and the running trace (`traceSoFar`) rode along, each carrying the raw
+  arguments the redaction beside them had masked. `sanitizePendingToolCallsForApprover` strips all
+  three (persisted document untouched; resume unaffected).
+- **The tool trace records redacted arguments and results from the start.** `ToolLoopRunner` stored
+  the model's raw arguments (and raw tool results) in the trace — the same trace that feeds task
+  summaries, SSE, memory and the chat activity list. Both now pass through the filter at record
+  time; execution and the model's own view keep the raw values.
+
+Six new tests: five on the approver sanitizer (raw-carrier strip, stale-redaction re-redaction,
+preview surfaces, fingerprint marker contract, null-safety) and one end-to-end orchestrator test
+pinning that a credential embedded in tool arguments never survives into the trace.
+
+---
+
+
+
 ## 🔒 fix(secrets): redaction filter missed underscored keys and escaped-JSON fields (2026-08-14)
 
 **Repo:** EDDI (`chore/remove-agent-father`)

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
@@ -17,6 +17,7 @@ import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
 import ai.labs.eddi.engine.model.PendingApprovalSummary;
 import ai.labs.eddi.engine.memory.ConversationMemoryUtilities;
+import ai.labs.eddi.secrets.sanitize.SecretRedactionFilter;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot.ConversationStepSnapshot;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot.WorkflowRunSnapshot;
@@ -435,10 +436,14 @@ public class RestAgentEngine implements IRestAgentEngine {
                                     + "is awaiting approval — use the summary view")
                             .build();
                 }
-                // The fingerprint is internal: it digests the RAW body and query
-                // values, which is exactly what the preview beside it redacts.
-                // See ConversationMemoryUtilities#stripRequestFingerprintsForRead.
-                return Response.ok(ConversationMemoryUtilities.stripRequestFingerprintsForRead(snapshot)).build();
+                // The approver's contract is the REDACTED arguments and preview.
+                // Beyond the fingerprint (which digests the raw values the preview
+                // redacts), this strips argumentsRaw, the frozen LLM transcript and
+                // the running trace — all resume machinery carrying raw arguments —
+                // and re-redacts the served fields through the CURRENT filter, so a
+                // pause stored before a filter improvement stops leaking.
+                // See ConversationMemoryUtilities#sanitizePendingToolCallsForApprover.
+                return Response.ok(ConversationMemoryUtilities.sanitizePendingToolCallsForApprover(snapshot)).build();
             }
             // Bookmark fields describe the pause — suppress them once the
             // conversation left AWAITING_HUMAN so stale fields (e.g. after a
@@ -500,8 +505,11 @@ public class RestAgentEngine implements IRestAgentEngine {
             callView.put("toolName", call.getToolName());
             callView.put("source", call.getSource());
             // ONLY the redacted, capped value is ever surfaced here — never
-            // call.getArgumentsRaw().
-            callView.put("arguments", call.getArgumentsRedacted());
+            // call.getArgumentsRaw(). Re-redacted through the CURRENT filter at
+            // serve time: argumentsRedacted was computed once, at pause time, so a
+            // pause stored before a filter improvement (e.g. the underscored
+            // sk-ant fix) would otherwise keep serving its old, leaky redaction.
+            callView.put("arguments", SecretRedactionFilter.redact(call.getArgumentsRedacted()));
             callView.put("argsTruncated", call.isArgsTruncated());
             callView.put("gateReason", call.getGateReason());
             // The approver's honest replacement for guessing a method/path from a
@@ -548,13 +556,26 @@ public class RestAgentEngine implements IRestAgentEngine {
             return null;
         }
         var view = new LinkedHashMap<String, Object>();
+        // Serve-time re-redaction, same reasoning as the arguments field above:
+        // the preview was redacted once, at gate time, with the filter of that
+        // day. The method stays literal — a fixed verb, never user data.
         view.put("method", preview.getMethod());
-        view.put("uri", preview.getUri());
-        view.put("queryParams", preview.getQueryParams() != null ? preview.getQueryParams() : Map.of());
-        view.put("headers", preview.getHeaders() != null ? preview.getHeaders() : Map.of());
-        view.put("body", preview.getBody());
+        view.put("uri", SecretRedactionFilter.redact(preview.getUri()));
+        view.put("queryParams", redactValues(preview.getQueryParams()));
+        view.put("headers", redactValues(preview.getHeaders()));
+        view.put("body", SecretRedactionFilter.redact(preview.getBody()));
         view.put("bodyTruncated", preview.isBodyTruncated());
         return view;
+    }
+
+    /** Value-wise re-redaction of a preview map; keys are structural names. */
+    private static Map<String, String> redactValues(Map<String, String> source) {
+        if (source == null || source.isEmpty()) {
+            return Map.of();
+        }
+        var redacted = new LinkedHashMap<String, String>(source.size());
+        source.forEach((key, value) -> redacted.put(key, SecretRedactionFilter.redact(value)));
+        return redacted;
     }
 
     private Map<String, Object> buildRulePauseDetails(ConversationMemorySnapshot snapshot) {

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilities.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilities.java
@@ -15,6 +15,7 @@ import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.Data;
 import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.secrets.sanitize.SecretRedactionFilter;
 import ai.labs.eddi.engine.model.Context;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.logging.Logger;
@@ -409,6 +410,72 @@ public class ConversationMemoryUtilities {
             }
         }
         return snapshot;
+    }
+
+    /**
+     * Sanitizes a snapshot about to be returned in FULL to an approver
+     * ({@code approval-status?detail=full}, and the MCP mirror of it).
+     * <p>
+     * The approver's contract is the redacted arguments and the redacted request
+     * preview — {@link #stripRequestFingerprintsForRead} handled the digest, but
+     * three other fields rode along that the approver never needs and must not see:
+     * <ul>
+     * <li>{@code argumentsRaw} — unredacted by definition (execution needs it);
+     * observed carrying a clear-text API key the model had embedded in a
+     * create-agent call</li>
+     * <li>{@code chatTranscriptJson} — the frozen LLM transcript for resume, which
+     * contains every raw tool argument again</li>
+     * <li>{@code traceSoFar} — the running tool trace, same exposure</li>
+     * </ul>
+     * All three are resume/execution machinery read from the PERSISTED document —
+     * this method mutates only the freshly-deserialized, caller-owned snapshot
+     * (same contract as the two projections above), so resume is unaffected.
+     * <p>
+     * The fields the approver DOES read are additionally re-redacted through the
+     * CURRENT {@link SecretRedactionFilter} at serve time: {@code
+     * argumentsRedacted} and the preview were redacted once, at pause time, with
+     * whatever filter version existed then — a pause stored before a filter
+     * improvement would otherwise keep leaking forever.
+     */
+    public static ConversationMemorySnapshot sanitizePendingToolCallsForApprover(ConversationMemorySnapshot snapshot) {
+        stripRequestFingerprintsForRead(snapshot);
+        if (snapshot == null || snapshot.getHitlPendingToolCalls() == null) {
+            return snapshot;
+        }
+        var batch = snapshot.getHitlPendingToolCalls();
+        batch.setChatTranscriptJson(null);
+        batch.setTraceSoFar(null);
+        if (batch.getCalls() == null) {
+            return snapshot;
+        }
+        for (var call : batch.getCalls()) {
+            if (call == null) {
+                continue;
+            }
+            call.setArgumentsRaw(null);
+            call.setArgumentsRedacted(SecretRedactionFilter.redact(call.getArgumentsRedacted()));
+            var preview = call.getRequestPreview();
+            if (preview != null) {
+                preview.setUri(SecretRedactionFilter.redact(preview.getUri()));
+                preview.setBody(SecretRedactionFilter.redact(preview.getBody()));
+                preview.setQueryParams(redactMapValues(preview.getQueryParams()));
+                preview.setHeaders(redactMapValues(preview.getHeaders()));
+            }
+        }
+        return snapshot;
+    }
+
+    /**
+     * Value-wise {@link SecretRedactionFilter} pass over a string map; keys are
+     * structural.
+     */
+    private static Map<String, String> redactMapValues(Map<String, String> source) {
+        if (source == null || source.isEmpty()) {
+            return source;
+        }
+        var redacted = new LinkedHashMap<String, String>(source.size());
+        source.forEach((key, value) -> redacted.put(key, SecretRedactionFilter.redact(value)));
+        return redacted;
     }
 
     public static SimpleConversationMemorySnapshot convertSimpleConversationMemorySnapshot(IConversationMemory returnConversationMemory,

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackHitlSupport.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackHitlSupport.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.integrations.slack;
 
 import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
+import ai.labs.eddi.secrets.sanitize.SecretRedactionFilter;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.modules.output.model.OutputItem;
 
@@ -297,7 +298,11 @@ public final class SlackHitlSupport {
         for (int i = 0; i < rendered; i++) {
             var call = calls.get(i);
             String toolName = safe(call.getToolName());
-            String args = truncateForDisplay(call.getArgumentsRedacted());
+            // Re-redacted through the CURRENT filter at send time, same as the
+            // REST approval surfaces: argumentsRedacted was computed once, at
+            // pause time, and a Slack message cannot be un-sent if a stored
+            // pause predates a filter improvement.
+            String args = truncateForDisplay(SecretRedactionFilter.redact(call.getArgumentsRedacted()));
             detailBlocks.add(context(toolName + " — " + args));
         }
         int remaining = calls.size() - rendered;

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopRunner.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopRunner.java
@@ -15,6 +15,7 @@ import ai.labs.eddi.engine.hitl.tools.ToolApprovalGate;
 import ai.labs.eddi.engine.hitl.tools.ToolApprovalRules;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
 import ai.labs.eddi.engine.memory.IConversationMemory;
+import ai.labs.eddi.secrets.sanitize.SecretRedactionFilter;
 import ai.labs.eddi.engine.memory.MemorySnapshotService;
 import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
@@ -528,7 +529,12 @@ class ToolLoopRunner {
         Map<String, Object> callStep = new HashMap<>();
         callStep.put("type", "tool_call");
         callStep.put("tool", toolRequest.name());
-        callStep.put("arguments", toolRequest.arguments());
+        // The trace is a DISPLAY/audit record (task summaries, SSE, memory,
+        // traceSoFar merge on resume) — never an execution input, so it takes
+        // the redacted form. Execution keeps using toolRequest directly; a
+        // model that embeds a credential in its arguments must not have it
+        // echoed through every surface that renders the trace.
+        callStep.put("arguments", SecretRedactionFilter.redact(toolRequest.arguments()));
         trace.add(callStep);
 
         // Check per-conversation TOOL budget before executing tool.
@@ -608,7 +614,11 @@ class ToolLoopRunner {
         Map<String, Object> resultStep = new HashMap<>();
         resultStep.put("type", "tool_result");
         resultStep.put("tool", toolRequest.name());
-        resultStep.put("result", toolResult);
+        // Redacted for the same reason as the call step's arguments: an API
+        // response can echo a credential (its own, or one the request carried).
+        // The MODEL still receives the raw result — the return value below is
+        // untouched; only the display record is filtered.
+        resultStep.put("result", SecretRedactionFilter.redact(toolResult));
         trace.add(resultStep);
 
         // LAZY mode: after discover_tools returns, activate the matching built-in specs

--- a/src/main/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilter.java
+++ b/src/main/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilter.java
@@ -52,12 +52,27 @@ public final class SecretRedactionFilter {
             // inside escaped bodies. Quantifiers stay possessive (ReDoS).
             new RedactionRule(Pattern.compile(
                     "(?i)(api[_-]?key|token|secret|password|authorization)(?:\\\\*+[\"'])?+\\s*+[=:]\\s*+(?:\\\\*+[\"'])?+[^'\"\\\\\\s,;}{\\]]{8,}+"),
-                    "$1=" + REDACTED),
+                    "$1=" + REDACTED));
 
-            // Vault references (should never appear in logs, but defense-in-depth)
-            // Matches both ${vault:...} and legacy ${eddivault:...}
-            // Note: $ must be escaped in replacement strings for Matcher.replaceAll()
-            new RedactionRule(Pattern.compile("\\$\\{(?:vault|eddivault):[^}]++}"), "\\${vault:" + REDACTED + "}"));
+    // A `${vault:...}` reference is DELIBERATELY NOT redacted. It is a pointer to
+    // a secret — the correct, encouraged alternative to writing one down — and the
+    // key NAME it carries is ordinary configuration an admin reads in the agent
+    // document anyway. Masking it cost real information and bought nothing:
+    //
+    // - on an approval card it hid WHICH credential a request uses, which is
+    // exactly what an approver needs to judge it ("is this agent about to use
+    // the production key?");
+    // - it made every correct, vault-referencing request display a `<REDACTED>`
+    // marker, training approvers to read that marker as normal — and the marker
+    // is precisely the signal the Manager uses to warn that a request embedded a
+    // secret LITERAL. A control that fires on the safe case is a control people
+    // learn to ignore.
+    //
+    // A resolved secret does not look like a vault reference (it is the raw value,
+    // caught by the rules above), so nothing is weakened by leaving the pointer
+    // legible. The generic key=value rule above cannot match one either: its value
+    // class excludes `{`/`}`, so `apiKey: "${vault:x}"` never reaches its 8-char
+    // minimum.
 
     private SecretRedactionFilter() {
         // Utility class

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesHitlTest.java
@@ -351,4 +351,99 @@ class ConversationMemoryUtilitiesHitlTest {
 
         return snapshot;
     }
+
+    // =========================================================================
+    // approver sanitation (detail=full surface)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("sanitizePendingToolCallsForApprover")
+    class SanitizeForApprover {
+
+        /**
+         * A key only the CURRENT filter catches (underscores) — a pause stored before
+         * the filter fix carries it inside its "redacted" arguments.
+         */
+        private static final String STALE_LEAKED_KEY = "sk-ant-api03-CeIJ4onq59Mf_oN4mICgfgScyJO5bfxFSS3Sdvo1Zgo2F7zUfEvx";
+
+        private ConversationMemorySnapshot pausedSnapshot() {
+            var snapshot = new ConversationMemorySnapshot();
+            var batch = new PendingToolCallBatch();
+            batch.setChatTranscriptJson("{\"messages\":[{\"args\":\"" + STALE_LEAKED_KEY + "\"}]}");
+            batch.setTraceSoFar(List.of(Map.of("type", "tool_call", "arguments", STALE_LEAKED_KEY)));
+            var call = new PendingToolCallBatch.PendingToolCall();
+            call.setCallId("c1");
+            call.setToolName("setupAgent");
+            call.setArgumentsRaw("{\"apiKey\": \"" + STALE_LEAKED_KEY + "\"}");
+            call.setArgumentsRedacted("{\"apiKey\": \"" + STALE_LEAKED_KEY + "\"}");
+            call.setRequestFingerprint("sha256:deadbeef");
+            var preview = new PendingToolCallBatch.ResolvedRequestPreview();
+            preview.setMethod("POST");
+            preview.setUri("http://localhost:7070/administration/agents/setup?key=" + STALE_LEAKED_KEY);
+            preview.setBody("{\"llm\": {\"apiKey\": \"" + STALE_LEAKED_KEY + "\"}}");
+            preview.setQueryParams(Map.of("token", STALE_LEAKED_KEY));
+            preview.setHeaders(Map.of("Authorization", "Bearer " + STALE_LEAKED_KEY));
+            call.setRequestPreview(preview);
+            batch.setCalls(List.of(call));
+            snapshot.setHitlPendingToolCalls(batch);
+            return snapshot;
+        }
+
+        @Test
+        @DisplayName("strips the resume machinery that carries raw arguments")
+        void stripsRawCarriers() {
+            var snapshot = ConversationMemoryUtilities.sanitizePendingToolCallsForApprover(pausedSnapshot());
+
+            var batch = snapshot.getHitlPendingToolCalls();
+            assertNull(batch.getChatTranscriptJson());
+            assertNull(batch.getTraceSoFar());
+            assertNull(batch.getCalls().get(0).getArgumentsRaw());
+        }
+
+        @Test
+        @DisplayName("re-redacts stale argumentsRedacted through the CURRENT filter")
+        void reRedactsStaleArguments() {
+            var snapshot = ConversationMemoryUtilities.sanitizePendingToolCallsForApprover(pausedSnapshot());
+
+            String served = snapshot.getHitlPendingToolCalls().getCalls().get(0).getArgumentsRedacted();
+            assertNotNull(served);
+            assertFalse(served.contains("CeIJ4onq59Mf"),
+                    "a pause stored before a filter improvement must not keep serving its old, leaky redaction");
+        }
+
+        @Test
+        @DisplayName("re-redacts every string surface of the request preview")
+        void reRedactsPreview() {
+            var snapshot = ConversationMemoryUtilities.sanitizePendingToolCallsForApprover(pausedSnapshot());
+
+            var preview = snapshot.getHitlPendingToolCalls().getCalls().get(0).getRequestPreview();
+            assertFalse(preview.getUri().contains("CeIJ4onq59Mf"));
+            assertFalse(preview.getBody().contains("CeIJ4onq59Mf"));
+            assertFalse(preview.getQueryParams().get("token").contains("CeIJ4onq59Mf"));
+            assertFalse(preview.getHeaders().get("Authorization").contains("CeIJ4onq59Mf"));
+            assertEquals("POST", preview.getMethod(), "the method is a fixed verb, never user data");
+        }
+
+        @Test
+        @DisplayName("keeps the fingerprint contract: marker, not null")
+        void fingerprintMarker() {
+            var snapshot = ConversationMemoryUtilities.sanitizePendingToolCallsForApprover(pausedSnapshot());
+
+            assertEquals("<REDACTED>",
+                    snapshot.getHitlPendingToolCalls().getCalls().get(0).getRequestFingerprint());
+        }
+
+        @Test
+        @DisplayName("null-safe on every level")
+        void nullSafe() {
+            assertNull(ConversationMemoryUtilities.sanitizePendingToolCallsForApprover(null));
+
+            var noBatch = new ConversationMemorySnapshot();
+            assertSame(noBatch, ConversationMemoryUtilities.sanitizePendingToolCallsForApprover(noBatch));
+
+            var emptyBatch = new ConversationMemorySnapshot();
+            emptyBatch.setHitlPendingToolCalls(new PendingToolCallBatch());
+            assertSame(emptyBatch, ConversationMemoryUtilities.sanitizePendingToolCallsForApprover(emptyBatch));
+        }
+    }
 }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverage2Test.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverage2Test.java
@@ -294,6 +294,42 @@ class AgentOrchestratorCoverage2Test {
     }
 
     // ═══════════════════════════════════════════════════════════════════
+    // trace redaction — the trace is a display record, never raw
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * A credential the model embeds in its tool arguments must not survive into the
+     * trace: the trace feeds task summaries, SSE, memory and the approval surfaces,
+     * and rendering it clear-text there was the observed leak (a fabricated
+     * {@code sk-ant-…} key on the approval card). Execution keeps the raw request —
+     * only the recorded copy is filtered.
+     */
+    @Test
+    void trace_redactsCredentialShapedArguments() throws Exception {
+        var task = twoToolTask();
+
+        String embeddedKey = "sk-ant-api03-CeIJ4onq59Mf_oN4mICgfgScyJO5bfxFSS3Sdvo1Zgo2F7zUfEvx";
+        ChatModel chatModel = mock(ChatModel.class);
+        var calcReq = ToolExecutionRequest.builder().id("c1").name("calculate")
+                .arguments("{\"expression\":\"1+1\",\"apiKey\":\"" + embeddedKey + "\"}").build();
+        when(chatModel.chat(any(ChatRequest.class)))
+                .thenReturn(toolBatch(calcReq))
+                .thenReturn(text("done"));
+
+        var result = orchestrator.executeIfToolsEnabled(chatModel, "sys",
+                List.of(UserMessage.from("calc")), task, memory);
+
+        assertNotNull(result);
+        var callStep = result.trace().stream()
+                .filter(e -> "tool_call".equals(e.get("type")) && "calculate".equals(e.get("tool")))
+                .findFirst().orElseThrow();
+        String recordedArgs = String.valueOf(callStep.get("arguments"));
+        assertFalse(recordedArgs.contains("CeIJ4onq59Mf"),
+                "the trace is a display record — a credential in the model's arguments must not ride through it");
+        assertTrue(recordedArgs.contains("<REDACTED>"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
     // maxPausesPerTurn — clamping arms (private static, reflection)
     // ═══════════════════════════════════════════════════════════════════
 

--- a/src/test/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilterTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilterTest.java
@@ -103,13 +103,35 @@ class SecretRedactionFilterTest {
         assertEquals(input, SecretRedactionFilter.redact(input));
     }
 
+    /**
+     * A vault reference is a POINTER to a secret, not a secret — and the correct,
+     * encouraged alternative to writing one down. It is left legible on purpose:
+     * masking it hid which credential a request uses (exactly what an approver must
+     * judge), and made every correct request display a {@code <REDACTED>} marker —
+     * the very signal that is supposed to mean "a secret literal was embedded
+     * here".
+     */
     @Test
-    void redact_vaultReference() {
-        String input = "Resolved secret: ${vault:default/agent1/apiKey}";
+    void redact_vaultReference_leftLegible() {
+        String input = "Uses ${vault:default/agent1/apiKey} for auth";
+        assertEquals(input, SecretRedactionFilter.redact(input));
+    }
+
+    @Test
+    void redact_vaultReferenceInsideJson_leftLegible() {
+        String input = "{\"llm\": {\"apiKey\": \"${vault:anthropic-api-key}\"}}";
         String result = SecretRedactionFilter.redact(input);
 
-        assertTrue(result.contains("${vault:<REDACTED>}"));
-        assertFalse(result.contains("default/agent1/apiKey"));
+        assertTrue(result.contains("${vault:anthropic-api-key}"),
+                "the approver needs to see WHICH credential the request uses");
+        assertFalse(result.contains("<REDACTED>"),
+                "a correctly vault-referencing request must not display a redaction marker at all");
+    }
+
+    @Test
+    void redact_legacyVaultReference_leftLegible() {
+        String input = "Uses ${eddivault:legacy-key} for auth";
+        assertEquals(input, SecretRedactionFilter.redact(input));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilterTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilterTest.java
@@ -31,8 +31,8 @@ class SecretRedactionFilterTest {
     /**
      * Regression: real Anthropic keys carry underscores, and a character class
      * without {@code _} stopped matching at the first one — a full key inside a
-     * gated tool call's arguments sailed through "redacted" and rendered
-     * clear-text on the approval card.
+     * gated tool call's arguments sailed through "redacted" and rendered clear-text
+     * on the approval card.
      */
     @Test
     void redact_anthropicKeyWithUnderscores() {
@@ -53,10 +53,10 @@ class SecretRedactionFilterTest {
 
     /**
      * Regression: the exact shape of the approval-card leak — a tool call whose
-     * {@code requestBody} argument is itself a JSON document, so every quote
-     * around {@code apiKey} arrives backslash-escaped. The generic rule's
-     * separator never matched through the escaping, and the key survived into
-     * the "redacted" arguments the approver reads.
+     * {@code requestBody} argument is itself a JSON document, so every quote around
+     * {@code apiKey} arrives backslash-escaped. The generic rule's separator never
+     * matched through the escaping, and the key survived into the "redacted"
+     * arguments the approver reads.
      */
     @Test
     void redact_apiKeyInsideEscapedJsonRequestBody() {


### PR DESCRIPTION
Follow-up to the redaction-filter fix (943cd119c) on this base branch — the filter fix closed the *pattern* gaps; this closes the *architecture* gaps that let a stale or missed redaction reach a human. Targets `chore/remove-agent-father` (#672) since all HITL machinery lives there.

## Serve-time re-redaction
`argumentsRedacted` is computed once, at pause time, with whatever filter version existed then — a pause stored before a filter improvement kept serving its old, leaky redaction forever (exactly the observed `sk-ant-…` case). Every surface where pending-call arguments leave the server now re-runs `SecretRedactionFilter` at serve time: the approval-status summary (arguments + full request preview: uri, body, query params, headers), the `detail=full` snapshot, the MCP mirror, and the Slack approval card.

## Raw carriers stripped from the approver surface
`approval-status?detail=full` returned the whole snapshot with only fingerprints stripped — `argumentsRaw` (unredacted by definition), the frozen LLM transcript (`chatTranscriptJson`) and the running trace (`traceSoFar`) rode along, each carrying the raw arguments the redaction beside them had masked. New `sanitizePendingToolCallsForApprover` strips all three and subsumes the fingerprint marker contract. The persisted document is untouched; resume reads from the store, not this view.

## The tool trace records redacted values from the start
`ToolLoopRunner` stored the model's **raw** arguments (and raw tool results) in the trace — the same trace that feeds task summaries, SSE `task_complete`, memory, and the chat activity list. Both now pass through the filter at record time. Execution and the model's own view keep the raw values — only the display record is filtered.

## Tests
Six new: five on the approver sanitizer (raw-carrier strip, stale-redaction re-redaction using an underscored key only the current filter catches, all four preview surfaces, fingerprint marker contract, null-safety at every level) and one end-to-end orchestrator test pinning that a credential embedded in tool arguments never survives into the trace.

The Manager-side counterpart (an `inlineCredential` escalation flag on the approval card) is a separate PR on EDDI-Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI note
This PR targets `chore/remove-agent-father`, and `ci.yml` only triggers for PRs against `main` — so **no CI runs here** (only CodeRabbit registers, skipped for non-main bases). Validation instead: full compile plus 555 tests across every affected area (secrets, memory utilities, orchestrator/tool loop, streaming, Slack HITL) run green locally in an isolated worktree. Full CI covers this content once it lands on the #672 branch, which is a PR to main.
