### PR TITLE
chore(deps): langchain4j 1.18.1 → 1.19.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,47 @@
 
 
 
+## ⬆️ chore(deps): langchain4j 1.18.1 → 1.19.0 (2026-08-14)
+
+**Repo:** EDDI (`chore/langchain4j-1.19.0`)
+
+`langchain4j` / `langchain4j-libs` → 1.19.0, `langchain4j-beta` → 1.19.0-beta29.
+
+`langchain4j-community` **stays at 1.18.0-beta28**: that project releases on its own cadence and
+1.19.0-beta29 does not exist there — verified against Maven Central, and the build fails to resolve
+`langchain4j-community-oci-genai:1.19.0-beta29`. The skew is safe in this direction: community
+modules depend on core, not the reverse.
+
+**The one behavioural change in 1.19.0 does not reach us.** "Disable Apache HttpClient's automatic
+retries by default" would matter to a deployment relying on transport-level retries — but every
+provider builder here pins `JdkHttpClient` explicitly (Anthropic, OpenAI, Gemini, Mistral, Ollama;
+Azure uses the Azure SDK pipeline), so no Apache client sits in the request path. EDDI's own
+`RetryConfiguration` remains the only retry layer, unchanged.
+
+**Fixes we simply gain**, all in paths this codebase exercises:
+
+- Anthropic: parallel tool use with no `toolChoice` — the tool loop's normal shape
+- Anthropic: `cache_control` applied to image/PDF content blocks — the attachment forwarder's
+  `ImageContent` / `PdfFileContent` path
+- Gemini / Google GenAI: missing finish reasons that previously broke deserialization
+- OpenAI: `reasoning` parsed as an alias for `reasoning_content`
+
+**Nothing from 1.18.0 or 1.19.0 is left unadopted.** The remaining headline items are for shapes
+this deployment does not run: batch models (`AnthropicBatchChatModel`, `MistralAiBatchChatModel`)
+serve bulk jobs rather than an interactive turn; the agentic BDI/HIL primitives duplicate EDDI's own
+gate and pause machinery; watsonx, Milvus V2 and Docling belong to integrations not wired here. Two
+are worth revisiting if the feature ever lands: Anthropic prompt caching with its new cache
+diagnostics (EDDI sets no `cache_control` today), and MCP tool-result `_meta`, now surfaced through
+`ToolExecutionResult.attributes()`.
+
+791 tests green locally. The 10 errors in `LanguageModelBuildersTest` are this machine's
+loopback-socket restriction hitting `JdkHttpClient` construction, NOT the upgrade — verified by
+running the same class on 1.18.1, which produces the identical 10 errors. CI covers that class.
+
+---
+
+
+
 ## 🔒 feat(secrets): defense-in-depth for HITL surfaces — serve-time re-redaction + raw-carrier strip (2026-08-14)
 
 **Repo:** EDDI (`fix/hitl-secret-hardening`, follow-up to the filter fix in 943cd119c)

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.38.1</quarkus.platform.version>
-        <langchain4j-beta.version>1.18.1-beta28</langchain4j-beta.version>
-        <langchain4j.version>1.18.1</langchain4j.version>
-        <langchain4j-libs.version>1.18.1</langchain4j-libs.version>
+        <langchain4j-beta.version>1.19.0-beta29</langchain4j-beta.version>
+        <langchain4j.version>1.19.0</langchain4j.version>
+        <langchain4j-libs.version>1.19.0</langchain4j-libs.version>
         <jandex-maven-plugin.version>3.6.0</jandex-maven-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>


### PR DESCRIPTION
Bumps `langchain4j` / `langchain4j-libs` to **1.19.0** and `langchain4j-beta` to **1.19.0-beta29**.

## Why community stays behind
`langchain4j-community` remains at **1.18.0-beta28**. That project releases on its own cadence and `1.19.0-beta29` does not exist there — confirmed against Maven Central (latest published is 1.18.0-beta28), and the build fails outright resolving `langchain4j-community-oci-genai:1.19.0-beta29`. The skew is safe in this direction: community modules depend on core, not the reverse.

## The one behavioural change doesn't reach us
1.19.0 disables Apache HttpClient's automatic retries by default. That would matter to a deployment leaning on transport-level retries — but every provider builder in this repo pins `JdkHttpClient` explicitly (Anthropic, OpenAI, Gemini, Mistral, Ollama; Azure goes through the Azure SDK pipeline), so no Apache client is in the request path at all. EDDI's own `RetryConfiguration` stays the only retry layer, unchanged.

## Fixes we gain, in paths we actually exercise
- **Anthropic: parallel tool use with no `toolChoice`** — the tool loop's normal shape
- **Anthropic: `cache_control` on image/PDF content blocks** — exactly the attachment forwarder's `ImageContent`/`PdfFileContent` path
- **Gemini/Google GenAI: missing finish reasons** that previously broke deserialization
- **OpenAI: `reasoning` as an alias for `reasoning_content`**

## Nothing left unadopted from 1.18.0 / 1.19.0
The remaining headline items target shapes this deployment doesn't run: batch models (`AnthropicBatchChatModel`, `MistralAiBatchChatModel`) are for bulk jobs, not interactive turns; the agentic BDI / human-in-the-loop primitives duplicate EDDI's own gate and pause machinery; watsonx, Milvus V2 and Docling belong to integrations not wired here. Two are worth revisiting if the feature lands: **Anthropic prompt caching** with its new cache diagnostics (EDDI sets no `cache_control` today), and **MCP tool-result `_meta`**, now surfaced via `ToolExecutionResult.attributes()`.

## Verification
791 tests green locally. `LanguageModelBuildersTest` reports 10 errors — this machine cannot open loopback sockets, which `JdkHttpClient` construction requires. Verified as pre-existing, not the upgrade: running that same class on 1.18.1 produces the **identical 10 errors**. CI covers it.

Targets `chore/remove-agent-father` (#672) rather than main, so it lands with the rest of that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)