### PR TITLE
fix(test): two assertions still pinned the old vault-redaction behaviour

### DIFF
--- a/src/test/java/ai/labs/eddi/integrations/slack/SlackToolPauseNotificationTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/slack/SlackToolPauseNotificationTest.java
@@ -128,7 +128,12 @@ class SlackToolPauseNotificationTest {
         var call = new PendingToolCall();
         call.setToolName("transfer_funds");
         call.setArgumentsRaw("{\"amount\":250,\"secret\":\"RAW_SECRET_VALUE_NEVER_SHOWN\"}");
-        call.setArgumentsRedacted("{\"amount\":250,\"secret\":\"[REDACTED]\"}");
+        // The project's canonical marker (RequestRedactor.REDACTED /
+        // SecretRedactionFilter), not a look-alike: the card re-runs the filter at
+        // send time so a stored pause cannot outlive a filter improvement, and a
+        // non-canonical "[REDACTED]" fixture was itself rewritten to the real
+        // marker — leaving the assertion below looking for a string no longer there.
+        call.setArgumentsRedacted("{\"amount\":250,\"secret\":\"<REDACTED>\"}");
         var batch = new PendingToolCallBatch();
         batch.setCalls(List.of(call));
 
@@ -139,7 +144,7 @@ class SlackToolPauseNotificationTest {
         String rendered = renderBlocksToText(blocks);
         assertFalse(rendered.contains("RAW_SECRET_VALUE_NEVER_SHOWN"),
                 "raw argument value must never reach the Slack approval card");
-        assertTrue(rendered.contains("[REDACTED]"));
+        assertTrue(rendered.contains("<REDACTED>"), rendered);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ResolvedRequestTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ResolvedRequestTest.java
@@ -268,10 +268,20 @@ class ResolvedRequestTest {
             assertEquals("{\"name\":\"billing-agent\",\"maxTurns\":5}", resolved.body());
         }
 
+        /**
+         * A vault reference stays LEGIBLE. It is a pointer to a secret, not a secret —
+         * and the correct alternative to writing one down. The approver has to see
+         * WHICH credential a request will use ("is this about to touch the production
+         * key?"), and masking it also made every correct, vault-referencing request
+         * display a redaction marker, training approvers to read that marker as normal
+         * when it is precisely the signal that a secret LITERAL was embedded. See
+         * {@code SecretRedactionFilter}.
+         */
         @Test
-        void aVaultReferenceIsRedactedToo() {
+        void aVaultReferenceIsLeftLegible() {
             var resolved = request("POST", "https://x/y", Map.of(), Map.of(), "{\"apiKey\":\"${vault:openai-key}\"}");
-            assertFalse(resolved.body().contains("openai-key"), resolved.body());
+            assertTrue(resolved.body().contains("${vault:openai-key}"), resolved.body());
+            assertFalse(resolved.body().contains("<REDACTED>"), resolved.body());
         }
 
         @Test


### PR DESCRIPTION
Fixes the two Build & Test failures on [#672](https://github.com/labsai/EDDI/pull/672). Both are fallout from the deliberate vault-reference change, not from the langchain4j upgrade that ran alongside it — and both were missed locally because neither class matched the filters I ran (`SlackHitl*`, `secrets.*`). Exactly the gap a full build closes.

## `ResolvedRequestTest`
`aVaultReferenceIsRedactedToo` asserted the behaviour we reversed on purpose: a `${vault:…}` reference is a **pointer** to a secret, not a secret, and stays legible so an approver can see *which* credential a request will use. Renamed to `aVaultReferenceIsLeftLegible` and inverted — it now also asserts that **no** redaction marker appears, since a correctly vault-referencing request displaying one is what trains approvers to read that marker as normal, when it is precisely the signal that a secret *literal* was embedded.

## `SlackToolPauseNotificationTest`
The fixture used a non-canonical `[REDACTED]` marker. The Slack card now re-runs the filter at send time (so a stored pause cannot outlive a filter improvement), which rewrote the look-alike into the project's real marker — leaving the assertion hunting a string that was no longer there. Fixture and assertion now both use `RequestRedactor.REDACTED`'s actual value. The property under test is unchanged and still enforced: the raw argument never reaches the card.

## Verification
Ran every test class that touches redaction — 27 classes, 679 tests. The only remaining error is `HitlToolPauseResumeIT`, which needs a Mongo testcontainer this machine cannot start; it is an IT, skipped by the normal build and covered in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)