### PR TITLE
fix(hitl+streaming): the paused turn's continuation was unreadable, then indistinguishable

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,41 @@
 
 
 
+## 🐛 fix(hitl): the pending-approval message was the same sentence on every pause (2026-08-14)
+
+**Repo:** EDDI (`fix/sse-data-line-padding`)
+
+Approving a gated batch and landing on the next pause looked like nothing had happened.
+
+A turn may pause up to `maxPausesPerTurn` times (default 3). Each pause writes a pending-approval
+placeholder into the step's `output`; the resume drops the previous one and the next pause writes
+its own. With no `toolApprovals.pendingMessage` configured, that text was a constant:
+
+> This action requires human approval before it can proceed. You will receive the result once a
+> reviewer decides.
+
+So the second pause re-rendered a bubble with byte-identical content. The approver clicked Approve,
+the turn genuinely advanced to a NEW gated call, and the screen showed the same sentence it had
+shown before the click — indistinguishable from a dead button.
+
+The default now names the gated tool ("I need your approval before I can run createAgent."), read
+off the pending batch via the `{toolNames}` substitution that configured templates already use. The
+name-free sentence is kept for a batch with no usable tool name, where "run ." would be worse.
+
+Determinism is the constraint that shaped this: `dropPendingApprovalPlaceholder` removes the
+placeholder by recomputing `resolvePendingMessage` and matching the exact string, so the default may
+only depend on the batch — which is still on memory at both call sites. A pause counter or a
+timestamp in the message would strand the placeholder above the answer. Four tests pin it: the
+default names the tool, two pauses on different tools do NOT render the same text, a nameless batch
+still falls back to the generic sentence, and an APPROVED resume drops the unconfigured default too.
+
+A configured `pendingMessage` (rule-level or scalar) is used exactly as before, with or without
+`{toolNames}` in it.
+
+---
+
+
+
 ## 🐛 fix(streaming): SSE data lines lost a leading space, mangling every streamed reply (2026-08-14)
 
 **Repo:** EDDI (`fix/sse-data-line-padding`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,41 @@
 
 
 
+## 🐛 fix(streaming): SSE data lines lost a leading space, mangling every streamed reply (2026-08-14)
+
+**Repo:** EDDI (`fix/sse-data-line-padding`)
+
+Streamed answers rendered as one mangled paragraph: bullet lists collapsed, and words split across
+tokens ran together ("quota enforcement" -> "quotaenforcement").
+
+The SSE grammar is `field ":" [ space ] value`, and every consumer strips ONE leading space per
+`data:` line - it cannot tell the separator from the payload's own first character. RESTEasy
+Reactive writes `data:` with NO separator, so a payload beginning with a space arrived one short.
+Captured from the live wire:
+
+```
+event:token
+data:-
+data: alpha
+data:- beta
+```
+
+The model emitted `"-"` then `" alpha"`; the client reassembled `-alpha`, which is no longer a
+Markdown list item. Newlines were never the problem - they survive as separate `data:` lines.
+
+`padDataLines` now prefixes EVERY line of every payload with one space, so the consumer's strip
+removes ours rather than the payload's. Per-line matters because RESTEasy emits one `data:` line
+per newline, so an indented continuation line would otherwise lose a space of its own indentation.
+Spec-compliant clients are unaffected - this makes EDDI's output match what they already assume,
+and the Manager needed no change.
+
+Five tests pin the round trip (leading space, per-line padding, ordinary payloads, null/empty),
+and the existing `onTokenSendsEvent` assertion was updated to the corrected wire format.
+
+---
+
+
+
 ## ⬆️ chore(deps): langchain4j 1.18.1 → 1.19.0 (2026-08-14)
 
 **Repo:** EDDI (`chore/langchain4j-1.19.0`)

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -274,6 +274,35 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
      * and at most once, so it never touches the Vert.x event loop and never
      * repeats.
      */
+    /**
+     * Prefix every line of an SSE payload with one space.
+     * <p>
+     * The SSE grammar is {@code field ":" [ space ] value}, and a consumer strips a
+     * single leading space from each {@code data:} line — it cannot tell a
+     * separator space from the payload's own first character. RESTEasy Reactive
+     * writes {@code data:} with NO separator, so a payload that begins with a space
+     * arrives one space short.
+     * <p>
+     * That is not cosmetic for a token stream. The model emits {@code "-"} then
+     * {@code " alpha"}; the client reassembled {@code "-alpha"}, which is no longer
+     * a Markdown list item, and words split across tokens ran together ("quota
+     * enforcement" → "quotaenforcement"). Whole replies rendered as one mangled
+     * paragraph.
+     * <p>
+     * Padding every line — not just the first — is what makes it correct: RESTEasy
+     * emits one {@code data:} line per {@code \n}, so an indented continuation line
+     * would otherwise lose a space of its own indentation. The consumer strips
+     * exactly the space added here and the payload survives byte for byte.
+     * Spec-compliant clients are unaffected by the change; this only makes EDDI's
+     * output match what they already assume.
+     */
+    static String padDataLines(String data) {
+        if (data == null || data.isEmpty()) {
+            return data;
+        }
+        return " " + data.replace("\n", "\n ");
+    }
+
     private final class SseStream {
         private final String conversationId;
         private final String safeConversationId;
@@ -308,7 +337,7 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
                 return;
             }
             try {
-                eventSink.send(sse.newEventBuilder().name(eventName).data(String.class, data).build());
+                eventSink.send(sse.newEventBuilder().name(eventName).data(String.class, padDataLines(data)).build());
             } catch (Exception e) {
                 LOGGER.warnf("Failed to send SSE event '%s': %s", eventName, e.getMessage());
                 // RESTEasy Reactive throws IllegalStateException synchronously when the

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -791,17 +791,34 @@ public class Conversation implements IConversation {
 
     /**
      * Default end-user pending message used when the agent config does not supply a
-     * {@code toolApprovals.pendingMessage}.
+     * {@code toolApprovals.pendingMessage} <b>and</b> the gated call names are
+     * unknown (a legacy batch, or one whose calls carry no tool name).
      */
     private static final String DEFAULT_PENDING_MESSAGE = "This action requires human approval before it can proceed. "
+            + "You will receive the result once a reviewer decides.";
+
+    /**
+     * Default pending message when the gated call names ARE known — the normal
+     * case.
+     * <p>
+     * Naming them is what makes a multi-pause turn legible. A turn may pause up to
+     * {@code maxPausesPerTurn} times (default 3), and every pause writes this
+     * message into the same step's output while the previous one is dropped on
+     * resume. With a constant sentence, deciding a batch and landing on the very
+     * next pause re-rendered a bubble with byte-identical text — which reads as "I
+     * approved it and nothing happened". The gated tool is the thing that actually
+     * changed between the two, so it is the thing the message says.
+     */
+    private static final String DEFAULT_PENDING_MESSAGE_WITH_TOOLS = "I need your approval before I can run {toolNames}. "
             + "You will receive the result once a reviewer decides.";
 
     /**
      * Resolves the end-user-facing pending message for a tool pause: the governing
      * {@code toolApprovals.rules} entry's {@code pendingMessage} if it set one,
      * else {@code toolApprovals.pendingMessage}, with {@code {toolNames}}
-     * substituted from the pending batch's gated call names, falling back to a
-     * generic default.
+     * substituted from the pending batch's gated call names, falling back to
+     * {@link #DEFAULT_PENDING_MESSAGE_WITH_TOOLS} (or, with no names to show,
+     * {@link #DEFAULT_PENDING_MESSAGE}).
      * <p>
      * Must stay deterministic from the persisted batch alone —
      * {@code dropPendingApprovalPlaceholder} recomputes this exact string on resume
@@ -827,9 +844,6 @@ public class Conversation implements IConversation {
         } else if (cfg != null && !isNullOrEmpty(cfg.getPendingMessage())) {
             template = cfg.getPendingMessage();
         }
-        if (template == null) {
-            template = DEFAULT_PENDING_MESSAGE;
-        }
         String names = "";
         if (batch != null && batch.getCalls() != null) {
             names = batch.getCalls().stream()
@@ -838,6 +852,12 @@ public class Conversation implements IConversation {
                     .distinct()
                     .reduce((a, b) -> a + ", " + b)
                     .orElse("");
+        }
+        // Resolved AFTER the names, because which default applies depends on whether
+        // there are any. A configured template is used as-is either way — an operator
+        // who wrote their own wording keeps it, with or without {toolNames} in it.
+        if (template == null) {
+            template = names.isBlank() ? DEFAULT_PENDING_MESSAGE : DEFAULT_PENDING_MESSAGE_WITH_TOOLS;
         }
         return template.replace("{toolNames}", names);
     }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingExtendedTest.java
@@ -173,7 +173,12 @@ class RestAgentEngineStreamingExtendedTest {
             handler.onToken("Hello");
 
             verify(eventBuilder).name("token");
-            verify(eventBuilder).data(eq(String.class), eq("Hello"));
+            // Payloads go out with one space per line prepended: RESTEasy writes
+            // "data:" with no separator, and every consumer strips one leading
+            // space, so an unpadded token beginning with a space arrived one short
+            // — which broke Markdown list markers ("-" + " alpha" -> "-alpha").
+            // See RestAgentEngineStreaming#padDataLines.
+            verify(eventBuilder).data(eq(String.class), eq(" Hello"));
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
@@ -521,4 +521,64 @@ class RestAgentEngineStreamingTest {
                     "the shipped default must keep the cost-saving cancel enabled");
         }
     }
+
+    /**
+     * The SSE grammar is `field ":" [ space ] value`, and every consumer strips one
+     * leading space per {@code data:} line — it cannot tell the separator from the
+     * payload's own first character. RESTEasy Reactive writes {@code data:} with no
+     * separator, so an unpadded payload beginning with a space arrived one space
+     * short.
+     * <p>
+     * Observed: the model emitted {@code "-"} then {@code " alpha"} and the client
+     * reassembled {@code "-alpha"} — no longer a Markdown list item — while words
+     * split across tokens ran together. Whole replies rendered as one mangled
+     * paragraph.
+     */
+    @org.junit.jupiter.api.Nested
+    @org.junit.jupiter.api.DisplayName("SSE data lines are padded so a leading space survives")
+    class DataLinePadding {
+
+        @org.junit.jupiter.api.Test
+        void aLeadingSpaceSurvivesTheConsumersStrip() {
+            String padded = RestAgentEngineStreaming.padDataLines(" alpha");
+            // What the consumer does: drop exactly one leading space per line.
+            assertEquals(" alpha", stripOneSpacePerLine(padded));
+        }
+
+        @org.junit.jupiter.api.Test
+        void everyLineIsPadded_notOnlyTheFirst() {
+            // RESTEasy emits one data: line per newline, so an indented continuation
+            // line loses a space of its own indentation unless each line is padded.
+            String value = "a\n  indented";
+            assertEquals(value, stripOneSpacePerLine(RestAgentEngineStreaming.padDataLines(value)));
+        }
+
+        @org.junit.jupiter.api.Test
+        void ordinaryPayloadsRoundTripUnchanged() {
+            for (String value : new String[]{"-", "plain token", "{\"taskId\":\"x\"}", "line1\nline2"}) {
+                assertEquals(value, stripOneSpacePerLine(RestAgentEngineStreaming.padDataLines(value)),
+                        "round-trip must be lossless for: " + value);
+            }
+        }
+
+        @org.junit.jupiter.api.Test
+        void nullAndEmptyAreLeftAlone() {
+            assertNull(RestAgentEngineStreaming.padDataLines(null));
+            assertEquals("", RestAgentEngineStreaming.padDataLines(""));
+        }
+
+        /** The consumer half of the contract, per the SSE spec. */
+        private String stripOneSpacePerLine(String wire) {
+            var out = new StringBuilder();
+            String[] lines = wire.split("\n", -1);
+            for (int i = 0; i < lines.length; i++) {
+                if (i > 0) {
+                    out.append('\n');
+                }
+                String line = lines[i];
+                out.append(line.startsWith(" ") ? line.substring(1) : line);
+            }
+            return out.toString();
+        }
+    }
 }

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationHitlTest.java
@@ -291,6 +291,73 @@ class ConversationHitlTest {
                     "a rule silent on pendingMessage must inherit the scalar; got: " + rendered);
         }
 
+        /**
+         * Arms a gated batch for {@code toolName} (no configured pendingMessage
+         * anywhere, so the DEFAULT applies) and runs one turn to the pause.
+         *
+         * @return the rendered {@code "output"} conversation-output of the paused step
+         */
+        private String pauseWithUnconfiguredMessage(String toolName) throws Exception {
+            memory.setConversationState(ConversationState.READY);
+            doAnswer(inv -> {
+                var call = new PendingToolCallBatch.PendingToolCall();
+                call.setToolName(toolName);
+                var batch = new PendingToolCallBatch();
+                batch.setCalls(List.of(call));
+                memory.setHitlPendingToolCalls(batch);
+                throw new ConversationPauseException("wf1", 2, "gated tool call",
+                        ConversationPauseException.PauseOrigin.TOOL_CALL);
+            }).when(lifecycleManager).executeLifecycle(any(), any());
+
+            createConversation().say("do it", Map.of());
+            return memory.getCurrentStep().getConversationOutput().get(MemoryKeys.OUTPUT_PREFIX).toString();
+        }
+
+        @Test
+        @DisplayName("with no pendingMessage configured, the default NAMES the gated tool")
+        void unconfiguredPendingMessageNamesTheTool() throws Exception {
+            String rendered = pauseWithUnconfiguredMessage("createAgent");
+
+            assertTrue(rendered.contains("createAgent"),
+                    "the default pending message must name the gated tool; got: " + rendered);
+            assertFalse(rendered.contains("{toolNames}"),
+                    "the placeholder token must be substituted, not rendered; got: " + rendered);
+        }
+
+        /**
+         * The regression this default exists for. A turn may pause up to
+         * maxPausesPerTurn times; each pause rewrites the placeholder into the same
+         * step. When the text was a constant, deciding one batch and landing on the
+         * next produced a byte-identical bubble — which reads as "I approved it and
+         * nothing happened". Two pauses on different tools must not render the same
+         * sentence.
+         */
+        @Test
+        @DisplayName("two pauses on different tools produce DIFFERENT pending messages")
+        void consecutivePausesOnDifferentToolsDiffer() throws Exception {
+            String first = pauseWithUnconfiguredMessage("createAgent");
+            // A fresh conversation stands in for the next pause of a multi-pause turn:
+            // what is under test is resolvePendingMessage's dependence on the batch,
+            // and the batch is the only thing that differs between the two.
+            String second = pauseWithUnconfiguredMessage("deployAgent");
+
+            assertNotEquals(first, second,
+                    "consecutive pauses on different tools must not render identical text; got: " + first);
+            assertTrue(second.contains("deployAgent") && !second.contains("createAgent"),
+                    "the second pause must name only its own gated tool; got: " + second);
+        }
+
+        @Test
+        @DisplayName("a batch with no usable tool name falls back to the generic default")
+        void unnamedCallsFallBackToGenericDefault() throws Exception {
+            // Legacy/degenerate batch: "run ." would be worse than saying nothing
+            // specific, so the name-free sentence is kept for exactly this case.
+            String rendered = pauseWithUnconfiguredMessage(null);
+
+            assertTrue(rendered.contains("This action requires human approval"),
+                    "a nameless batch must fall back to the generic default; got: " + rendered);
+        }
+
         @Test
         @DisplayName("normal (non-pause) turn DOES purge step-scoped properties — companion to Invariant 9")
         void normalTurnPurgesStepProperties() throws Exception {

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
@@ -322,6 +322,55 @@ class ConversationToolResumeTest {
                 "the resumed step must render ONLY the final answer, not [placeholder, answer]; got: " + out);
     }
 
+    /**
+     * The drop is by exact-string match against a RECOMPUTED
+     * {@code resolvePendingMessage}, so the DEFAULT message has to be just as
+     * deterministic as a configured one. It now names the gated tool — read off the
+     * batch, which is still on memory at both call sites — and this pins that: make
+     * the default depend on anything that changes between pause and resume (a pause
+     * counter, a timestamp, the decision) and the recomputed string stops matching,
+     * stranding the placeholder above the answer.
+     */
+    @Test
+    @DisplayName("APPROVED resume drops the placeholder for the UNCONFIGURED default too")
+    void approvedResumeDropsUnconfiguredDefaultPlaceholder() throws Exception {
+        memory.setConversationState(ConversationState.READY);
+        doAnswer(inv -> {
+            var call = new PendingToolCallBatch.PendingToolCall();
+            call.setToolName("delete_record");
+            var b = new PendingToolCallBatch();
+            b.setLlmTaskId("ai.labs.llm");
+            b.setLlmTaskIndex(0);
+            b.setCalls(List.of(call));
+            // No effectiveToolApprovals and no agent-level config: the default applies.
+            memory.setHitlPendingToolCalls(b);
+            throw new ConversationPauseException("wf1", 0, "gated tool call",
+                    ConversationPauseException.PauseOrigin.TOOL_CALL);
+        }).when(lifecycleManager).executeLifecycle(any(), any());
+        var conv = createConversation();
+        conv.say("delete it", Map.of());
+
+        var paused = outputList();
+        assertNotNull(paused);
+        assertTrue(paused.stream().anyMatch(o -> String.valueOf(o).contains("delete_record")),
+                "the default placeholder must name the gated tool; got: " + paused);
+
+        String finalAnswer = "Record deleted successfully.";
+        doAnswer(inv -> {
+            memory.getCurrentStep().addConversationOutputList(
+                    MemoryKeys.OUTPUT_PREFIX, List.of(new TextOutputItem(finalAnswer, 0)));
+            return null;
+        }).when(lifecycleManager).executeLifecycleFromIndex(eq(memory), anyInt());
+
+        conv.resume(decision(HitlVerdict.APPROVED));
+
+        var out = outputList();
+        assertEquals(1, out.size(),
+                "the recomputed default must match and be removed, leaving only the answer; got: " + out);
+        assertTrue(out.stream().anyMatch(o -> String.valueOf(o).equals(finalAnswer)),
+                "the final answer must be present; got: " + out);
+    }
+
     @Test
     @DisplayName("REJECTED tool resume: the graceful answer replaces the placeholder (only the answer remains)")
     void rejectedResumeDropsPlaceholder() throws Exception {

--- a/src/test/java/ai/labs/eddi/integrations/slack/SlackToolPauseNotificationTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/slack/SlackToolPauseNotificationTest.java
@@ -128,7 +128,12 @@ class SlackToolPauseNotificationTest {
         var call = new PendingToolCall();
         call.setToolName("transfer_funds");
         call.setArgumentsRaw("{\"amount\":250,\"secret\":\"RAW_SECRET_VALUE_NEVER_SHOWN\"}");
-        call.setArgumentsRedacted("{\"amount\":250,\"secret\":\"[REDACTED]\"}");
+        // The project's canonical marker (RequestRedactor.REDACTED /
+        // SecretRedactionFilter), not a look-alike: the card re-runs the filter at
+        // send time so a stored pause cannot outlive a filter improvement, and a
+        // non-canonical "[REDACTED]" fixture was itself rewritten to the real
+        // marker — leaving the assertion below looking for a string no longer there.
+        call.setArgumentsRedacted("{\"amount\":250,\"secret\":\"<REDACTED>\"}");
         var batch = new PendingToolCallBatch();
         batch.setCalls(List.of(call));
 
@@ -139,7 +144,7 @@ class SlackToolPauseNotificationTest {
         String rendered = renderBlocksToText(blocks);
         assertFalse(rendered.contains("RAW_SECRET_VALUE_NEVER_SHOWN"),
                 "raw argument value must never reach the Slack approval card");
-        assertTrue(rendered.contains("[REDACTED]"));
+        assertTrue(rendered.contains("<REDACTED>"), rendered);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ResolvedRequestTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ResolvedRequestTest.java
@@ -268,10 +268,20 @@ class ResolvedRequestTest {
             assertEquals("{\"name\":\"billing-agent\",\"maxTurns\":5}", resolved.body());
         }
 
+        /**
+         * A vault reference stays LEGIBLE. It is a pointer to a secret, not a secret —
+         * and the correct alternative to writing one down. The approver has to see
+         * WHICH credential a request will use ("is this about to touch the production
+         * key?"), and masking it also made every correct, vault-referencing request
+         * display a redaction marker, training approvers to read that marker as normal
+         * when it is precisely the signal that a secret LITERAL was embedded. See
+         * {@code SecretRedactionFilter}.
+         */
         @Test
-        void aVaultReferenceIsRedactedToo() {
+        void aVaultReferenceIsLeftLegible() {
             var resolved = request("POST", "https://x/y", Map.of(), Map.of(), "{\"apiKey\":\"${vault:openai-key}\"}");
-            assertFalse(resolved.body().contains("openai-key"), resolved.body());
+            assertTrue(resolved.body().contains("${vault:openai-key}"), resolved.body());
+            assertFalse(resolved.body().contains("<REDACTED>"), resolved.body());
         }
 
         @Test


### PR DESCRIPTION
Two defects that both landed on the same surface: what a user sees after the agent stops to ask for approval.

Stacked on #681 (its commit is included here; it drops out of this diff once #681 merges).

## 1. Streamed replies arrived mangled

The SSE grammar is `field ":" [ space ] value`, and every consumer strips ONE leading space per `data:` line — it cannot tell the separator from the payload's own first character. RESTEasy Reactive writes `data:` with no separator, so a payload starting with a space arrived one short. Captured from the live wire:

```
event:token
data:-
data: alpha
data:- beta
```

The model emitted `"-"` then `" alpha"`; the client reassembled `-alpha`, which is no longer a Markdown list item. That is why bullet lists collapsed and words ran together (`quota enforcement` → `quotaenforcement`).

Newlines were never the problem — they survive as separate `data:` lines. `padDataLines` prefixes EVERY line of every payload with one space, so the consumer's strip removes ours instead of the payload's. Per-line matters because RESTEasy emits one `data:` line per newline, so an indented continuation would otherwise lose a space of its own indentation. Spec-compliant clients are unaffected: this makes EDDI match what they already assume, and the Manager needed no change.

## 2. Every pause said the same sentence

A turn may pause up to `maxPausesPerTurn` times (default 3). Each pause writes a pending-approval placeholder into the step's `output`; the resume drops the previous one and the next pause writes its own. With no `toolApprovals.pendingMessage` configured that text was a **constant**, so the second pause re-rendered a bubble with byte-identical content — the approver clicked Approve, the turn genuinely advanced to a NEW gated call, and the screen showed exactly what it had shown before the click.

The default now names the gated tool, read off the pending batch through the `{toolNames}` substitution configured templates already use. The name-free sentence is kept for a batch with no usable tool name, where `run .` would be worse than saying nothing specific. A configured `pendingMessage` is used exactly as before.

**Determinism is the constraint that shaped this.** `dropPendingApprovalPlaceholder` removes the placeholder by recomputing `resolvePendingMessage` and matching the exact string, so the default may only depend on the batch — which is still on memory at both call sites. A pause counter or a timestamp in the message would strand the placeholder above the answer. One of the four tests pins exactly that.

## Tests

- 5 for the SSE round trip (leading space, per-line padding, ordinary payloads, null/empty); the existing `onTokenSendsEvent` assertion moved to the corrected wire format.
- 4 for the pending message: the default names the tool, two pauses on different tools do NOT render the same text, a nameless batch still falls back to the generic sentence, an APPROVED resume drops the unconfigured default too.
- Verified by mutation — pinning the template back to the constant fails two of them.
- Locally: 1120 unit tests green. The one error is `GroupHitlIT`, which needs Docker/testcontainers (unavailable here).