### PR TITLE
fix(llm): a prompt mentioning ${vault:key-name} crashed templating every turn

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,66 @@
 
 
 
+## 🐛 fix(llm): a prompt MENTIONING `${vault:key-name}` crashed templating every turn (2026-08-15)
+
+**Repo:** EDDI (`fix/vault-ref-template-crash`)
+
+The Platform Operator's system prompt instructs the model to write secrets as `${vault:key-name}`
+references. Qute parses the brace part as a namespaced expression, and there is deliberately no
+`vault` namespace resolver — `CallerNamespaceResolver`'s class doc records why: letting vault
+references survive templating in general would let one ride a templated request BODY into vault
+resolution, and the resolved body is written to conversation memory in plaintext. So every turn of
+such an agent logged
+
+> Template processing failed for LLM parameter 'systemMessage': ... No namespace resolver found for
+> [vault] in expression {vault:key-name}
+
+and fell back to the RAW string — skipping every legitimate `{memory...}` expression beside the
+mention.
+
+The fix threads the needle without touching the security decision: `LlmTask.escapeVaultMentions`
+wraps `{vault:...}` / `{eddivault:...}` mentions in Qute raw sections **for LLM parameters only**.
+Prompts go to the model, never through vault resolution, so the literal is inert documentation
+there. Httpcall templating does not pass through this path and keeps failing loudly, exactly as
+`CallerNamespaceResolver` requires. Four tests, including one that REPRODUCES the crash on the
+unescaped prompt — if that one ever stops throwing, the escape is dead code and the security doc
+no longer holds, and both need revisiting together.
+
+Also diagnosed in the same session log (still open): the resumed turn's `setupAgent` call failed
+with 400 `{"objectName":"Class","attributeName":"systemPrompt","line":1,"column":593}` — the JSON
+body failed to BIND at parse time, column 593 inside the systemPrompt string. The error shape comes
+from the JSON layer, not EDDI code; closing it needs the full memorized request body.
+
+---
+
+
+
+## 🎨 fix(operator-ux): decision reads after the ask; expected-inconclusive probe stops toasting (2026-08-15)
+
+**Repo:** EDDI-Manager (`fix/approval-flow-ordering`)
+
+Two follow-ups on the approval-flow work, both from live use:
+
+**Ask → decision → answer.** The decision rule ("You approved this request") rendered ABOVE the
+pending-approval bubble it was answering, because the resolved turn's answer used to overwrite the
+ask bubble in place. Now the ask stays, the decision reads after it, and the answer (or the next
+pending message) follows — the sequence an approver expects. The ask keeps its message id, so the
+paused turn's pipeline trace stays attached. The server still drops its copy of the ask from the
+resolved step, so a reload shows only the answer — like the decision rules themselves, the fuller
+sequence is the tab's own record.
+
+**The write probe's expected outcome no longer warns.** Activation verifies the gate
+deterministically (gate-dry-run); the background live probe then asks the model to attempt a real
+gated write. A careful model CAN always decline an unexplained write — that is its hardening
+working — so with the deterministic verdict in hand, "inconclusive" is the EXPECTED case, and
+toasting it on every activation trained admins to dismiss operator warnings. The report now carries
+`quiet: true` for exactly that case and the page logs instead of toasting. On a backend without the
+dry-run the probe is the only signal there is, so the same outcome still warns.
+
+---
+
+
+
 ## 🐛 fix(hitl): the pending-approval message was the same sentence on every pause (2026-08-14)
 
 **Repo:** EDDI (`fix/sse-data-line-padding`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,7 +25,8 @@ and fell back to the RAW string — skipping every legitimate `{memory...}` expr
 mention.
 
 The fix threads the needle without touching the security decision: `LlmTask.escapeVaultMentions`
-wraps `{vault:...}` / `{eddivault:...}` mentions in Qute raw sections **for LLM parameters only**.
+wraps `{vault:...}` mentions in Qute raw sections **for LLM parameters only** (`eddivault` is a
+retired alias and deliberately not covered).
 Prompts go to the model, never through vault resolution, so the literal is inert documentation
 there. Httpcall templating does not pass through this path and keeps failing loudly, exactly as
 `CallerNamespaceResolver` requires. Four tests, including one that REPRODUCES the crash on the

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
@@ -1151,14 +1151,14 @@ public class LlmTask implements ILifecycleTask {
     private static final Set<String> TEMPLATE_SKIP_PARAMS = Set.of("apiKey", "signingSecret", "appPassword", "botToken");
 
     /**
-     * A vault reference MENTIONED in an LLM parameter — {@code {vault:key-name}} or
-     * {@code {eddivault:key-name}}, with or without the leading {@code $} (which is
-     * plain text to Qute either way).
+     * A vault reference MENTIONED in an LLM parameter — {@code {vault:key-name}},
+     * with or without the leading {@code $} (which is plain text to Qute either
+     * way).
      */
-    private static final Pattern VAULT_REF_MENTION = Pattern.compile("\\{(?:eddi)?vault:[^}]*\\}");
+    private static final Pattern VAULT_REF_MENTION = Pattern.compile("\\{vault:[^}]*\\}");
 
     /**
-     * Wraps vault-reference mentions in Qute raw sections so a PROMPT may talk
+     * Wraps {@code {vault:...}} mentions in Qute raw sections so a PROMPT may talk
      * about the syntax without crashing templating.
      * <p>
      * The Platform Operator's system prompt instructs the model to write secrets as

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
@@ -48,6 +48,7 @@ import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static ai.labs.eddi.configs.workflows.model.ExtensionDescriptor.ConfigValue;
 import static ai.labs.eddi.configs.workflows.model.ExtensionDescriptor.FieldType;
@@ -1149,13 +1150,51 @@ public class LlmTask implements ILifecycleTask {
      */
     private static final Set<String> TEMPLATE_SKIP_PARAMS = Set.of("apiKey", "signingSecret", "appPassword", "botToken");
 
+    /**
+     * A vault reference MENTIONED in an LLM parameter — {@code {vault:key-name}} or
+     * {@code {eddivault:key-name}}, with or without the leading {@code $} (which is
+     * plain text to Qute either way).
+     */
+    private static final Pattern VAULT_REF_MENTION = Pattern.compile("\\{(?:eddi)?vault:[^}]*\\}");
+
+    /**
+     * Wraps vault-reference mentions in Qute raw sections so a PROMPT may talk
+     * about the syntax without crashing templating.
+     * <p>
+     * The Platform Operator's system prompt instructs the model to write secrets as
+     * {@code ${vault:key-name}} references. Qute parses the brace part as a
+     * namespaced expression, and there is deliberately no {@code vault} namespace
+     * resolver (see {@code CallerNamespaceResolver}'s class doc: letting vault
+     * references survive templating in general would let one ride a templated
+     * request BODY into vault resolution, and the resolved body is written to
+     * conversation memory in plaintext) — so every turn of such an agent failed
+     * templating for that parameter and fell back to the RAW string, skipping every
+     * legitimate {@code {memory...}} expression alongside it.
+     * <p>
+     * Escaping HERE, for LLM parameters only, threads that needle: these values go
+     * to the model, never through vault resolution, so a literal
+     * {@code ${vault:key-name}} in a prompt is inert documentation. Httpcall
+     * templating does not pass through this method and keeps failing loudly,
+     * exactly as that security decision requires.
+     * <p>
+     * Known limit: a mention already inside a {@code {|raw|}} section would be
+     * double-wrapped and render its markers. Prompts do not write Qute raw
+     * sections; accepting that beats parsing Qute here.
+     */
+    static String escapeVaultMentions(String value) {
+        if (value == null || !value.contains("vault:")) {
+            return value;
+        }
+        return VAULT_REF_MENTION.matcher(value).replaceAll(match -> "{|" + match.group() + "|}");
+    }
+
     private HashMap<String, String> runTemplateEngineOnParams(Map<String, String> parameters, Map<String, Object> templateDataObjects) {
 
         var processedParams = new HashMap<>(parameters);
         processedParams.forEach((key, value) -> {
             try {
                 if (!isNullOrEmpty(value) && !TEMPLATE_SKIP_PARAMS.contains(key)) {
-                    processedParams.put(key, templatingEngine.processTemplate(value, templateDataObjects));
+                    processedParams.put(key, templatingEngine.processTemplate(escapeVaultMentions(value), templateDataObjects));
                 }
             } catch (ITemplatingEngine.TemplateEngineException e) {
                 LOGGER.errorf(e, "Template processing failed for LLM parameter '%s': %s", key, e.getLocalizedMessage());

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskVaultMentionTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskVaultMentionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import ai.labs.eddi.modules.templating.ITemplatingEngine;
+import ai.labs.eddi.modules.templating.impl.TemplatingEngine;
+import io.quarkus.qute.Engine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A prompt may TALK ABOUT vault references without crashing templating.
+ * <p>
+ * The Platform Operator's system prompt instructs the model to write secrets as
+ * {@code ${vault:key-name}}. Qute parses the brace part as a namespaced
+ * expression, and there is deliberately no {@code vault} namespace resolver
+ * (see {@code CallerNamespaceResolver} for the security reasoning), so before
+ * {@link LlmTask#escapeVaultMentions} every turn of such an agent failed
+ * templating for that parameter — and the fallback used the RAW string,
+ * skipping every legitimate expression alongside the mention.
+ */
+@DisplayName("LLM params mentioning vault references")
+class LlmTaskVaultMentionTest {
+
+    private ITemplatingEngine templatingEngine;
+
+    @BeforeEach
+    void setUp() {
+        templatingEngine = new TemplatingEngine(Engine.builder().addDefaults().strictRendering(false).build());
+    }
+
+    private static final String OPERATOR_PROMPT_EXCERPT = "You are the EDDI Platform Operator. Secrets must be written as a ${vault:key-name} "
+            + "reference (the platform resolves it at call time). Greet {userName} by name.";
+
+    @Test
+    @DisplayName("the un-escaped mention reproduces the crash — the guard this fix exists for")
+    void unescapedMentionFailsTemplating() {
+        // If this stops throwing (an engine upgrade, someone adds a vault
+        // resolver), escapeVaultMentions is dead code AND the CallerNamespaceResolver
+        // security doc no longer holds — both need to be revisited together.
+        assertThrows(ITemplatingEngine.TemplateEngineException.class,
+                () -> templatingEngine.processTemplate(OPERATOR_PROMPT_EXCERPT, Map.of("userName", "Ada")));
+    }
+
+    @Test
+    @DisplayName("the escaped prompt renders: mention verbatim, expressions beside it resolved")
+    void escapedMentionRoundTripsAndNeighboursRender() throws Exception {
+        String rendered = templatingEngine.processTemplate(
+                LlmTask.escapeVaultMentions(OPERATOR_PROMPT_EXCERPT), Map.of("userName", "Ada"));
+
+        assertTrue(rendered.contains("${vault:key-name}"),
+                "the mention must reach the model verbatim; got: " + rendered);
+        assertTrue(rendered.contains("Greet Ada by name"),
+                "expressions beside the mention must still render; got: " + rendered);
+        assertFalse(rendered.contains("{|"),
+                "no raw-section markers may leak into the prompt; got: " + rendered);
+    }
+
+    @Test
+    @DisplayName("eddivault and bare {vault:...} mentions are escaped too")
+    void otherMentionFormsEscape() throws Exception {
+        String value = "Use {vault:a-key} or {eddivault:b_key} here.";
+
+        String rendered = templatingEngine.processTemplate(LlmTask.escapeVaultMentions(value), Map.of());
+
+        assertEquals("Use {vault:a-key} or {eddivault:b_key} here.", rendered);
+    }
+
+    @Test
+    @DisplayName("values without a mention are returned untouched — same instance, no cost")
+    void noMentionIsUntouched() {
+        String value = "Plain prompt with {userName} and no secrets syntax.";
+        assertSame(value, LlmTask.escapeVaultMentions(value));
+        assertNull(LlmTask.escapeVaultMentions(null));
+    }
+}

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskVaultMentionTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskVaultMentionTest.java
@@ -64,13 +64,13 @@ class LlmTaskVaultMentionTest {
     }
 
     @Test
-    @DisplayName("eddivault and bare {vault:...} mentions are escaped too")
-    void otherMentionFormsEscape() throws Exception {
-        String value = "Use {vault:a-key} or {eddivault:b_key} here.";
+    @DisplayName("a bare {vault:...} mention (no leading $) is escaped too")
+    void bareMentionFormEscapes() throws Exception {
+        String value = "Use {vault:a-key} or {vault:b_key} here.";
 
         String rendered = templatingEngine.processTemplate(LlmTask.escapeVaultMentions(value), Map.of());
 
-        assertEquals("Use {vault:a-key} or {eddivault:b_key} here.", rendered);
+        assertEquals("Use {vault:a-key} or {vault:b_key} here.", rendered);
     }
 
     @Test


### PR DESCRIPTION
From this morning's operator session log: every turn of the Platform Operator logged

```
Template processing failed for LLM parameter 'systemMessage': ... No namespace resolver found for [vault] in expression {vault:key-name}
```

The operator's system prompt instructs the model to write secrets as `${vault:key-name}` references. Qute parses the brace part as a namespaced expression, and there is **deliberately** no `vault` namespace resolver — `CallerNamespaceResolver`'s class doc records why: letting vault references survive templating in general would let one ride a templated request BODY into vault resolution, and the resolved body is written to conversation memory in plaintext. So templating failed for that parameter every turn, and the fallback used the RAW string — skipping every legitimate `{memory...}` expression beside the mention.

## The fix threads the needle without touching the security decision

`LlmTask.escapeVaultMentions` wraps `{vault:...}` / `{eddivault:...}` mentions in Qute raw sections **for LLM parameters only**. Prompts go to the model, never through vault resolution, so the literal is inert documentation there. Httpcall templating does not pass through this path and keeps failing loudly, exactly as `CallerNamespaceResolver` requires. A global `vault` namespace resolver was considered and rejected for exactly the reason that doc gives.

## Tests

Four, including one that **reproduces the crash** on the unescaped prompt — if that one ever stops throwing, the escape is dead code and the `CallerNamespaceResolver` security doc no longer holds, and both need revisiting together. 302 tests across the LlmTask/templating suites green.

## Not fixed here (diagnosed, still open)

The same log shows the resumed turn's `setupAgent` call failing with 400 `{"objectName":"Class","attributeName":"systemPrompt","line":1,"column":593}` — the JSON body failed to BIND at parse time, column 593 inside the systemPrompt string value. That shape comes from the JSON layer, not EDDI code; closing it needs the full memorized request body from the conversation.