### PR TITLE
fix(apicalls): a failed httpcall tool returned "{}" — the model could not know it failed

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,36 @@
 
 
 
+## 🐛 fix(apicalls): a failed httpcall tool returned "{}" — the model could not know it failed (2026-08-15)
+
+**Repo:** EDDI (`fix/tool-result-contract`)
+
+From the same operator session log as the vault-mention fix: the human approved `setupAgent`, the
+call went out and got a 400 — and the model was handed `{}` as the tool result.
+`HttpCallToolsProvider` serializes `ApiCallExecutor.execute()`'s returned map verbatim, and that map
+was only ever populated inside `if (isResponseSuccessful && call.getSaveResponse())`. On a non-2xx
+it stayed EMPTY; on a 2xx with `saveResponse=false` it stayed empty too. So the model could neither
+report a failure nor confirm a success — a human-approved call that 400'd looked exactly like one
+that worked, which is precisely the "I approved it and nothing happened" experience.
+
+Now:
+
+- **non-2xx** → `{"httpCode": 400, "body": "<error body, truncated to 2000 chars>"}` (status
+  message when the body is blank). Same keys as the success path, not a new `error` namespace —
+  `ApiCallsTask` merges this map into template data, where that vocabulary is already established.
+- **2xx with `saveResponse=false`** → `{"httpCode": 204}`. The body stays out (that is what the
+  flag means), but a model whose tool returned `{}` cannot tell a 204 from a crash.
+- The response OBJECT semantics are untouched: an error body still never lands under
+  `responseObjectName`, and memory still sees it only under the `*Error` key.
+
+Four new tests pin the contract (error body + code, blank-body fallback, truncation in the result,
+code-only on quiet success); four existing tests that pinned the empty-map behaviour were updated —
+they were pinning the bug.
+
+---
+
+
+
 ## 🐛 fix(llm): a prompt MENTIONING `${vault:key-name}` crashed templating every turn (2026-08-15)
 
 **Repo:** EDDI (`fix/vault-ref-template-crash`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,8 +29,10 @@ Now:
 - The response OBJECT semantics are untouched: an error body still never lands under
   `responseObjectName`, and memory still sees it only under the `*Error` key.
 
-Four new tests pin the contract (error body + code, blank-body fallback, truncation in the result,
-code-only on quiet success); four existing tests that pinned the empty-map behaviour were updated —
+Five new tests pin the contract (error body + code, blank-body fallback, truncation in the result,
+code-only on quiet success, and a mutation-verified regression for the retried-failure leak: a 503's
+error body must not survive into a succeeding retry's quiet-success result — the map is cleared per
+attempt, final attempt wins); four existing tests that pinned the empty-map behaviour were updated —
 they were pinning the bug.
 
 ---

--- a/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
@@ -145,6 +145,12 @@ public class ApiCallExecutor implements IApiCallExecutor {
                 Map<String, Object> result = new HashMap<>();
 
                 do {
+                    // Final attempt wins, entirely: a retried failure populated
+                    // "body"/"httpCode" on its pass through the loop, and a
+                    // succeeding retry that does NOT save its response would
+                    // otherwise inherit the failed attempt's error body next to
+                    // its own 2xx code — a self-contradictory tool result.
+                    result.clear();
                     request = buildRequest(targetServerUrl, call, templateDataObjects);
                     var objectName = call.getName() + "Request";
                     var requestMap = request.toMap();

--- a/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
@@ -164,14 +164,29 @@ public class ApiCallExecutor implements IApiCallExecutor {
                         LOGGER.warn(format(message, call.getName(), response.getHttpCode()));
                         LOGGER.warn("Error Msg:" + response.getHttpCodeMessage());
 
+                        String errorBody = response.getContentAsString();
+                        String truncatedError = errorBody != null && errorBody.length() > 2000
+                                ? errorBody.substring(0, 2000)
+                                : errorBody;
+
+                        // The returned map is what an LLM tool call receives as its result
+                        // (HttpCallToolsProvider serializes it verbatim). It used to stay
+                        // EMPTY on a non-2xx, so the model was handed "{}" for a failed
+                        // call — with no httpCode and no error it could neither report the
+                        // failure nor tell it apart from success, and a human-approved
+                        // setupAgent that 400'd looked exactly like one that worked. Same
+                        // keys as the success path ("body"/"httpCode"), not a new "error"
+                        // namespace: ApiCallsTask merges this map into template data,
+                        // where that vocabulary is already established.
+                        result.put("httpCode", response.getHttpCode());
+                        result.put("body", truncatedError != null && !truncatedError.isBlank()
+                                ? truncatedError
+                                : response.getHttpCodeMessage());
+
                         // Store error body in memory so downstream templates / rules can inspect it
                         if (call.getSaveResponse()) {
-                            String errorBody = response.getContentAsString();
                             String errorObjectName = call.getResponseObjectName() + "Error";
-                            if (errorBody != null && !errorBody.isBlank()) {
-                                String truncatedError = errorBody.length() > 2000
-                                        ? errorBody.substring(0, 2000)
-                                        : errorBody;
+                            if (truncatedError != null && !truncatedError.isBlank()) {
                                 prePostUtils.createMemoryEntry(currentStep, truncatedError, errorObjectName, KEY_HTTP_CALLS);
                                 templateDataObjects.put(errorObjectName, truncatedError);
                             }
@@ -223,6 +238,12 @@ public class ApiCallExecutor implements IApiCallExecutor {
                         templateDataObjects.put(responseObjectName, responseObject);
                         prePostUtils.createMemoryEntry(currentStep, responseObject, responseObjectName, KEY_HTTP_CALLS);
                         result.put("body", responseObject);
+                        result.put("httpCode", response.getHttpCode());
+                    } else if (isResponseSuccessful) {
+                        // saveResponse=false keeps the BODY out of memory and out of the
+                        // tool result on purpose, but the status code still travels: a
+                        // model whose tool returned "{}" cannot tell a 204 from a crash,
+                        // and honestly reporting "it worked" requires knowing that it did.
                         result.put("httpCode", response.getHttpCode());
                     }
 

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorBranchCoverageTest.java
@@ -207,7 +207,7 @@ class ApiCallExecutorBranchCoverageTest {
         }
 
         @Test
-        @DisplayName("non-2xx response with saveResponse=true → doesn't save body")
+        @DisplayName("non-2xx response → error body and code reach the tool result, response object untouched")
         void non2xxResponse() throws Exception {
             ApiCall call = createCall("fail-call", true);
             when(mockResponse.getHttpCode()).thenReturn(500);
@@ -216,7 +216,10 @@ class ApiCallExecutorBranchCoverageTest {
             when(mockResponse.getHttpHeader()).thenReturn(new HashMap<>());
 
             Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
-            assertFalse(result.containsKey("body"));
+            // The result map is the LLM's tool result; "{}" on failure made a
+            // 400'd call indistinguishable from one that worked.
+            assertEquals("error", result.get("body"));
+            assertEquals(500, result.get("httpCode"));
         }
     }
 
@@ -554,7 +557,7 @@ class ApiCallExecutorBranchCoverageTest {
     class SaveResponseFalse {
 
         @Test
-        @DisplayName("should not include body in result when saveResponse is false")
+        @DisplayName("should not include body in result when saveResponse is false — but the code still travels")
         void noBodyInResult() throws Exception {
             ApiCall call = createCall("no-save", false);
             setupSuccessResponse(200, "response-body", "application/json");
@@ -562,7 +565,8 @@ class ApiCallExecutorBranchCoverageTest {
             Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
 
             assertFalse(result.containsKey("body"));
-            assertFalse(result.containsKey("httpCode"));
+            // A model whose tool returned "{}" cannot tell a success from a crash.
+            assertEquals(200, result.get("httpCode"));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorTest.java
@@ -299,6 +299,42 @@ class ApiCallExecutorTest {
     }
 
     @Test
+    void execute_retriedFailureThenQuietSuccess_doesNotLeakTheErrorBody() throws Exception {
+        // A 503 populates "body" with its error on the first pass through the
+        // retry loop; the succeeding retry has saveResponse=false, so it writes
+        // only "httpCode". Without clearing between attempts the model would be
+        // handed {"httpCode": 200, "body": "<the 503's error>"} — a
+        // self-contradictory tool result.
+        ApiCall call = createSimpleApiCall("flaky-call", false);
+        HttpPostResponse postResponse = new HttpPostResponse();
+        RetryApiCallInstruction retryInstruction = new RetryApiCallInstruction();
+        retryInstruction.setMaxRetries(1);
+        retryInstruction.setRetryOnHttpCodes(List.of(503));
+        retryInstruction.setExponentialBackoffDelayInMillis(0);
+        postResponse.setRetryApiCallInstruction(retryInstruction);
+        call.setPostResponse(postResponse);
+
+        // Two distinct response mocks, switched per ATTEMPT via send(): the code
+        // under test reads getHttpCode() several times within one iteration, so
+        // sequential stubbing on a single mock would flip mid-attempt.
+        IResponse failing = mock(IResponse.class);
+        when(failing.getHttpCode()).thenReturn(503);
+        when(failing.getContentAsString()).thenReturn("upstream flaked");
+        when(failing.getHttpCodeMessage()).thenReturn("Service Unavailable");
+        when(failing.getHttpHeader()).thenReturn(new HashMap<>());
+        IResponse succeeding = mock(IResponse.class);
+        when(succeeding.getHttpCode()).thenReturn(200);
+        when(succeeding.getContentAsString()).thenReturn("ok");
+        when(succeeding.getHttpHeader()).thenReturn(new HashMap<>());
+        when(mockRequest.send()).thenReturn(failing).thenReturn(succeeding);
+
+        Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
+
+        assertEquals(200, result.get("httpCode"));
+        assertFalse(result.containsKey("body"), "the failed attempt's error body must not survive the retry");
+    }
+
+    @Test
     void execute_successWithoutSaveResponse_resultStillCarriesHttpCode() throws Exception {
         // The body stays out (that is what saveResponse=false means), but a model
         // whose tool returned "{}" cannot tell a 204 from a crash.

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorTest.java
@@ -246,6 +246,71 @@ class ApiCallExecutorTest {
         verify(mockRequest, times(1)).send();
     }
 
+    // ==================== Tool-result contract (what the LLM sees)
+    // ====================
+    //
+    // HttpCallToolsProvider serializes execute()'s returned map VERBATIM as the
+    // tool result. It used to stay empty on a non-2xx — the model was handed "{}"
+    // for a failed call, so a human-approved setupAgent that 400'd looked exactly
+    // like one that worked, and the model could neither report the failure nor
+    // tell the approver anything happened at all.
+
+    @Test
+    void execute_non2xx_resultCarriesHttpCodeAndErrorBody() throws Exception {
+        ApiCall call = createSimpleApiCall("failing-call", true);
+        when(mockResponse.getHttpCode()).thenReturn(400);
+        when(mockResponse.getContentAsString()).thenReturn("{\"attributeName\":\"systemPrompt\",\"column\":593}");
+        when(mockResponse.getHttpCodeMessage()).thenReturn("Bad Request");
+        when(mockResponse.getHttpHeader()).thenReturn(new HashMap<>());
+
+        Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
+
+        assertEquals(400, result.get("httpCode"));
+        assertEquals("{\"attributeName\":\"systemPrompt\",\"column\":593}", result.get("body"));
+    }
+
+    @Test
+    void execute_non2xxWithEmptyBody_resultFallsBackToStatusMessage() throws Exception {
+        // saveResponse=false as well: the tool-result contract must not depend on
+        // the memory-persistence flag.
+        ApiCall call = createSimpleApiCall("failing-call", false);
+        when(mockResponse.getHttpCode()).thenReturn(503);
+        when(mockResponse.getContentAsString()).thenReturn("");
+        when(mockResponse.getHttpCodeMessage()).thenReturn("Service Unavailable");
+        when(mockResponse.getHttpHeader()).thenReturn(new HashMap<>());
+
+        Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
+
+        assertEquals(503, result.get("httpCode"));
+        assertEquals("Service Unavailable", result.get("body"));
+    }
+
+    @Test
+    void execute_non2xx_errorBodyIsTruncatedInTheResultToo() throws Exception {
+        ApiCall call = createSimpleApiCall("failing-call", false);
+        when(mockResponse.getHttpCode()).thenReturn(500);
+        when(mockResponse.getContentAsString()).thenReturn("x".repeat(5000));
+        when(mockResponse.getHttpCodeMessage()).thenReturn("Internal Server Error");
+        when(mockResponse.getHttpHeader()).thenReturn(new HashMap<>());
+
+        Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
+
+        assertEquals(2000, ((String) result.get("body")).length());
+    }
+
+    @Test
+    void execute_successWithoutSaveResponse_resultStillCarriesHttpCode() throws Exception {
+        // The body stays out (that is what saveResponse=false means), but a model
+        // whose tool returned "{}" cannot tell a 204 from a crash.
+        ApiCall call = createSimpleApiCall("quiet-call", false);
+        setupSuccessResponse(204, "", "text/plain");
+
+        Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
+
+        assertEquals(204, result.get("httpCode"));
+        assertNull(result.get("body"));
+    }
+
     // ==================== Validation Tests ====================
 
     @Test
@@ -727,7 +792,7 @@ class ApiCallExecutorTest {
     // ==================== Non-2xx Response Tests ====================
 
     @Test
-    void execute_non2xxResponse_doesNotSaveBody() throws Exception {
+    void execute_non2xxResponse_doesNotPromoteBodyToTheResponseObject() throws Exception {
         ApiCall call = createSimpleApiCall("err-call", true);
         when(mockResponse.getHttpCode()).thenReturn(500);
         when(mockResponse.getHttpCodeMessage()).thenReturn("Internal Server Error");
@@ -736,8 +801,13 @@ class ApiCallExecutorTest {
 
         Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
 
-        assertFalse(result.containsKey("body"));
+        // The error body IS the tool result now (an LLM whose tool returned "{}"
+        // could not report the failure) — but it is never parsed as the response
+        // object, and memory only ever sees it under the *Error key.
+        assertEquals("error body", result.get("body"));
+        assertEquals(500, result.get("httpCode"));
         verify(jsonSerialization, never()).deserialize(any(), any());
+        verify(prePostUtils, never()).createMemoryEntry(eq(currentStep), any(), eq("response"), any());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorValidationErrorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorValidationErrorTest.java
@@ -153,8 +153,13 @@ class ApiCallExecutorValidationErrorTest {
         verify(prePostUtils).createMemoryEntry(currentStep, 500, "responseHttpCode", KEY_HTTP_CALLS);
         assertEquals("x".repeat(2000), templateDataObjects.get("responseError"));
         assertEquals(500, templateDataObjects.get("responseHttpCode"));
-        // An error body is never promoted to the response object / result body.
-        assertFalse(result.containsKey("body"), "an unsuccessful response must not be stored as the response body");
+        // An error body is never promoted to the response OBJECT (memory sees it
+        // only under the *Error key, verified above) — but it IS the tool result:
+        // an LLM whose failed call returned "{}" could not report the failure, so
+        // the result map carries the same truncated body plus the code.
+        assertEquals("x".repeat(2000), result.get("body"),
+                "the truncated error body must reach the tool result");
+        assertEquals(500, result.get("httpCode"));
         verify(prePostUtils, times(1)).runPostResponse(eq(memory), eq(call.getPostResponse()), any(), eq(500), eq(false));
     }
 


### PR DESCRIPTION
The missing piece of "after approval, nothing happened": the human approved `setupAgent`, the call went out, got a 400 — and the model was handed `{}` as its tool result.

`HttpCallToolsProvider` serializes `ApiCallExecutor.execute()`'s returned map verbatim, and that map was only populated inside `if (isResponseSuccessful && call.getSaveResponse())`. On a non-2xx it stayed **empty**; on a 2xx with `saveResponse=false`, empty too. So the model could neither report a failure nor confirm a success — a human-approved call that 400'd looked exactly like one that worked. (Live evidence: `Httpcall tool 'setupAgent' result: keys=[] size=2` right after the 400 in this morning's log.)

## Contract now

| case | tool result |
|---|---|
| non-2xx | `{"httpCode": 400, "body": "<error body, truncated to 2000>"}` — status message when the body is blank |
| 2xx, `saveResponse=false` | `{"httpCode": 204}` — body stays out, that is what the flag means |
| 2xx, `saveResponse=true` | unchanged (`body` + `httpCode`) |

Same keys as the success path rather than a new `error` namespace: `ApiCallsTask` merges this map into template data, where that vocabulary is already established. Response **object** semantics are untouched — an error body still never lands under `responseObjectName`, and memory still sees it only under the `*Error` key.

## Tests

Five new tests pin the contract (error body + code, blank-body fallback, truncation in the result, code-only on quiet success, and a mutation-verified regression for the retried-failure leak — a 503's error body must not survive into a succeeding retry's quiet-success result; the map is cleared per attempt, final attempt wins). Four existing tests asserted the empty map and were updated — they were pinning the bug. 488 tests across the apicalls/LlmTask suites green.