### PR TITLE
fix(hitl): a second pause on the same tool rendered byte-identical text

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,28 @@
 
 
 
+## 🐛 fix(hitl): a second pause on the SAME tool rendered byte-identical text (2026-08-15)
+
+**Repo:** EDDI (`fix/pause-ordinal`)
+
+The tool-named default made pauses on *different* tools distinguishable; a turn that pauses twice
+on the SAME tool — approve → the call fails → the model retries with fixed arguments — still
+rendered byte-identical asks. On screen: ask, "You approved this request", ask again with exactly
+the same sentence, reported as "approval need text now shows up double". It is not a duplicate; it
+is a second, real request — it just looked like a rendering bug.
+
+Repeat pauses now carry their ordinal: "I need your approval before I can run setupAgent. … (approval
+2 this turn)". The ordinal comes off the batch's own `pauseCountThisTurn` — persisted WITH the batch,
+so `dropPendingApprovalPlaceholder`'s resume-time recomputation reads the identical value, keeping the
+determinism placeholder-dropping requires. Only the built-in default gains the suffix (a configured
+`pendingMessage` is the operator's wording, kept verbatim), first pauses stay clean, and legacy
+batches (ordinal 0) are unaffected. Three tests: same-tool pauses differ, the configured template
+never gains the suffix, and an APPROVED resume still drops the suffixed default.
+
+---
+
+
+
 ## 🐛 fix(apicalls): a failed httpcall tool returned "{}" — the model could not know it failed (2026-08-15)
 
 **Repo:** EDDI (`fix/tool-result-contract`)

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -856,10 +856,26 @@ public class Conversation implements IConversation {
         // Resolved AFTER the names, because which default applies depends on whether
         // there are any. A configured template is used as-is either way — an operator
         // who wrote their own wording keeps it, with or without {toolNames} in it.
-        if (template == null) {
+        boolean usedDefault = template == null;
+        if (usedDefault) {
             template = names.isBlank() ? DEFAULT_PENDING_MESSAGE : DEFAULT_PENDING_MESSAGE_WITH_TOOLS;
         }
-        return template.replace("{toolNames}", names);
+        String rendered = template.replace("{toolNames}", names);
+        // Naming the tool made pauses on DIFFERENT tools distinguishable; a turn
+        // that pauses twice on the SAME tool (approve → the call fails → the model
+        // retries with fixed arguments) still rendered byte-identical text, which
+        // reads as a duplicated bubble — or a dead Approve button. The batch's own
+        // pause ordinal disambiguates. It is persisted WITH the batch, so the
+        // resume-time recomputation in dropPendingApprovalPlaceholder reads the
+        // identical value — the determinism that placeholder-dropping requires.
+        // Only the built-in default gains the suffix: a configured template is the
+        // operator's wording, kept verbatim. First pauses (and legacy batches,
+        // whose ordinal is 0) stay clean.
+        int pauseOrdinal = batch != null ? batch.getPauseCountThisTurn() : 0;
+        if (usedDefault && pauseOrdinal >= 2) {
+            rendered += " (approval " + pauseOrdinal + " this turn)";
+        }
+        return rendered;
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationHitlTest.java
@@ -298,12 +298,17 @@ class ConversationHitlTest {
          * @return the rendered {@code "output"} conversation-output of the paused step
          */
         private String pauseWithUnconfiguredMessage(String toolName) throws Exception {
+            return pauseWithUnconfiguredMessage(toolName, 1);
+        }
+
+        private String pauseWithUnconfiguredMessage(String toolName, int pauseCountThisTurn) throws Exception {
             memory.setConversationState(ConversationState.READY);
             doAnswer(inv -> {
                 var call = new PendingToolCallBatch.PendingToolCall();
                 call.setToolName(toolName);
                 var batch = new PendingToolCallBatch();
                 batch.setCalls(List.of(call));
+                batch.setPauseCountThisTurn(pauseCountThisTurn);
                 memory.setHitlPendingToolCalls(batch);
                 throw new ConversationPauseException("wf1", 2, "gated tool call",
                         ConversationPauseException.PauseOrigin.TOOL_CALL);
@@ -345,6 +350,54 @@ class ConversationHitlTest {
                     "consecutive pauses on different tools must not render identical text; got: " + first);
             assertTrue(second.contains("deployAgent") && !second.contains("createAgent"),
                     "the second pause must name only its own gated tool; got: " + second);
+        }
+
+        /**
+         * The user-visible failure this pins: approve → the call fails → the model
+         * retries the SAME tool → the second pause rendered byte-identical text, which
+         * reads as a duplicated bubble (or a dead Approve button). The batch's own
+         * ordinal — persisted with it, so resume-time recomputation matches — makes the
+         * second ask visibly a second ask.
+         */
+        @Test
+        @DisplayName("a second pause on the SAME tool renders differently from the first")
+        void secondPauseOnSameToolDiffers() throws Exception {
+            String first = pauseWithUnconfiguredMessage("setupAgent", 1);
+            String second = pauseWithUnconfiguredMessage("setupAgent", 2);
+
+            assertNotEquals(first, second,
+                    "consecutive pauses on the same tool must not render identical text; got: " + first);
+            assertTrue(second.contains("(approval 2 this turn)"),
+                    "the repeat ask must carry its ordinal; got: " + second);
+            assertFalse(first.contains("(approval"),
+                    "the FIRST ask stays clean — no ordinal suffix; got: " + first);
+        }
+
+        @Test
+        @DisplayName("a configured pendingMessage never gains the ordinal suffix")
+        void configuredMessageKeepsOperatorWordingVerbatim() throws Exception {
+            memory.setConversationState(ConversationState.READY);
+            var agentLevel = new ToolApprovalsConfig();
+            agentLevel.setPendingMessage("Own wording for {toolNames}");
+            memory.setAgentToolApprovalsConfig(agentLevel);
+            doAnswer(inv -> {
+                var call = new PendingToolCallBatch.PendingToolCall();
+                call.setToolName("setupAgent");
+                var batch = new PendingToolCallBatch();
+                batch.setCalls(List.of(call));
+                batch.setPauseCountThisTurn(2);
+                memory.setHitlPendingToolCalls(batch);
+                throw new ConversationPauseException("wf1", 2, "gated tool call",
+                        ConversationPauseException.PauseOrigin.TOOL_CALL);
+            }).when(lifecycleManager).executeLifecycle(any(), any());
+
+            createConversation().say("do it", Map.of());
+
+            String rendered = memory.getCurrentStep().getConversationOutput().get(MemoryKeys.OUTPUT_PREFIX).toString();
+            assertTrue(rendered.contains("Own wording for setupAgent"),
+                    "the configured wording must render; got: " + rendered);
+            assertFalse(rendered.contains("approval 2"),
+                    "an operator's own wording is kept verbatim; got: " + rendered);
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
@@ -342,6 +342,10 @@ class ConversationToolResumeTest {
             b.setLlmTaskId("ai.labs.llm");
             b.setLlmTaskIndex(0);
             b.setCalls(List.of(call));
+            // A REPEAT pause: the default gains its "(approval 2 this turn)" suffix,
+            // and the drop must still match — the ordinal comes off the batch, which
+            // is identical at pause time and at resume time.
+            b.setPauseCountThisTurn(2);
             // No effectiveToolApprovals and no agent-level config: the default applies.
             memory.setHitlPendingToolCalls(b);
             throw new ConversationPauseException("wf1", 0, "gated tool call",


### PR DESCRIPTION
From the latest screenshot: ask → "You approved this request" → the exact same ask again — reported as *"approval need text now shows up double"*. It is not a duplicate: the turn genuinely paused a second time on `setupAgent` (approve → the call 400'd → the model retried with fixed arguments). But byte-identical text makes a real second request look like a rendering bug — or a dead Approve button.

Repeat pauses now carry their ordinal:

> I need your approval before I can run setupAgent. You will receive the result once a reviewer decides. **(approval 2 this turn)**

**Determinism, again, is the constraint:** `dropPendingApprovalPlaceholder` removes the placeholder by recomputing the exact string on resume. The ordinal comes off the batch's own `pauseCountThisTurn` — persisted with the batch and immutable across the pause — so pause-time and resume-time renderings cannot disagree. A step-data read would have worked too, but the batch field is deterministic *by construction* rather than by argument.

Scope guards: only the built-in default gains the suffix (a configured `pendingMessage` is the operator's wording, kept verbatim); first pauses stay clean; legacy batches (ordinal 0) unaffected.

**Tests:** same-tool consecutive pauses render differently; the configured template never gains the suffix; an APPROVED resume still drops the suffixed default (the determinism proof). 95 tests across the conversation-HITL suites green.