### PR TITLE
fix(review): operator-stack audit — cross-version placeholders, contract leaks, live-path self-guard

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,80 @@
 
 
 
+## 🛡️ fix(review): four-agent audit of the operator stack — cross-version placeholders, contract widenings, live-path guard (2026-08-15)
+
+**Repo:** EDDI (`fix/operator-review-findings`)
+
+A four-reviewer audit of everything merged into `chore/remove-agent-father` (#679–#689) plus an
+end-to-end trace of the operator paths. Confirmed findings, all fixed here:
+
+**Cross-version placeholder stranding (the audit's sharpest catch).** `dropPendingApprovalPlaceholder`
+removes the pending-approval bubble by recomputing `resolvePendingMessage` and matching the exact
+string — which silently assumed pause and resume run the same build. Two releases changed the
+default wording (tool-named, then the repeat ordinal), so a conversation paused under the previous
+build recomputes a string that is not in its output, the removal no-ops, and the resolved turn
+renders [stale placeholder, answer] — the artifact those changes exist to kill, once per in-flight
+pause on the first post-upgrade resume. The resume path now recognises its predecessors' wording
+(`pendingPlaceholderCandidates`): the current rendering, the suffix-less variant, and the legacy
+constant. Two upgrade-boundary tests simulate a pre-upgrade pause and resume with current code.
+
+**Self-conversation guard now holds WITHOUT a pause.** #689's rule ("an agent may not send a request
+to its own conversation") was enforced only in `ToolLoopResumer` — the approval-execution path — so
+a call the gate let through live (ungated method, or the HITL kill-switch off) executed with no
+check anywhere. The rule is absolute; `ToolLoopRunner`'s live loop now runs the same check
+(`targetsOwnConversationLive`, shared core extracted) and refuses with the same `NOT_EXECUTED`
+envelope and `hitl_self_conversation` trace. A second review round then caught that the FIRST
+version of this fix missed the mixed-batch pause branch — ungated calls executed before the pause
+is thrown, frozen into the batch, never rechecked — so the guard runs there too. Accepted cost,
+documented in code: resolver-less tools (built-ins, MCP) fall back to raw-argument containment,
+where a mere MENTION of the id refuses the call; kept because that fallback is the only check
+covering `converse_with_agent` handed the agent's own conversationId.
+
+**#684 contract widenings, narrowed.** The tool-result contract (`body`/`httpCode` on failures)
+leaked past its intent in three places: (1) `ApiCallsTask` merged FAILED results into cross-call
+template data, where a failed call's error text could overwrite a previous success's `{body}` for a
+later call in the same step — failures no longer merge (`isFailureResult`); the scoped
+`{name}Error`/`{name}HttpCode` keys are unchanged. (2) The RAG path pasted a failed retrieval's
+error body into the SYSTEM prompt as "## Search Results" — up to 2KB of proxy/WAF error page,
+attacker-influenced in some architectures, masquerading as retrieved knowledge; failed retrievals
+now contribute nothing, as pre-contract. (3) The error body itself is now REDACTED
+(`SecretRedactionFilter`) before entering the tool result — a 401 routinely echoes the credential
+that failed, and the body flows into the transcript, pause batches and traces. The memory-side
+`{name}Error` entry keeps the raw text as before.
+
+**Test-drive read-back returned nothing to quote.** Every generated tool parameter is REQUIRED, so a
+model with no field filter to express sends `returningFields=""` — which bound as `[""]` and nulled
+steps, outputs AND properties from the snapshot: a working agent looked broken to the operator.
+Blank entries now mean NO filter (`ConversationMemoryUtilities`).
+
+**A guessed say-body was silently swallowed.** The say tool's body schema is a `$ref` the parser
+leaves unresolved, so its description carried zero field names; a guessed `{"message": ...}` bound
+to `InputData`'s defaults (empty input), answered 200, and a human-approved test message was never
+delivered. Body `$refs` now resolve one level (`resolveComponentRef`), so the description names
+`input`/`context` and requiredness — for every generated tool, not just say.
+
+**Enum values and defaults now reach parameter descriptions** (`appendSchemaHints`): the generated
+schema types every parameter as a required string, so the description is the model's only view of
+the value space. Observed with `environment`, where a guessed value silently fell back to production
+on the lenient server-side enum parse — a test-drive quietly exercising the wrong deployment.
+
+**Smaller items:** `padDataLines` normalises bare `\r` so its continuation line stays padded
+(RESTEasy starts a new `data:` line on either); `Authentication-Info`/`Proxy-Authentication-Info`
+join the credential response-header deny-list (RFC 7615 challenge material). Disclosure owed from
+#688: the credential-header stripping sits on the SHARED executor path, so a hand-authored config
+that captured `Set-Cookie`/`Authorization` from a response now reads them as absent — deliberate
+(those values are never data), but it is a behaviour change for such configs.
+
+Verified sound by the same audit, no change needed: `maxPausesPerTurn` exhaustion is fail-closed
+(synthetic DENIED, never ungated execution); every resume entry point restores the full persisted
+batch, so the ordinal is deterministic across REST/Slack/MCP/timeout/group resumes; #687's JSON
+guard runs post-approval by design and cannot diverge from the pinned fingerprint; conversation ids
+are globally unique across environments, so test-environment conversations read back fine.
+
+---
+
+
+
 ## 🔒 fix(hitl): an agent may not send a request to its own conversation (2026-08-15)
 
 **Repo:** EDDI (`fix/self-conversation-tool-call`)

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -300,7 +300,13 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
         if (data == null || data.isEmpty()) {
             return data;
         }
-        return " " + data.replace("\n", "\n ");
+        // \r is a line break to RESTEasy's SSE serializer too (SseUtil starts a
+        // new data: line on either), so a payload with a bare \r would get an
+        // UNPADDED continuation line. Normalise \r\n and \r to \n first; the
+        // consumer reassembles data lines with \n regardless, so the
+        // normalisation is invisible to it.
+        String normalised = data.replace("\r\n", "\n").replace('\r', '\n');
+        return " " + normalised.replace("\n", "\n ");
     }
 
     private final class SseStream {

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpApiToolBuilder.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpApiToolBuilder.java
@@ -115,7 +115,7 @@ public final class McpApiToolBuilder {
                     // Determine group (first tag, or "General")
                     String group = (operation.getTags() != null && !operation.getTags().isEmpty()) ? operation.getTags().get(0) : DEFAULT_GROUP;
 
-                    ApiCall httpCall = buildApiCall(method, path, operation, apiAuth);
+                    ApiCall httpCall = buildApiCall(method, path, operation, apiAuth, openAPI);
                     callsByGroup.computeIfAbsent(group, k -> new ArrayList<>()).add(httpCall);
                     endpointCount++;
 
@@ -210,7 +210,7 @@ public final class McpApiToolBuilder {
     /**
      * Build a single ApiCall from an OpenAPI operation.
      */
-    private static ApiCall buildApiCall(String method, String path, Operation operation, String apiAuth) {
+    private static ApiCall buildApiCall(String method, String path, Operation operation, String apiAuth, OpenAPI openAPI) {
         var httpCall = new ApiCall();
 
         // Name: operationId or generated slug
@@ -284,6 +284,14 @@ public final class McpApiToolBuilder {
             for (Parameter param : operation.getParameters()) {
                 String paramName = param.getName();
                 String paramDesc = param.getDescription() != null ? param.getDescription() : paramName;
+                // The description is the model's ONLY view of the value space —
+                // the generated tool schema types every parameter as a plain
+                // string, and every one is REQUIRED. Without the allowed values
+                // and the default spelled out, the model guesses: observed with
+                // `environment`, where a guessed value silently falls back to
+                // production on the lenient server-side enum parse — a
+                // test-drive that quietly exercises the wrong deployment.
+                paramDesc = appendSchemaHints(paramDesc, param.getSchema());
 
                 if ("query".equals(param.getIn())) {
                     // Query params use Qute template for LLM-provided values
@@ -303,7 +311,18 @@ public final class McpApiToolBuilder {
             MediaType jsonMedia = content.get("application/json");
             if (jsonMedia != null) {
                 request.setContentType("application/json");
-                var body = buildBodyTemplate(jsonMedia.getSchema());
+                // One level of $ref resolution, HERE and deliberately not resolveFully():
+                // the parser leaves component references unresolved, so a body
+                // declared as $ref: InputData reached describeBodySchema as a
+                // nameless shell and the parameter description degraded to "a
+                // single JSON object" with ZERO field names. The model then
+                // guesses keys — observed with the say tool, where a guessed
+                // {"message": ...} bound to InputData's DEFAULTS, returned 200,
+                // and the approved test message was silently never delivered.
+                // Nested property refs stay unresolved: the top-level field
+                // names and requiredness are what the model needs to write a
+                // correct body.
+                var body = buildBodyTemplate(resolveComponentRef(jsonMedia.getSchema(), openAPI));
                 // The body template's variables must be declared as tool parameters,
                 // or the model has no documented way to fill them: the tool schema is
                 // built from getParameters() alone (AgentOrchestrator), and with
@@ -441,6 +460,29 @@ public final class McpApiToolBuilder {
     /** Name of the whole-body variable used when the schema has no properties. */
     static final String WHOLE_BODY_VARIABLE = "requestBody";
 
+    /**
+     * Resolves a top-level {@code $ref: #/components/schemas/X} to its component
+     * schema, one level deep. Anything else — no ref, unknown name, no components —
+     * returns the input unchanged.
+     */
+    private static Schema<?> resolveComponentRef(Schema<?> schema, OpenAPI openAPI) {
+        if (schema == null || schema.get$ref() == null || openAPI == null
+                || openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+            return schema;
+        }
+        String ref = schema.get$ref();
+        // Schemas namespace ONLY: a malformed ref into another components
+        // namespace (requestBodies, parameters) must degrade to the safe
+        // nameless form rather than resolving a same-named SCHEMA and
+        // describing the wrong type's fields.
+        String prefix = "#/components/schemas/";
+        if (!ref.startsWith(prefix)) {
+            return schema;
+        }
+        Schema<?> resolved = openAPI.getComponents().getSchemas().get(ref.substring(prefix.length()));
+        return resolved != null ? resolved : schema;
+    }
+
     private static BodyTemplate buildBodyTemplate(Schema<?> schema) {
         if (schema == null) {
             // A declared body with no schema still needs a variable, or the model has
@@ -478,6 +520,29 @@ public final class McpApiToolBuilder {
      * and marks which are required. Types are included because the model must
      * produce real JSON — an integer field unquoted, a string field quoted.
      */
+    /**
+     * Appends the schema's allowed values and default to a parameter description,
+     * when it declares them. See the call site for why this is the model's only
+     * channel for either.
+     */
+    private static String appendSchemaHints(String description, Schema<?> schema) {
+        if (schema == null) {
+            return description;
+        }
+        var sb = new StringBuilder(description);
+        List<?> allowed = schema.getEnum();
+        if (allowed != null && !allowed.isEmpty()) {
+            sb.append(" Allowed values: ");
+            sb.append(String.join(", ", allowed.stream().map(String::valueOf).toList()));
+            sb.append(".");
+        }
+        Object defaultValue = schema.getDefault();
+        if (defaultValue != null && !String.valueOf(defaultValue).isBlank()) {
+            sb.append(" Default: ").append(defaultValue).append(".");
+        }
+        return sb.toString();
+    }
+
     private static String describeBodySchema(Schema<?> schema) {
         // Name the container the schema actually declares. Saying "a single JSON
         // object" for a top-level array makes the model wrap the payload in braces,

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilities.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilities.java
@@ -492,6 +492,18 @@ public class ConversationMemoryUtilities {
 
         var memorySnapshot = convertSimpleConversationMemory(conversationMemorySnapshot, returnDetailed, returnCurrentStepOnly);
 
+        // Blank entries mean NO filter, not "select nothing". A present-but-empty
+        // query parameter (?returningFields=) binds as [""], and LLM-generated
+        // tools make that shape routine: every generated parameter is required,
+        // so a model with no filter to express sends the empty string — and the
+        // branches below would then null out steps, outputs AND properties,
+        // leaving the operator's test-drive read-back with nothing to quote.
+        // "" selects no field under any reading, so dropping blanks recovers the
+        // caller's intent on every interpretation.
+        if (returningFields != null) {
+            returningFields = returningFields.stream().filter(f -> f != null && !f.isBlank()).toList();
+        }
+
         if (returnCurrentStepOnly) {
             if (isNullOrEmpty(returningFields) || returningFields.contains(KEY_CONVERSATION_STEPS)) {
                 var conversationSteps = memorySnapshot.getConversationSteps();

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -879,6 +879,57 @@ public class Conversation implements IConversation {
     }
 
     /**
+     * Every string {@link #pauseConversation} may have written as the pending
+     * placeholder for the CURRENT batch — under this build or a previous one. First
+     * entry is what this build writes; the rest are legacy renderings.
+     * <p>
+     * Exists because the determinism argument ("recompute the exact string on
+     * resume") silently assumed pause and resume run the same build. Two releases
+     * changed the DEFAULT wording — the tool-named default, then the repeat-pause
+     * ordinal — so a conversation paused under the previous build recomputes a
+     * string that is not in its output list, the removal no-ops, and the resolved
+     * turn renders [stale placeholder, answer]: the exact artifact those changes
+     * exist to kill, once per in-flight pause on the first post-upgrade resume.
+     * There is no schema migration for conversation output, so the resume path
+     * itself must recognise its predecessors' wording.
+     * <p>
+     * Only DEFAULT renderings accumulate variants — a configured
+     * {@code pendingMessage} has never been rewritten by a release, so it stays a
+     * single candidate. (An operator editing their template between pause and
+     * resume strands the placeholder exactly as before; that is config drift, not a
+     * version boundary, and predates all of this.)
+     */
+    private List<String> pendingPlaceholderCandidates(IConversationMemory memory) {
+        String current = resolvePendingMessage(memory);
+        var candidates = new ArrayList<String>();
+        candidates.add(current);
+
+        var batch = memory.getHitlPendingToolCalls();
+        var cfg = batch != null && batch.getEffectiveToolApprovals() != null
+                ? batch.getEffectiveToolApprovals()
+                : memory.getAgentToolApprovalsConfig();
+        var rule = batch != null ? batch.getEffectiveRule() : null;
+        boolean configured = (rule != null && rule.getPendingMessage() != null && !rule.getPendingMessage().isBlank())
+                || (cfg != null && !isNullOrEmpty(cfg.getPendingMessage()));
+        if (!configured) {
+            // Pre-ordinal build: the tool-named default without the suffix. The
+            // ordinal itself predates the suffix (it was persisted for cap
+            // enforcement), so a repeat pause persisted by that build re-reads
+            // its ordinal today and gains a suffix the stored text never had.
+            var suffix = java.util.regex.Pattern.compile("^(.*) \\(approval \\d+ this turn\\)$",
+                    java.util.regex.Pattern.DOTALL).matcher(current);
+            if (suffix.matches()) {
+                candidates.add(suffix.group(1));
+            }
+            // Pre-tool-named build: the constant, regardless of names.
+            if (!candidates.contains(DEFAULT_PENDING_MESSAGE)) {
+                candidates.add(DEFAULT_PENDING_MESSAGE);
+            }
+        }
+        return candidates;
+    }
+
+    /**
      * Removes the pending-approval placeholder that {@link #pauseConversation}
      * added to the current step on a TOOL_CALL pause, so the resumed step renders
      * ONLY the final answer.
@@ -902,11 +953,18 @@ public class Conversation implements IConversation {
      * writer replaced it we leave it alone.
      */
     private void dropPendingApprovalPlaceholder(IWritableConversationStep currentStep) {
-        String pending = resolvePendingMessage(conversationMemory);
-        currentStep.removeConversationOutputListItem(MemoryKeys.OUTPUT_PREFIX, pending);
+        // ALL renderings this or a previous build may have written for this batch
+        // — see pendingPlaceholderCandidates. At most one of them is actually in
+        // the list (each pause writes exactly one placeholder), so removing every
+        // candidate removes exactly the placeholder and cannot touch legitimate
+        // output: a candidate that was never written simply no-ops.
+        List<String> candidates = pendingPlaceholderCandidates(conversationMemory);
+        for (String pending : candidates) {
+            currentStep.removeConversationOutputListItem(MemoryKeys.OUTPUT_PREFIX, pending);
+        }
 
         IData<?> outputData = currentStep.getData(MemoryKeys.OUTPUT_PREFIX);
-        if (outputData != null && List.of(pending).equals(outputData.getResult())) {
+        if (outputData != null && candidates.stream().anyMatch(p -> List.of(p).equals(outputData.getResult()))) {
             var blanked = new Data<>(MemoryKeys.OUTPUT_PREFIX, new ArrayList<>());
             blanked.setPublic(true);
             currentStep.storeData(blanked);

--- a/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
@@ -21,6 +21,7 @@ import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import ai.labs.eddi.utils.LogSanitizer;
 import ai.labs.eddi.secrets.SecretResolver;
+import ai.labs.eddi.secrets.sanitize.SecretRedactionFilter;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -106,7 +107,10 @@ public class ApiCallExecutor implements IApiCallExecutor {
      */
     private static final Set<String> CREDENTIAL_RESPONSE_HEADERS = Set.of(
             "set-cookie", "set-cookie2", "authorization", "proxy-authorization",
-            "www-authenticate", "proxy-authenticate");
+            "www-authenticate", "proxy-authenticate",
+            // RFC 7615: server-authentication material (rspauth, nextnonce) —
+            // challenge-response state, never data.
+            "authentication-info", "proxy-authentication-info");
 
     private final IHttpClient httpClient;
     private final IJsonSerialization jsonSerialization;
@@ -239,9 +243,21 @@ public class ApiCallExecutor implements IApiCallExecutor {
                         // namespace: ApiCallsTask merges this map into template data,
                         // where that vocabulary is already established.
                         result.put("httpCode", response.getHttpCode());
-                        result.put("body", truncatedError != null && !truncatedError.isBlank()
-                                ? truncatedError
-                                : response.getHttpCodeMessage());
+                        // REDACTED before it reaches the model: an error body is
+                        // server-authored text, and a 401/403 routinely echoes the
+                        // credential that failed ("invalid api key sk-…"). The
+                        // success path stays untouched — response bodies are the
+                        // data the call exists to fetch — but an error body's
+                        // value to the model is the failure REASON, which survives
+                        // redaction. The memory-side {name}Error entry keeps the
+                        // raw text, as it always has, for operators debugging via
+                        // the store.
+                        // The status-message fallback is server-authored text of the
+                        // same trust class as the body — redacted for the same reason.
+                        String toolErrorBody = truncatedError != null && !truncatedError.isBlank()
+                                ? SecretRedactionFilter.redact(truncatedError)
+                                : SecretRedactionFilter.redact(response.getHttpCodeMessage());
+                        result.put("body", toolErrorBody);
 
                         // Store error body in memory so downstream templates / rules can inspect it
                         if (call.getSaveResponse()) {

--- a/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTask.java
+++ b/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTask.java
@@ -86,10 +86,31 @@ public class ApiCallsTask implements ILifecycleTask {
             // ApiCallExecutor stores response in conversation memory via prePostUtils.
             // We also merge into templateDataObjects so subsequent calls in this loop can
             // reference previous results.
-            if (httpCallResult != null && !httpCallResult.isEmpty()) {
+            //
+            // SUCCESSFUL results only. The result map doubles as the LLM tool
+            // contract, which now populates "body"/"httpCode" on FAILURES too (the
+            // model must be able to see a call failed) — but this pipeline's
+            // cross-call template contract predates that and never included error
+            // text: a failed call used to merge nothing. Without this guard, a
+            // failed call's error body would overwrite a previous successful
+            // call's {body} and a later call templating it would silently send
+            // error text as its payload. Failure details remain available to
+            // templates under the scoped keys the executor has always written
+            // ({responseObjectName}Error / {responseObjectName}HttpCode).
+            if (httpCallResult != null && !httpCallResult.isEmpty() && !isFailureResult(httpCallResult)) {
                 templateDataObjects.putAll(httpCallResult);
             }
         }
+    }
+
+    /**
+     * Whether the executor's result map describes a FAILED call — a non-2xx
+     * {@code httpCode}. A missing code is not failure: fire-and-forget returns an
+     * empty map, and pre-contract results carried no code at all.
+     */
+    // Package-private for unit testing.
+    static boolean isFailureResult(Map<String, Object> result) {
+        return result.get("httpCode") instanceof Integer code && (code < 200 || code >= 300);
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
@@ -1548,6 +1548,20 @@ public class LlmTask implements ILifecycleTask {
                         templateDataObjects.put("userInput", userInput);
 
                         Map<String, Object> result = apiCallExecutor.execute(apiCall, memory, templateDataObjects, targetServerUrl);
+
+                        // A FAILED retrieval contributes nothing. Its result now
+                        // carries the error body (so LLM TOOLS can report
+                        // failures), but this path pastes the serialized result
+                        // into the SYSTEM prompt as "## Search Results" — where
+                        // up to 2KB of proxy/WAF error page, attacker-influenced
+                        // in some architectures, would masquerade as retrieved
+                        // knowledge. Pre-contract, a failed call contributed an
+                        // empty map here; keep that meaning.
+                        if (result.get("httpCode") instanceof Integer code && (code < 200 || code >= 300)) {
+                            LOGGER.warnf("httpCall RAG '%s' returned %d — omitting from context", httpCallName, code);
+                            return null;
+                        }
+
                         String serialized = jsonSerialization.serialize(result);
 
                         LOGGER.infof("httpCall RAG '%s' executed: keys=%s, size=%d", httpCallName, result.keySet(), serialized.length());

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopResumer.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopResumer.java
@@ -515,34 +515,77 @@ class ToolLoopResumer {
      */
     String targetsOwnConversation(PendingToolCallBatch.PendingToolCall c, String amendedArguments,
                                   Map<String, ToolRequestResolver> resolvers, String conversationId) {
+        return targetsOwnConversation(c.getToolName(),
+                amendedArguments != null ? amendedArguments : c.getArgumentsRaw(),
+                req -> {
+                    var resolver = resolvers.get(c.getToolName());
+                    return resolver != null ? resolver.resolve(rebuiltRequest(c, req)) : null;
+                },
+                conversationId);
+    }
 
+    /**
+     * The LIVE-path form of the same rule, for a call the gate let through WITHOUT
+     * a pause — an ungated method, or the whole gate inert.
+     * <p>
+     * Exists because the resume-path check alone couples the boundary to the gate
+     * configuration: "an agent may not send a request to its own conversation" was
+     * enforced only for calls that paused, so an agent whose config did not gate
+     * the method — or a deployment with the HITL kill-switch off — could
+     * self-message with no check anywhere in the engine. The rule is absolute; it
+     * runs wherever a request is about to be sent, not only where approvals funnel.
+     * <p>
+     * Cost, accepted with eyes open: resolvers exist only for httpcall tools, so a
+     * resolver-less tool (built-ins, MCP) falls back to raw-argument containment —
+     * and on THIS path a false positive is a silent {@code NOT_EXECUTED} with no
+     * human to override, where on the resume path it cost one refused approval. The
+     * fallback is kept anyway: it is the only check covering the real built-in
+     * route ({@code converse_with_agent} handed the agent's own conversationId),
+     * and the false-positive shape — arguments that merely MENTION the id — is the
+     * same asymmetry the whole guard already accepts: a refusal costs a retry, a
+     * miss costs the boundary.
+     */
+    static String targetsOwnConversationLive(dev.langchain4j.agent.tool.ToolExecutionRequest toolRequest,
+                                             Map<String, ToolRequestResolver> resolvers, String conversationId) {
+        return targetsOwnConversation(toolRequest.name(), toolRequest.arguments(),
+                args -> {
+                    var resolver = resolvers != null ? resolvers.get(toolRequest.name()) : null;
+                    return resolver != null ? resolver.resolve(toolRequest) : null;
+                },
+                conversationId);
+    }
+
+    /**
+     * The shared core: resolve if possible and check the URI; otherwise check the
+     * raw arguments (the coarser test, and the safe direction to err in).
+     */
+    private static String targetsOwnConversation(String toolName, String rawArguments,
+                                                 ResolutionAttempt resolution, String conversationId) {
         if (conversationId == null || conversationId.isBlank()) {
             return null;
         }
-        var resolver = resolvers.get(c.getToolName());
-        if (resolver != null) {
-            try {
-                String args = amendedArguments != null ? amendedArguments : c.getArgumentsRaw();
-                ResolvedRequest current = resolver.resolve(rebuiltRequest(c, args));
-                if (uriTargetsConversation(current.uri(), conversationId)) {
-                    return "the request targets the conversation the agent is running in";
-                }
-                return null;
-            } catch (Exception e) {
-                // Type only, never the throwable: a request-build failure quotes the
-                // material being rendered, which would undo the redaction beside it.
-                LOGGER.warnf("Could not resolve the request for approved tool '%s' (%s); "
-                        + "falling back to its arguments for the self-conversation check.",
-                        sanitize(c.getToolName()), e.getClass().getSimpleName());
+        try {
+            ResolvedRequest current = resolution.resolve(rawArguments);
+            if (current != null) {
+                return uriTargetsConversation(current.uri(), conversationId)
+                        ? "the request targets the conversation the agent is running in"
+                        : null;
             }
+        } catch (Exception e) {
+            // Type only, never the throwable: a request-build failure quotes the
+            // material being rendered, which would undo the redaction beside it.
+            LOGGER.warnf("Could not resolve the request for tool '%s' (%s); "
+                    + "falling back to its arguments for the self-conversation check.",
+                    sanitize(toolName), e.getClass().getSimpleName());
         }
-        // No resolver, or resolution failed. The arguments are what the request is
-        // built FROM, so an id that will end up in the URI is already in them —
-        // a coarser test than the resolved URI, and the safe direction to err in.
-        String args = amendedArguments != null ? amendedArguments : c.getArgumentsRaw();
-        return uriTargetsConversation(args, conversationId)
+        return uriTargetsConversation(rawArguments, conversationId)
                 ? "the request targets the conversation the agent is running in"
                 : null;
+    }
+
+    @FunctionalInterface
+    private interface ResolutionAttempt {
+        ResolvedRequest resolve(String rawArguments) throws Exception;
     }
 
     /** Case-insensitive containment, tolerating percent-encoding. */

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopRunner.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopRunner.java
@@ -366,6 +366,23 @@ class ToolLoopRunner {
                         } else {
                             // 1) execute the ungated calls of this batch normally
                             for (ToolExecutionRequest allowedReq : gateResult.allowed()) {
+                                // Same absolute rule as the main allowed() loop below.
+                                // This branch runs BEFORE the pause is thrown, and its
+                                // results are frozen into the batch the resume replays
+                                // — a self-conversation call slipping through here is
+                                // never checked again anywhere. A mixed batch (one
+                                // gated call, one ungated self-message) was exactly
+                                // the remaining hole.
+                                String selfTargetedPre = ToolLoopResumer.targetsOwnConversationLive(
+                                        allowedReq, setup.toolRequestResolvers(), conversationId);
+                                if (selfTargetedPre != null) {
+                                    LOGGER.warnf("Refusing ungated tool '%s': %s", sanitize(allowedReq.name()), selfTargetedPre);
+                                    currentMessages.add(ToolExecutionResultMessage.from(allowedReq,
+                                            "{\"status\":\"NOT_EXECUTED\",\"reason\":\"an agent may not send a request to its own conversation\"}"));
+                                    trace.add(Map.of("type", "hitl_self_conversation", "tool", allowedReq.name(),
+                                            "detail", selfTargetedPre));
+                                    continue;
+                                }
                                 executeSingleToolCall(allowedReq, memory, currentMessages, trace, toolExecutors,
                                         toolRateLimits, toolCanonicalNames, defaultRateLimit, maxBudget, conversationId,
                                         enableRateLimiting, enableCaching, enableCostTracking, task, isLazy, builtInSpecs, activeSpecs);
@@ -418,6 +435,23 @@ class ToolLoopRunner {
                         // Thread.interrupted() clears the flag so it cannot leak to later work.
                         if (Thread.interrupted()) {
                             throw new LifecycleException("Agent execution cancelled (interrupted) before tool: " + toolRequest.name());
+                        }
+
+                        // "An agent may not send a request to its own conversation" is
+                        // an ABSOLUTE rule, and this loop is the one place it was not
+                        // enforced: a call the gate lets through live (ungated method,
+                        // or the whole gate inert) executed with no check anywhere.
+                        // The resume path has its own copy; a rule enforced only where
+                        // approvals funnel is a rule that vanishes with the gate.
+                        String selfTargeted = ToolLoopResumer.targetsOwnConversationLive(
+                                toolRequest, setup.toolRequestResolvers(), conversationId);
+                        if (selfTargeted != null) {
+                            LOGGER.warnf("Refusing ungated tool '%s': %s", sanitize(toolRequest.name()), selfTargeted);
+                            currentMessages.add(ToolExecutionResultMessage.from(toolRequest,
+                                    "{\"status\":\"NOT_EXECUTED\",\"reason\":\"an agent may not send a request to its own conversation\"}"));
+                            trace.add(Map.of("type", "hitl_self_conversation", "tool", toolRequest.name(),
+                                    "detail", selfTargeted));
+                            continue;
                         }
 
                         executeSingleToolCall(toolRequest, memory, currentMessages, trace, toolExecutors,

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
@@ -538,6 +538,16 @@ class RestAgentEngineStreamingTest {
     @org.junit.jupiter.api.DisplayName("SSE data lines are padded so a leading space survives")
     class DataLinePadding {
 
+        @Test
+        @DisplayName("a bare carriage return is normalised so its continuation line stays padded")
+        void carriageReturnContinuationIsPadded() {
+            // RESTEasy's SSE serializer starts a new data: line on \r as well
+            // as \n - an unnormalised \r would produce an UNPADDED continuation
+            // whose first character the consumer then eats.
+            String padded = RestAgentEngineStreaming.padDataLines("a\rb\r\nc");
+            assertEquals(" a\n b\n c", padded);
+        }
+
         @org.junit.jupiter.api.Test
         void aLeadingSpaceSurvivesTheConsumersStrip() {
             String padded = RestAgentEngineStreaming.padDataLines(" alpha");

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpApiToolBuilderTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpApiToolBuilderTest.java
@@ -668,4 +668,72 @@ class McpApiToolBuilderTest {
         assertFalse(McpApiToolBuilder.looksLikeInlineSpec("https://petstore.example.com/openapi.json"));
         assertFalse(McpApiToolBuilder.looksLikeInlineSpec("file:///etc/passwd"));
     }
+
+    /**
+     * The silent-swallow this closes: the say tool's body was a $ref the parser
+     * left unresolved, so its parameter description carried ZERO field names. The
+     * model guessed keys, the guessed body bound to the DTO's defaults (empty
+     * input), the API answered 200 — and a human-approved test message was never
+     * delivered, with nothing anywhere saying so.
+     */
+    @Test
+    @DisplayName("a $ref body resolves one level, so the description names the real fields")
+    void parseAndBuild_refBodyDescriptionNamesFields() {
+        String spec = """
+                {"openapi":"3.0.0","info":{"title":"t","version":"1"},"paths":{"/say":{"post":{
+                "operationId":"say","tags":["chat"],
+                "requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/InputData"}}}},
+                "responses":{"200":{"description":"ok"}}}}},
+                "components":{"schemas":{"InputData":{"type":"object","required":["input"],
+                "properties":{"input":{"type":"string"},"context":{"type":"object"}}}}}}
+                """;
+        var result = McpApiToolBuilder.parseAndBuild(spec, null, null, null);
+        ApiCall say = result.configsByGroup().get("chat").getHttpCalls().get(0);
+
+        String description = say.getParameters().get(McpApiToolBuilder.WHOLE_BODY_VARIABLE);
+        assertTrue(description.contains("input"), "the body fields must be named; got: " + description);
+        assertTrue(description.contains("context"), description);
+        assertTrue(description.contains("required"), "requiredness must be conveyed; got: " + description);
+    }
+
+    @Test
+    @DisplayName("an unknown $ref still degrades to the nameless whole-body form, never throws")
+    void parseAndBuild_unknownRefStillDegrades() {
+        String spec = """
+                {"openapi":"3.0.0","info":{"title":"t","version":"1"},"paths":{"/x":{"post":{
+                "operationId":"x","tags":["g"],
+                "requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/Missing"}}}},
+                "responses":{"200":{"description":"ok"}}}}},
+                "components":{"schemas":{}}}
+                """;
+        var result = McpApiToolBuilder.parseAndBuild(spec, null, null, null);
+        ApiCall x = result.configsByGroup().get("g").getHttpCalls().get(0);
+        assertEquals("{" + McpApiToolBuilder.WHOLE_BODY_VARIABLE + "}", x.getRequest().getBody());
+    }
+
+    /**
+     * The description is the model's ONLY view of a parameter's value space — the
+     * generated schema types everything as a required string. Observed with
+     * `environment`: a guessed value silently fell back to production on the
+     * lenient server-side enum parse, so a test-drive quietly exercised the wrong
+     * deployment.
+     */
+    @Test
+    @DisplayName("enum values and defaults reach the query-parameter description")
+    void parseAndBuild_enumAndDefaultReachParamDescription() {
+        String spec = """
+                {"openapi":"3.0.0","info":{"title":"t","version":"1"},"paths":{"/start":{"post":{
+                "operationId":"start","tags":["chat"],
+                "parameters":[{"name":"environment","in":"query","description":"Deployment environment.",
+                "schema":{"type":"string","enum":["production","test"],"default":"production"}}],
+                "responses":{"201":{"description":"created"}}}}}}
+                """;
+        var result = McpApiToolBuilder.parseAndBuild(spec, null, null, null);
+        ApiCall start = result.configsByGroup().get("chat").getHttpCalls().get(0);
+
+        String description = start.getParameters().get("environment");
+        assertTrue(description.contains("production"), description);
+        assertTrue(description.contains("test"), description);
+        assertTrue(description.contains("Default: production"), description);
+    }
 }

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesTest.java
@@ -232,6 +232,36 @@ class ConversationMemoryUtilitiesTest {
             assertNotNull(simple.getConversationOutputs());
             assertNotNull(simple.getConversationProperties());
         }
+
+        /**
+         * A present-but-empty query parameter ({@code ?returningFields=}) binds as
+         * {@code [""]}, and LLM-generated tools make that shape routine: every
+         * generated parameter is required, so a model with no filter to express sends
+         * the empty string. Treating {@code [""]} as a selection nulled steps, outputs
+         * AND properties — the operator's test-drive read-back returned a snapshot with
+         * nothing to quote, so a working agent looked broken. Blank entries mean NO
+         * filter.
+         */
+        @Test
+        @DisplayName("a blank entry means NO filter, not 'select nothing'")
+        void blankEntryMeansNoFilter() {
+            var snapshot = buildMultiStepSnapshot(2);
+            var simple = ConversationMemoryUtilities.convertSimpleConversationMemorySnapshot(
+                    snapshot, true, true, List.of(""));
+            assertNotNull(simple.getConversationSteps(), "[\"\"] must behave like no filter");
+            assertNotNull(simple.getConversationOutputs());
+            assertNotNull(simple.getConversationProperties());
+        }
+
+        @Test
+        @DisplayName("blank entries are dropped, real entries still filter")
+        void blankBesideRealEntryStillFilters() {
+            var snapshot = buildMultiStepSnapshot(2);
+            var simple = ConversationMemoryUtilities.convertSimpleConversationMemorySnapshot(
+                    snapshot, true, true, java.util.Arrays.asList("", "conversationOutputs", "  "));
+            assertNull(simple.getConversationSteps(), "the real entry keeps filtering");
+            assertNotNull(simple.getConversationOutputs());
+        }
     }
 
     // ─── Test Helpers ────────────────────────────────────────────

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
@@ -323,6 +323,91 @@ class ConversationToolResumeTest {
     }
 
     /**
+     * The version boundary the determinism argument silently skipped: a pause
+     * PERSISTED by a previous build holds that build's placeholder wording, and
+     * recomputing with the current code produces a different string — so the
+     * removal no-ops and the resolved turn renders [stale placeholder, answer]. Two
+     * releases changed the default (tool-named, then the repeat ordinal); the
+     * resume path must recognise both predecessors.
+     */
+    @Test
+    @DisplayName("upgrade boundary: a placeholder written by the PRE-tool-named build is still dropped")
+    void preToolNamedPlaceholderStillDropped() throws Exception {
+        var conv = pauseViaToolCallWithDefaultMessage(1);
+        // Swap the freshly written placeholder for the old build's constant — the
+        // step output now looks exactly as a pre-upgrade pause left it.
+        String legacy = "This action requires human approval before it can proceed. "
+                + "You will receive the result once a reviewer decides.";
+        var out = outputList();
+        out.clear();
+        out.add(legacy);
+
+        doAnswer(inv -> {
+            memory.getCurrentStep().addConversationOutputList(
+                    MemoryKeys.OUTPUT_PREFIX, List.of(new TextOutputItem("Done.", 0)));
+            return null;
+        }).when(lifecycleManager).executeLifecycleFromIndex(eq(memory), anyInt());
+
+        conv.resume(decision(HitlVerdict.APPROVED));
+
+        var after = outputList();
+        assertFalse(after.stream().anyMatch(o -> String.valueOf(o).equals(legacy)),
+                "the previous build's placeholder must be recognised and dropped; got: " + after);
+        assertEquals(1, after.size(), "only the answer remains; got: " + after);
+    }
+
+    @Test
+    @DisplayName("upgrade boundary: a repeat-pause placeholder written WITHOUT the ordinal suffix is still dropped")
+    void preOrdinalPlaceholderStillDropped() throws Exception {
+        // pauseCountThisTurn predates the suffix (it was persisted for cap
+        // enforcement), so a repeat pause persisted by the pre-ordinal build
+        // re-reads ordinal 2 today and recomputes a suffixed string the stored
+        // text never had.
+        var conv = pauseViaToolCallWithDefaultMessage(2);
+        String suffixless = "I need your approval before I can run delete_record. "
+                + "You will receive the result once a reviewer decides.";
+        var out = outputList();
+        out.clear();
+        out.add(suffixless);
+
+        doAnswer(inv -> {
+            memory.getCurrentStep().addConversationOutputList(
+                    MemoryKeys.OUTPUT_PREFIX, List.of(new TextOutputItem("Done.", 0)));
+            return null;
+        }).when(lifecycleManager).executeLifecycleFromIndex(eq(memory), anyInt());
+
+        conv.resume(decision(HitlVerdict.APPROVED));
+
+        var after = outputList();
+        assertFalse(after.stream().anyMatch(o -> String.valueOf(o).equals(suffixless)),
+                "the pre-ordinal placeholder must be recognised and dropped; got: " + after);
+        assertEquals(1, after.size(), "only the answer remains; got: " + after);
+    }
+
+    /**
+     * Pauses with NO configured pendingMessage (the default applies) at the given
+     * persisted pause ordinal — the shape both upgrade-boundary tests need.
+     */
+    private Conversation pauseViaToolCallWithDefaultMessage(int pauseCountThisTurn) throws Exception {
+        memory.setConversationState(ConversationState.READY);
+        doAnswer(inv -> {
+            var call = new PendingToolCallBatch.PendingToolCall();
+            call.setToolName("delete_record");
+            var b = new PendingToolCallBatch();
+            b.setLlmTaskId("ai.labs.llm");
+            b.setLlmTaskIndex(0);
+            b.setCalls(List.of(call));
+            b.setPauseCountThisTurn(pauseCountThisTurn);
+            memory.setHitlPendingToolCalls(b);
+            throw new ConversationPauseException("wf1", 0, "gated tool call",
+                    ConversationPauseException.PauseOrigin.TOOL_CALL);
+        }).when(lifecycleManager).executeLifecycle(any(), any());
+        var conv = createConversation();
+        conv.say("do it", Map.of());
+        return conv;
+    }
+
+    /**
      * The drop is by exact-string match against a RECOMPUTED
      * {@code resolvePendingMessage}, so the DEFAULT message has to be just as
      * deterministic as a configured one. It now names the gated tool — read off the

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutorTest.java
@@ -334,6 +334,29 @@ class ApiCallExecutorTest {
         assertFalse(result.containsKey("body"), "the failed attempt's error body must not survive the retry");
     }
 
+    /**
+     * An error body is server-authored text, and a 401 routinely echoes the
+     * credential that failed. The body flows into the LLM transcript (and from
+     * there into pause batches and traces), so it is redacted on the way into the
+     * tool result. The memory-side *Error entry keeps the raw text, as it always
+     * has, for operators debugging via the store.
+     */
+    @Test
+    void execute_non2xx_errorBodyIsRedactedInTheToolResult() throws Exception {
+        ApiCall call = createSimpleApiCall("auth-call", true);
+        when(mockResponse.getHttpCode()).thenReturn(401);
+        when(mockResponse.getContentAsString())
+                .thenReturn("invalid api key sk-ant-api03-verySecretValue1234567890abcdefghij provided");
+        when(mockResponse.getHttpCodeMessage()).thenReturn("Unauthorized");
+        when(mockResponse.getHttpHeader()).thenReturn(new HashMap<>());
+
+        Map<String, Object> result = executor.execute(call, memory, new HashMap<>(), "http://example.com");
+
+        String body = (String) result.get("body");
+        assertFalse(body.contains("verySecretValue"), "the echoed credential must not reach the model: " + body);
+        assertTrue(body.contains("invalid api key"), "the failure REASON must survive redaction: " + body);
+    }
+
     @Test
     void execute_successWithoutSaveResponse_resultStillCarriesHttpCode() throws Exception {
         // The body stays out (that is what saveResponse=false means), but a model

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTaskTest.java
@@ -416,4 +416,23 @@ class ApiCallsTaskTest {
         assertEquals("Http Calls", descriptor.getDisplayName());
         assertTrue(descriptor.getConfigs().containsKey("uri"));
     }
+
+    /**
+     * The result map doubles as the LLM tool contract, which now populates
+     * body/httpCode on FAILURES too — but this task's cross-call template merge
+     * predates that contract and never included error text. isFailureResult is the
+     * guard keeping a failed call's error body from overwriting a previous
+     * successful call's {body} in template data.
+     */
+    @Test
+    void isFailureResult_classifiesByHttpCode() {
+        assertTrue(ApiCallsTask.isFailureResult(java.util.Map.of("httpCode", 400, "body", "boom")));
+        assertTrue(ApiCallsTask.isFailureResult(java.util.Map.of("httpCode", 503)));
+        assertFalse(ApiCallsTask.isFailureResult(java.util.Map.of("httpCode", 200, "body", "ok")));
+        assertFalse(ApiCallsTask.isFailureResult(java.util.Map.of("httpCode", 204)));
+        // No code is NOT failure: fire-and-forget returns an empty map, and
+        // pre-contract results carried no code at all.
+        assertFalse(ApiCallsTask.isFailureResult(java.util.Map.of("body", "legacy")));
+        assertFalse(ApiCallsTask.isFailureResult(java.util.Map.of()));
+    }
 }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/ToolLoopResumerSelfConversationTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/ToolLoopResumerSelfConversationTest.java
@@ -157,4 +157,51 @@ class ToolLoopResumerSelfConversationTest {
                 "https://x/a%/agents/" + CONVERSATION_ID, CONVERSATION_ID));
         assertFalse(ToolLoopResumer.uriTargetsConversation("https://x/agents/" + OTHER_CONVERSATION_ID, CONVERSATION_ID));
     }
+
+    /**
+     * The LIVE-path form. The resume-path check alone coupled the rule to the gate
+     * configuration: a call an inert or non-matching gate let straight through
+     * executed with no self-conversation check anywhere in the engine. These pin
+     * the live variant so the boundary survives without a pause.
+     */
+    @Test
+    @DisplayName("live path: refuses an ungated call whose resolved URI is the agent's own conversation")
+    void livePathRefusesSelfTargetedCall() {
+        var request = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+                .name("say").arguments("{}").build();
+
+        String reason = ToolLoopResumer.targetsOwnConversationLive(request,
+                resolverFor("https://eddi.example/agents/" + CONVERSATION_ID), CONVERSATION_ID);
+
+        assertNotNull(reason, "the rule is absolute — it must hold without a pause");
+    }
+
+    @Test
+    @DisplayName("live path: allows an ungated call to a different conversation")
+    void livePathAllowsOtherConversation() {
+        var request = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+                .name("say").arguments("{}").build();
+
+        assertNull(ToolLoopResumer.targetsOwnConversationLive(request,
+                resolverFor("https://eddi.example/agents/" + OTHER_CONVERSATION_ID), CONVERSATION_ID));
+    }
+
+    @Test
+    @DisplayName("live path: falls back to the raw arguments when no resolver exists")
+    void livePathFallsBackToArguments() {
+        var request = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+                .name("say").arguments("{\"conversationId\":\"" + CONVERSATION_ID + "\"}").build();
+
+        assertNotNull(ToolLoopResumer.targetsOwnConversationLive(request, Map.of(), CONVERSATION_ID));
+    }
+
+    @Test
+    @DisplayName("live path: tolerates a null resolver map and a blank conversation id")
+    void livePathToleratesMissingInputs() {
+        var request = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+                .name("say").arguments("{}").build();
+
+        assertNull(ToolLoopResumer.targetsOwnConversationLive(request, null, null));
+        assertNull(ToolLoopResumer.targetsOwnConversationLive(request, null, " "));
+    }
 }


### PR DESCRIPTION
A four-reviewer audit of everything merged into this branch (#679–#689) plus an end-to-end trace of the operator paths — then a **second adversarial round over the fix itself**, which caught a HIGH defect in my own first version. The changelog entry carries the full account; the highlights:

## Confirmed findings, fixed

**Cross-version placeholder stranding.** `dropPendingApprovalPlaceholder` removes the pending bubble by recomputing the exact string — silently assuming pause and resume run the same build. Two releases changed the default wording, so every in-flight pause across the upgrade would have rendered `[stale placeholder, answer]` on its first resume: the precise artifact those releases were written to kill. Resume now recognises its predecessors' wording; two upgrade-boundary tests simulate a pre-upgrade pause.

**Self-conversation guard now holds without a pause — including the branch round two caught.** #689's rule was enforced only on the approval path, so an ungated call executed with no check anywhere. My first fix guarded the main live loop; the second review round found the **mixed-batch pause branch** (ungated calls execute *before* the pause is thrown, frozen into the batch, never rechecked — one gated `delete` plus one ungated self-`say` in a single model turn slipped through). Both loops now refuse with the same `NOT_EXECUTED` envelope. Accepted cost documented in code: resolver-less tools fall back to raw-argument containment, kept because it is the only check covering `converse_with_agent` handed the agent's own conversationId.

**#684 contract leaks narrowed.** Failed results no longer enter `ApiCallsTask`'s cross-call template merge (a failed call's error text could overwrite a previous success's `{body}` for a later call's payload) nor the RAG system prompt (up to 2KB of proxy/WAF error page masquerading as "## Search Results"). Error bodies — and the status-message fallback — are **redacted** before reaching the model; a 401 routinely echoes the credential that failed. Memory-side `*Error` keys unchanged.

**Test-drive actually works end-to-end now.** Two silent breaks: `returningFields=""` (the natural fill for a required parameter) nulled steps/outputs/properties from the read-back, so a working agent looked broken; and the say tool's `$ref` body description carried zero field names, so a guessed `{"message": …}` bound to `InputData` defaults and a human-approved test message was **never delivered, with a 200**. Body `$refs` resolve one level (schemas namespace only — round two caught the wrong-namespace resolution risk); enum values and defaults reach parameter descriptions (the `environment` typo→production trap).

**Smaller:** bare-`\r` SSE padding, RFC 7615 headers in the credential deny-list, #688's shared-path stripping disclosed.

## Verified sound by the audit, no change needed

`maxPausesPerTurn` exhaustion is fail-closed; the pause ordinal is deterministic across all six resume entry points; #687's guard cannot diverge from the pinned fingerprint; conversation ids are globally unique across environments, so test-env conversations read back fine.

## Tests

264 across the affected suites — including upgrade-boundary resumes, live-path refusals, refused-mid-batch behaviour, blank-filter recovery, and redaction survival of the failure reason. Local full unit baseline unchanged (`GroupHitlIT` needs Docker, as always).