### PR TITLE
fix(style): hoist inline fully-qualified names out of the operator-audit changes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,32 @@
 
 
 
+## 🧹 fix(style): hoist inline fully-qualified names out of the operator-audit changes (2026-08-15)
+
+**Repo:** EDDI (`fix/import-style-violations`)
+
+`ImportStyleTest.noInlineFullyQualifiedNames` (AGENTS.md §4.7) went red on `chore/remove-agent-father`
+right after #690 merged. Three files from that PR used inline fully-qualified names:
+
+- `Conversation.java` — `java.util.regex.Pattern` spelled out twice inside `pendingPlaceholderCandidates()`.
+  The compiled pattern is now an `ORDINAL_SUFFIX` constant beside the other pending-message constants,
+  so it is also compiled once at class-init instead of on every resume, rather than merely renamed.
+- `ApiCallsTaskTest.java` — six `java.util.Map.of(...)` calls in `isFailureResult_classifiesByHttpCode`,
+  now plain `Map.of(...)` (the import was already present).
+- `ConversationMemoryUtilitiesTest.java` — `java.util.Arrays.asList(...)` in
+  `blankBesideRealEntryStillFilters`, now `List.of(...)`.
+
+No behaviour change: the regex text and the `DOTALL` flag are byte-identical to what they replaced.
+
+**Why it escaped local verification:** the affected suites were run by name (`-Dtest=...`) and
+`ImportStyleTest` was not among them, so the enforcement test only ever ran in CI. Style-rule tests are
+repo-wide rather than change-local — they belong in the pre-push check unconditionally, not in a list
+inferred from which files were touched.
+
+---
+
+
+
 ## 🛡️ fix(review): four-agent audit of the operator stack — cross-version placeholders, contract widenings, live-path guard (2026-08-15)
 
 **Repo:** EDDI (`fix/operator-review-findings`)

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -27,6 +27,7 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.ArrayList;
 
 import static ai.labs.eddi.engine.memory.ContextUtilities.storeContextLanguageInLongTermMemory;
@@ -797,6 +798,10 @@ public class Conversation implements IConversation {
     private static final String DEFAULT_PENDING_MESSAGE = "This action requires human approval before it can proceed. "
             + "You will receive the result once a reviewer decides.";
 
+    /** Matches a rendered default carrying the repeat-pause ordinal suffix. */
+    private static final Pattern ORDINAL_SUFFIX = Pattern.compile(
+            "^(.*) \\(approval \\d+ this turn\\)$", Pattern.DOTALL);
+
     /**
      * Default pending message when the gated call names ARE known — the normal
      * case.
@@ -916,8 +921,7 @@ public class Conversation implements IConversation {
             // ordinal itself predates the suffix (it was persisted for cap
             // enforcement), so a repeat pause persisted by that build re-reads
             // its ordinal today and gains a suffix the stored text never had.
-            var suffix = java.util.regex.Pattern.compile("^(.*) \\(approval \\d+ this turn\\)$",
-                    java.util.regex.Pattern.DOTALL).matcher(current);
+            var suffix = ORDINAL_SUFFIX.matcher(current);
             if (suffix.matches()) {
                 candidates.add(suffix.group(1));
             }

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesTest.java
@@ -258,7 +258,7 @@ class ConversationMemoryUtilitiesTest {
         void blankBesideRealEntryStillFilters() {
             var snapshot = buildMultiStepSnapshot(2);
             var simple = ConversationMemoryUtilities.convertSimpleConversationMemorySnapshot(
-                    snapshot, true, true, java.util.Arrays.asList("", "conversationOutputs", "  "));
+                    snapshot, true, true, List.of("", "conversationOutputs", "  "));
             assertNull(simple.getConversationSteps(), "the real entry keeps filtering");
             assertNotNull(simple.getConversationOutputs());
         }

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/ApiCallsTaskTest.java
@@ -426,13 +426,13 @@ class ApiCallsTaskTest {
      */
     @Test
     void isFailureResult_classifiesByHttpCode() {
-        assertTrue(ApiCallsTask.isFailureResult(java.util.Map.of("httpCode", 400, "body", "boom")));
-        assertTrue(ApiCallsTask.isFailureResult(java.util.Map.of("httpCode", 503)));
-        assertFalse(ApiCallsTask.isFailureResult(java.util.Map.of("httpCode", 200, "body", "ok")));
-        assertFalse(ApiCallsTask.isFailureResult(java.util.Map.of("httpCode", 204)));
+        assertTrue(ApiCallsTask.isFailureResult(Map.of("httpCode", 400, "body", "boom")));
+        assertTrue(ApiCallsTask.isFailureResult(Map.of("httpCode", 503)));
+        assertFalse(ApiCallsTask.isFailureResult(Map.of("httpCode", 200, "body", "ok")));
+        assertFalse(ApiCallsTask.isFailureResult(Map.of("httpCode", 204)));
         // No code is NOT failure: fire-and-forget returns an empty map, and
         // pre-contract results carried no code at all.
-        assertFalse(ApiCallsTask.isFailureResult(java.util.Map.of("body", "legacy")));
-        assertFalse(ApiCallsTask.isFailureResult(java.util.Map.of()));
+        assertFalse(ApiCallsTask.isFailureResult(Map.of("body", "legacy")));
+        assertFalse(ApiCallsTask.isFailureResult(Map.of()));
     }
 }


### PR DESCRIPTION
`ImportStyleTest.noInlineFullyQualifiedNames` (AGENTS.md §4.7) went red on `chore/remove-agent-father` immediately after #690 merged — this restores it. It is the only failing check on #672 right now.

### Offenders

| File | Was | Now |
| --- | --- | --- |
| `Conversation.java` | `java.util.regex.Pattern` written out twice inside `pendingPlaceholderCandidates()` | `ORDINAL_SUFFIX` constant beside the other pending-message constants |
| `ApiCallsTaskTest.java` | `java.util.Map.of(...)` × 6 | `Map.of(...)` (import already present) |
| `ConversationMemoryUtilitiesTest.java` | `java.util.Arrays.asList(...)` | `List.of(...)` |

Hoisting the `Conversation` pattern to a constant also compiles it once at class-init rather than on every resume, so it is a small win beyond the rename.

### No behaviour change

The regex text and the `DOTALL` flag are byte-identical to what they replaced.

### Verification

`ImportStyleTest, ConversationToolResumeTest, ConversationHitlTest, ApiCallsTaskTest, ConversationMemoryUtilitiesTest` — 84 tests, 0 failures, `BUILD SUCCESS`.

### Why CI caught this and I did not

The affected suites were run by name (`-Dtest=...`), and `ImportStyleTest` was not in that list — so a repo-wide enforcement test only ever ran in CI. Style rules are not change-local; they belong in the pre-push check unconditionally rather than in a list inferred from which files were touched.