### PR TITLE
fix(streaming): known client conditions are typed error events, not opaque 500s

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,40 @@
 
 
 
+## 🛡️ fix(streaming): known client conditions are typed error events, not opaque 500s (2026-08-16)
+
+**Repo:** EDDI (`fix/streaming-known-conditions`)
+
+Observed live in the operator flow: sending a message into an `AWAITING_HUMAN` conversation is
+correctly refused by `ConversationService.sayStreaming` (`ConversationAwaitingApprovalException`),
+but `RestAgentEngineStreaming`'s catch-all wrapped it in `logAndBuildOpaqueErrorEvent` — the client
+saw `{"message":"Internal server error","correlationId":…}` and the Manager rendered a dead error
+blob with no way to react. The non-streaming twin (`RestAgentEngine`) has always given this a 409
+with a client-safe body; the streaming path threw that distinction away.
+
+**Change:** `buildKnownConditionOrOpaqueErrorEvent` maps the six conditions `sayStreaming` rejects
+synchronously to `{"message":…,"code":…}` error events — `awaiting_approval`, `conversation_ended`,
+`agent_not_ready`, `agent_mismatch`, `quota_exceeded`, `processing_restricted`. Per exception, the
+message mirrors exactly what the twin already discloses: echoed where the twin echoes (fixed safe
+templates), replaced by the twin's fixed text where the exception message names deployment internals
+(agent-not-ready carries environment+agentId; mismatch carries ids). Everything else stays opaque —
+that path exists because store-layer messages can name collections, hosts and replica-set members.
+Known rejections log at WARN without a stack trace; only genuine internal errors keep the
+ERROR + correlationId treatment.
+
+The `code` field is what the Manager keys on: `awaiting_approval` lets it re-render the approval
+banner instead of an error blob when input races an undecided pause (the Manager-side half is a
+separate fix — its settle-poll treated the resume CAS's persisted `IN_PROGRESS` window as "settled",
+which is what enabled input during a pause in the first place).
+
+**Tests:** 5 new (`KnownConditionErrorEvents`) — typed code+message per condition, the
+non-disclosure property (agent-not-ready must not leak `environment=…`), and the opaque fallback.
+Mutation-verified: reverting the main change fails all 4 typed tests.
+
+---
+
+
+
 ## 🧹 fix(style): hoist inline fully-qualified names out of the operator-audit changes (2026-08-15)
 
 **Repo:** EDDI (`fix/import-style-violations`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,43 @@
 
 
 
+## 🧭 fix(operator): approvals finally read as a flow — settle window, resync, receipt, per-pause banner (2026-08-16)
+
+**Repo:** EDDI-Manager (`fix/operator-resume-settle`, commit `dfb97078`) — documented here because the
+ecosystem changelog lives in this repo; the EDDI half is the entry below.
+
+Live repro (operator "create a test agent … and chat with it"): approving setupAgent re-rendered the
+byte-identical ask, the approval controls vanished, the next pause never appeared, and typing into the
+still-paused conversation printed a raw `{"message":"Internal server error"}` blob. Four defects:
+
+1. **The settle poll read the resume CAS window as "settled".** Accepting a resume persists
+   `AWAITING_HUMAN→IN_PROGRESS` immediately (`ConversationHitlService`'s claim CAS); the outcome
+   persists only in `onComplete`. So 1.5s after approving, `pollUntilSettled` saw "not AWAITING_HUMAN"
+   with PRE-decision outputs — old ask duplicated as "the answer", `isPaused` cleared, pause 2
+   invisible. `IN_PROGRESS` now keeps polling; only terminal states or a NEW `hitlPausedAt` settle.
+2. **A paused-conversation send rejected over the open stream rendered raw JSON.** On the backend's
+   new `awaiting_approval` code the chat re-syncs the pause (drops the unsent bubbles, restores the
+   banner, back-fills the ask); other error events render their `message`, never the envelope.
+3. **Approved work was invisible.** The model often goes from an approved call straight into its next
+   tool call with no text between, so "You approved" → next ask showed the created agent nowhere. A
+   receipt ("Ran setupAgent ✓") now lands after the decision, diffed against a pre-decision baseline
+   of the step's executed `httpCalls` (`<name>Request` marks execution, `<name>_response` merges only
+   on success). New `operator.decisionLog.executed` key in all 11 locales.
+4. **The banner showed the PREVIOUS pause's calls.** `useApprovalStatus` was keyed on conversation id
+   alone, and — verified live — `removeQueries` after deciding produces no refetch on an
+   actively-observed query. The key now includes the pause's `hitlPausedAt`; operator page, drawer and
+   conversation-detail pass it.
+
+**Verified end-to-end against the running deployment:** approve startConversation → 4 polls ride the
+IN_PROGRESS window → "You approved this request" → "Ran startConversation ✓" → the `say` ask
+("approval 3 this turn") with a fresh 0-of-1 banner → approve → final answer "✅ Agent created,
+deployed, and verified working" with the test agent's actual in-character reply. 8 new tests, each
+mutation-verified; full suite 5365 green.
+
+---
+
+
+
 ## 🛡️ fix(streaming): known client conditions are typed error events, not opaque 500s (2026-08-16)
 
 **Repo:** EDDI (`fix/streaming-known-conditions`)

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -6,7 +6,9 @@ package ai.labs.eddi.engine.internal;
 
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IRestAgentEngineStreaming;
+import ai.labs.eddi.engine.gdpr.ProcessingRestrictedException;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 
 import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
@@ -220,9 +222,65 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
                     });
         } catch (Exception e) {
             stream.markTerminal();
-            stream.send("error", logAndBuildOpaqueErrorEvent("Failed to start streaming for conversation " + safeConversationId, e));
+            stream.send("error", buildKnownConditionOrOpaqueErrorEvent(
+                    "Failed to start streaming for conversation " + safeConversationId, e));
             stream.close();
         }
+    }
+
+    /**
+     * Maps the known client conditions {@code sayStreaming} rejects synchronously
+     * to a typed {@code error} event — {@code {"message":…,"code":…}} — instead of
+     * the opaque internal-error shape.
+     * <p>
+     * These are not internal errors: the non-streaming twin
+     * ({@code RestAgentEngine}) gives each a proper status (409/410/404/429/403)
+     * with a client-safe body, and before this method the SAME condition on the
+     * streaming path surfaced as {@code {"message":"Internal server error"}} —
+     * observed live when a message was sent into an AWAITING_HUMAN conversation:
+     * the backend refused correctly and the client rendered an opaque 500-style
+     * blob with no way to react.
+     * <p>
+     * Per exception, the message mirrors exactly what the twin already discloses —
+     * echoed for the conditions whose message is a fixed safe template
+     * (awaiting-approval, quota, GDPR restriction), replaced by the twin's fixed
+     * text for those whose message names deployment internals (agent-not-ready
+     * carries environment and agentId; mismatch carries ids). No new disclosure
+     * either way. Everything else stays opaque via
+     * {@link #logAndBuildOpaqueErrorEvent}: those paths' messages can name
+     * collections, hosts and replica-set members.
+     * <p>
+     * The {@code code} field is the machine-readable part clients key on —
+     * {@code awaiting_approval} is what lets the Manager re-render the approval
+     * banner instead of an error blob when input races an undecided pause.
+     */
+    private String buildKnownConditionOrOpaqueErrorEvent(String context, Exception e) {
+        String code;
+        String message;
+        if (e instanceof IConversationService.ConversationAwaitingApprovalException) {
+            code = "awaiting_approval";
+            message = e.getMessage();
+        } else if (e instanceof IConversationService.ConversationEndedException) {
+            code = "conversation_ended";
+            message = "Conversation has ended";
+        } else if (e instanceof IConversationService.AgentNotReadyException) {
+            code = "agent_not_ready";
+            message = "Agent is not deployed or not ready";
+        } else if (e instanceof IConversationService.AgentMismatchException) {
+            code = "agent_mismatch";
+            message = "Agent version mismatch";
+        } else if (e instanceof QuotaExceededException) {
+            code = "quota_exceeded";
+            message = e.getMessage();
+        } else if (e instanceof ProcessingRestrictedException) {
+            code = "processing_restricted";
+            message = e.getMessage();
+        } else {
+            return logAndBuildOpaqueErrorEvent(context, e);
+        }
+        // WARN, not ERROR with stack trace: the request was rejected by design.
+        LOGGER.warnf("%s: %s", context, e.getMessage());
+        return String.format("{\"message\":\"%s\",\"code\":\"%s\"}", escapeJson(message), code);
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
@@ -591,4 +591,106 @@ class RestAgentEngineStreamingTest {
             return out.toString();
         }
     }
+
+    /**
+     * The known client conditions {@code ConversationService.sayStreaming} rejects
+     * synchronously must surface as TYPED error events —
+     * {@code {"message":…,"code":…}} — not the opaque internal-error shape.
+     * Observed live: input sent into an AWAITING_HUMAN conversation was refused
+     * correctly by the backend but reached the client as
+     * {@code {"message":"Internal server error"}}, which the Manager rendered as a
+     * dead error blob instead of re-showing the approval banner.
+     */
+    @Nested
+    @DisplayName("sayStreaming known client conditions (typed error events)")
+    class KnownConditionErrorEvents {
+
+        private SseEventSink eventSink;
+        private Sse sse;
+        private OutboundSseEvent.Builder eventBuilder;
+        private ArgumentCaptor<String> payloads;
+
+        @BeforeEach
+        void wireSse() {
+            eventSink = mock(SseEventSink.class);
+            sse = mock(Sse.class);
+            eventBuilder = mock(OutboundSseEvent.Builder.class);
+            var sseEvent = mock(OutboundSseEvent.class);
+            payloads = ArgumentCaptor.forClass(String.class);
+            when(eventSink.isClosed()).thenReturn(false);
+            when(sse.newEventBuilder()).thenReturn(eventBuilder);
+            when(eventBuilder.name(anyString())).thenReturn(eventBuilder);
+            when(eventBuilder.data(any(Class.class), payloads.capture())).thenReturn(eventBuilder);
+            when(eventBuilder.build()).thenReturn(sseEvent);
+        }
+
+        private String errorPayloadFor(Exception thrown) throws Exception {
+            doThrow(thrown).when(conversationService)
+                    .sayStreaming(anyString(), any(), any(), any(), any(), any());
+            var inputData = new InputData();
+            inputData.setInput("Hello");
+            streaming.sayStreaming("conv-1", false, false, List.of(), inputData, eventSink, sse);
+            verify(eventBuilder, atLeastOnce()).name("error");
+            return payloads.getValue();
+        }
+
+        @Test
+        @DisplayName("awaiting approval → code=awaiting_approval with the twin's 409 message")
+        void awaitingApprovalIsTyped() throws Exception {
+            String message = "Conversation is awaiting human approval — a reviewer must resolve it via"
+                    + " POST /agents/conv-1/resume (or cancel) before new input is accepted";
+            String payload = errorPayloadFor(
+                    new IConversationService.ConversationAwaitingApprovalException(message));
+
+            assertTrue(payload.contains("\"code\":\"awaiting_approval\""), payload);
+            assertTrue(payload.contains("awaiting human approval"), payload);
+            assertFalse(payload.contains("Internal server error"), payload);
+        }
+
+        @Test
+        @DisplayName("conversation ended → code=conversation_ended")
+        void conversationEndedIsTyped() throws Exception {
+            String payload = errorPayloadFor(
+                    new IConversationService.ConversationEndedException("Conversation has ended!"));
+
+            assertTrue(payload.contains("\"code\":\"conversation_ended\""), payload);
+            assertFalse(payload.contains("Internal server error"), payload);
+        }
+
+        @Test
+        @DisplayName("agent not ready → fixed text, NOT the message naming environment and agentId")
+        void agentNotReadyDisclosesNothing() throws Exception {
+            String payload = errorPayloadFor(new IConversationService.AgentNotReadyException(
+                    "Agent not deployed (environment=restricted, conversationId=conv-1, version=7)"));
+
+            assertTrue(payload.contains("\"code\":\"agent_not_ready\""), payload);
+            assertTrue(payload.contains("Agent is not deployed or not ready"), payload);
+            // The exception's own message mirrors what the non-streaming twin
+            // withholds behind a bare 404 — it must not leak here either.
+            assertFalse(payload.contains("environment=restricted"), payload);
+        }
+
+        @Test
+        @DisplayName("agent mismatch → the twin's fixed 409 text, not the id-bearing message")
+        void agentMismatchUsesFixedText() throws Exception {
+            String payload = errorPayloadFor(new IConversationService.AgentMismatchException(
+                    "Supplied agentId (agent-7) is incompatible with conversationId (conv-1)"));
+
+            assertTrue(payload.contains("\"code\":\"agent_mismatch\""), payload);
+            assertTrue(payload.contains("Agent version mismatch"), payload);
+            assertFalse(payload.contains("agent-7"), payload);
+        }
+
+        @Test
+        @DisplayName("anything else stays opaque: fixed message + correlationId, no code")
+        void unknownExceptionsStayOpaque() throws Exception {
+            String payload = errorPayloadFor(
+                    new RuntimeException("mongodb://replica-set-member:27017 unreachable"));
+
+            assertTrue(payload.contains("Internal server error"), payload);
+            assertTrue(payload.contains("correlationId"), payload);
+            assertFalse(payload.contains("\"code\""), payload);
+            assertFalse(payload.contains("mongodb://"), payload);
+        }
+    }
 }


### PR DESCRIPTION
Observed live in the operator flow: sending a message into an `AWAITING_HUMAN` conversation is correctly refused by `ConversationService.sayStreaming` (`ConversationAwaitingApprovalException`), but the streaming REST layer''s catch-all wrapped the rejection in the opaque internal-error event — the client saw `{"message":"Internal server error","correlationId":…}` and rendered a dead error blob over a live approval. The non-streaming twin (`RestAgentEngine`) has always mapped the same condition to a 409 with a client-safe body.

### Change

`buildKnownConditionOrOpaqueErrorEvent` maps the six conditions `sayStreaming` rejects synchronously to typed `{"message":…,"code":…}` error events:

| Exception | code | message |
| --- | --- | --- |
| `ConversationAwaitingApprovalException` | `awaiting_approval` | echoed (fixed safe template, same as the twin''s 409 body) |
| `ConversationEndedException` | `conversation_ended` | fixed text (twin: 410) |
| `AgentNotReadyException` | `agent_not_ready` | **twin''s fixed 404 text** — the exception message names environment+agentId and is withheld, matching the twin |
| `AgentMismatchException` | `agent_mismatch` | **twin''s fixed 409 text** — ids withheld |
| `QuotaExceededException` | `quota_exceeded` | echoed (twin: 429) |
| `ProcessingRestrictedException` | `processing_restricted` | echoed (twin: 403) |

Everything else stays opaque with a correlationId — that path exists because store-layer messages can name collections, hosts and replica-set members. Known rejections log at WARN without a stack trace.

The `code` field is what the Manager keys on: `awaiting_approval` lets it re-render the approval banner instead of an error blob when input races an undecided pause (Manager half: labsai/EDDI-Manager `fix/operator-resume-settle`).

### Verification

New `KnownConditionErrorEvents` suite (5 tests): typed code+message per condition, the non-disclosure property (`environment=…` must not leak), and the opaque fallback. **Mutation-verified**: reverting the main change fails all four typed tests. Ran with `ImportStyleTest` + both streaming suites — 45 tests, `BUILD SUCCESS`.

Note for reviewers: PRs into `chore/remove-agent-father` never run `Build & Test` (ci.yml triggers only on PRs into `main`), so the local run above is the compile/test gate; the umbrella PR #672 re-verifies after merge.