### PR TITLE
fix(streaming): done events carry the pause identity — hitlPausedAt

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,44 @@
 
 
 
+## 🆔 fix(streaming): done events carry the pause identity — hitlPausedAt (2026-08-16)
+
+**Repo:** EDDI (`fix/done-event-pause-identity`) + EDDI-Manager (`fix/operator-resume-settle`,
+commit `33b1ebe8`).
+
+Second live round on the operator flow: approving STILL stalled ("the Approve button only works
+after a weird timeout"), and the streamed message explaining what the approval was about vanished
+when the card appeared. Root cause of the stall: `RestAgentEngineStreaming.toJson` hand-builds the
+`done` payload with only `conversationState` + `conversationOutputs` — **no `hitlPausedAt`** — so a
+STREAMED pause reached the Manager identityless (`decidedPausedAt: null`), and the settle-poll's
+conservative null-fallback read every re-pause as "the pause we decided", spinning the full 90s
+with the next batch's Approve disabled (`isResolvingPause` still true). The earlier E2E validation
+missed it because it hydrated the conversation over REST — which does carry the timestamp.
+
+**EDDI:** the done payload now includes `hitlPausedAt` as `Instant.toString()` — ISO_INSTANT, the
+same formatter Jackson's `InstantSerializer` uses for the REST snapshot (null formatter →
+`value.toString()`), so cross-channel string comparison is sound byte-for-byte. Two tests, one
+mutation-verified.
+
+**Manager (`33b1ebe8`):** three fixes. (1) `resolveApproval`'s pre-resume baseline read now doubles
+as identity recovery — it adopts the REST snapshot's `hitlPausedAt` (locally, not into the store,
+which would flip the banner's query key mid-decide), making the poll comparison
+REST-serializer-vs-REST-serializer and fixing the stall against OLD backends too. (2) Streamed
+interim commentary is kept when the turn pauses, with the pending ask appended as its own bubble —
+snapping the bubble to the pending text destroyed the one message that explained the approval.
+(3) Two poll ceilings: an observably-`IN_PROGRESS` turn earns 300s (chained model calls + tools run
+minutes; the streaming backstop alone is 120s/call); 90s stays the cap for a decision never acted
+on. 3 new tests + 1 rewritten (it pinned the snap-to-pending behaviour), each mutation-verified.
+
+Also triaged from the same session: the `/agentstore/agents/{id}/currentversion` 404s in the console
+are gate-status refetches for a DELETED operator agent from a still-open old tab — noise, not a
+defect in this flow. The "message channel closed" uncaught rejection is a browser-extension
+artifact.
+
+---
+
+
+
 ## 🧭 fix(operator): approvals finally read as a flow — settle window, resync, receipt, per-pause banner (2026-08-16)
 
 **Repo:** EDDI-Manager (`fix/operator-resume-settle`, commit `dfb97078`) — documented here because the

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -515,6 +515,20 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
         try {
             var sb = new StringBuilder("{");
             sb.append("\"conversationState\":\"").append(snapshot.getConversationState()).append("\"");
+            // The pause's IDENTITY, not just its existence. A turn may pause up
+            // to maxPausesPerTurn times, and hitlPausedAt is the only field
+            // that distinguishes one pause from the next — clients compare it
+            // to decide whether a decision has been acted on and to key their
+            // approval-detail caches. Omitting it here (while the REST snapshot
+            // carried it) left streamed pauses identityless: the Manager's
+            // settle-poll then read every re-pause as the pause it had already
+            // decided and spun to its timeout with the Approve button dead.
+            // Instant.toString() is ISO_INSTANT — the same formatter Jackson's
+            // JavaTimeModule uses for the REST snapshot, so the two channels
+            // stay byte-identical and string comparison across them is sound.
+            if (snapshot.getHitlPausedAt() != null) {
+                sb.append(",\"hitlPausedAt\":\"").append(snapshot.getHitlPausedAt()).append("\"");
+            }
             if (snapshot.getConversationOutputs() != null) {
                 sb.append(",\"conversationOutputs\":")
                         .append(MAPPER.writeValueAsString(snapshot.getConversationOutputs()));

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
@@ -26,6 +26,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -139,6 +140,42 @@ class RestAgentEngineStreamingTest {
             String json = (String) method.invoke(streaming, snapshot);
 
             assertTrue(json.contains("conversationOutputs"));
+        }
+
+        @Test
+        @DisplayName("carries the pause identity: hitlPausedAt as the ISO instant, verbatim")
+        void includesPauseIdentity() throws Exception {
+            // hitlPausedAt is the only field distinguishing one pause of a turn
+            // from the next. The done event omitting it left streamed pauses
+            // identityless: the Manager's settle-poll read every re-pause as
+            // the pause it had already decided and spun to its timeout with
+            // the Approve button dead. The value must be the same ISO_INSTANT
+            // string the REST snapshot serializes, so cross-channel string
+            // comparison stays sound.
+            Method method = RestAgentEngineStreaming.class.getDeclaredMethod("toJson", SimpleConversationMemorySnapshot.class);
+            method.setAccessible(true);
+
+            var snapshot = new SimpleConversationMemorySnapshot();
+            snapshot.setConversationState(ConversationState.AWAITING_HUMAN);
+            snapshot.setHitlPausedAt(Instant.parse("2026-08-16T00:05:41.984599700Z"));
+
+            String json = (String) method.invoke(streaming, snapshot);
+
+            assertTrue(json.contains("\"hitlPausedAt\":\"2026-08-16T00:05:41.984599700Z\""), json);
+        }
+
+        @Test
+        @DisplayName("omits hitlPausedAt when the conversation is not paused")
+        void omitsPauseIdentityWhenAbsent() throws Exception {
+            Method method = RestAgentEngineStreaming.class.getDeclaredMethod("toJson", SimpleConversationMemorySnapshot.class);
+            method.setAccessible(true);
+
+            var snapshot = new SimpleConversationMemorySnapshot();
+            snapshot.setConversationState(ConversationState.READY);
+
+            String json = (String) method.invoke(streaming, snapshot);
+
+            assertFalse(json.contains("hitlPausedAt"), json);
         }
     }
 


### PR DESCRIPTION
`hitlPausedAt` is the only field distinguishing one pause of a turn from the next, and the streamed `done` payload — hand-built JSON with just `conversationState` + `conversationOutputs` — never carried it. A **streamed** pause therefore reached clients identityless: the Manager''s settle-poll read every re-pause as the pause it had already decided and spun to its full timeout with the Approve button dead. Observed live ("the Approve button only works after a weird timeout"); the earlier E2E missed it because REST hydration does carry the timestamp.

### Change

`toJson` appends `"hitlPausedAt":"<ISO>"` when the conversation is paused, via `Instant.toString()` — ISO_INSTANT, the same output Jackson''s `InstantSerializer` produces for the REST snapshot (null formatter → `value.toString()`), so cross-channel string comparison stays byte-identical. Omitted when not paused, as before.

The Manager half (identity recovery from the pre-resume baseline read, so old backends are covered too) is labsai/EDDI-Manager `fix/operator-resume-settle`.

### Verification

2 new tests (identity verbatim incl. nanosecond precision; absent when not paused), mutation-verified. Ran with `ImportStyleTest` + both streaming suites — 47 tests, `BUILD SUCCESS`. As with #691/#692: PRs into this base run no `Build & Test` (ci.yml triggers only on `main`), so the local run is the gate and #672 re-verifies after merge.