### PR TITLE
fix(hitl): a tool pause keeps the model's own explanation of what it is about to do

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,67 @@
 
 
 
+## 💬 fix(hitl): a tool pause keeps the model's own explanation of what it is about to do (2026-08-16)
+
+**Repo:** EDDI (`fix/pause-keeps-interim-text`) + EDDI-Manager (`fix/operator-resume-settle`, follow-up
+commit).
+
+Third live round on the operator flow: "the confirmation message got removed — this time when the
+second approval came in, it was visible on the first though." Root cause is structural, not a UI
+slip: a tool pause aborts the turn BEFORE the output tasks run, so the only text the paused step
+carried was the pending-approval placeholder. The model's own narration in the very message that
+carried the gated calls ("config checks out — I'll now start a test conversation, which needs your
+approval") was dropped on the floor. On a STREAMED turn the client had already shown it live (and
+the previous Manager fix kept it on screen — hence "visible on the first"); on a RESUMED turn — which
+is not streamed — it never existed anywhere the user could see, so the second approval arrived with
+no explanation at all. And a reload lost it on both.
+
+**EDDI:** `PendingToolCallBatch` gains `interimText` — the trailing `AiMessage`'s text at gate time,
+redacted with the same filter as the call arguments (it is model output over tool results, so an
+echoed secret is possible) and capped at 2000 chars. `ToolApprovalGateSupport.buildPendingBatch`
+derives it from `currentMessages` (no signature change); `Conversation.pauseConversation` writes it
+AHEAD of the placeholder, so the paused step's output is `[narration, ask]`. The resume-side
+placeholder drop was made surgical: it removes only the placeholder from both the output list and
+its `Data` twin (the old twin logic blanked the whole entry when it equalled `[placeholder]`, which
+would now have thrown away the narration). Null on legacy batches and on bare tool calls → old
+behaviour. Excluded from the names-only REST projection like the other batch internals — it is
+already in the step's public output where it belongs.
+
+**Manager:** the streamed pause path treats the done snapshot as `[narration?, ask]` — the ask is
+always the last part. It keeps the streamed bubble (which IS the narration, so it is never rendered
+twice from the snapshot), back-fills the bubble from the snapshot when nothing was streamed, and
+appends the ask as its own bubble. Resume/hydrate already render one bubble per part, so
+`[narration, ask]` reads correctly there with no change; the error-event resync back-fills the ask
+only.
+
+**Also in the same Manager follow-up (round-3 findings):**
+- The second pause's banner stuck on "Loading approval details…": the operator page's post-decision
+  `removeQueries(["approval-status", id])` — the pre-per-pause-key remedy — matches by prefix, so it
+  `destroy()`ed the NEXT pause's freshly-launched query out from under its mounted observer, which
+  then rendered `isLoading` forever with no data. The per-pause key already guarantees the fresh
+  fetch; the removal is gone.
+- The "Running the approved step…" row moved BELOW the approval block: it narrates the consequence
+  of the decision just made, so it belongs where the eye lands after clicking Approve.
+- Reload-safety: a reload while an approved step was executing hydrated as read-only "This
+  conversation is finished" and stayed there until the admin reloaded again. `hydrate` and
+  `selectConversation` now follow an `IN_PROGRESS` conversation through — poll with the shared settle
+  predicate (a new `NO_DECIDED_PAUSE` sentinel: for a reload ANY pause is a settle, unlike the
+  decision path's conservative `null`), then re-hydrate — so the answer or the next card appears as
+  it would have without the reload. Supersession (a reset, a newer pick, a re-pick of the same id)
+  is checked with the same "is this still my controller?" rule the other loaders use.
+
+**Tests (EDDI):** pause writes `[narration, ask]`; APPROVED resume keeps the narration and strips
+only the placeholder from list AND Data twin; `interimTextOf` unit suite (trailing-AI text, bare
+call → null, non-AI tail → null, redaction, cap). Both Conversation behaviours mutation-verified.
+**Tests (Manager):** narration dedup vs streamed text, snapshot back-fill when nothing streamed,
+IN_PROGRESS follow-through, follow-through yields to a newer pick AND to a same-id re-pick (the
+latter is what makes the controller clause load-bearing — verified by mutation), each mutation-
+verified where the mechanism allowed. Full suite 5375 green.
+
+---
+
+
+
 ## 🆔 fix(streaming): done events carry the pause identity — hitlPausedAt (2026-08-16)
 
 **Repo:** EDDI (`fix/done-event-pause-identity`) + EDDI-Manager (`fix/operator-resume-settle`,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -60,9 +60,23 @@ only.
 bare `storeData`), so a multi-pause turn kept only the latest explanation in the detailed step view
 while the output list kept them all — two channels disagreeing, the exact class of bug the surgical
 drop exists to prevent, and retrospectively "what was going on" would have been missing its first
-half. The twin now accumulates like the list. Pinned by a two-pause end-to-end test asserting
-`[expl1, expl2, answer]` on BOTH channels at each stage; mutation-verified (replace-instead-of-
-accumulate loses `expl1` at exactly that assertion).
+half. The twin now accumulates like the list. Pinned by a two-pause end-to-end test asserting the
+paused shapes (`[expl1, ask1]` then `[expl1, expl2, ask2]`) on BOTH channels, and the final record —
+output list `[expl1, expl2, answer]`, Data twin `[expl1, expl2]` (LlmTask writes the answer to the
+list only); mutation-verified (replace-instead-of-accumulate loses `expl1` at exactly that
+assertion).
+
+**Copilot findings on the PR, all addressed:** (1) the surgical drop removed the FIRST match on the
+list (`List.remove(value)`) and every match on the Data twin — on a mixed list a piece of narration
+that happened to equal a candidate string could be deleted or the real trailing placeholder left
+stranded; both channels now remove the LAST candidate occurrence, matched on `String` identity, and
+an adversarial test (narration byte-equal to the legacy candidate) pins it — mutation-verified,
+first-occurrence fails it. (2) The 2000-char cap was exceeded by the appended ellipsis; the ellipsis
+now counts against it. (3) A javadoc named a constant that does not exist. (4) The stale "resumed
+step renders ONLY the final answer" method-level contract on the drop, rewritten. (5) The new field
+is now asserted in `PendingToolCallBatchSnapshotTest` (round-trips) and, with a canary, in
+`ConversationMemoryUtilitiesHitlTest` (absent from the names-only projection) — the two paths a
+reload depends on.
 
 **Tests (EDDI):** pause writes `[narration, ask]`; APPROVED resume keeps the narration and strips
 only the placeholder from list AND Data twin; two-pause turn keeps every explanation on both channels; `interimTextOf` unit suite (trailing-AI text, bare

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -56,8 +56,16 @@ only.
   it would have without the reload. Supersession (a reset, a newer pick, a re-pick of the same id)
   is checked with the same "is this still my controller?" rule the other loaders use.
 
+**Review-round finding (own):** the pause writer REPLACED the output `Data` twin on each pause (a
+bare `storeData`), so a multi-pause turn kept only the latest explanation in the detailed step view
+while the output list kept them all — two channels disagreeing, the exact class of bug the surgical
+drop exists to prevent, and retrospectively "what was going on" would have been missing its first
+half. The twin now accumulates like the list. Pinned by a two-pause end-to-end test asserting
+`[expl1, expl2, answer]` on BOTH channels at each stage; mutation-verified (replace-instead-of-
+accumulate loses `expl1` at exactly that assertion).
+
 **Tests (EDDI):** pause writes `[narration, ask]`; APPROVED resume keeps the narration and strips
-only the placeholder from list AND Data twin; `interimTextOf` unit suite (trailing-AI text, bare
+only the placeholder from list AND Data twin; two-pause turn keeps every explanation on both channels; `interimTextOf` unit suite (trailing-AI text, bare
 call → null, non-AI tail → null, redaction, cap). Both Conversation behaviours mutation-verified.
 **Tests (Manager):** narration dedup vs streamed text, snapshot back-fill when nothing streamed,
 IN_PROGRESS follow-through, follow-through yields to a newer pick AND to a same-id re-pick (the

--- a/src/main/java/ai/labs/eddi/engine/memory/model/PendingToolCallBatch.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/model/PendingToolCallBatch.java
@@ -306,12 +306,13 @@ public class PendingToolCallBatch {
      * <p>
      * Redacted with the same filter as the call arguments: it is model output over
      * tool results, so a secret that reached the model can be echoed here. Capped
-     * ({@code Conversation.MAX_INTERIM_TEXT_CHARS}) — it is a sentence or two by
-     * nature, and the whole batch is persisted with the pause. Null when the
-     * assistant message had no text, and on every batch persisted before this field
-     * existed — readers treat null as "nothing to show", the old behaviour.
-     * Excluded from the names-only projection like {@link #effectiveToolApprovals}
-     * — it is already in the step's public output where it belongs.
+     * at 2000 chars ({@code ToolApprovalGateSupport.INTERIM_TEXT_MAX_CHARS},
+     * ellipsis included) — it is a sentence or two by nature, and the whole batch
+     * is persisted with the pause. Null when the assistant message had no text, and
+     * on every batch persisted before this field existed — readers treat null as
+     * "nothing to show", the old behaviour. Excluded from the names-only projection
+     * like {@link #effectiveToolApprovals} — it is already in the step's public
+     * output where it belongs.
      */
     private String interimText;
 

--- a/src/main/java/ai/labs/eddi/engine/memory/model/PendingToolCallBatch.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/model/PendingToolCallBatch.java
@@ -290,6 +290,30 @@ public class PendingToolCallBatch {
      * persisted before this field existed does.
      */
     private ToolApprovalsConfig.ApprovalRule effectiveRule;
+    /**
+     * What the model SAID in the assistant message that carried the gated tool
+     * calls — its narration of what it is about to do — redacted and capped.
+     * <p>
+     * A tool pause aborts the turn before the output tasks run, so the only text
+     * the paused step used to carry was the pending-approval placeholder; the
+     * model's own "the config checks out, I'll now start a test conversation, which
+     * needs your approval" was dropped on the floor. On a streamed turn the client
+     * had already shown it live; on a RESUMED turn (which is not streamed) it never
+     * existed anywhere the user could see — the second approval of a turn arrived
+     * with no explanation at all, which is how it was reported.
+     * {@code Conversation.pauseConversation} writes this ahead of the placeholder,
+     * so both channels — and a reload — show what the approval is about.
+     * <p>
+     * Redacted with the same filter as the call arguments: it is model output over
+     * tool results, so a secret that reached the model can be echoed here. Capped
+     * ({@code Conversation.MAX_INTERIM_TEXT_CHARS}) — it is a sentence or two by
+     * nature, and the whole batch is persisted with the pause. Null when the
+     * assistant message had no text, and on every batch persisted before this field
+     * existed — readers treat null as "nothing to show", the old behaviour.
+     * Excluded from the names-only projection like {@link #effectiveToolApprovals}
+     * — it is already in the step's public output where it belongs.
+     */
+    private String interimText;
 
     public String getPauseEpoch() {
         return pauseEpoch;
@@ -401,6 +425,14 @@ public class PendingToolCallBatch {
 
     public void setPauseCountThisTurn(int pauseCountThisTurn) {
         this.pauseCountThisTurn = pauseCountThisTurn;
+    }
+
+    public String getInterimText() {
+        return interimText;
+    }
+
+    public void setInterimText(String interimText) {
+        this.interimText = interimText;
     }
 
     public ToolApprovalsConfig getEffectiveToolApprovals() {

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -961,55 +961,65 @@ public class Conversation implements IConversation {
 
     /**
      * Removes the pending-approval placeholder that {@link #pauseConversation}
-     * added to the current step on a TOOL_CALL pause, so the resumed step renders
-     * ONLY the final answer.
+     * added to the current step on a TOOL_CALL pause — and ONLY the placeholder, so
+     * the resumed step keeps everything the model said it was doing (the interim
+     * narration written ahead of the placeholder, and every earlier pause's
+     * narration in a multi-pause turn) and gains the final answer.
      * <p>
-     * Robust identification without dropping legitimate earlier output: the
-     * placeholder is the exact string produced by {@link #resolvePendingMessage},
-     * which is deterministic from the still-present pending batch (its effective
-     * tool-approvals config and gated call names survive on memory until LlmTask
-     * consumes them). We recompute that string and remove ONLY that value from the
-     * {@code "output"} conversation-output list — an earlier task's output in a
-     * multi-task step (e.g. {@code [earlierOutput, placeholder]}) keeps its entry.
-     * <p>
-     * We also blank the mirror public step-{@code Data<>} that pauseConversation
-     * stored under the bare {@code "output"} key (surfaced in detailed step-data
-     * snapshots via {@code startsWith("output")}) when it still holds exactly the
-     * placeholder — otherwise a client reading the detailed view would see the
-     * stale placeholder a second time. We overwrite that EXACT key with an empty
-     * list (not {@code removeData}, whose {@code startsWith} semantics would also
-     * wipe an earlier task's {@code output:text:*} data in a multi-task step) and
-     * only when it is untouched (equals {@code [placeholder]}); if some other
-     * writer replaced it we leave it alone.
+     * Identification: the placeholder is the exact string produced by
+     * {@link #resolvePendingMessage} (or a previous build's rendering — see
+     * {@link #pendingPlaceholderCandidates}), deterministic from the still-present
+     * pending batch. It is always the TRAILING element the latest pause appended,
+     * so the LAST occurrence of a candidate is the one removed — never the first,
+     * which on a mixed list could be an earlier output or a piece of narration that
+     * happens to equal a candidate string. Applied identically to both channels:
+     * the {@code "output"} conversation-output list and its mirror public
+     * step-{@code Data<>} under the bare {@code "output"} key (surfaced in detailed
+     * step-data snapshots via {@code startsWith("output")}). The Data twin is
+     * overwritten with the stripped list on that EXACT key — not
+     * {@code removeData}, whose {@code startsWith} semantics would also wipe an
+     * earlier task's {@code output:text:*} data in a multi-task step.
      */
     private void dropPendingApprovalPlaceholder(IWritableConversationStep currentStep) {
-        // ALL renderings this or a previous build may have written for this batch
-        // — see pendingPlaceholderCandidates. At most one of them is actually in
-        // the list (each pause writes exactly one placeholder), so removing every
-        // candidate removes exactly the placeholder and cannot touch legitimate
-        // output: a candidate that was never written simply no-ops.
         List<String> candidates = pendingPlaceholderCandidates(conversationMemory);
-        for (String pending : candidates) {
-            currentStep.removeConversationOutputListItem(MemoryKeys.OUTPUT_PREFIX, pending);
+
+        // Output list: drop the LAST candidate occurrence only.
+        Object rawList = currentStep.getConversationOutput().get(MemoryKeys.OUTPUT_PREFIX);
+        if (rawList instanceof List<?> outputList) {
+            int idx = lastCandidateIndex(outputList, candidates);
+            if (idx >= 0) {
+                outputList.remove(idx);
+            }
         }
 
-        // The Data twin of the output entry: strip the placeholder from it too, and
-        // ONLY the placeholder — the interim narration written ahead of it (see
-        // pauseConversation) is legitimate output that must survive the resume,
-        // exactly as it does in the conversationOutput list above.
+        // Data twin: same rule, written back on the exact key.
         IData<?> outputData = currentStep.getData(MemoryKeys.OUTPUT_PREFIX);
-        if (outputData != null && outputData.getResult() instanceof List<?> stored
-                && stored.stream().anyMatch(candidates::contains)) {
-            var kept = new ArrayList<Object>();
-            for (Object item : stored) {
-                if (!candidates.contains(item)) {
-                    kept.add(item);
-                }
+        if (outputData != null && outputData.getResult() instanceof List<?> stored) {
+            int idx = lastCandidateIndex(stored, candidates);
+            if (idx >= 0) {
+                var kept = new ArrayList<Object>(stored);
+                kept.remove(idx);
+                var stripped = new Data<>(MemoryKeys.OUTPUT_PREFIX, kept);
+                stripped.setPublic(true);
+                currentStep.storeData(stripped);
             }
-            var stripped = new Data<>(MemoryKeys.OUTPUT_PREFIX, kept);
-            stripped.setPublic(true);
-            currentStep.storeData(stripped);
         }
+    }
+
+    /**
+     * Index of the last element that IS one of the candidate strings, or -1. Object
+     * equality on purpose: the placeholder is stored as a plain String, and a
+     * rendered {@code TextOutputItem} whose text merely reads the same must not be
+     * mistaken for it.
+     */
+    private static int lastCandidateIndex(List<?> items, List<String> candidates) {
+        for (int i = items.size() - 1; i >= 0; i--) {
+            Object item = items.get(i);
+            if (item instanceof String text && candidates.contains(text)) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -768,10 +768,21 @@ public class Conversation implements IConversation {
             // templating tasks run, so without this the chat client renders NOTHING
             // for the paused turn. Mirror the REJECTED path's Data/output pattern.
             String pending = resolvePendingMessage(conversationMemory);
-            var pendingData = new Data<>(MemoryKeys.OUTPUT_PREFIX, List.of(pending));
+            // The model's own narration of what it is about to do goes AHEAD of the
+            // placeholder — see PendingToolCallBatch#interimText. Without it a resumed
+            // (non-streamed) turn's second approval arrived with no explanation at all,
+            // and even a streamed one lost the explanation on reload.
+            var outputs = new ArrayList<String>(2);
+            var batch = conversationMemory.getHitlPendingToolCalls();
+            String interim = batch != null ? batch.getInterimText() : null;
+            if (interim != null && !interim.isBlank() && !interim.equals(pending)) {
+                outputs.add(interim);
+            }
+            outputs.add(pending);
+            var pendingData = new Data<>(MemoryKeys.OUTPUT_PREFIX, List.copyOf(outputs));
             pendingData.setPublic(true);
             conversationMemory.getCurrentStep().storeData(pendingData);
-            conversationMemory.getCurrentStep().addConversationOutputList(MemoryKeys.OUTPUT_PREFIX, List.of(pending));
+            conversationMemory.getCurrentStep().addConversationOutputList(MemoryKeys.OUTPUT_PREFIX, List.copyOf(outputs));
         } else {
             // A RULE pause must never carry a stale tool batch (e.g. the gate tripped
             // earlier in the same turn on a path that recovered) — belt and braces.
@@ -967,11 +978,22 @@ public class Conversation implements IConversation {
             currentStep.removeConversationOutputListItem(MemoryKeys.OUTPUT_PREFIX, pending);
         }
 
+        // The Data twin of the output entry: strip the placeholder from it too, and
+        // ONLY the placeholder — the interim narration written ahead of it (see
+        // pauseConversation) is legitimate output that must survive the resume,
+        // exactly as it does in the conversationOutput list above.
         IData<?> outputData = currentStep.getData(MemoryKeys.OUTPUT_PREFIX);
-        if (outputData != null && candidates.stream().anyMatch(p -> List.of(p).equals(outputData.getResult()))) {
-            var blanked = new Data<>(MemoryKeys.OUTPUT_PREFIX, new ArrayList<>());
-            blanked.setPublic(true);
-            currentStep.storeData(blanked);
+        if (outputData != null && outputData.getResult() instanceof List<?> stored
+                && stored.stream().anyMatch(candidates::contains)) {
+            var kept = new ArrayList<Object>();
+            for (Object item : stored) {
+                if (!candidates.contains(item)) {
+                    kept.add(item);
+                }
+            }
+            var stripped = new Data<>(MemoryKeys.OUTPUT_PREFIX, kept);
+            stripped.setPublic(true);
+            currentStep.storeData(stripped);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -779,10 +779,25 @@ public class Conversation implements IConversation {
                 outputs.add(interim);
             }
             outputs.add(pending);
-            var pendingData = new Data<>(MemoryKeys.OUTPUT_PREFIX, List.copyOf(outputs));
+            var step = conversationMemory.getCurrentStep();
+            // The Data twin must ACCUMULATE, exactly as the output list does: a turn
+            // may pause several times, and each pause's explanation is a permanent
+            // part of the record — retrospectively, the admin must be able to see
+            // everything the model said it was doing. Replacing the twin (as a bare
+            // storeData would) kept only the latest pause's text in the detailed
+            // step view while the output list kept them all, and two channels that
+            // disagree is exactly the class of bug the surgical placeholder drop
+            // exists to prevent.
+            var accumulated = new ArrayList<Object>();
+            IData<?> previous = step.getData(MemoryKeys.OUTPUT_PREFIX);
+            if (previous != null && previous.getResult() instanceof List<?> prior) {
+                accumulated.addAll(prior);
+            }
+            accumulated.addAll(outputs);
+            var pendingData = new Data<>(MemoryKeys.OUTPUT_PREFIX, accumulated);
             pendingData.setPublic(true);
-            conversationMemory.getCurrentStep().storeData(pendingData);
-            conversationMemory.getCurrentStep().addConversationOutputList(MemoryKeys.OUTPUT_PREFIX, List.copyOf(outputs));
+            step.storeData(pendingData);
+            step.addConversationOutputList(MemoryKeys.OUTPUT_PREFIX, List.copyOf(outputs));
         } else {
             // A RULE pause must never carry a stale tool batch (e.g. the gate tripped
             // earlier in the same turn on a path that recovered) — belt and braces.

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupport.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupport.java
@@ -76,6 +76,13 @@ public class ToolApprovalGateSupport {
 
     private static final int PAUSE_REASON_MAX_CHARS = 500;
 
+    /**
+     * Cap on the model's interim narration carried with a pause. A sentence or two
+     * by nature; the cap only guards against a runaway preamble bloating the
+     * persisted batch and the paused step's public output.
+     */
+    static final int INTERIM_TEXT_MAX_CHARS = 2_000;
+
     private final ChatTranscriptCodec chatTranscriptCodec;
 
     public ToolApprovalGateSupport(ChatTranscriptCodec chatTranscriptCodec) {
@@ -114,6 +121,28 @@ public class ToolApprovalGateSupport {
     }
 
     // ─── Approver-facing strings ───
+
+    /**
+     * The redacted, capped text of the trailing {@link AiMessage} — the narration
+     * the model emitted in the same message as its gated tool calls — or null when
+     * the transcript does not end in an AiMessage or that message carries no text.
+     */
+    static String interimTextOf(List<ChatMessage> currentMessages) {
+        if (currentMessages == null || currentMessages.isEmpty()) {
+            return null;
+        }
+        if (!(currentMessages.getLast() instanceof AiMessage ai)) {
+            return null;
+        }
+        String text = ai.text();
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        String redacted = SecretRedactionFilter.redact(text.strip());
+        return redacted.length() > INTERIM_TEXT_MAX_CHARS
+                ? redacted.substring(0, INTERIM_TEXT_MAX_CHARS) + "…"
+                : redacted;
+    }
 
     /** First non-blank of the two, or null. */
     public static String firstNonBlank(String preferred, String fallback) {
@@ -249,6 +278,10 @@ public class ToolApprovalGateSupport {
         ChatTranscriptCodec.CodecResult codecResult = chatTranscriptCodec.serialize(currentMessages, transcriptMaxBytes);
         batch.setChatTranscriptJson(codecResult.json());
         batch.setTranscriptOmitted(codecResult.omitted());
+        // What the model said alongside the gated calls — see
+        // PendingToolCallBatch#interimText. The gating AiMessage is the last
+        // message the runner appended before classifying its tool requests.
+        batch.setInterimText(interimTextOf(currentMessages));
 
         // Per gated call: cap raw args, redact + cap redacted args, carry gate reason.
         List<PendingToolCallBatch.PendingToolCall> calls = new ArrayList<>();

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupport.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupport.java
@@ -139,8 +139,9 @@ public class ToolApprovalGateSupport {
             return null;
         }
         String redacted = SecretRedactionFilter.redact(text.strip());
+        // The ellipsis counts against the cap, so the persisted value never exceeds it.
         return redacted.length() > INTERIM_TEXT_MAX_CHARS
-                ? redacted.substring(0, INTERIM_TEXT_MAX_CHARS) + "…"
+                ? redacted.substring(0, INTERIM_TEXT_MAX_CHARS - 1) + "…"
                 : redacted;
     }
 

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilitiesHitlTest.java
@@ -203,6 +203,7 @@ class ConversationMemoryUtilitiesHitlTest {
         private static final String CANARY_TRANSCRIPT = "[{\"type\":\"AI\",\"text\":\"" + CANARY_SECRET + "\"}]";
         private static final String CANARY_FINGERPRINT = "sha256-request-fingerprint-CANARY";
         private static final String CANARY_PREVIEW_URI = "https://eddi.internal/CANARY-should-not-leak/{id}";
+        private static final String CANARY_INTERIM = "CANARY-interim-narration-not-in-projection";
 
         private ConversationMemorySnapshot toolPausedSnapshot() {
             var snapshot = buildMinimalSnapshot();
@@ -230,6 +231,7 @@ class ConversationMemoryUtilitiesHitlTest {
             batch.setLlmTaskId("task-a");
             batch.setChatTranscriptJson(CANARY_TRANSCRIPT);
             batch.setTraceSoFar(List.of(Map.of("args", CANARY_ARGS)));
+            batch.setInterimText(CANARY_INTERIM);
             batch.setFingerprint("sha256-" + CANARY_SECRET);
             batch.setCalls(List.of(call));
             // Fix #1: the batch carries the effective tool-approval config — it must NOT
@@ -266,6 +268,13 @@ class ConversationMemoryUtilitiesHitlTest {
                     "trace must be projected to null in generic simple-snapshot JSON");
             assertTrue(json.contains("\"fingerprint\":null"),
                     "fingerprint must be projected to null in generic simple-snapshot JSON");
+            // The narration is deliberately NOT carried by the projected batch — it is
+            // already in the step's public output where it belongs, and the projection
+            // is names-only by contract.
+            assertTrue(json.contains("\"interimText\":null"),
+                    "interimText must be projected to null in generic simple-snapshot JSON");
+            assertFalse(json.contains(CANARY_INTERIM),
+                    "interim narration leaked through the names-only projection: " + json);
             // And per-call argument fields must never carry a value.
             assertFalse(json.contains("\"argumentsRaw\":\""),
                     "argumentsRaw value leaked into generic simple-snapshot JSON");

--- a/src/test/java/ai/labs/eddi/engine/memory/model/PendingToolCallBatchSnapshotTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/model/PendingToolCallBatchSnapshotTest.java
@@ -71,6 +71,7 @@ class PendingToolCallBatchSnapshotTest {
         batch.setFingerprint("sha256-xyz");
         batch.setAutoApproveCount(1);
         batch.setPauseCountThisTurn(2);
+        batch.setInterimText("Config checks out — deleting the record next, which needs your approval.");
 
         var effective = new ToolApprovalsConfig();
         effective.setRequireApproval(List.of("delete_*", "mcp:*"));
@@ -138,6 +139,14 @@ class PendingToolCallBatchSnapshotTest {
         assertEquals("Deleting a record — check the id", batch.getEffectiveRule().getPauseReason());
         assertEquals("Waiting on a reviewer for {toolNames}", batch.getEffectiveRule().getPendingMessage());
         assertEquals("mcp:delete_*", batch.getCalls().get(1).getMatchedRule());
+
+        // The model's narration must survive persistence:
+        // Conversation.pauseConversation
+        // reads it back from the STORED batch, and a reload of a paused conversation
+        // rebuilds the transcript from the persisted step — both would show only the
+        // placeholder if this field did not round-trip.
+        assertEquals("Config checks out — deleting the record next, which needs your approval.",
+                batch.getInterimText());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationHitlTest.java
@@ -186,6 +186,36 @@ class ConversationHitlTest {
         }
 
         @Test
+        @DisplayName("TOOL_CALL pause writes the model's interim narration AHEAD of the placeholder")
+        void toolPauseKeepsInterimText() throws Exception {
+            // A tool pause aborts the turn before the output tasks run, so the only
+            // text the paused step used to carry was the placeholder — the model's
+            // own "the config checks out, I'll now start a test conversation" was
+            // dropped. On a resumed (non-streamed) turn that meant the second
+            // approval arrived with no explanation at all.
+            memory.setConversationState(ConversationState.READY);
+            doAnswer(inv -> {
+                var call = new PendingToolCallBatch.PendingToolCall();
+                call.setToolName("startConversation");
+                var batch = new PendingToolCallBatch();
+                batch.setCalls(List.of(call));
+                batch.setInterimText("Config checks out — starting a test conversation next, which needs your approval.");
+                memory.setHitlPendingToolCalls(batch);
+                throw new ConversationPauseException("wf1", 2, "gated tool call",
+                        ConversationPauseException.PauseOrigin.TOOL_CALL);
+            }).when(lifecycleManager).executeLifecycle(any(), any());
+
+            var conv = createConversation();
+            conv.say("create the agent and test it", Map.of());
+
+            @SuppressWarnings("unchecked")
+            var rendered = (List<String>) memory.getCurrentStep().getConversationOutput().get(MemoryKeys.OUTPUT_PREFIX);
+            assertEquals(2, rendered.size(), "narration + placeholder, in that order; got: " + rendered);
+            assertEquals("Config checks out — starting a test conversation next, which needs your approval.", rendered.get(0));
+            assertTrue(rendered.get(1).contains("startConversation"), "placeholder names the gated tool; got: " + rendered.get(1));
+        }
+
+        @Test
         @DisplayName("TOOL_CALL pause with legacy batch (null effective config) falls back to the agent-level pendingMessage")
         void toolPauseLegacyBatchFallsBackToAgentLevel() throws Exception {
             memory.setConversationState(ConversationState.READY);

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
@@ -440,6 +440,51 @@ class ConversationToolResumeTest {
         assertEquals(List.of(expl1, expl2), strings(dataList()), "final record: Data twin (answer is written via the list by LlmTask)");
     }
 
+    @Test
+    @DisplayName("the drop removes the LAST placeholder occurrence, never an earlier entry that merely reads the same")
+    void dropRemovesLastOccurrenceOnly() throws Exception {
+        // Adversarial: the model's narration is byte-identical to a placeholder
+        // CANDIDATE (the pre-tool-named build's constant, which the resume path must
+        // still recognise for upgrade safety) while the real trailing placeholder is
+        // the current rendering. A first-match removal deletes the narration and
+        // strands the placeholder; a remove-every-match deletes both. Only the
+        // trailing one may go, on both channels.
+        memory.setConversationState(ConversationState.READY);
+        // No configured pendingMessage → the DEFAULT applies, so BOTH the current
+        // tool-named default and the legacy constant are candidates.
+        String legacyConstant = "This action requires human approval before it can proceed. "
+                + "You will receive the result once a reviewer decides.";
+        String currentPlaceholder = "I need your approval before I can run delete_record. "
+                + "You will receive the result once a reviewer decides.";
+        doAnswer(inv -> {
+            var call = new PendingToolCallBatch.PendingToolCall();
+            call.setToolName("delete_record");
+            var b = new PendingToolCallBatch();
+            b.setLlmTaskId("ai.labs.llm");
+            b.setLlmTaskIndex(0);
+            b.setCalls(List.of(call));
+            b.setInterimText(legacyConstant); // narration that happens to equal a legacy candidate
+            memory.setHitlPendingToolCalls(b);
+            throw new ConversationPauseException("wf1", 0, "gated", ConversationPauseException.PauseOrigin.TOOL_CALL);
+        }).when(lifecycleManager).executeLifecycle(any(), any());
+        var conv = createConversation();
+        conv.say("delete it", Map.of());
+        assertEquals(List.of(legacyConstant, currentPlaceholder), strings(outputList()), "paused shape");
+
+        String answer = "Record deleted successfully.";
+        doAnswer(inv -> {
+            memory.getCurrentStep().addConversationOutputList(
+                    MemoryKeys.OUTPUT_PREFIX, List.of(new TextOutputItem(answer, 0)));
+            return null;
+        }).when(lifecycleManager).executeLifecycleFromIndex(eq(memory), anyInt());
+        conv.resume(decision(HitlVerdict.APPROVED));
+
+        // The narration (legacy-equal) survives; the trailing current placeholder is
+        // gone.
+        assertEquals(List.of(legacyConstant, answer), strings(outputList()), "list");
+        assertEquals(List.of(legacyConstant), strings(dataList()), "Data twin");
+    }
+
     private static List<String> strings(List<?> items) {
         return items == null ? List.of() : items.stream().map(String::valueOf).toList();
     }

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
@@ -322,6 +322,56 @@ class ConversationToolResumeTest {
                 "the resumed step must render ONLY the final answer, not [placeholder, answer]; got: " + out);
     }
 
+    @Test
+    @DisplayName("APPROVED tool resume drops ONLY the placeholder — the model's interim narration written ahead of it survives")
+    void approvedResumeKeepsInterimText() throws Exception {
+        // The narration ("the config checks out, I'll now start a test conversation")
+        // is legitimate output written by pauseConversation ahead of the placeholder;
+        // the drop must be surgical. Also exercises the Data-twin strip: the stored
+        // Data is [interim, placeholder], not [placeholder] alone, and the old
+        // "blank when equal to [placeholder]" branch would have left the twin
+        // untouched — inconsistent with the list.
+        memory.setConversationState(ConversationState.READY);
+        var effective = new ToolApprovalsConfig();
+        effective.setPendingMessage("Approval required for {toolNames}");
+        String interim = "Config checks out — deleting the record next, which needs your approval.";
+        doAnswer(inv -> {
+            var call = new PendingToolCallBatch.PendingToolCall();
+            call.setToolName("delete_record");
+            var b = new PendingToolCallBatch();
+            b.setLlmTaskId("ai.labs.llm");
+            b.setLlmTaskIndex(0);
+            b.setCalls(List.of(call));
+            b.setEffectiveToolApprovals(effective);
+            b.setInterimText(interim);
+            memory.setHitlPendingToolCalls(b);
+            throw new ConversationPauseException("wf1", 0, "gated tool call",
+                    ConversationPauseException.PauseOrigin.TOOL_CALL);
+        }).when(lifecycleManager).executeLifecycle(any(), any());
+        var conv = createConversation();
+        conv.say("delete it", Map.of());
+        assertEquals(List.of(interim, PENDING), outputList().stream().map(String::valueOf).toList(),
+                "paused: narration then placeholder");
+
+        String finalAnswer = "Record deleted successfully.";
+        doAnswer(inv -> {
+            memory.getCurrentStep().addConversationOutputList(
+                    MemoryKeys.OUTPUT_PREFIX, List.of(new TextOutputItem(finalAnswer, 0)));
+            return null;
+        }).when(lifecycleManager).executeLifecycleFromIndex(eq(memory), anyInt());
+
+        conv.resume(decision(HitlVerdict.APPROVED));
+
+        var out = outputList().stream().map(String::valueOf).toList();
+        assertEquals(List.of(interim, finalAnswer), out,
+                "resumed: narration kept, placeholder gone, answer appended; got: " + out);
+        // The Data twin agrees with the list.
+        var data = memory.getCurrentStep().getData(MemoryKeys.OUTPUT_PREFIX);
+        assertNotNull(data);
+        assertEquals(List.of(interim), data.getResult(),
+                "the Data twin must have had ONLY the placeholder stripped; got: " + data.getResult());
+    }
+
     /**
      * The version boundary the determinism argument silently skipped: a pause
      * PERSISTED by a previous build holds that build's placeholder wording, and

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationToolResumeTest.java
@@ -372,6 +372,83 @@ class ConversationToolResumeTest {
                 "the Data twin must have had ONLY the placeholder stripped; got: " + data.getResult());
     }
 
+    @Test
+    @DisplayName("a two-pause turn keeps BOTH explanations retrospectively — only the one-line asks are ever removed, on both channels")
+    void twoPauseTurnKeepsEveryExplanation() throws Exception {
+        // The record the admin reads afterwards must show everything the model
+        // said it was doing: [expl1, expl2, answer]. Only the one-sentence asks
+        // come and go. And the output list and its Data twin must agree at every
+        // step: the twin used to be REPLACED by each pause (keeping only the
+        // latest explanation in the detailed step view) while the list appended.
+        memory.setConversationState(ConversationState.READY);
+        var effective = new ToolApprovalsConfig();
+        effective.setPendingMessage("Approval required for {toolNames}");
+        String expl1 = "Creating the agent first — that is a write, so it needs your approval.";
+        String expl2 = "Agent created and deployed. Now starting a test conversation to verify it — approval needed.";
+        String ask1 = "Approval required for setupAgent";
+        String ask2 = "Approval required for startConversation";
+
+        // Pause 1 (via say).
+        doAnswer(inv -> {
+            var call = new PendingToolCallBatch.PendingToolCall();
+            call.setToolName("setupAgent");
+            var b = new PendingToolCallBatch();
+            b.setLlmTaskId("ai.labs.llm");
+            b.setLlmTaskIndex(0);
+            b.setCalls(List.of(call));
+            b.setEffectiveToolApprovals(effective);
+            b.setInterimText(expl1);
+            memory.setHitlPendingToolCalls(b);
+            throw new ConversationPauseException("wf1", 0, "gated", ConversationPauseException.PauseOrigin.TOOL_CALL);
+        }).when(lifecycleManager).executeLifecycle(any(), any());
+        var conv = createConversation();
+        conv.say("create an agent and test it", Map.of());
+        assertEquals(List.of(expl1, ask1), strings(outputList()));
+        assertEquals(List.of(expl1, ask1), strings(dataList()));
+
+        // Approve 1 → the resumed turn runs setupAgent, then re-pauses on
+        // startConversation.
+        doAnswer(inv -> {
+            var call = new PendingToolCallBatch.PendingToolCall();
+            call.setToolName("startConversation");
+            var b = new PendingToolCallBatch();
+            b.setLlmTaskId("ai.labs.llm");
+            b.setLlmTaskIndex(0);
+            b.setCalls(List.of(call));
+            b.setEffectiveToolApprovals(effective);
+            b.setInterimText(expl2);
+            b.setPauseCountThisTurn(2);
+            memory.setHitlPendingToolCalls(b);
+            throw new ConversationPauseException("wf1", 0, "gated", ConversationPauseException.PauseOrigin.TOOL_CALL);
+        }).when(lifecycleManager).executeLifecycleFromIndex(eq(memory), anyInt());
+        conv.resume(decision(HitlVerdict.APPROVED));
+        assertEquals(ConversationState.AWAITING_HUMAN, memory.getConversationState());
+        // ask1 gone, expl1 kept, expl2 + ask2 appended — on both channels.
+        assertEquals(List.of(expl1, expl2, ask2), strings(outputList()), "after re-pause: list");
+        assertEquals(List.of(expl1, expl2, ask2), strings(dataList()), "after re-pause: Data twin");
+
+        // Approve 2 → the final answer.
+        String answer = "Done: agent created, deployed and verified.";
+        doAnswer(inv -> {
+            memory.getCurrentStep().addConversationOutputList(
+                    MemoryKeys.OUTPUT_PREFIX, List.of(new TextOutputItem(answer, 0)));
+            return null;
+        }).when(lifecycleManager).executeLifecycleFromIndex(eq(memory), anyInt());
+        conv.resume(decision(HitlVerdict.APPROVED));
+
+        assertEquals(List.of(expl1, expl2, answer), strings(outputList()), "final record: list");
+        assertEquals(List.of(expl1, expl2), strings(dataList()), "final record: Data twin (answer is written via the list by LlmTask)");
+    }
+
+    private static List<String> strings(List<?> items) {
+        return items == null ? List.of() : items.stream().map(String::valueOf).toList();
+    }
+
+    private List<?> dataList() {
+        var data = memory.getCurrentStep().getData(MemoryKeys.OUTPUT_PREFIX);
+        return data == null ? null : (List<?>) data.getResult();
+    }
+
     /**
      * The version boundary the determinism argument silently skipped: a pause
      * PERSISTED by a previous build holds that build's placeholder wording, and

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupportInterimTextTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupportInterimTextTest.java
@@ -83,7 +83,8 @@ class ToolApprovalGateSupportInterimTextTest {
                 AiMessage.builder().text(huge).toolExecutionRequests(List.of(call())).build());
 
         String text = ToolApprovalGateSupport.interimTextOf(messages);
-        assertTrue(text.length() <= ToolApprovalGateSupport.INTERIM_TEXT_MAX_CHARS + 1, "capped (+ ellipsis); was " + text.length());
+        assertEquals(ToolApprovalGateSupport.INTERIM_TEXT_MAX_CHARS, text.length(),
+                "the ellipsis counts against the cap — the persisted value never exceeds it");
         assertTrue(text.endsWith("…"));
     }
 }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupportInterimTextTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupportInterimTextTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl.orchestration;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link ToolApprovalGateSupport#interimTextOf}: the model's narration in the
+ * assistant message that carried the gated tool calls, as persisted with the
+ * pause so the paused step (and a reload) can show what the approval is about.
+ */
+@DisplayName("ToolApprovalGateSupport.interimTextOf")
+class ToolApprovalGateSupportInterimTextTest {
+
+    private static ToolExecutionRequest call() {
+        return ToolExecutionRequest.builder().id("c1").name("startConversation").arguments("{}").build();
+    }
+
+    @Test
+    @DisplayName("takes the trailing AiMessage's text alongside its tool calls, stripped")
+    void takesTrailingAiText() {
+        List<ChatMessage> messages = List.of(
+                UserMessage.from("create the agent and test it"),
+                AiMessage.builder()
+                        .text("  Config checks out — I'll now start a test conversation, which needs your approval.  ")
+                        .toolExecutionRequests(List.of(call()))
+                        .build());
+
+        assertEquals("Config checks out — I'll now start a test conversation, which needs your approval.",
+                ToolApprovalGateSupport.interimTextOf(messages));
+    }
+
+    @Test
+    @DisplayName("null when the gating message carried no text — a bare tool call")
+    void nullWhenNoText() {
+        List<ChatMessage> messages = List.of(
+                UserMessage.from("do it"),
+                AiMessage.from(List.of(call())));
+
+        assertNull(ToolApprovalGateSupport.interimTextOf(messages));
+    }
+
+    @Test
+    @DisplayName("null when the transcript does not end in an AiMessage, or is empty")
+    void nullWhenNotTrailingAi() {
+        assertNull(ToolApprovalGateSupport.interimTextOf(List.of(UserMessage.from("hi"))));
+        assertNull(ToolApprovalGateSupport.interimTextOf(List.of()));
+        assertNull(ToolApprovalGateSupport.interimTextOf(null));
+    }
+
+    @Test
+    @DisplayName("redacts secrets the model echoed from tool results")
+    void redactsSecrets() {
+        List<ChatMessage> messages = List.of(
+                AiMessage.builder()
+                        .text("Using key sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghij to start.")
+                        .toolExecutionRequests(List.of(call()))
+                        .build());
+
+        String text = ToolApprovalGateSupport.interimTextOf(messages);
+        assertFalse(text.contains("sk-ant-api03-abcdefghij"), "the key must not survive into the persisted narration: " + text);
+    }
+
+    @Test
+    @DisplayName("caps a runaway preamble")
+    void capsLongText() {
+        String huge = "x".repeat(ToolApprovalGateSupport.INTERIM_TEXT_MAX_CHARS + 500);
+        List<ChatMessage> messages = List.of(
+                AiMessage.builder().text(huge).toolExecutionRequests(List.of(call())).build());
+
+        String text = ToolApprovalGateSupport.interimTextOf(messages);
+        assertTrue(text.length() <= ToolApprovalGateSupport.INTERIM_TEXT_MAX_CHARS + 1, "capped (+ ellipsis); was " + text.length());
+        assertTrue(text.endsWith("…"));
+    }
+}


### PR DESCRIPTION
Third live round on the operator flow: *"the confirmation message got removed — this time when the second approval came in, it was visible on the first though."*

### Root cause (structural, not a UI slip)

A tool pause aborts the turn **before** the output tasks run, so the only text the paused step carried was the pending-approval placeholder. The model''s own narration in the very message that carried the gated calls — *"config checks out — I''ll now start a test conversation, which needs your approval"* — was dropped. On a **streamed** turn the client had already shown it live (and the previous Manager fix kept it on screen — hence "visible on the first"); on a **resumed** turn, which is not streamed, it never existed anywhere the user could see, so the second approval arrived with no explanation at all. A reload lost it on both.

### Change

- `PendingToolCallBatch.interimText` — the trailing `AiMessage`''s text at gate time, **redacted** with the same filter as the call arguments (model output over tool results can echo a secret) and **capped** at 2000 chars.
- `ToolApprovalGateSupport.buildPendingBatch` derives it from `currentMessages` (no signature change).
- `Conversation.pauseConversation` writes it **ahead of** the placeholder → the paused step''s output is `[narration, ask]`.
- The resume-side placeholder drop is now **surgical**: only the placeholder is removed, from both the output list and its `Data` twin. The old twin logic blanked the whole entry when it equalled `[placeholder]`, which would now discard the narration.
- Null on legacy batches and bare tool calls → old behaviour. Excluded from the names-only REST projection like the other batch internals — it is already in the step''s public output.

No double-render risk: `LlmTask` writes `responseContent` only for the loop''s **final** answer, never the gated interim message; a re-pause builds a fresh batch whose narration is the new message''s.

Manager half (renders `[narration, ask]` without duplicating the streamed bubble): labsai/EDDI-Manager `fix/operator-round-three`.

### Verification

- `ConversationHitlTest`: pause writes `[narration, ask]`.
- `ConversationToolResumeTest`: APPROVED resume keeps the narration and strips only the placeholder from list **and** Data twin.
- New `ToolApprovalGateSupportInterimTextTest`: trailing-AI text stripped, bare call → null, non-AI tail/empty/null → null, redaction (`sk-ant-…`), cap with ellipsis.
- Both `Conversation` behaviours **mutation-verified** (never-write → 2 failures; wholesale-blank twin → 1 failure).
- 134 tests incl. `ImportStyleTest` + `DocumentationLinksTest`, `BUILD SUCCESS`. As with the other child PRs, this base runs no `Build & Test`; #672 re-verifies after merge.