### PR TITLE
fix(docker): bump UBI9 base digest for CVE-2026-11940

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,7 @@
 
 **Repo:** EDDI (`fix/trivy-cve-2026-11940-base-image`)
 
-`main` was red: the blocking Trivy image scan in `ci.yml` flagged 2 HIGH CVEs against
+`main` was red: the blocking Trivy image scan in `ci.yml` flagged one HIGH CVE affecting two packages in
 `labsai/eddi:6.2.0-b1065` — `python3` and `python3-libs` at `3.9.25-7.el9_8.2`, both fixed in
 `3.9.25-7.el9_8.3` (CVE-2026-11940, CPython tarfile extraction filter bypass allowing escape from
 the destination directory). Both come from the UBI9 base layer, not from anything we build; the jar

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,38 @@
 
 
 
+## 🔒 fix(docker): bump UBI9 base digest for CVE-2026-11940 (python3 tarfile filter bypass) (2026-08-17)
+
+**Repo:** EDDI (`fix/trivy-cve-2026-11940-base-image`)
+
+`main` was red: the blocking Trivy image scan in `ci.yml` flagged 2 HIGH CVEs against
+`labsai/eddi:6.2.0-b1065` — `python3` and `python3-libs` at `3.9.25-7.el9_8.2`, both fixed in
+`3.9.25-7.el9_8.3` (CVE-2026-11940, CPython tarfile extraction filter bypass allowing escape from
+the destination directory). Both come from the UBI9 base layer, not from anything we build; the jar
+layer scanned clean (0 findings across every `deployments/lib/**` entry).
+
+Followed the "Trivy CVE Remediation Procedure" in AGENTS.md and took the clean fix rather than the
+escape hatch: Red Hat had already republished the same `1.24` tag with the patched package, so
+`src/main/docker/Dockerfile` moves from `@sha256:de073e98…` to `@sha256:6b320cbb…`. No
+`microdnf update` stopgap and no `.trivyignore` entry were needed — `.trivyignore` stays empty of
+CVEs, which is where we want it.
+
+**Verified locally** (the CI gate is `severity: CRITICAL,HIGH`, `ignore-unfixed: true`, `exit-code: 1`):
+
+- `rpm -q python3 python3-libs` in the new digest → `3.9.25-7.el9_8.3` on both, i.e. the fixed build.
+- Trivy `image --severity CRITICAL,HIGH --ignore-unfixed` against the new base → **0** vulnerabilities,
+  so nothing else fixable is waiting behind this one.
+- Smoke-checked the layer contract the Dockerfile depends on: `run-java.sh` present at the ENTRYPOINT
+  path, uid 185 (`default`) resolves, `curl` present for the `HEALTHCHECK`, `java -version` →
+  OpenJDK 25.0.4 LTS.
+
+The digest pin is retained (OpenSSF supply-chain requirement) — only its value changed.
+`base-image-check.yml` continues to watch for future republished digests weekly.
+
+---
+
+
+
 ## 💬 fix(hitl): a tool pause keeps the model's own explanation of what it is about to do (2026-08-16)
 
 **Repo:** EDDI (`fix/pause-keeps-interim-text`) + EDDI-Manager (`fix/operator-resume-settle`, follow-up

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -78,7 +78,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24@sha256:de073e98f1bb4be12f1454e1685c37db876af845896e0495f4eab0931154f9e4
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24@sha256:6b320cbb20bd8b74ed4b44d0ea086cc9651bfc64396fbe6c0d906a8da12bdd20
 
 ### Red Hat Container Certification — required labels
 ARG EDDI_VERSION=6.2.0


### PR DESCRIPTION
## Why main is red

The blocking Trivy image scan in `ci.yml` failed on `labsai/eddi:6.2.0-b1065` with one HIGH CVE affecting two packages, both from the UBI9 base layer:

| Package | Installed | Fixed | CVE |
|---|---|---|---|
| `python3` | 3.9.25-7.el9_8.2 | 3.9.25-7.el9_8.3 | CVE-2026-11940 |
| `python3-libs` | 3.9.25-7.el9_8.2 | 3.9.25-7.el9_8.3 | CVE-2026-11940 |

CVE-2026-11940 is a CPython tarfile extraction filter bypass that allows escaping the destination directory. Nothing we build is implicated — every `deployments/lib/**` jar scanned clean.

That job is `severity: CRITICAL,HIGH`, `ignore-unfixed: true`, `exit-code: 1` and sits ahead of the Docker Hub login, so the failure also stops the push, the `:latest` retag, the cosign signature and the SLSA attestation.

## The fix

Per the "Trivy CVE Remediation Procedure" in `AGENTS.md`, this is the clean fix rather than the escape hatch: Red Hat has already republished the same `1.24` tag with the patched package, so only the digest changes.

```
-FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24@sha256:de073e98...
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24@sha256:6b320cbb...
```

No `microdnf update` stopgap, no `.trivyignore` entry (it still holds zero CVEs), digest pin retained for OpenSSF supply-chain compliance.

## Verification (local)

- `rpm -q python3 python3-libs` **pulled by the pinned digest** → `3.9.25-7.el9_8.3` on both.
- `mvnw package` + `docker build -f src/main/docker/Dockerfile` → builds clean on the new base.
- Trivy against that built image with the CI gate's exact flags (`--severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 --ignorefile .trivyignore`) → **0 vulnerabilities, exit 0**.
- Base image scanned separately → 0 fixable CRITICAL/HIGH, so nothing else is queued behind this one.
- Layer contract the Dockerfile depends on is intact: `run-java.sh` at the ENTRYPOINT path, uid 185 (`default`) resolves, `curl` present for the `HEALTHCHECK`, `java -version` → OpenJDK 25.0.4 LTS.
- `docker buildx imagetools inspect …:1.24` returns exactly the pinned digest, so `base-image-check.yml` will report "digest current" rather than opening a duplicate bump PR.

## Note, out of scope

The failing image was tagged `6.2.0-b1065` while `ARG EDDI_VERSION=6.2.0` in the Dockerfile — if the 6.3.0 bump is in flight, that label needs updating too. Left untouched here to keep this PR to the build fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Updated the UBI OpenJDK 25 runtime image with fixes for CVE-2026-11940.
  - Updated patched Python package versions.
  - Verified no remaining container vulnerabilities and completed runtime smoke checks.
  - Retained digest pinning with weekly monitoring.

- **Documentation**
  - Added a changelog entry documenting the security update and verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
