### PR TITLE
fix(setup): reuse vault keys instead of minting one per agent

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -68,3 +68,13 @@ eebfe898b34858918d5cbbe11e60336d1b6a916e:src/test/java/ai/labs/eddi/secrets/sani
 # introduced it stays in history and still needs an entry. Never a real key: it
 # never authenticated against anything.
 96df3c83fa449e02250c08c1aa420a11617f2ebb:src/test/java/ai/labs/eddi/modules/apicalls/impl/ResolvedRequestTest.java:generic-api-key:193
+
+# AgentSetupVaultKeyReuseTest: the same mistake as the two entries above, made
+# a third time. The fixture standing in for a provider API key was written as a
+# realistic "sk-live-" + hex literal, which is precisely the shape a real leaked
+# key takes. Renamed in a follow-up commit to a value that reads as a fixture,
+# but gitleaks scans a PR's whole commit range, so the commit that introduced it
+# stays in history and still needs an entry. Never a real key: nothing in these
+# tests authenticates against anything — the value is compared for equality and
+# hashed for a checksum, and any string would do.
+30ff68d1d2eaa568e7399fa24dc6acf7315b30f6:src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java:generic-api-key:50

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -110,6 +110,30 @@ A second read of the change turned up six things, all fixed on this branch:
 the extra `SetupResult` component. 356 tests across the setup suites and repo-wide guards, green,
 Checkstyle clean.
 
+### Second review pass (different reviewer)
+
+One real bug and three smaller items, all fixed:
+
+- **`vaultKeyName: "${vault:acme/openai"` created the secret in the `default` tenant.** `useNamedVaultKey` parsed
+  the tenant for the *lookup* but `storeSecret` rebuilt the reference with `DEFAULT_TENANT` for the *create* — so a
+  missing tenant-qualified key produced a setup that "worked" and an agent whose reference pointed at nothing.
+  `storeSecret` now takes the full `SecretReference`. Mutation-checked: reverting it fails the new test.
+- **`eddi.setup.vault-key-reuse` silently degraded on a typo.** `checksumm` behaved as `never` — dedup off, which is
+  the original bug back with every visible sign saying it is on. Now strict-parsed in a `@PostConstruct`, failing
+  startup, matching the `eddi.vault.grant-enforcement` convention. Directly constructed instances (tests) are unaffected.
+- **A dangling `apiKey: "${vault:typo}"` was accepted in silence.** Pass-through stays accepted (a caller may vault the
+  key after setup) but the entry is now looked up and a WARN logged if absent — the alternative was an agent that
+  deploys clean and fails on its first turn. The `verifyNoInteractions` assertions on the old pass-through tests became
+  `never().store(...)`, which is what they actually meant.
+- Two error messages tightened (`already holds a different value` was wrong when the stored checksum is null;
+  `no apiKey was supplied` was wrong when a *reference* was supplied), and both MCP `apiKey` tool descriptions now
+  say that `apiKeyVaultReference` from an earlier call can be passed back to share the key.
+
+Not changed after consideration: `group-wizard.tsx` builds every member slot from a template up front, so
+seeding-on-add would not reach them; the backend checksum dedup covers the vault-growth half regardless.
+
+360 backend tests green (`AgentSetupVaultKeyReuseTest` at 29), Checkstyle clean.
+
 ### EDDI-Manager — `feat/setup-vault-key-reuse`
 
 The earlier note in this entry said the wizard and team builder "still render the API key as a bare text

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -171,6 +171,45 @@ first-time setups with the same key can create two entries, and later setups con
 now renders `resources.vaultWarning` verbatim (backend-authored, no new i18n keys) — its picker lists every
 vault key including narrowly granted ones, and this is where the user learns why such an agent will not deploy.
 
+### PR review — CodeRabbit and Copilot (#699)
+
+Both bots reviewed; every finding was valid. Two were real bugs this branch had introduced:
+
+- **Generated key names could collide** (CodeRabbit). `setup.<agent>.<timestamp>.apiKey` is not unique for two
+  same-named agents in the same millisecond, and `store` is an upsert — so one silently overwrote the other's
+  credential. Now carries a random suffix; the timestamp stays only because it dates the entry for an operator.
+- **An unparseable OpenAPI spec leaked a vault secret** (Copilot). Moving key resolution to "step 0" put it ahead
+  of the spec parse, and `createApiAgent`'s pre-existing `catch (AgentSetupException) { throw e; }` rethrows
+  without rolling back — so under `vault-key-reuse=never` every invalid request left an orphan secret. Fixed at
+  both ends: the parse now runs first (it creates nothing, so a bad spec never reaches the vault at all), and
+  that catch arm now rolls back, which also closes the pre-existing document leak on the same path.
+
+Two more were correct and are now handled:
+
+- **A direct vault write did not invalidate the resolver cache** (Copilot). `RestSecretStore` invalidates even on
+  creation, precisely because a model may be cached holding an unresolved `${vault:...}` literal — and this
+  service is the one that deliberately allows such dangling references and later fills them in. `storeSecret`
+  now invalidates, matching that path.
+- **The dangling-reference warning only reached the log** (CodeRabbit), while the restricted-grant warning
+  reached the caller. Both end in an agent that cannot use its credential, and only one vault key is resolved
+  per setup, so they were merged into one `resources.vaultWarning` (renamed from `vaultGrantWarning`).
+
+Two concurrency findings were partly addressed and honestly bounded rather than claimed fixed. Creating a
+caller-named key is read-then-write, and the checksum scan is separate from the write that follows it, so
+concurrent setups can still race — the named path now reads back and fails loudly before anything is created,
+and both javadocs state exactly what remains open. Closing them needs a create-if-absent (and a checksum
+reservation) in the persistence layer for Mongo and Postgres both — an SPI change shared with the three other
+`store` callers, all of which upsert today, and deliberately not designed around this one caller. See the
+[thread](https://github.com/labsai/EDDI/pull/699#discussion_r3805688054).
+
+Doc claims that overstated the feature were made conditional: MCP checksum de-duplication depends on
+`eddi.setup.vault-key-reuse` and on an unrestricted grant; `apiKeyVaultReference` is also null for keyless
+providers; and the `vaultKeyName` charset applies to the parsed tenant/key components, not the `${vault:…}`
+wrapper — it now ships as a table of the three accepted shapes. `ImportStyleTest` caught an inline
+`java.util.HashSet` in the new test (AGENTS.md 4.7).
+
+369 backend tests green; every fix above is mutation-checked.
+
 ### EDDI-Manager — `feat/setup-vault-key-reuse`
 
 The earlier note in this entry said the wizard and team builder "still render the API key as a bare text

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,7 +62,7 @@ decisions, not defaults. Field-injected like the neighbouring
 `vaultKeyName` is deliberately **not** exposed on the MCP `setup_agent` / `create_api_agent` tools. *(Rationale
 corrected in the third review pass below — an earlier version of this paragraph claimed it stopped a model
 pointing an agent at an arbitrary secret, which `apiKey: "${vault:...}"` already allows.)* The MCP path
-still de-duplicates by checksum, so it does not grow the vault either.
+still de-duplicates by checksum wherever the deployment leaves that enabled, so it does not grow the vault either.
 
 **Files:** `AgentSetupService.java` (trim, `useNamedVaultKey`, `findReusableSecret`, `storeSecret`,
 step-0 move, validation now accepts `vaultKeyName` in place of `apiKey` for cloud providers),
@@ -114,7 +114,7 @@ Checkstyle clean.
 
 One real bug and three smaller items, all fixed:
 
-- **`vaultKeyName: "${vault:acme/openai"` created the secret in the `default` tenant.** `useNamedVaultKey` parsed
+- **`vaultKeyName: "${vault:acme/openai}"` created the secret in the `default` tenant.** `useNamedVaultKey` parsed
   the tenant for the *lookup* but `storeSecret` rebuilt the reference with `DEFAULT_TENANT` for the *create* — so a
   missing tenant-qualified key produced a setup that "worked" and an agent whose reference pointed at nothing.
   `storeSecret` now takes the full `SecretReference`. Mutation-checked: reverting it fails the new test.
@@ -148,7 +148,7 @@ findings, all fixed:
 2. **Restricted grants were handled inconsistently.** The checksum path skipped narrowed entries (correctly),
    but naming one via `vaultKeyName`, or pasting its reference, sailed through and ended as `deployed: false`
    with the reason only in the server log — a brand-new agent's ID cannot be on any existing grant list, so
-   under `enforce` that outcome is certain. Both paths now WARN and put `resources.vaultGrantWarning` in the
+   under `enforce` that outcome is certain. Both paths now WARN and put `resources.vaultWarning` in the
    response. Not refused: setup-without-deploy → widen grant → deploy is the legitimate flow.
 3. **The MCP rationale was false.** "A model that could choose the name could point a new agent at any
    unrestricted secret" — the tool already advertises `apiKey: "${vault:name}"`, so it already can. The real
@@ -168,7 +168,7 @@ who can already read checksums via the secrets list gains no new oracle from che
 first-time setups with the same key can create two entries, and later setups converge on the older one.
 
 365 backend tests green (`AgentSetupVaultKeyReuseTest` at 34), Checkstyle clean. Manager: the wizard success screen
-now renders `resources.vaultGrantWarning` verbatim (backend-authored, no new i18n keys) — its picker lists every
+now renders `resources.vaultWarning` verbatim (backend-authored, no new i18n keys) — its picker lists every
 vault key including narrowly granted ones, and this is where the user learns why such an agent will not deploy.
 
 ### EDDI-Manager — `feat/setup-vault-key-reuse`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -199,7 +199,9 @@ caller-named key is read-then-write, and the checksum scan is separate from the 
 concurrent setups can still race — the named path now reads back and fails loudly before anything is created,
 and both javadocs state exactly what remains open. Closing them needs a create-if-absent (and a checksum
 reservation) in the persistence layer for Mongo and Postgres both — an SPI change shared with the three other
-`store` callers, all of which upsert today, and deliberately not designed around this one caller. See the
+`store` callers, all of which upsert today, and deliberately not designed around this one caller. Tracked in
+[issue #700](https://github.com/labsai/EDDI/issues/700), which carries the caller inventory and the per-backend
+sketch; the mitigation's javadoc links it so it does not read as a finished job. See also the
 [thread](https://github.com/labsai/EDDI/pull/699#discussion_r3805688054).
 
 Doc claims that overstated the feature were made conditional: MCP checksum de-duplication depends on

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,9 +59,9 @@ decisions, not defaults. Field-injected like the neighbouring
   `vaultKeyName` must fail while rollback still has nothing to undo, not after a parser, ruleset, LLM
   config and workflow already exist.
 
-`vaultKeyName` is deliberately **not** exposed on the MCP `setup_agent` / `create_api_agent` tools (the
-same call the existing `hitlConfig` and `maxToolIterations` comments make): a model that could choose
-the name could point a new agent at any unrestricted secret in the vault by naming it. The MCP path
+`vaultKeyName` is deliberately **not** exposed on the MCP `setup_agent` / `create_api_agent` tools. *(Rationale
+corrected in the third review pass below — an earlier version of this paragraph claimed it stopped a model
+pointing an agent at an arbitrary secret, which `apiKey: "${vault:...}"` already allows.)* The MCP path
 still de-duplicates by checksum, so it does not grow the vault either.
 
 **Files:** `AgentSetupService.java` (trim, `useNamedVaultKey`, `findReusableSecret`, `storeSecret`,
@@ -133,6 +133,43 @@ Not changed after consideration: `group-wizard.tsx` builds every member slot fro
 seeding-on-add would not reach them; the backend checksum dedup covers the vault-growth half regardless.
 
 360 backend tests green (`AgentSetupVaultKeyReuseTest` at 29), Checkstyle clean.
+
+### Third review pass (max effort)
+
+Read the final file state end-to-end and reasoned about the system around it — rollback, the deploy-time
+grant gate, tenants, concurrency, and what the lower-privileged MCP tier can do with the new surface. Four
+findings, all fixed:
+
+1. **Rollback could delete a secret other agents already shared.** Under `checksum` reuse, agent A stores
+   `setup.a.T.apiKey`, agents B..N (parallel bulk provisioning, same key) reuse it, A fails at step 6 → A's
+   rollback deleted the entry B..N point at; they deployed fine and would break on their first turn. The
+   growth that rollback exists to prevent cannot happen under `checksum` (a retry finds A's entry by value), so
+   a generated entry is now registered for rollback **only under `never`**, where nobody else can find it.
+2. **Restricted grants were handled inconsistently.** The checksum path skipped narrowed entries (correctly),
+   but naming one via `vaultKeyName`, or pasting its reference, sailed through and ended as `deployed: false`
+   with the reason only in the server log — a brand-new agent's ID cannot be on any existing grant list, so
+   under `enforce` that outcome is certain. Both paths now WARN and put `resources.vaultGrantWarning` in the
+   response. Not refused: setup-without-deploy → widen grant → deploy is the legitimate flow.
+3. **The MCP rationale was false.** "A model that could choose the name could point a new agent at any
+   unrestricted secret" — the tool already advertises `apiKey: "${vault:name}"`, so it already can. The real
+   reason: MCP setup tools are reachable by `eddi-editor` while REST setup is `eddi-admin`, and what
+   `vaultKeyName` uniquely adds (naming a new entry; a value-must-match check) is a name-squatting and
+   value-oracle surface an editor does not need. Corrected in the two `McpSetupTools` comments, the docs, and
+   the paragraph above.
+4. `SetupResult.apiKeyVaultReference` javadoc now also names the keyless-provider null case.
+
+Verified against the real `VaultSecretProvider` rather than the mocks: `getMetadata` and `listKeys` both
+return the checksum (so the mismatch check and the reuse scan actually see it), `getMetadata` has no
+access-timestamp side effect, and `store` runs `getOrCreateDek`, so a tenant-qualified `vaultKeyName` can
+create the first secret in a new tenant.
+
+Considered and left: the checksum scan lists all default-tenant metadata per setup (setup is rare); an admin
+who can already read checksums via the secrets list gains no new oracle from checksum reuse; two concurrent
+first-time setups with the same key can create two entries, and later setups converge on the older one.
+
+365 backend tests green (`AgentSetupVaultKeyReuseTest` at 34), Checkstyle clean. Manager: the wizard success screen
+now renders `resources.vaultGrantWarning` verbatim (backend-authored, no new i18n keys) — its picker lists every
+vault key including narrowly granted ones, and this is where the user learns why such an agent will not deploy.
 
 ### EDDI-Manager — `feat/setup-vault-key-reuse`
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,7 +62,7 @@ decisions, not defaults. Field-injected like the neighbouring
 `vaultKeyName` is deliberately **not** exposed on the MCP `setup_agent` / `create_api_agent` tools. *(Rationale
 corrected in the third review pass below — an earlier version of this paragraph claimed it stopped a model
 pointing an agent at an arbitrary secret, which `apiKey: "${vault:...}"` already allows.)* The MCP path
-still de-duplicates by checksum wherever the deployment leaves that enabled, so it does not grow the vault either.
+still de-duplicates by checksum wherever the deployment leaves that enabled and the matching entry is granted to all agents, so it does not grow the vault either.
 
 **Files:** `AgentSetupService.java` (trim, `useNamedVaultKey`, `findReusableSecret`, `storeSecret`,
 step-0 move, validation now accepts `vaultKeyName` in place of `apiKey` for cloud providers),
@@ -178,9 +178,9 @@ Both bots reviewed; every finding was valid. Two were real bugs this branch had 
 - **Generated key names could collide** (CodeRabbit). `setup.<agent>.<timestamp>.apiKey` is not unique for two
   same-named agents in the same millisecond, and `store` is an upsert — so one silently overwrote the other's
   credential. Now carries a random suffix; the timestamp stays only because it dates the entry for an operator.
-- **An unparseable OpenAPI spec leaked a vault secret** (Copilot). Moving key resolution to "step 0" put it ahead
+- **An unparseable OpenAPI spec left an orphaned vault entry** (Copilot). Moving key resolution to "step 0" put it ahead
   of the spec parse, and `createApiAgent`'s pre-existing `catch (AgentSetupException) { throw e; }` rethrows
-  without rolling back — so under `vault-key-reuse=never` every invalid request left an orphan secret. Fixed at
+  without rolling back — so under `vault-key-reuse=never` every invalid request left an orphaned secret behind. Fixed at
   both ends: the parse now runs first (it creates nothing, so a bad spec never reaches the vault at all), and
   that catch arm now rolls back, which also closes the pre-existing document leak on the same path.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,84 @@
 
 
 
+## 🔑 fix(setup): stop agent setup minting a new vault key per agent (2026-08-18)
+
+**Repo:** EDDI (`fix/setup-vault-key-reuse`)
+
+Provisioning several agents against one provider key left one vault entry **per agent**
+(`setup.<agent>.<timestamp>.apiKey`), and pasting a `${vault:...}` reference into the wizard's API-key
+field did not reliably avoid it. Rotating that provider key then meant hunting down N unguessably named
+entries.
+
+**Root cause of the reference case.** `vaultApiKey()` recognised an existing reference with a
+**full-string** regex match, but never trimmed its input. A reference copied out of a UI list or a
+config carries surrounding whitespace, so `"${vault:openai-prod}\n"` failed the match, fell through to
+the "plaintext" branch, and was vaulted *as a secret whose value is a reference* — a brand-new, useless
+key on every setup. One `trim()`, applied before the check and to the stored value, closes it.
+
+**Three ways to share one key**, in the order `AgentSetupService.vaultApiKey()` considers them:
+
+1. **`vaultKeyName`** (new, REST-only field on `SetupAgentRequest` / `CreateApiAgentRequest`) — names
+   the entry. With `apiKey` it creates it under exactly that name; without one, the entry must already
+   exist, so a second agent needs no plaintext at all. Accepts `openai-prod` or `${vault:openai-prod}`.
+   Refuses to overwrite an entry holding a different value: other agents may already point at it, and
+   silently rewriting it rotates their credential. Also refuses (rather than degrading to plaintext)
+   when the vault is off — naming an entry is a request for one specific shared secret, and writing the
+   key in plaintext instead is not a smaller version of that request.
+2. **`apiKey` already a reference** — used as-is, now whitespace-tolerant.
+3. **`apiKey` plaintext the vault already holds** — reused instead of duplicated.
+
+**Plaintext reuse is checksum-based.** `SecretMetadata` already carries `sha256Hex(plaintext)` per
+entry, so a match needs no decryption and compares a digest of a value the caller just supplied — it
+reveals nothing they did not already know. Only entries with `allowedAgents` unset or `["*"]` qualify:
+referencing a deliberately narrowed grant from a new agent yields a config that `VaultGrantGate`
+rejects at deploy time, i.e. a reuse that "works" until it matters. Ties break oldest-first by
+`createdAt` then key name, so repeated setups converge on one entry instead of depending on listing
+order. A vault that cannot be listed falls through to storing a new entry — reuse is an optimisation,
+never a gate.
+
+**Configurable**, per §4.1 rule 1: `eddi.setup.vault-key-reuse=checksum|never`. `never` restores the
+pre-change per-agent behaviour, for deployments where two agents hold the same-valued key today but
+must be able to rotate independently. Neither value touches cases 1 and 2 — those are explicit caller
+decisions, not defaults. Field-injected like the neighbouring
+`eddi.setup.llm.log-conversation-content`, so directly constructed instances get the default.
+
+**Two correctness details worth naming:**
+
+- **A reused entry is never recorded under `VAULTED_SECRET_KEY`.** Rollback deletes whatever it finds
+  there; recording a shared entry would let a *later* agent's failed setup delete a key an earlier
+  agent is still referencing. Only `storeSecret()` — the single place that writes — records.
+- **Key resolution moved to "step 0"**, ahead of every store call in both `setupAgent` and
+  `createApiAgent`, matching the existing reasoning for up-front `hitlConfig` validation: an unusable
+  `vaultKeyName` must fail while rollback still has nothing to undo, not after a parser, ruleset, LLM
+  config and workflow already exist.
+
+`vaultKeyName` is deliberately **not** exposed on the MCP `setup_agent` / `create_api_agent` tools (the
+same call the existing `hitlConfig` and `maxToolIterations` comments make): a model that could choose
+the name could point a new agent at any unrestricted secret in the vault by naming it. The MCP path
+still de-duplicates by checksum, so it does not grow the vault either.
+
+**Files:** `AgentSetupService.java` (trim, `useNamedVaultKey`, `findReusableSecret`, `storeSecret`,
+step-0 move, validation now accepts `vaultKeyName` in place of `apiKey` for cloud providers),
+`SetupAgentRequest.java`, `CreateApiAgentRequest.java`, `McpSetupTools.java`, `CreateSubAgentTool.java`
+(both pass `null`), `application.properties`, `docs/secrets-vault.md`.
+
+**Tests:** new `AgentSetupVaultKeyReuseTest` — 17 tests over the trim regression, checksum reuse,
+grant-scoped skip, deterministic winner, the `never` switch, list-failure degradation, and all six
+`vaultKeyName` outcomes. Mutation-checked: reverting the `trim()` and the reuse lookup fails 5 of them,
+so they are not passing for the wrong reason. Full local run of `AgentSetup*Test`, `McpSetupToolsTest`,
+`CreateSubAgentTool*Test`, `SetupWizardConfigsPassStrictBoundaryTest` (261 tests) plus the repo-wide
+guards (`ImportStyleTest`, `DocumentationLinksTest`, `StrictBoundaryShippedConfigsTest`,
+`RuleSetStoreShippedRulesetsTest`) — all green.
+
+**What's next / not done here:** the Manager's agent wizard and Workforce team builder still render the
+API key as a bare text input. `operator-activation.tsx` already offers "Paste your API key, or pick a
+vault key" via `use-secrets` + `vault-ref.ts`; extending that picker to those two forms (and wiring it
+to `vaultKeyName`) is the matching EDDI-Manager change, and is where the multi-agent case gets a UI
+rather than a JSON field.
+
+---
+
 ## 🔒 fix(docker): bump UBI9 base digest for CVE-2026-11940 (python3 tarfile filter bypass) (2026-08-17)
 
 **Repo:** EDDI (`fix/trivy-cve-2026-11940-base-image`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -77,11 +77,68 @@ so they are not passing for the wrong reason. Full local run of `AgentSetup*Test
 guards (`ImportStyleTest`, `DocumentationLinksTest`, `StrictBoundaryShippedConfigsTest`,
 `RuleSetStoreShippedRulesetsTest`) — all green.
 
-**What's next / not done here:** the Manager's agent wizard and Workforce team builder still render the
-API key as a bare text input. `operator-activation.tsx` already offers "Paste your API key, or pick a
-vault key" via `use-secrets` + `vault-ref.ts`; extending that picker to those two forms (and wiring it
-to `vaultKeyName`) is the matching EDDI-Manager change, and is where the multi-agent case gets a UI
-rather than a JSON field.
+### Review pass — findings addressed
+
+A second read of the change turned up six things, all fixed on this branch:
+
+1. **The reused key was invisible.** The whole complaint is "I can't reuse the key because I can't find
+   its name", and the first cut made that *worse*: a newly created key showed up in
+   `resources.vaultedSecretKeyName`, but a reused one appeared nowhere. `SetupResult` now carries
+   **`apiKeyVaultReference`** on every setup — created or reused — to hand straight back as
+   `vaultKeyName` next time. It is null when the vault is off and the key went in as plaintext:
+   `vaultReferenceOrNull()` gates it, because the "effective api key" is the caller's secret in that
+   case and echoing it in a response body would put it through every proxy log on the way out.
+2. **A named key was rollback fodder, and that was a cross-agent delete.** Agent A creates
+   `${vault:openai-prod}`, agent B reuses it, A then fails → A's rollback deleted the key B now points
+   at. Fixed by not registering caller-named creations at all: rollback exists to stop a retry loop
+   growing the vault, and a chosen name cannot grow it (a retry reuses the same name), so deleting was
+   the riskier of the two options rather than the safer one.
+3. **`vaultKeyName` was not validated.** The value gets embedded in `${vault:<tenant>/<key>}`, where a
+   bare name containing `/` silently re-parses as a tenant separator and a `}` truncates the reference —
+   the agent then resolves a *different* secret, or none. Now checked against `[a-zA-Z0-9._-]{1,128}`,
+   the same charset `RestSecretStore` enforces on create.
+4. **Contradictory input resolved silently.** `vaultKeyName: "a"` with `apiKey: "${vault:b}"` honoured
+   `a` and dropped `b` on the floor — deploying the agent against a credential the caller did not pick.
+   Rejected now.
+5. **The rollback record was written before the store succeeded**, so a failed write left a name for a
+   secret that never existed and rollback logged a "could not remove" warning chasing it. Recorded after.
+6. **Key resolution moved out of the `try`.** It was already at "step 0", but inside the block, so a
+   clean `vaultKeyName 'x' does not exist` came back wrapped in `Failed to set up agent:`. Outside, the
+   400 says what is actually wrong. Also dropped the now-dead two-arg `vaultApiKey` overload.
+
+`AgentSetupVaultKeyReuseTest` grew to 25 tests covering each of these; `DynamicAgentToolsTest` picked up
+the extra `SetupResult` component. 356 tests across the setup suites and repo-wide guards, green,
+Checkstyle clean.
+
+### EDDI-Manager — `feat/setup-vault-key-reuse`
+
+The earlier note in this entry said the wizard and team builder "still render the API key as a bare text
+input". That was wrong — both already use `SecretKeyPicker`, which lists vault keys and can create one
+inline. What was actually missing was everything *around* the pick:
+
+- **`SecretKeyPicker` trims before deciding a value is a reference**, and normalises a pasted one. This
+  is the frontend half of the backend trim bug: a reference pasted with whitespace failed
+  `startsWith("${vault:")`, so the field stayed a masked password and the user had no way to tell the
+  paste had registered as a reference at all.
+- **The success screen shows `apiKeyVaultReference`** with a copy button — the answer to "which key did
+  this agent end up on".
+- **"Create Another" carries provider, model and the credential forward**, but only when it came back as
+  a reference. A plaintext key must not survive an explicit form reset, and with the vault off there is
+  nothing to reuse anyway.
+- **The Workforce team builder seeds a new advisor from the previous one.** A board is one provider and
+  one key across every member; without this the vault key had to be picked once per advisor — the exact
+  repetition that motivated this work.
+- Types: `vaultKeyName` on both requests, `apiKeyVaultReference` on `SetupResult`. `vaultKeyName`
+  deliberately gets **no form field**: the picker on `apiKey` already produces `${vault:<name>}` and can
+  create a named entry inline, so a second field would only be a second way to say the same thing.
+- Eleven locales updated (the `i18n-drift` gate covers all of them, not just `en`).
+
+Manager: 5,383 tests green, `tsc -b` clean, `eslint --max-warnings 0` clean. The two behavioural
+frontend changes are mutation-checked — reverting the trim and the seeding fails four of them.
+
+**What's next:** nothing outstanding for this feature. The Manager change is a separate PR and needs
+this backend merged first; against an older backend `apiKeyVaultReference` is simply absent and the
+success-screen block does not render.
 
 ---
 

--- a/docs/secrets-vault.md
+++ b/docs/secrets-vault.md
@@ -306,7 +306,13 @@ Every setup response carries **`apiKeyVaultReference`** — the reference the cr
 
 `vaultKeyName` must match `[a-zA-Z0-9._-]{1,128}` — the same charset the secrets REST API enforces, because the value gets embedded in `${vault:<tenant>/<key>}` where a `/` would re-parse as a tenant separator and a `}` would truncate the reference. Use the `${vault:tenant/key}` form for a non-default tenant. Naming one key in `vaultKeyName` and a *different* one in `apiKey` is rejected rather than silently resolved in favour of either.
 
-`vaultKeyName` is a REST-only field. It is deliberately absent from the MCP `setup_agent` / `create_api_agent` tools, where a model choosing the name could point a new agent at any unrestricted secret in the vault by naming it.
+`vaultKeyName` is a REST-only field (`eddi-admin`). The MCP `setup_agent` / `create_api_agent` tools do not carry it — not to prevent reuse, which their `apiKey` already supports as a `${vault:...}` reference, but because the two things it *adds* (choosing the name of a newly created entry, and a value-must-match check on an existing one) are not needed to provision an agent and do not belong on the `eddi-editor` tier those tools are open to: name-squatting an entry an operator intends to create, and a per-request "does key X hold value V" oracle.
+
+Naming, or pasting a reference to, a secret whose `allowedAgents` is narrowed is accepted — the legitimate flow is setup without deploy, widen the grant to the new agent's ID, deploy — but a brand-new agent cannot be on any existing grant list, so under `enforce` a `deploy: true` setup will end as `deployed: false`. The response says so up front in `resources.vaultGrantWarning`. (Plaintext reuse simply skips such entries.)
+
+### What rollback does with the vault
+
+A setup that fails part-way rolls back the documents it created. It also removes the secret it vaulted — but only when nothing else can be referencing it: under `never` (unique per-agent names) it does; under `checksum` a freshly stored entry is a shared resource the moment a second setup with the same key runs, so it is left in place — a retry finds it by value and reuses it, and at worst it is one orphan. A caller-named entry is never rolled back for the same reason.
 
 ### Collision Prevention
 

--- a/docs/secrets-vault.md
+++ b/docs/secrets-vault.md
@@ -302,6 +302,10 @@ Plaintext reuse is matched on the SHA-256 checksum the vault already stores per 
 
 Set `eddi.setup.vault-key-reuse=never` to switch plaintext reuse off and give every agent its own entry again — appropriate when two agents hold the same-valued key today but must be able to rotate independently. Neither setting affects the first two rows above: those are explicit caller decisions.
 
+Every setup response carries **`apiKeyVaultReference`** — the reference the created agent's LLM config actually points at, whether this call vaulted the key or reused an entry that already held it. Pass it straight back as `vaultKeyName` (or as `apiKey`) on the next setup to put another agent on the same credential. It is `null` when the vault is disabled and the key was stored in plaintext: the plaintext is a secret and is never echoed back in a response body.
+
+`vaultKeyName` must match `[a-zA-Z0-9._-]{1,128}` — the same charset the secrets REST API enforces, because the value gets embedded in `${vault:<tenant>/<key>}` where a `/` would re-parse as a tenant separator and a `}` would truncate the reference. Use the `${vault:tenant/key}` form for a non-default tenant. Naming one key in `vaultKeyName` and a *different* one in `apiKey` is rejected rather than silently resolved in favour of either.
+
 `vaultKeyName` is a REST-only field. It is deliberately absent from the MCP `setup_agent` / `create_api_agent` tools, where a model choosing the name could point a new agent at any unrestricted secret in the vault by naming it.
 
 ### Collision Prevention

--- a/docs/secrets-vault.md
+++ b/docs/secrets-vault.md
@@ -295,12 +295,12 @@ One provider key usually serves many agents, so setup avoids storing it many tim
 | What you pass | What setup does |
 | ------------- | --------------- |
 | `vaultKeyName: "openai-prod"` (with or without `apiKey`) | Uses that entry. With `apiKey` it **creates** the entry under exactly that name; without one, the entry must already exist. Never overwrites an entry holding a different value — the request is rejected instead, because other agents may already point at it. Accepts the `${vault:openai-prod}` form too. |
-| `apiKey: "${vault:openai-prod}"` | Used as-is, never re-vaulted. Surrounding whitespace is trimmed first, so a pasted reference still counts as one. |
+| `apiKey: "${vault:openai-prod}"` | Used as-is, never re-vaulted. Surrounding whitespace is trimmed first, so a pasted reference still counts as one. If the key does not exist the setup still succeeds (you may vault it afterwards) but a warning is logged — the agent cannot resolve its credential until it does. |
 | `apiKey: "sk-…"` (plaintext) | Reused if the vault already holds that exact value, otherwise stored under a generated name. |
 
 Plaintext reuse is matched on the SHA-256 checksum the vault already stores per entry — nothing is decrypted to make the decision — and only entries with `allowedAgents` unset or `["*"]` are candidates, since referencing a narrowed grant from a new agent produces a config that [grant enforcement](#agent-grants-allowedagents) rejects at deploy time. When several entries match, the oldest wins, so repeated setups converge on one entry rather than depending on listing order.
 
-Set `eddi.setup.vault-key-reuse=never` to switch plaintext reuse off and give every agent its own entry again — appropriate when two agents hold the same-valued key today but must be able to rotate independently. Neither setting affects the first two rows above: those are explicit caller decisions.
+Set `eddi.setup.vault-key-reuse=never` to switch plaintext reuse off and give every agent its own entry again — appropriate when two agents hold the same-valued key today but must be able to rotate independently. Neither setting affects the first two rows above: those are explicit caller decisions. Any other value fails startup, as `eddi.vault.grant-enforcement` does — a typo must not silently switch de-duplication off.
 
 Every setup response carries **`apiKeyVaultReference`** — the reference the created agent's LLM config actually points at, whether this call vaulted the key or reused an entry that already held it. Pass it straight back as `vaultKeyName` (or as `apiKey`) on the next setup to put another agent on the same credential. It is `null` when the vault is disabled and the key was stored in plaintext: the plaintext is a secret and is never echoed back in a response body.
 

--- a/docs/secrets-vault.md
+++ b/docs/secrets-vault.md
@@ -332,7 +332,7 @@ A setup that fails part-way rolls back the documents it created. It also removes
 
 A generated vault key is named `setup.<agent>.<timestamp>-<random>.apiKey`. The timestamp alone was not sufficient: two setups for agents with the same name landing in the same millisecond produced the same name, and `store` is an upsert, so one silently overwrote the other's credential. The random suffix is what makes the name unique; the timestamp is kept because it tells you when the entry was made.
 
-A **caller-chosen** `vaultKeyName` has no such suffix, by design — that is the point of naming it. Creating one is read-then-write rather than a conditional insert, so two setups naming the same new key with different values can race; the loser is detected on read-back and fails before anything is created, but a write landing after that read is not caught. Prefer creating a shared key through the secrets REST API first, then naming it.
+A **caller-chosen** `vaultKeyName` has no such suffix, by design — that is the point of naming it. Creating one is read-then-write rather than a conditional insert, so two setups naming the same new key with different values can race; the loser is detected on read-back and fails before anything is created, but a write landing after that read is not caught (an atomic create-if-absent for the vault SPI is tracked in [issue #700](https://github.com/labsai/EDDI/issues/700)). Prefer creating a shared key through the secrets REST API first, then naming it.
 
 ### Graceful Degradation
 

--- a/docs/secrets-vault.md
+++ b/docs/secrets-vault.md
@@ -302,13 +302,27 @@ Plaintext reuse is matched on the SHA-256 checksum the vault already stores per 
 
 Set `eddi.setup.vault-key-reuse=never` to switch plaintext reuse off and give every agent its own entry again — appropriate when two agents hold the same-valued key today but must be able to rotate independently. Neither setting affects the first two rows above: those are explicit caller decisions. Any other value fails startup, as `eddi.vault.grant-enforcement` does — a typo must not silently switch de-duplication off.
 
-Every setup response carries **`apiKeyVaultReference`** — the reference the created agent's LLM config actually points at, whether this call vaulted the key or reused an entry that already held it. Pass it straight back as `vaultKeyName` (or as `apiKey`) on the next setup to put another agent on the same credential. It is `null` when the vault is disabled and the key was stored in plaintext: the plaintext is a secret and is never echoed back in a response body.
+Every setup response carries **`apiKeyVaultReference`** — the reference the created agent's LLM config actually points at, whether this call vaulted the key or reused an entry that already held it. Pass it straight back as `vaultKeyName` (or as `apiKey`) on the next setup to put another agent on the same credential.
 
-`vaultKeyName` must match `[a-zA-Z0-9._-]{1,128}` — the same charset the secrets REST API enforces, because the value gets embedded in `${vault:<tenant>/<key>}` where a `/` would re-parse as a tenant separator and a `}` would truncate the reference. Use the `${vault:tenant/key}` form for a non-default tenant. Naming one key in `vaultKeyName` and a *different* one in `apiKey` is rejected rather than silently resolved in favour of either.
+It is `null` in two cases: the provider needs no key at all (`ollama`, `jlama`, `bedrock`, `oracle-genai`, …), and the vault is disabled so the key was stored in plaintext — a plaintext key is a secret and is never echoed back in a response body.
+
+A setup can also return **`resources.vaultWarning`**: the chosen key does not exist, or it is granted only to other agents. Neither fails the setup — see *Reusing one key across agents* above — but both end in an agent that was created and cannot use its credential, so both are reported rather than only logged.
+
+`vaultKeyName` accepts three shapes:
+
+| Shape | Parsed as |
+| --- | --- |
+| `openai-prod` | key `openai-prod` in the `default` tenant |
+| `${vault:openai-prod}` | the same — the wrapper is unwrapped, not stored |
+| `${vault:acme/openai-prod}` | key `openai-prod` in tenant `acme` |
+
+The **tenant and key components** must each match `[a-zA-Z0-9._-]{1,128}` — the same charset the secrets REST API enforces on create. (The `${vault:…}` wrapper itself is of course not expected to match; it is stripped first.) The constraint is not cosmetic: the components are re-embedded into `${vault:<tenant>/<key>}`, where a `/` inside a *bare* name would re-parse as a tenant separator and a `}` would truncate the reference, leaving the agent pointing at a different secret or none.
+
+Naming one key in `vaultKeyName` and a *different* one in `apiKey` is rejected rather than silently resolved in favour of either.
 
 `vaultKeyName` is a REST-only field (`eddi-admin`). The MCP `setup_agent` / `create_api_agent` tools do not carry it — not to prevent reuse, which their `apiKey` already supports as a `${vault:...}` reference, but because the two things it *adds* (choosing the name of a newly created entry, and a value-must-match check on an existing one) are not needed to provision an agent and do not belong on the `eddi-editor` tier those tools are open to: name-squatting an entry an operator intends to create, and a per-request "does key X hold value V" oracle.
 
-Naming, or pasting a reference to, a secret whose `allowedAgents` is narrowed is accepted — the legitimate flow is setup without deploy, widen the grant to the new agent's ID, deploy — but a brand-new agent cannot be on any existing grant list, so under `enforce` a `deploy: true` setup will end as `deployed: false`. The response says so up front in `resources.vaultGrantWarning`. (Plaintext reuse simply skips such entries.)
+Naming, or pasting a reference to, a secret whose `allowedAgents` is narrowed is accepted — the legitimate flow is setup without deploy, widen the grant to the new agent's ID, deploy — but a brand-new agent cannot be on any existing grant list, so under `enforce` a `deploy: true` setup will end as `deployed: false`. The response says so up front in `resources.vaultWarning`. (Plaintext reuse simply skips such entries.)
 
 ### What rollback does with the vault
 
@@ -316,7 +330,9 @@ A setup that fails part-way rolls back the documents it created. It also removes
 
 ### Collision Prevention
 
-A generated vault key includes an epoch-millisecond timestamp suffix. This prevents key collisions when two agents share the same name — each gets a unique vault entry.
+A generated vault key is named `setup.<agent>.<timestamp>-<random>.apiKey`. The timestamp alone was not sufficient: two setups for agents with the same name landing in the same millisecond produced the same name, and `store` is an upsert, so one silently overwrote the other's credential. The random suffix is what makes the name unique; the timestamp is kept because it tells you when the entry was made.
+
+A **caller-chosen** `vaultKeyName` has no such suffix, by design — that is the point of naming it. Creating one is read-then-write rather than a conditional insert, so two setups naming the same new key with different values can race; the loser is detected on read-back and fails before anything is created, but a write landing after that read is not caught. Prefer creating a shared key through the secrets REST API first, then naming it.
 
 ### Graceful Degradation
 

--- a/docs/secrets-vault.md
+++ b/docs/secrets-vault.md
@@ -192,6 +192,11 @@ eddi.vault.cache-max-size=1000
 # Whether an agent referencing a secret it is not granted may deploy:
 # off | warn | enforce (default). See "Agent Grants" above.
 eddi.vault.grant-enforcement=enforce
+
+# Whether agent setup reuses a vault entry that already holds the same
+# plaintext key: checksum (default) | never.
+# See "Reusing one key across agents" below.
+eddi.setup.vault-key-reuse=checksum
 ```
 
 > **⚠️ Important:** The vault master key encrypts all stored API keys. If the master key is lost, all encrypted secrets become **permanently unrecoverable**. Back up your `~/.eddi/.env` file.
@@ -279,17 +284,35 @@ When creating agents through the Manager's agent wizard, the Platform Operator, 
 ### How It Works
 
 1. User provides an API key during agent setup
-2. `AgentSetupService.vaultApiKey()` stores the key in the vault
-3. A vault reference (`${vault:setup.<agent-name>.<timestamp>.apiKey}`) is written to the LLM configuration
+2. `AgentSetupService.vaultApiKey()` resolves it against the vault (see *Reusing one key across agents* below)
+3. A vault reference (`${vault:setup.<agent-name>.<timestamp>.apiKey}`, or the name you chose) is written to the LLM configuration
 4. When the vault is enabled, the plaintext key is never persisted in MongoDB — only the vault reference is stored
+
+### Reusing one key across agents
+
+One provider key usually serves many agents, so setup avoids storing it many times. Three ways to say "use this key", in the order setup considers them:
+
+| What you pass | What setup does |
+| ------------- | --------------- |
+| `vaultKeyName: "openai-prod"` (with or without `apiKey`) | Uses that entry. With `apiKey` it **creates** the entry under exactly that name; without one, the entry must already exist. Never overwrites an entry holding a different value — the request is rejected instead, because other agents may already point at it. Accepts the `${vault:openai-prod}` form too. |
+| `apiKey: "${vault:openai-prod}"` | Used as-is, never re-vaulted. Surrounding whitespace is trimmed first, so a pasted reference still counts as one. |
+| `apiKey: "sk-…"` (plaintext) | Reused if the vault already holds that exact value, otherwise stored under a generated name. |
+
+Plaintext reuse is matched on the SHA-256 checksum the vault already stores per entry — nothing is decrypted to make the decision — and only entries with `allowedAgents` unset or `["*"]` are candidates, since referencing a narrowed grant from a new agent produces a config that [grant enforcement](#agent-grants-allowedagents) rejects at deploy time. When several entries match, the oldest wins, so repeated setups converge on one entry rather than depending on listing order.
+
+Set `eddi.setup.vault-key-reuse=never` to switch plaintext reuse off and give every agent its own entry again — appropriate when two agents hold the same-valued key today but must be able to rotate independently. Neither setting affects the first two rows above: those are explicit caller decisions.
+
+`vaultKeyName` is a REST-only field. It is deliberately absent from the MCP `setup_agent` / `create_api_agent` tools, where a model choosing the name could point a new agent at any unrestricted secret in the vault by naming it.
 
 ### Collision Prevention
 
-Each vault key includes an epoch-millisecond timestamp suffix. This prevents key collisions when two agents share the same name — each gets a unique vault entry.
+A generated vault key includes an epoch-millisecond timestamp suffix. This prevents key collisions when two agents share the same name — each gets a unique vault entry.
 
 ### Graceful Degradation
 
 When the vault is disabled (no `EDDI_VAULT_MASTER_KEY`), the setup service logs a warning and falls back to plaintext storage. This ensures agent setup works in local development without requiring vault configuration.
+
+A request carrying `vaultKeyName` is the exception: it fails with a clear error instead. Naming a vault entry is a request for one specific shared secret, and quietly writing the key in plaintext is not a smaller version of that.
 
 > **Production recommendation:** Always set `EDDI_VAULT_MASTER_KEY` in production. The installer does this automatically.
 

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
@@ -59,7 +59,9 @@ public class McpSetupTools {
                              @ToolArg(description = "API key for the LLM provider. Required for most cloud providers "
                                      + "(anthropic, openai, gemini, mistral). Not needed for bedrock (uses IAM), "
                                      + "oracle-genai (uses OCI auth), or local LLMs (ollama, jlama). "
-                                     + "Can be a vault reference like '${vault:openai-key}'.") String apiKey,
+                                     + "Can be a vault reference like '${vault:openai-key}'. To put several agents on ONE key, "
+                                     + "pass the apiKeyVaultReference returned by an earlier setup_agent call here — a plaintext "
+                                     + "key that the vault already holds is also reused rather than stored again.") String apiKey,
                              @ToolArg(description = "Base URL for the LLM provider (optional). "
                                      + "Useful for ollama when running in Docker (e.g. 'http://host.docker.internal:11434')") String baseUrl,
                              @ToolArg(description = "Greeting message shown when a conversation starts (optional)") String introMessage,
@@ -121,7 +123,8 @@ public class McpSetupTools {
                                  @ToolArg(description = "Model name (default: 'claude-sonnet-4-6')") String model,
                                  @ToolArg(description = "LLM API key (required for most cloud providers: anthropic, openai, gemini, mistral). "
                                          + "Not needed for bedrock (IAM) or oracle-genai (OCI auth). "
-                                         + "Use vault reference: '${vault:key-name}'.") String apiKey,
+                                         + "Use vault reference: '${vault:key-name}', e.g. the apiKeyVaultReference returned by an "
+                                         + "earlier setup call, to share one key across agents.") String apiKey,
                                  @ToolArg(description = "Override the API base URL from the spec (optional)") String apiBaseUrl,
                                  @ToolArg(description = "Authorization header for API calls, e.g. 'Bearer token123' (optional). "
                                          + "Use vault reference: '${vault:api-token}'.") String apiAuth,

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
@@ -92,12 +92,16 @@ public class McpSetupTools {
             // REST setup endpoint.
             var request = new SetupAgentRequest(agentName, systemPrompt, provider, model, apiKey, baseUrl, introMessage, enableBuiltInTools,
                     builtInToolsWhitelist, enableQuickReplies, enableSentimentAnalysis, mcpServerUrls, deploy, environment, null,
-                    // vaultKeyName is not exposed here either: naming the vault entry
-                    // an agent's credential lands in is an operator decision, and a
-                    // model that could choose it could point a new agent at any
-                    // unrestricted secret in the vault by name. A plaintext apiKey
-                    // still de-duplicates by checksum, so the MCP path does not grow
-                    // the vault either.
+                    // vaultKeyName is not exposed here. Not for reuse — apiKey already
+                    // accepts a ${vault:...} reference (see its description), so an
+                    // MCP caller can put an agent on an existing key today, and a
+                    // plaintext apiKey de-duplicates by checksum. What vaultKeyName adds
+                    // is choosing the NAME of a newly created entry and a
+                    // value-must-match check on an existing one — and these tools are
+                    // reachable by eddi-editor while REST setup is eddi-admin. Neither
+                    // is needed to provision an agent, and neither belongs on the
+                    // lower tier: name-squatting an entry an operator intends to create,
+                    // and a per-request "does key X hold value V" oracle.
                     null);
             var result = agentSetupService.setupAgent(request);
             return jsonSerialization.serialize(result);
@@ -150,7 +154,7 @@ public class McpSetupTools {
             // a model provisioning an agent must not raise its own iteration budget.
             var request = new CreateApiAgentRequest(agentName, systemPrompt, openApiSpec, provider, model, apiKey, apiBaseUrl, apiAuth, endpoints,
                     enableQuickReplies, enableSentimentAnalysis, deploy, environment, llmBaseUrl, null, mcpServerUrls, null,
-                    null); // vaultKeyName — withheld from this tool for the reason given on setup_agent
+                    null); // vaultKeyName — withheld for the reason given on setup_agent
             var result = agentSetupService.createApiAgent(request);
             return jsonSerialization.serialize(result);
         } catch (AgentSetupException e) {

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
@@ -60,8 +60,10 @@ public class McpSetupTools {
                                      + "(anthropic, openai, gemini, mistral). Not needed for bedrock (uses IAM), "
                                      + "oracle-genai (uses OCI auth), or local LLMs (ollama, jlama). "
                                      + "Can be a vault reference like '${vault:openai-key}'. To put several agents on ONE key, "
-                                     + "pass the apiKeyVaultReference returned by an earlier setup_agent call here — a plaintext "
-                                     + "key that the vault already holds is also reused rather than stored again.") String apiKey,
+                                     + "pass the apiKeyVaultReference returned by an earlier setup_agent call here — that always "
+                                     + "reuses the named entry. A plaintext key the vault already holds is reused too, but only "
+                                     + "when the deployment leaves eddi.setup.vault-key-reuse at 'checksum' and the existing entry "
+                                     + "is granted to all agents; otherwise it is stored as a new entry.") String apiKey,
                              @ToolArg(description = "Base URL for the LLM provider (optional). "
                                      + "Useful for ollama when running in Docker (e.g. 'http://host.docker.internal:11434')") String baseUrl,
                              @ToolArg(description = "Greeting message shown when a conversation starts (optional)") String introMessage,
@@ -95,7 +97,8 @@ public class McpSetupTools {
                     // vaultKeyName is not exposed here. Not for reuse — apiKey already
                     // accepts a ${vault:...} reference (see its description), so an
                     // MCP caller can put an agent on an existing key today, and a
-                    // plaintext apiKey de-duplicates by checksum. What vaultKeyName adds
+                    // plaintext apiKey de-duplicates by checksum wherever the
+                    // deployment has that enabled. What vaultKeyName adds
                     // is choosing the NAME of a newly created entry and a
                     // value-must-match check on an existing one — and these tools are
                     // reachable by eddi-editor while REST setup is eddi-admin. Neither

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
@@ -89,7 +89,14 @@ public class McpSetupTools {
             // ungated agent at will. Provisioning a gated agent goes through the
             // REST setup endpoint.
             var request = new SetupAgentRequest(agentName, systemPrompt, provider, model, apiKey, baseUrl, introMessage, enableBuiltInTools,
-                    builtInToolsWhitelist, enableQuickReplies, enableSentimentAnalysis, mcpServerUrls, deploy, environment, null);
+                    builtInToolsWhitelist, enableQuickReplies, enableSentimentAnalysis, mcpServerUrls, deploy, environment, null,
+                    // vaultKeyName is not exposed here either: naming the vault entry
+                    // an agent's credential lands in is an operator decision, and a
+                    // model that could choose it could point a new agent at any
+                    // unrestricted secret in the vault by name. A plaintext apiKey
+                    // still de-duplicates by checksum, so the MCP path does not grow
+                    // the vault either.
+                    null);
             var result = agentSetupService.setupAgent(request);
             return jsonSerialization.serialize(result);
         } catch (AgentSetupException e) {
@@ -139,7 +146,8 @@ public class McpSetupTools {
             // Trailing null: maxToolIterations is not exposed on this MCP tool either —
             // a model provisioning an agent must not raise its own iteration budget.
             var request = new CreateApiAgentRequest(agentName, systemPrompt, openApiSpec, provider, model, apiKey, apiBaseUrl, apiAuth, endpoints,
-                    enableQuickReplies, enableSentimentAnalysis, deploy, environment, llmBaseUrl, null, mcpServerUrls, null);
+                    enableQuickReplies, enableSentimentAnalysis, deploy, environment, llmBaseUrl, null, mcpServerUrls, null,
+                    null); // vaultKeyName — withheld from this tool for the reason given on setup_agent
             var result = agentSetupService.createApiAgent(request);
             return jsonSerialization.serialize(result);
         } catch (AgentSetupException e) {

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -1089,10 +1089,18 @@ public class AgentSetupService {
         }
 
         try {
-            // Namespace: setup.<sanitized-agent-name>.<timestamp>.apiKey
-            // Timestamp suffix prevents collision when two agents share the same name
+            // Namespace: setup.<sanitized-agent-name>.<timestamp>-<random>.apiKey
+            //
+            // The timestamp alone did not make this unique. Two setups for agents with
+            // the same name, landing in the same millisecond, produced the same key
+            // name — and secretProvider.store is an UPSERT, so the second silently
+            // overwrote the first, leaving one agent referencing the other's
+            // credential. The random suffix is what actually prevents that; the
+            // timestamp stays because it tells an operator reading the vault when the
+            // entry was made.
             String sanitizedName = agentName.toLowerCase().replaceAll("[^a-z0-9]", "-");
-            String keyName = "setup." + sanitizedName + "." + System.currentTimeMillis() + ".apiKey";
+            String keyName = "setup." + sanitizedName + "." + System.currentTimeMillis() + "-"
+                    + UUID.randomUUID().toString().substring(0, 8) + ".apiKey";
             // Rollback deletes what is recorded here, and that is only safe while nobody
             // else can be referencing the entry. Under `never` that holds: the name is
             // unique and no other setup will find it. Under `checksum` it does not — the
@@ -1185,9 +1193,40 @@ public class AgentSetupService {
             // triggers rollback, a concurrent setup may already have reused the entry,
             // and rollback would pull the key out from under an agent that is not ours.
             // Leaving it also means the retry finds the key already in place.
-            return storeSecret(ref, key, agentName, null);
+            String reference = storeSecret(ref, key, agentName, null);
+            verifyStoredValue(ref, key);
+            return reference;
         } catch (ISecretProvider.SecretProviderException e) {
             throw new AgentSetupException("Could not store the API key under vault key '" + ref.keyName() + "': " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Read the entry back and fail if it does not hold what was just written.
+     * <p>
+     * The absent-then-create sequence above is not atomic: {@code store} is an
+     * UPSERT (every {@link ISecretProvider} caller uses it that way — there is no
+     * create-if-absent in the SPI), so two setups naming the same key with
+     * different values can both find it missing and both write. Without this check
+     * the loser proceeds and provisions an agent pointing at the winner's
+     * credential.
+     * <p>
+     * This narrows the window rather than closing it: a write that lands after this
+     * read is still missed. Closing it properly needs a conditional insert in the
+     * persistence layer (Mongo and Postgres both), which is an SPI change shared
+     * with three other callers and does not belong in this one. What it does buy is
+     * that the common interleaving fails loudly, here, before a single document is
+     * created — instead of silently.
+     */
+    private void verifyStoredValue(SecretReference ref, String expectedPlaintext) throws AgentSetupException {
+        try {
+            SecretMetadata written = secretProvider.getMetadata(ref);
+            if (written.checksum() != null && !EnvelopeCrypto.sha256Hex(expectedPlaintext).equals(written.checksum())) {
+                throw new AgentSetupException("Vault key '" + ref.keyName() + "' was written concurrently by another setup and now holds "
+                        + "a different value. Nothing was created; retry, or choose a vaultKeyName that is not in contention.");
+            }
+        } catch (ISecretProvider.SecretNotFoundException | ISecretProvider.SecretProviderException e) {
+            LOGGER.debugf("Could not read back vault key '%s' after storing it: %s", LogSanitizer.sanitize(ref.keyName()), e.getMessage());
         }
     }
 
@@ -1260,12 +1299,16 @@ public class AgentSetupService {
     }
 
     /**
-     * {@code SetupResult.resources} key under which a non-fatal vault warning is
-     * returned to the caller. {@code resources} is already the channel for
-     * {@code deployWarning}/{@code deployError}, and the REST and MCP callers see
-     * it; a server-side log line alone would not reach them.
+     * {@code SetupResult.resources} key under which a non-fatal problem with the
+     * vault key the new agent points at is returned to the caller — the key does
+     * not exist, or it is granted only to other agents. Both end the same way, in
+     * an agent that was created successfully and cannot use its credential, so both
+     * belong in the response: {@code resources} is already the channel for
+     * {@code deployWarning}/{@code deployError}, and a server-side log line alone
+     * does not reach the caller. Only one vault key is resolved per setup, so the
+     * two cases cannot collide over this entry.
      */
-    static final String VAULT_GRANT_WARNING = "vaultGrantWarning";
+    static final String VAULT_WARNING = "vaultWarning";
 
     /**
      * A pass-through {@code apiKey} reference is accepted as-is — that has always
@@ -1283,8 +1326,8 @@ public class AgentSetupService {
         try {
             warnIfRestricted(secretProvider.getMetadata(ref), agentName, resources);
         } catch (ISecretProvider.SecretNotFoundException e) {
-            LOGGER.warnf("Agent '%s' references vault key '%s', which does not exist (yet). The agent will fail to resolve its API "
-                    + "key at runtime until that secret is created.", LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(ref.keyName()));
+            warn(resources, agentName, "Vault key '" + ref.keyName() + "' does not exist. The agent was created, but cannot resolve its "
+                    + "API key at runtime until that secret is stored (secrets REST API).");
         } catch (ISecretProvider.SecretProviderException e) {
             LOGGER.debugf("Could not check vault key '%s': %s", LogSanitizer.sanitize(ref.keyName()), e.getMessage());
         }
@@ -1304,13 +1347,17 @@ public class AgentSetupService {
         if (metadata == null || isUnrestricted(metadata)) {
             return;
         }
-        String warning = "Vault key '" + metadata.keyName() + "' is granted only to " + metadata.allowedAgents()
+        warn(resources, agentName, "Vault key '" + metadata.keyName() + "' is granted only to " + metadata.allowedAgents()
                 + ". The agent being created cannot be on that list yet, so with eddi.vault.grant-enforcement=enforce its "
                 + "deployment will be blocked until the grant is widened to '*' or to the new agent's ID (secrets REST API, "
-                + "PATCH allowedAgents).";
+                + "PATCH allowedAgents).");
+    }
+
+    /** Log a non-fatal vault problem and return it to the caller. */
+    private void warn(Map<String, Object> resources, String agentName, String warning) {
         LOGGER.warnf("Agent '%s': %s", LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(warning));
         if (resources != null) {
-            resources.put(VAULT_GRANT_WARNING, warning);
+            resources.put(VAULT_WARNING, warning);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -356,7 +356,8 @@ public class AgentSetupService {
 
         // The auto-vaulted secret is created BEFORE the LLM document, so a later
         // failure would leave a unique setup.<name>.<timestamp>.apiKey behind and a
-        // retry loop would grow the vault without bound.
+        // retry loop would grow the vault without bound. Only ever set for an entry
+        // no other setup can be referencing — see vaultApiKey for when that holds.
         Object vaultedKey = createdResources.get(VAULTED_SECRET_KEY);
         if (vaultedKey instanceof String keyName) {
             try {
@@ -1042,10 +1043,14 @@ public class AgentSetupService {
      *            to store under and reuse; null or blank to let this method choose
      * @param createdResources
      *            when non-null, the key name of a secret <b>newly created</b> by
-     *            this call is recorded here so a failed setup can remove it again.
-     *            A <em>reused</em> entry is deliberately never recorded: rollback
-     *            deletes what it finds there, and a shared key must survive the
-     *            failure of one agent that happened to reference it.
+     *            this call — and that no other setup can find — is recorded here so
+     *            a failed setup can remove it again. A <em>reused</em> entry, a
+     *            caller-<em>named</em> entry, and (under {@code checksum} reuse) a
+     *            generated one are deliberately never recorded: rollback deletes
+     *            what it finds there, and a key another agent may already point at
+     *            must survive the failure of the one that happened to create it.
+     *            Also used to carry non-fatal warnings (see
+     *            {@link #VAULT_GRANT_WARNING}) into {@code SetupResult.resources}.
      */
     private String vaultApiKey(String apiKey, String agentName, String vaultKeyName, Map<String, Object> createdResources)
             throws AgentSetupException {
@@ -1066,7 +1071,7 @@ public class AgentSetupService {
         // ${eddivault:...})
         if (isVaultReference(key)) {
             LOGGER.infof("API key for agent '%s' is already a vault reference — using as-is.", LogSanitizer.sanitize(agentName));
-            warnIfMissing(SecretReference.parse(key), agentName);
+            checkReferencedSecret(SecretReference.parse(key), agentName, createdResources);
             return key;
         }
 
@@ -1088,7 +1093,18 @@ public class AgentSetupService {
             // Timestamp suffix prevents collision when two agents share the same name
             String sanitizedName = agentName.toLowerCase().replaceAll("[^a-z0-9]", "-");
             String keyName = "setup." + sanitizedName + "." + System.currentTimeMillis() + ".apiKey";
-            return storeSecret(new SecretReference(SecretReference.DEFAULT_TENANT, keyName), key, agentName, createdResources);
+            // Rollback deletes what is recorded here, and that is only safe while nobody
+            // else can be referencing the entry. Under `never` that holds: the name is
+            // unique and no other setup will find it. Under `checksum` it does not — the
+            // moment a second setup with the same key runs, this entry is THEIR
+            // reference too, and a rollback triggered by this setup's later failure
+            // would break every agent that reused it in the meantime. The growth this
+            // rollback was added to prevent (a retry loop minting a key per attempt)
+            // cannot happen under `checksum` anyway: the retry finds this very entry by
+            // value and reuses it. So under `checksum` the entry is left in place, and
+            // is either reused by the retry or is one harmless orphan.
+            Map<String, Object> rollbackRegistry = VAULT_KEY_REUSE_NEVER.equalsIgnoreCase(vaultKeyReuse) ? createdResources : null;
+            return storeSecret(new SecretReference(SecretReference.DEFAULT_TENANT, keyName), key, agentName, rollbackRegistry);
         } catch (ISecretProvider.SecretProviderException e) {
             LOGGER.error("Failed to vault API key for agent '" + LogSanitizer.sanitize(agentName) + "': " + e.getMessage()
                     + " — falling back to plaintext storage.");
@@ -1152,6 +1168,7 @@ public class AgentSetupService {
             }
             LOGGER.infof("Agent '%s' reuses existing vault key '%s'.", LogSanitizer.sanitize(agentName),
                     LogSanitizer.sanitize(ref.keyName()));
+            warnIfRestricted(existing, agentName, createdResources);
             return ref.toReferenceString();
         }
 
@@ -1243,24 +1260,57 @@ public class AgentSetupService {
     }
 
     /**
+     * {@code SetupResult.resources} key under which a non-fatal vault warning is
+     * returned to the caller. {@code resources} is already the channel for
+     * {@code deployWarning}/{@code deployError}, and the REST and MCP callers see
+     * it; a server-side log line alone would not reach them.
+     */
+    static final String VAULT_GRANT_WARNING = "vaultGrantWarning";
+
+    /**
      * A pass-through {@code apiKey} reference is accepted as-is — that has always
      * been the contract, and callers may legitimately vault the key after setup or
      * hold it under a tenant this check cannot see. But by far the commonest cause
      * of a dangling reference is a typo in a paste, and the result is an agent that
-     * deploys fine and fails on its first turn. Say so now, in the log, while the
-     * caller is still looking.
+     * deploys fine and fails on its first turn. Say so now, while the caller is
+     * still looking. Likewise for a grant the new agent cannot satisfy — see
+     * {@link #warnIfRestricted}.
      */
-    private void warnIfMissing(SecretReference ref, String agentName) {
+    private void checkReferencedSecret(SecretReference ref, String agentName, Map<String, Object> resources) {
         if (!secretProvider.isAvailable()) {
             return;
         }
         try {
-            secretProvider.getMetadata(ref);
+            warnIfRestricted(secretProvider.getMetadata(ref), agentName, resources);
         } catch (ISecretProvider.SecretNotFoundException e) {
             LOGGER.warnf("Agent '%s' references vault key '%s', which does not exist (yet). The agent will fail to resolve its API "
                     + "key at runtime until that secret is created.", LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(ref.keyName()));
         } catch (ISecretProvider.SecretProviderException e) {
             LOGGER.debugf("Could not check vault key '%s': %s", LogSanitizer.sanitize(ref.keyName()), e.getMessage());
+        }
+    }
+
+    /**
+     * The checksum path simply skips a narrowly granted entry, but a caller who
+     * NAMED one, or pasted its reference, meant it — and a brand-new agent's ID
+     * cannot be in any grant list that already exists, so under
+     * {@code eddi.vault.grant-enforcement=enforce} the deployment WILL be blocked.
+     * That is not a reason to refuse the setup: the legitimate flow is exactly
+     * setup without deploy, widen the grant to the new agent ID, then deploy. It is
+     * a reason to say so now, in the response as well as the log, instead of
+     * letting the caller discover it as {@code deployed: false}.
+     */
+    private void warnIfRestricted(SecretMetadata metadata, String agentName, Map<String, Object> resources) {
+        if (metadata == null || isUnrestricted(metadata)) {
+            return;
+        }
+        String warning = "Vault key '" + metadata.keyName() + "' is granted only to " + metadata.allowedAgents()
+                + ". The agent being created cannot be on that list yet, so with eddi.vault.grant-enforcement=enforce its "
+                + "deployment will be blocked until the grant is widened to '*' or to the new agent's ID (secrets REST API, "
+                + "PATCH allowedAgents).";
+        LOGGER.warnf("Agent '%s': %s", LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(warning));
+        if (resources != null) {
+            resources.put(VAULT_GRANT_WARNING, warning);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -45,6 +45,7 @@ import ai.labs.eddi.secrets.crypto.EnvelopeCrypto;
 import ai.labs.eddi.secrets.model.SecretMetadata;
 import ai.labs.eddi.secrets.model.SecretReference;
 import ai.labs.eddi.utils.LogSanitizer;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -134,6 +135,21 @@ public class AgentSetupService {
     @Inject
     @ConfigProperty(name = "eddi.setup.vault-key-reuse", defaultValue = VAULT_KEY_REUSE_CHECKSUM)
     String vaultKeyReuse = VAULT_KEY_REUSE_CHECKSUM;
+
+    /**
+     * Strict parse, same reasoning as {@code VaultGrantGate.Mode.parseStrict}: an
+     * unrecognised value fails startup rather than degrading. The degraded
+     * behaviour here would be "no reuse" — exactly the vault growth this setting
+     * exists to prevent, with every visible sign saying it is on. Runs only under
+     * CDI; a directly constructed instance (tests) keeps the default.
+     */
+    @PostConstruct
+    void validateVaultKeyReuse() {
+        if (!VAULT_KEY_REUSE_CHECKSUM.equalsIgnoreCase(vaultKeyReuse) && !VAULT_KEY_REUSE_NEVER.equalsIgnoreCase(vaultKeyReuse)) {
+            throw new IllegalArgumentException("Unknown eddi.setup.vault-key-reuse value '" + vaultKeyReuse + "'. Valid values: "
+                    + VAULT_KEY_REUSE_CHECKSUM + ", " + VAULT_KEY_REUSE_NEVER);
+        }
+    }
 
     @Inject
     public AgentSetupService(IRestInterfaceFactory restInterfaceFactory, IRestAgentAdministration agentAdmin,
@@ -1050,6 +1066,7 @@ public class AgentSetupService {
         // ${eddivault:...})
         if (isVaultReference(key)) {
             LOGGER.infof("API key for agent '%s' is already a vault reference — using as-is.", LogSanitizer.sanitize(agentName));
+            warnIfMissing(SecretReference.parse(key), agentName);
             return key;
         }
 
@@ -1071,7 +1088,7 @@ public class AgentSetupService {
             // Timestamp suffix prevents collision when two agents share the same name
             String sanitizedName = agentName.toLowerCase().replaceAll("[^a-z0-9]", "-");
             String keyName = "setup." + sanitizedName + "." + System.currentTimeMillis() + ".apiKey";
-            return storeSecret(keyName, key, agentName, createdResources);
+            return storeSecret(new SecretReference(SecretReference.DEFAULT_TENANT, keyName), key, agentName, createdResources);
         } catch (ISecretProvider.SecretProviderException e) {
             LOGGER.error("Failed to vault API key for agent '" + LogSanitizer.sanitize(agentName) + "': " + e.getMessage()
                     + " — falling back to plaintext storage.");
@@ -1129,9 +1146,9 @@ public class AgentSetupService {
 
         if (existing != null) {
             if (haveNewPlaintext && !EnvelopeCrypto.sha256Hex(key).equals(existing.checksum())) {
-                throw new AgentSetupException("vaultKeyName '" + ref.keyName() + "' already holds a different value. Setup will not "
-                        + "overwrite it, because other agents may reference it. Use a different vaultKeyName, omit apiKey to reuse the "
-                        + "stored value, or rotate the key through the secrets API first.");
+                throw new AgentSetupException("vaultKeyName '" + ref.keyName() + "' already holds a value that does not match the "
+                        + "apiKey supplied. Setup will not overwrite it, because other agents may reference it. Use a different "
+                        + "vaultKeyName, omit apiKey to reuse the stored value, or rotate the key through the secrets API first.");
             }
             LOGGER.infof("Agent '%s' reuses existing vault key '%s'.", LogSanitizer.sanitize(agentName),
                     LogSanitizer.sanitize(ref.keyName()));
@@ -1139,8 +1156,8 @@ public class AgentSetupService {
         }
 
         if (!haveNewPlaintext) {
-            throw new AgentSetupException("vaultKeyName '" + ref.keyName() + "' does not exist in the vault and no apiKey was supplied to "
-                    + "create it. Supply apiKey to store the key under that name, or name an existing vault key.");
+            throw new AgentSetupException("vaultKeyName '" + ref.keyName() + "' does not exist in the vault and no plaintext apiKey was "
+                    + "supplied to create it. Supply the key in apiKey to store it under that name, or name an existing vault key.");
         }
 
         try {
@@ -1151,7 +1168,7 @@ public class AgentSetupService {
             // triggers rollback, a concurrent setup may already have reused the entry,
             // and rollback would pull the key out from under an agent that is not ours.
             // Leaving it also means the retry finds the key already in place.
-            return storeSecret(ref.keyName(), key, agentName, null);
+            return storeSecret(ref, key, agentName, null);
         } catch (ISecretProvider.SecretProviderException e) {
             throw new AgentSetupException("Could not store the API key under vault key '" + ref.keyName() + "': " + e.getMessage(), e);
         }
@@ -1161,9 +1178,8 @@ public class AgentSetupService {
      * Write one secret and record it for rollback. Split out so the named and the
      * generated path cannot drift on the grant list or the rollback bookkeeping.
      */
-    private String storeSecret(String keyName, String plaintext, String agentName, Map<String, Object> createdResources)
+    private String storeSecret(SecretReference ref, String plaintext, String agentName, Map<String, Object> createdResources)
             throws ISecretProvider.SecretProviderException {
-        var ref = new SecretReference(SecretReference.DEFAULT_TENANT, keyName);
         // "*" is deliberate. allowedAgents IS enforced now (VaultGrantGate, at
         // deploy time), so this list is a real access-control decision — but the
         // agent being set up does not have an ID yet at this point, and the key is
@@ -1177,9 +1193,9 @@ public class AgentSetupService {
         // Recorded only once the write succeeded: a name whose store threw does not
         // exist, and rollback would log a spurious "could not remove" warning for it.
         if (createdResources != null) {
-            createdResources.put(VAULTED_SECRET_KEY, keyName);
+            createdResources.put(VAULTED_SECRET_KEY, ref.keyName());
         }
-        LOGGER.infof("API key vaulted for agent '%s' (key: %s)", LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(keyName));
+        LOGGER.infof("API key vaulted for agent '%s' (key: %s)", LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(ref.keyName()));
         return ref.toReferenceString();
     }
 
@@ -1223,6 +1239,28 @@ public class AgentSetupService {
             // fall through and store a new entry rather than failing the setup.
             LOGGER.debugf("Could not scan the vault for a reusable API key: %s", e.getMessage());
             return null;
+        }
+    }
+
+    /**
+     * A pass-through {@code apiKey} reference is accepted as-is — that has always
+     * been the contract, and callers may legitimately vault the key after setup or
+     * hold it under a tenant this check cannot see. But by far the commonest cause
+     * of a dangling reference is a typo in a paste, and the result is an agent that
+     * deploys fine and fails on its first turn. Say so now, in the log, while the
+     * caller is still looking.
+     */
+    private void warnIfMissing(SecretReference ref, String agentName) {
+        if (!secretProvider.isAvailable()) {
+            return;
+        }
+        try {
+            secretProvider.getMetadata(ref);
+        } catch (ISecretProvider.SecretNotFoundException e) {
+            LOGGER.warnf("Agent '%s' references vault key '%s', which does not exist (yet). The agent will fail to resolve its API "
+                    + "key at runtime until that secret is created.", LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(ref.keyName()));
+        } catch (ISecretProvider.SecretProviderException e) {
+            LOGGER.debugf("Could not check vault key '%s': %s", LogSanitizer.sanitize(ref.keyName()), e.getMessage());
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -1250,9 +1250,9 @@ public class AgentSetupService {
      * This narrows the window rather than closing it: a write that lands after this
      * read is still missed. Closing it properly needs a conditional insert in the
      * persistence layer (Mongo and Postgres both), which is an SPI change shared
-     * with three other callers and does not belong in this one. What it does buy is
-     * that the common interleaving fails loudly, here, before a single document is
-     * created — instead of silently.
+     * with three other callers and does not belong in this one — tracked in issue
+     * #700. What it does buy is that the common interleaving fails loudly, here,
+     * before a single document is created — instead of silently.
      */
     private void verifyStoredValue(SecretReference ref, String expectedPlaintext) throws AgentSetupException {
         try {

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -41,6 +41,7 @@ import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
 import ai.labs.eddi.modules.output.model.types.TextOutputItem;
 import ai.labs.eddi.modules.templating.TemplateEscaping;
 import ai.labs.eddi.secrets.ISecretProvider;
+import ai.labs.eddi.secrets.SecretResolver;
 import ai.labs.eddi.secrets.crypto.EnvelopeCrypto;
 import ai.labs.eddi.secrets.model.SecretMetadata;
 import ai.labs.eddi.secrets.model.SecretReference;
@@ -135,6 +136,26 @@ public class AgentSetupService {
     @Inject
     @ConfigProperty(name = "eddi.setup.vault-key-reuse", defaultValue = VAULT_KEY_REUSE_CHECKSUM)
     String vaultKeyReuse = VAULT_KEY_REUSE_CHECKSUM;
+
+    /**
+     * Cache invalidation for secrets this service writes, exactly as
+     * {@code RestSecretStore} does after its own store.
+     * <p>
+     * It matters most on <em>creation</em>, which is counter-intuitive enough that
+     * {@code RestSecretStore} spells it out: a model may already be cached having
+     * resolved the reference to nothing and kept the literal {@code ${vault:...}}
+     * string as its API key. This service deliberately accepts such dangling
+     * references (it warns rather than refusing), so it is precisely the path that
+     * later fills one in — and without invalidating, every agent already pointing
+     * at that name keeps its broken cached model until the model cache expires.
+     * <p>
+     * Field-injected for the same reason as {@link #logConversationContent}: a
+     * directly constructed instance (tests, non-CDI callers) simply has none, and
+     * {@link #storeSecret} null-checks rather than requiring every call site to
+     * wire a resolver it does not otherwise need.
+     */
+    @Inject
+    SecretResolver secretResolver;
 
     /**
      * Strict parse, same reasoning as {@code VaultGrantGate.Mode.parseStrict}: an
@@ -303,6 +324,9 @@ public class AgentSetupService {
             return resultBuilder.build();
 
         } catch (Exception e) {
+            // No separate AgentSetupException arm here, unlike createApiAgent: nothing
+            // inside this try declares one, and every vault error is raised at step 0
+            // above, outside it. A catch for an unreachable case is not symmetry.
             rollbackCreatedResources(createdResources, request.agentName(), e);
             throw new AgentSetupException("Failed to set up agent: " + e.getMessage(), e);
         }
@@ -455,20 +479,25 @@ public class AgentSetupService {
         var params = resolveParamsValidated(request.provider(), request.model(), request.deploy(), request.environment());
         var createdResources = new LinkedHashMap<String, Object>();
 
-        // --- Step 0: Resolve the API key against the vault ---
+        // --- Step 0a: Parse the OpenAPI spec ---
+        // Before the vault, deliberately. Parsing creates nothing, so ordering it
+        // first means an unparseable spec — the likeliest way this call fails — never
+        // reaches the vault at all, rather than relying on rollback to remove a secret
+        // it should not have written. Key resolution still precedes every store call.
+        McpApiToolBuilder.ApiBuildResult buildResult;
+        try {
+            buildResult = McpApiToolBuilder.parseAndBuild(request.openApiSpec(), request.endpoints(), request.apiBaseUrl(), request.apiAuth());
+        } catch (IllegalArgumentException e) {
+            throw new AgentSetupException("OpenAPI parsing failed: " + e.getMessage(), e);
+        }
+
+        // --- Step 0b: Resolve the API key against the vault ---
         // Outside the try, so an unusable vaultKeyName fails while rollback still has
         // nothing to undo and its message reaches the caller unwrapped. See setupAgent
         // for the full note.
         String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), request.vaultKeyName(), createdResources);
 
         try {
-            // --- Step 1: Parse OpenAPI and build grouped httpcalls configs ---
-            McpApiToolBuilder.ApiBuildResult buildResult;
-            try {
-                buildResult = McpApiToolBuilder.parseAndBuild(request.openApiSpec(), request.endpoints(), request.apiBaseUrl(), request.apiAuth());
-            } catch (IllegalArgumentException e) {
-                throw new AgentSetupException("OpenAPI parsing failed: " + e.getMessage(), e);
-            }
 
             // --- Step 2: Create ApiCalls resources (one per group) ---
             var httpCallsLocations = new ArrayList<String>();
@@ -567,6 +596,13 @@ public class AgentSetupService {
             return resultBuilder.build();
 
         } catch (AgentSetupException e) {
+            // Rethrown unwrapped, so the caller sees the real reason rather than it
+            // nested inside "Failed to create API agent:" — but it still has to roll
+            // back. Without this, every AgentSetupException raised AFTER the first
+            // store (an unparseable spec, a rejected maxToolIterations) orphaned
+            // everything created up to that point, and once key resolution moved
+            // ahead of the try that included the vaulted secret.
+            rollbackCreatedResources(createdResources, request.agentName(), e);
             throw e;
         } catch (Exception e) {
             rollbackCreatedResources(createdResources, request.agentName(), e);
@@ -1246,6 +1282,9 @@ public class AgentSetupService {
         // Operators who want a narrow grant set it after setup, via the secrets
         // REST API; see docs/secrets-vault.md "Agent Grants".
         secretProvider.store(ref, plaintext, "Auto-vaulted by AgentSetupService for agent: " + agentName, List.of("*"));
+        if (secretResolver != null) {
+            secretResolver.invalidateCache(ref);
+        }
         // Recorded only once the write succeeded: a name whose store threw does not
         // exist, and rollback would log a spurious "could not remove" warning for it.
         if (createdResources != null) {
@@ -1268,6 +1307,15 @@ public class AgentSetupService {
      * scoped deliberately, and handing its reference to a new agent would produce a
      * config that {@code VaultGrantGate} refuses at deploy time — a reuse that
      * "works" until the moment it matters.
+     * <p>
+     * <b>Convergence is eventual, not immediate.</b> The scan and the write that
+     * follows it are separate operations, so N setups running <em>concurrently</em>
+     * with the same first-time key can all see nothing to reuse and each store
+     * their own entry. Every later setup then finds one of them and reuses it, so
+     * the vault stops growing — but a parallel bulk provision can still leave more
+     * than one copy. Collapsing those would need a checksum reservation in the
+     * persistence layer; sequential provisioning, which is what the wizard and the
+     * setup API actually do, converges on the first entry immediately.
      *
      * @return the reference string of the entry to reuse, or null
      */

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -41,6 +41,8 @@ import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
 import ai.labs.eddi.modules.output.model.types.TextOutputItem;
 import ai.labs.eddi.modules.templating.TemplateEscaping;
 import ai.labs.eddi.secrets.ISecretProvider;
+import ai.labs.eddi.secrets.crypto.EnvelopeCrypto;
+import ai.labs.eddi.secrets.model.SecretMetadata;
 import ai.labs.eddi.secrets.model.SecretReference;
 import ai.labs.eddi.utils.LogSanitizer;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -50,6 +52,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.*;
 import java.util.Map;
 
@@ -95,6 +98,42 @@ public class AgentSetupService {
     @ConfigProperty(name = "eddi.setup.llm.log-conversation-content", defaultValue = "false")
     boolean logConversationContent;
 
+    /**
+     * {@link #vaultKeyReuse} value: reuse a vault entry that already holds the same
+     * value.
+     */
+    static final String VAULT_KEY_REUSE_CHECKSUM = "checksum";
+
+    /** {@link #vaultKeyReuse} value: always vault a fresh, uniquely named entry. */
+    static final String VAULT_KEY_REUSE_NEVER = "never";
+
+    /**
+     * What setup does when it is handed a <b>plaintext</b> API key that the vault
+     * already holds under some key name.
+     * <ul>
+     * <li>{@code checksum} (default) — reuse that entry and reference it, so
+     * provisioning ten agents with one provider key leaves one secret in the vault
+     * rather than ten copies of it. Matching is by the SHA-256 checksum the vault
+     * already stores per entry, so no stored plaintext is decrypted to make the
+     * decision, and only unrestricted entries ({@code allowedAgents} unset or
+     * {@code ["*"]}) are candidates — reusing a narrowly granted secret would hand
+     * the new agent a reference that {@code VaultGrantGate} rejects at deploy
+     * time.</li>
+     * <li>{@code never} — restores the pre-6.3 behaviour: every setup writes its
+     * own {@code setup.<agent>.<timestamp>.apiKey} entry.</li>
+     * </ul>
+     * Neither value affects an {@code apiKey} that is already a
+     * {@code ${vault:...}} reference (always used as-is) or a request carrying an
+     * explicit {@code vaultKeyName} (always honoured) — those are caller decisions,
+     * not defaults.
+     * <p>
+     * Field-injected for the same reason as {@link #logConversationContent}: a
+     * directly constructed instance gets the default.
+     */
+    @Inject
+    @ConfigProperty(name = "eddi.setup.vault-key-reuse", defaultValue = VAULT_KEY_REUSE_CHECKSUM)
+    String vaultKeyReuse = VAULT_KEY_REUSE_CHECKSUM;
+
     @Inject
     public AgentSetupService(IRestInterfaceFactory restInterfaceFactory, IRestAgentAdministration agentAdmin,
             ISecretProvider secretProvider,
@@ -120,8 +159,12 @@ public class AgentSetupService {
         // Validate required params
         validateNameAndPrompt(request.agentName(), request.systemPrompt());
         boolean isLocalLLM = isLocalLlmProvider(request.provider());
-        if (!isLocalLLM && (request.apiKey() == null || request.apiKey().isBlank())) {
-            throw new AgentSetupException("API key is required for cloud LLM providers (anthropic, openai, gemini)");
+        // vaultKeyName alone is enough: it names a key the vault already holds, which
+        // is the whole point of provisioning a second agent against an existing one.
+        if (!isLocalLLM && isNullOrBlank(request.apiKey()) && isNullOrBlank(request.vaultKeyName())) {
+            throw new AgentSetupException(
+                    "API key is required for cloud LLM providers (anthropic, openai, gemini) — pass apiKey, or vaultKeyName to reuse a key "
+                            + "already in the vault");
         }
         // Validate the HITL config HERE, before a single resource exists — same
         // reasoning as createApiAgent: AgentStore.create validates it too, but only
@@ -144,6 +187,13 @@ public class AgentSetupService {
         var createdResources = new LinkedHashMap<String, Object>();
 
         try {
+            // --- Step 0: Resolve the API key against the vault ---
+            // Ahead of every store call, for the same reason the HITL config is
+            // validated above: an unusable vaultKeyName (missing, or holding a
+            // different value) has to fail while rollback still has nothing to undo,
+            // not after a parser, a ruleset and a workflow already exist.
+            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), request.vaultKeyName(), createdResources);
+
             // --- Step 1: Create Parser ---
             var parserConfig = createParserConfig();
             Response parserResponse = getRestStore(IRestParserStore.class).createParser(parserConfig);
@@ -163,9 +213,6 @@ public class AgentSetupService {
             patchDescriptor(behaviorId, behaviorVersion, request.agentName());
 
             // --- Step 3: Create LLM Configuration ---
-            // Auto-vault the API key: store encrypted in vault, use vault reference in
-            // config
-            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), createdResources);
             var llmConfig = createLlmConfig(params.providerType, params.modelId, effectiveApiKey, request.systemPrompt(), toolsEnabled,
                     request.builtInToolsWhitelist(), request.baseUrl(), promptResponseJson, quickReplies, sentiment, null);
             Response llmResponse = getRestStore(IRestLlmStore.class).createLlm(llmConfig);
@@ -355,8 +402,10 @@ public class AgentSetupService {
             throw new AgentSetupException("OpenAPI spec is required");
         }
         boolean isLocalLLM = isLocalLlmProvider(request.provider());
-        if (!isLocalLLM && (request.apiKey() == null || request.apiKey().isBlank())) {
-            throw new AgentSetupException("API key is required for cloud LLM providers");
+        // See setupAgent: vaultKeyName alone names a key the vault already holds.
+        if (!isLocalLLM && isNullOrBlank(request.apiKey()) && isNullOrBlank(request.vaultKeyName())) {
+            throw new AgentSetupException(
+                    "API key is required for cloud LLM providers — pass apiKey, or vaultKeyName to reuse a key already in the vault");
         }
         // Scheme-level check only. Full SSRF validation would reject loopback and
         // private addresses, which is precisely where a local LLM provider lives —
@@ -384,6 +433,11 @@ public class AgentSetupService {
         var createdResources = new LinkedHashMap<String, Object>();
 
         try {
+            // --- Step 0: Resolve the API key against the vault ---
+            // Ahead of every store call, so an unusable vaultKeyName fails while
+            // rollback still has nothing to undo. See setupAgent for the full note.
+            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), request.vaultKeyName(), createdResources);
+
             // --- Step 1: Parse OpenAPI and build grouped httpcalls configs ---
             McpApiToolBuilder.ApiBuildResult buildResult;
             try {
@@ -428,8 +482,6 @@ public class AgentSetupService {
             boolean quickReplies = request.enableQuickReplies() != null && request.enableQuickReplies();
             boolean sentiment = request.enableSentimentAnalysis() != null && request.enableSentimentAnalysis();
             String promptResponseJson = buildPromptResponseJson(quickReplies, sentiment);
-            // Auto-vault the API key before storing in LLM config
-            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), createdResources);
             // 7th slot is the LLM's own base URL — not apiBaseUrl, which is the target
             // server of the generated tools. Passing null here left local providers
             // (Ollama, Jlama) with no endpoint to reach.
@@ -910,6 +962,10 @@ public class AgentSetupService {
         return null;
     }
 
+    private static boolean isNullOrBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
     private static String firstNonBlank(String... values) {
         for (String value : values) {
             if (value != null && !value.isBlank()) {
@@ -948,32 +1004,80 @@ public class AgentSetupService {
      * @return the vault reference string, or the plaintext key if vault is
      *         unavailable
      */
-    private String vaultApiKey(String apiKey, String agentName) {
-        return vaultApiKey(apiKey, agentName, null);
+    private String vaultApiKey(String apiKey, String agentName) throws AgentSetupException {
+        return vaultApiKey(apiKey, agentName, null, null);
     }
 
     /**
+     * Resolve the value that goes into the generated LLM config's {@code apiKey}
+     * parameter, vaulting the plaintext only when the vault does not already hold
+     * it.
+     * <p>
+     * Four inputs, in the order they are considered:
+     * <ol>
+     * <li><b>{@code vaultKeyName} given</b> — the caller names the entry, so the
+     * caller decides. An existing entry is referenced (and, when {@code apiKey} is
+     * also given, must hold the same value — setup will not silently overwrite a
+     * secret other agents already point at); a missing one is created under exactly
+     * that name from the supplied {@code apiKey}. This is the field that makes
+     * "provision N agents against one key" a single, stable, human-readable
+     * reference.</li>
+     * <li><b>{@code apiKey} is already a {@code ${vault:...}} reference</b> — used
+     * as-is, never re-vaulted. Note the {@link String#trim()} below: the check is a
+     * full-string match, so before it a value pasted out of a UI list carried its
+     * trailing newline into the "not a reference" branch and was vaulted <em>as
+     * plaintext whose content is a reference</em> — a fresh, useless key on every
+     * setup, which is the very thing this method exists to prevent.</li>
+     * <li><b>{@code apiKey} is plaintext the vault already holds</b> — reused by
+     * checksum, unless {@code eddi.setup.vault-key-reuse=never}. See
+     * {@link #vaultKeyReuse}.</li>
+     * <li><b>{@code apiKey} is plaintext the vault does not hold</b> — stored under
+     * the generated {@code setup.<agent>.<timestamp>.apiKey} name, as before.</li>
+     * </ol>
+     *
+     * @param vaultKeyName
+     *            explicit vault key name (or full {@code ${vault:...}} reference)
+     *            to store under and reuse; null or blank to let this method choose
      * @param createdResources
-     *            when non-null, the key name of a secret vaulted by this call is
-     *            recorded here so a failed setup can remove it again
+     *            when non-null, the key name of a secret <b>newly created</b> by
+     *            this call is recorded here so a failed setup can remove it again.
+     *            A <em>reused</em> entry is deliberately never recorded: rollback
+     *            deletes what it finds there, and a shared key must survive the
+     *            failure of one agent that happened to reference it.
      */
-    private String vaultApiKey(String apiKey, String agentName, Map<String, Object> createdResources) {
-        if (apiKey == null || apiKey.isBlank()) {
+    private String vaultApiKey(String apiKey, String agentName, String vaultKeyName, Map<String, Object> createdResources)
+            throws AgentSetupException {
+        // Trimmed once, here, and used for every subsequent decision AND as the stored
+        // value: a key with a stray newline is not a usable credential either.
+        String key = apiKey == null ? null : apiKey.trim();
+        String requestedName = vaultKeyName == null ? null : vaultKeyName.trim();
+
+        if (requestedName != null && !requestedName.isEmpty()) {
+            return useNamedVaultKey(requestedName, key, agentName, createdResources);
+        }
+
+        if (key == null || key.isEmpty()) {
             return apiKey;
         }
 
         // Already a vault reference — use it directly, don't re-vault (supports legacy
         // ${eddivault:...})
-        if (SecretReference.isVaultReference(apiKey)
-                && SecretReference.compiledPattern().matcher(apiKey).matches()) {
-            LOGGER.infof("API key for agent '%s' is already a vault reference — using as-is.", agentName);
-            return apiKey;
+        if (isVaultReference(key)) {
+            LOGGER.infof("API key for agent '%s' is already a vault reference — using as-is.", LogSanitizer.sanitize(agentName));
+            return key;
         }
 
         if (!secretProvider.isAvailable()) {
             LOGGER.warn("Secrets Vault is not configured — API key will be stored in plaintext. "
                     + "Set EDDI_VAULT_MASTER_KEY to enable encrypted storage.");
-            return apiKey;
+            return key;
+        }
+
+        String reusable = findReusableSecret(key);
+        if (reusable != null) {
+            LOGGER.infof("API key for agent '%s' is already in the vault as '%s' — reusing it instead of storing a second copy.",
+                    LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(reusable));
+            return reusable;
         }
 
         try {
@@ -981,28 +1085,150 @@ public class AgentSetupService {
             // Timestamp suffix prevents collision when two agents share the same name
             String sanitizedName = agentName.toLowerCase().replaceAll("[^a-z0-9]", "-");
             String keyName = "setup." + sanitizedName + "." + System.currentTimeMillis() + ".apiKey";
-            if (createdResources != null) {
-                createdResources.put(VAULTED_SECRET_KEY, keyName);
-            }
-            var ref = new SecretReference(SecretReference.DEFAULT_TENANT, keyName);
-            // "*" is deliberate. allowedAgents IS enforced now (VaultGrantGate, at
-            // deploy time), so this list is a real access-control decision — but the
-            // agent being set up does not have an ID yet at this point, and the key is
-            // created for whichever agent this setup produces. Narrowing it here would
-            // have to guess that ID, and guessing wrong blocks the very agent the key
-            // was vaulted for.
-            //
-            // Operators who want a narrow grant set it after setup, via the secrets
-            // REST API; see docs/secrets-vault.md "Agent Grants".
-            secretProvider.store(ref, apiKey, "Auto-vaulted by AgentSetupService for agent: " + agentName,
-                    List.of("*"));
-            LOGGER.infof("API key vaulted for agent '%s' (key: %s)", agentName, keyName);
-            return ref.toReferenceString();
+            return storeSecret(keyName, key, agentName, createdResources);
         } catch (ISecretProvider.SecretProviderException e) {
-            LOGGER.error("Failed to vault API key for agent '" + agentName + "': " + e.getMessage()
+            LOGGER.error("Failed to vault API key for agent '" + LogSanitizer.sanitize(agentName) + "': " + e.getMessage()
                     + " — falling back to plaintext storage.");
-            return apiKey;
+            return key;
         }
+    }
+
+    /**
+     * Honour an explicit {@code vaultKeyName}. Unlike the generated-name path this
+     * one fails loudly rather than degrading: a caller who named a key asked for
+     * one specific shared secret, and quietly writing a plaintext key or a second
+     * copy under a different name would defeat the reason they named it.
+     */
+    private String useNamedVaultKey(String requestedName, String key, String agentName, Map<String, Object> createdResources)
+            throws AgentSetupException {
+        // Accept both "my-openai-key" and "${vault:my-openai-key}" — the Manager and
+        // the stored configs show the reference form, so pasting that form into a
+        // field labelled "key name" is the obvious mistake to absorb rather than
+        // reject.
+        SecretReference ref = isVaultReference(requestedName)
+                ? SecretReference.parse(requestedName)
+                : new SecretReference(SecretReference.DEFAULT_TENANT, requestedName);
+
+        if (!secretProvider.isAvailable()) {
+            throw new AgentSetupException("vaultKeyName '" + ref.keyName() + "' cannot be used: the secrets vault is unavailable or "
+                    + "disabled. Set EDDI_VAULT_MASTER_KEY, or omit vaultKeyName to pass the key through as plaintext.");
+        }
+
+        SecretMetadata existing;
+        try {
+            existing = secretProvider.getMetadata(ref);
+        } catch (ISecretProvider.SecretNotFoundException e) {
+            existing = null;
+        } catch (ISecretProvider.SecretProviderException e) {
+            throw new AgentSetupException("Could not read vault key '" + ref.keyName() + "': " + e.getMessage(), e);
+        }
+
+        boolean haveNewPlaintext = key != null && !key.isEmpty() && !isVaultReference(key);
+
+        if (existing != null) {
+            if (haveNewPlaintext && !EnvelopeCrypto.sha256Hex(key).equals(existing.checksum())) {
+                throw new AgentSetupException("vaultKeyName '" + ref.keyName() + "' already holds a different value. Setup will not "
+                        + "overwrite it, because other agents may reference it. Use a different vaultKeyName, omit apiKey to reuse the "
+                        + "stored value, or rotate the key through the secrets API first.");
+            }
+            LOGGER.infof("Agent '%s' reuses existing vault key '%s'.", LogSanitizer.sanitize(agentName),
+                    LogSanitizer.sanitize(ref.keyName()));
+            return ref.toReferenceString();
+        }
+
+        if (!haveNewPlaintext) {
+            throw new AgentSetupException("vaultKeyName '" + ref.keyName() + "' does not exist in the vault and no apiKey was supplied to "
+                    + "create it. Supply apiKey to store the key under that name, or name an existing vault key.");
+        }
+
+        try {
+            return storeSecret(ref.keyName(), key, agentName, createdResources);
+        } catch (ISecretProvider.SecretProviderException e) {
+            throw new AgentSetupException("Could not store the API key under vault key '" + ref.keyName() + "': " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Write one secret and record it for rollback. Split out so the named and the
+     * generated path cannot drift on the grant list or the rollback bookkeeping.
+     */
+    private String storeSecret(String keyName, String plaintext, String agentName, Map<String, Object> createdResources)
+            throws ISecretProvider.SecretProviderException {
+        if (createdResources != null) {
+            createdResources.put(VAULTED_SECRET_KEY, keyName);
+        }
+        var ref = new SecretReference(SecretReference.DEFAULT_TENANT, keyName);
+        // "*" is deliberate. allowedAgents IS enforced now (VaultGrantGate, at
+        // deploy time), so this list is a real access-control decision — but the
+        // agent being set up does not have an ID yet at this point, and the key is
+        // created for whichever agent this setup produces. Narrowing it here would
+        // have to guess that ID, and guessing wrong blocks the very agent the key
+        // was vaulted for.
+        //
+        // Operators who want a narrow grant set it after setup, via the secrets
+        // REST API; see docs/secrets-vault.md "Agent Grants".
+        secretProvider.store(ref, plaintext, "Auto-vaulted by AgentSetupService for agent: " + agentName, List.of("*"));
+        LOGGER.infof("API key vaulted for agent '%s' (key: %s)", LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(keyName));
+        return ref.toReferenceString();
+    }
+
+    /**
+     * Find a vault entry that already holds {@code plaintext}, so setup references
+     * it instead of storing a duplicate.
+     * <p>
+     * Matching is on the SHA-256 checksum the vault stores alongside every entry —
+     * nothing is decrypted, and the digest being compared is one this call computes
+     * from a value it was already handed, so the comparison reveals nothing the
+     * caller did not already know.
+     * <p>
+     * Only unrestricted entries qualify. A secret granted to specific agents was
+     * scoped deliberately, and handing its reference to a new agent would produce a
+     * config that {@code VaultGrantGate} refuses at deploy time — a reuse that
+     * "works" until the moment it matters.
+     *
+     * @return the reference string of the entry to reuse, or null
+     */
+    private String findReusableSecret(String plaintext) {
+        if (!VAULT_KEY_REUSE_CHECKSUM.equalsIgnoreCase(vaultKeyReuse)) {
+            return null;
+        }
+        try {
+            String checksum = EnvelopeCrypto.sha256Hex(plaintext);
+            return secretProvider.listKeys(SecretReference.DEFAULT_TENANT).stream()
+                    .filter(metadata -> checksum.equals(metadata.checksum()))
+                    .filter(AgentSetupService::isUnrestricted)
+                    // Oldest first, key name as tie-break: repeated setups with the same key
+                    // must converge on ONE entry, so the choice cannot depend on listing order.
+                    .min(Comparator
+                            .<SecretMetadata, Instant>comparing(
+                                    metadata -> metadata.createdAt() == null ? Instant.EPOCH : metadata.createdAt())
+                            .thenComparing(SecretMetadata::keyName))
+                    .map(metadata -> new SecretReference(
+                            metadata.tenantId() == null ? SecretReference.DEFAULT_TENANT : metadata.tenantId(), metadata.keyName())
+                            .toReferenceString())
+                    .orElse(null);
+        } catch (Exception e) {
+            // Reuse is an optimisation, never a gate: if the vault cannot be listed,
+            // fall through and store a new entry rather than failing the setup.
+            LOGGER.debugf("Could not scan the vault for a reusable API key: %s", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * {@code allowedAgents} unset, empty or {@code ["*"]} — usable by any agent.
+     */
+    private static boolean isUnrestricted(SecretMetadata metadata) {
+        List<String> allowed = metadata.allowedAgents();
+        return allowed == null || allowed.isEmpty() || allowed.contains("*");
+    }
+
+    /**
+     * True when the whole string is a {@code ${vault:...}} reference, not merely
+     * contains one — {@code "plaintext${vault:key}"} is not a reference.
+     */
+    private static boolean isVaultReference(String value) {
+        return SecretReference.isVaultReference(value) && SecretReference.compiledPattern().matcher(value).matches();
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -55,6 +55,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.*;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Service that encapsulates the business logic for setting up EDDI agents. Used
@@ -186,14 +187,16 @@ public class AgentSetupService {
 
         var createdResources = new LinkedHashMap<String, Object>();
 
-        try {
-            // --- Step 0: Resolve the API key against the vault ---
-            // Ahead of every store call, for the same reason the HITL config is
-            // validated above: an unusable vaultKeyName (missing, or holding a
-            // different value) has to fail while rollback still has nothing to undo,
-            // not after a parser, a ruleset and a workflow already exist.
-            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), request.vaultKeyName(), createdResources);
+        // --- Step 0: Resolve the API key against the vault ---
+        // Outside the try, for the same reason the HITL config is validated above: an
+        // unusable vaultKeyName (missing, or holding a different value) has to fail
+        // while rollback still has nothing to undo, not after a parser, a ruleset and
+        // a workflow already exist. Outside also keeps the message intact — a caller
+        // reading a 400 wants "vaultKeyName 'x' does not exist", not that sentence
+        // wrapped in "Failed to set up agent".
+        String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), request.vaultKeyName(), createdResources);
 
+        try {
             // --- Step 1: Create Parser ---
             var parserConfig = createParserConfig();
             Response parserResponse = getRestStore(IRestParserStore.class).createParser(parserConfig);
@@ -263,7 +266,10 @@ public class AgentSetupService {
 
             // --- Step 8: Deploy ---
             var resultBuilder = SetupResult.builder().action("setup_complete").agentId(agentId != null ? agentId : "unknown")
-                    .agentName(request.agentName()).provider(params.providerType).model(params.modelId);
+                    .agentName(request.agentName()).provider(params.providerType).model(params.modelId)
+                    // So the next agent can be put on this same credential without the
+                    // caller having to go digging for the generated key name.
+                    .apiKeyVaultReference(vaultReferenceOrNull(effectiveApiKey));
 
             if (quickReplies)
                 resultBuilder.quickRepliesEnabled(true);
@@ -432,12 +438,13 @@ public class AgentSetupService {
         var params = resolveParamsValidated(request.provider(), request.model(), request.deploy(), request.environment());
         var createdResources = new LinkedHashMap<String, Object>();
 
-        try {
-            // --- Step 0: Resolve the API key against the vault ---
-            // Ahead of every store call, so an unusable vaultKeyName fails while
-            // rollback still has nothing to undo. See setupAgent for the full note.
-            String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), request.vaultKeyName(), createdResources);
+        // --- Step 0: Resolve the API key against the vault ---
+        // Outside the try, so an unusable vaultKeyName fails while rollback still has
+        // nothing to undo and its message reaches the caller unwrapped. See setupAgent
+        // for the full note.
+        String effectiveApiKey = vaultApiKey(request.apiKey(), request.agentName(), request.vaultKeyName(), createdResources);
 
+        try {
             // --- Step 1: Parse OpenAPI and build grouped httpcalls configs ---
             McpApiToolBuilder.ApiBuildResult buildResult;
             try {
@@ -528,7 +535,9 @@ public class AgentSetupService {
             // --- Step 8: Deploy ---
             var resultBuilder = SetupResult.builder().action("api_agent_created").agentId(agentId != null ? agentId : "unknown")
                     .agentName(request.agentName()).provider(params.providerType).model(params.modelId).endpointCount(buildResult.endpointCount())
-                    .groups(groupNames);
+                    .groups(groupNames)
+                    // See setupAgent: hands the caller the reference to reuse next time.
+                    .apiKeyVaultReference(vaultReferenceOrNull(effectiveApiKey));
 
             if (params.shouldDeploy && agentId != null) {
                 var deployResult = deployAndWait(params.env, agentId, agentVersion);
@@ -986,29 +995,6 @@ public class AgentSetupService {
     }
 
     /**
-     * Auto-vault an API key if the vault is available. When the vault is active,
-     * the plaintext key is stored encrypted and a vault reference string
-     * ({@code ${vault:keyName}}) is returned. Downstream consumers
-     * ({@link ai.labs.eddi.modules.llm.impl.ChatModelRegistry}) resolve vault
-     * references transparently at model-load time.
-     *
-     * <p>
-     * When the vault is <b>not</b> configured (common in dev mode without
-     * {@code EDDI_VAULT_MASTER_KEY}), the plaintext key is returned as-is. This
-     * ensures the setup flow never breaks due to missing vault config.
-     *
-     * @param apiKey
-     *            the plaintext API key (may be null for local LLM providers)
-     * @param agentName
-     *            used for the vault key namespace and description
-     * @return the vault reference string, or the plaintext key if vault is
-     *         unavailable
-     */
-    private String vaultApiKey(String apiKey, String agentName) throws AgentSetupException {
-        return vaultApiKey(apiKey, agentName, null, null);
-    }
-
-    /**
      * Resolve the value that goes into the generated LLM config's {@code apiKey}
      * parameter, vaulting the plaintext only when the vault does not already hold
      * it.
@@ -1108,6 +1094,22 @@ public class AgentSetupService {
         SecretReference ref = isVaultReference(requestedName)
                 ? SecretReference.parse(requestedName)
                 : new SecretReference(SecretReference.DEFAULT_TENANT, requestedName);
+        // Same charset the secrets REST API enforces on create. Not decoration: the
+        // value is about to be embedded in "${vault:<tenant>/<key>}", where a '/' in a
+        // BARE name would silently re-parse as a tenant separator and a '}' would
+        // truncate the reference — the agent would then resolve a different secret, or
+        // none. Multi-tenant callers use the ${vault:tenant/key} form, which is parsed
+        // above rather than guessed at here.
+        validateSecretName(ref.tenantId(), "tenant in vaultKeyName");
+        validateSecretName(ref.keyName(), "vaultKeyName");
+
+        // Two different keys named in one request. Honouring vaultKeyName and dropping
+        // the apiKey reference on the floor would deploy an agent against a credential
+        // the caller did not pick, so say so instead.
+        if (key != null && isVaultReference(key) && !SecretReference.parse(key).equals(ref)) {
+            throw new AgentSetupException("apiKey references vault key '" + SecretReference.parse(key).keyName()
+                    + "' but vaultKeyName says '" + ref.keyName() + "'. Pass one or the other.");
+        }
 
         if (!secretProvider.isAvailable()) {
             throw new AgentSetupException("vaultKeyName '" + ref.keyName() + "' cannot be used: the secrets vault is unavailable or "
@@ -1142,7 +1144,14 @@ public class AgentSetupService {
         }
 
         try {
-            return storeSecret(ref.keyName(), key, agentName, createdResources);
+            // Deliberately NOT registered for rollback (null, not createdResources).
+            // Rollback exists to stop a retry loop growing the vault without bound, and
+            // a caller-chosen name cannot: a retry reuses the same name. Deleting it
+            // would be the more dangerous act — between this store and the failure that
+            // triggers rollback, a concurrent setup may already have reused the entry,
+            // and rollback would pull the key out from under an agent that is not ours.
+            // Leaving it also means the retry finds the key already in place.
+            return storeSecret(ref.keyName(), key, agentName, null);
         } catch (ISecretProvider.SecretProviderException e) {
             throw new AgentSetupException("Could not store the API key under vault key '" + ref.keyName() + "': " + e.getMessage(), e);
         }
@@ -1154,9 +1163,6 @@ public class AgentSetupService {
      */
     private String storeSecret(String keyName, String plaintext, String agentName, Map<String, Object> createdResources)
             throws ISecretProvider.SecretProviderException {
-        if (createdResources != null) {
-            createdResources.put(VAULTED_SECRET_KEY, keyName);
-        }
         var ref = new SecretReference(SecretReference.DEFAULT_TENANT, keyName);
         // "*" is deliberate. allowedAgents IS enforced now (VaultGrantGate, at
         // deploy time), so this list is a real access-control decision — but the
@@ -1168,6 +1174,11 @@ public class AgentSetupService {
         // Operators who want a narrow grant set it after setup, via the secrets
         // REST API; see docs/secrets-vault.md "Agent Grants".
         secretProvider.store(ref, plaintext, "Auto-vaulted by AgentSetupService for agent: " + agentName, List.of("*"));
+        // Recorded only once the write succeeded: a name whose store threw does not
+        // exist, and rollback would log a spurious "could not remove" warning for it.
+        if (createdResources != null) {
+            createdResources.put(VAULTED_SECRET_KEY, keyName);
+        }
         LOGGER.infof("API key vaulted for agent '%s' (key: %s)", LogSanitizer.sanitize(agentName), LogSanitizer.sanitize(keyName));
         return ref.toReferenceString();
     }
@@ -1213,6 +1224,28 @@ public class AgentSetupService {
             LOGGER.debugf("Could not scan the vault for a reusable API key: %s", e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Same charset the secrets REST API enforces, so a name created here stays
+     * addressable there.
+     */
+    private static final Pattern VALID_SECRET_NAME = Pattern.compile("[a-zA-Z0-9._-]{1,128}");
+
+    private static void validateSecretName(String value, String label) throws AgentSetupException {
+        if (value == null || !VALID_SECRET_NAME.matcher(value).matches()) {
+            throw new AgentSetupException(label + " must match [a-zA-Z0-9._-]{1,128}, got: " + value);
+        }
+    }
+
+    /**
+     * The reference, or null when the value is a plaintext key. Guards what reaches
+     * {@link SetupResult}: with the vault disabled the "effective api key" IS the
+     * caller's secret, and echoing that back in an HTTP response body would put it
+     * through every proxy log between here and the client.
+     */
+    private static String vaultReferenceOrNull(String effectiveApiKey) {
+        return effectiveApiKey != null && isVaultReference(effectiveApiKey) ? effectiveApiKey : null;
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/setup/CreateApiAgentRequest.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/CreateApiAgentRequest.java
@@ -64,5 +64,26 @@ public record CreateApiAgentRequest(@JsonProperty(required = true) String agentN
          * Appended last for the same positional-constructor reason as llmBaseUrl; the
          * MCP create_api_agent tool passes null.
          */
-        Integer maxToolIterations) {
+        Integer maxToolIterations,
+        /*
+         * Name of the vault entry the LLM API key lives under, so several agents can be
+         * provisioned against ONE stored credential.
+         *
+         * Without it the only way to share a key was to paste the previous agent's
+         * ${vault:...} reference into apiKey — which works, but only if you can find
+         * the reference, and the generated names (setup.<agent>.<timestamp>.apiKey) are
+         * neither guessable nor meaningful. Naming the entry makes the shared key a
+         * deliberate, stable choice: "${vault:openai-prod}", set once, reused by every
+         * agent that should rotate together.
+         *
+         * Accepts a bare name ("openai-prod") or the full reference form
+         * ("${vault:openai-prod}"). Combined with apiKey it CREATES the entry under
+         * that name; alone it REQUIRES the entry to already exist. It never overwrites
+         * an entry that holds a different value — see
+         * AgentSetupService.useNamedVaultKey.
+         *
+         * Appended last for the same positional-constructor reason as llmBaseUrl; the
+         * MCP create_api_agent tool passes null.
+         */
+        String vaultKeyName) {
 }

--- a/src/main/java/ai/labs/eddi/engine/setup/SetupAgentRequest.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/SetupAgentRequest.java
@@ -36,5 +36,27 @@ public record SetupAgentRequest(@JsonProperty(required = true)
          * positional-constructor call site adds new fields at the end so existing
          * argument positions never shift.
          */
-        AgentConfiguration.HitlConfig hitlConfig) {
+        AgentConfiguration.HitlConfig hitlConfig,
+        /*
+         * Name of the vault entry the LLM API key lives under, so several agents can be
+         * provisioned against ONE stored credential.
+         *
+         * Without it the only way to share a key was to paste the previous agent's
+         * ${vault:...} reference into apiKey — which works, but only if you can find
+         * the reference, and the generated names (setup.<agent>.<timestamp>.apiKey) are
+         * neither guessable nor meaningful. Naming the entry makes the shared key a
+         * deliberate, stable choice: "${vault:openai-prod}", set once, reused by every
+         * agent that should rotate together.
+         *
+         * Accepts a bare name ("openai-prod") or the full reference form
+         * ("${vault:openai-prod}"). Combined with apiKey it CREATES the entry under
+         * that name; alone it REQUIRES the entry to already exist. It never overwrites
+         * an entry that holds a different value — see
+         * AgentSetupService.useNamedVaultKey.
+         *
+         * Appended last, matching this record's convention: every positional
+         * constructor call site adds new fields at the end so existing argument
+         * positions never shift.
+         */
+        String vaultKeyName) {
 }

--- a/src/main/java/ai/labs/eddi/engine/setup/SetupResult.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/SetupResult.java
@@ -34,11 +34,20 @@ import java.util.Map;
  *            whether sentiment analysis is enabled
  * @param resources
  *            map of created resource locations
+ * @param apiKeyVaultReference
+ *            the {@code ${vault:...}} reference the created agent's LLM config
+ *            points at — whether this setup vaulted the key or reused an entry
+ *            that already held it. Pass it back as {@code vaultKeyName} (or as
+ *            {@code apiKey}) on the next setup to put another agent on the same
+ *            credential without re-entering it. Null when the vault is disabled
+ *            and the key was stored in plaintext: the plaintext is a secret and
+ *            is deliberately never echoed back in a response body.
  *
  * @author ginccc
  */
 public record SetupResult(String action, String agentId, String agentName, String provider, String model, Boolean deployed, String deploymentStatus,
-        Integer endpointCount, List<String> groups, Boolean quickRepliesEnabled, Boolean sentimentAnalysisEnabled, Map<String, Object> resources) {
+        Integer endpointCount, List<String> groups, Boolean quickRepliesEnabled, Boolean sentimentAnalysisEnabled, Map<String, Object> resources,
+        String apiKeyVaultReference) {
 
     /**
      * Builder for fluent construction.
@@ -60,6 +69,7 @@ public record SetupResult(String action, String agentId, String agentName, Strin
         private Boolean quickRepliesEnabled;
         private Boolean sentimentAnalysisEnabled;
         private Map<String, Object> resources;
+        private String apiKeyVaultReference;
 
         public Builder action(String action) {
             this.action = action;
@@ -109,10 +119,14 @@ public record SetupResult(String action, String agentId, String agentName, Strin
             this.resources = resources;
             return this;
         }
+        public Builder apiKeyVaultReference(String apiKeyVaultReference) {
+            this.apiKeyVaultReference = apiKeyVaultReference;
+            return this;
+        }
 
         public SetupResult build() {
             return new SetupResult(action, agentId, agentName, provider, model, deployed, deploymentStatus, endpointCount, groups,
-                    quickRepliesEnabled, sentimentAnalysisEnabled, resources);
+                    quickRepliesEnabled, sentimentAnalysisEnabled, resources, apiKeyVaultReference);
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/setup/SetupResult.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/SetupResult.java
@@ -39,9 +39,10 @@ import java.util.Map;
  *            points at — whether this setup vaulted the key or reused an entry
  *            that already held it. Pass it back as {@code vaultKeyName} (or as
  *            {@code apiKey}) on the next setup to put another agent on the same
- *            credential without re-entering it. Null when the vault is disabled
- *            and the key was stored in plaintext: the plaintext is a secret and
- *            is deliberately never echoed back in a response body.
+ *            credential without re-entering it. Null for a provider that needs
+ *            no key, and null when the vault is disabled and the key was stored
+ *            in plaintext: the plaintext is a secret and is deliberately never
+ *            echoed back in a response body.
  *
  * @author ginccc
  */

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/CreateSubAgentTool.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/CreateSubAgentTool.java
@@ -256,9 +256,12 @@ public class CreateSubAgentTool {
                     null, // mcpServerUrls
                     true, // deploy
                     null, // environment
-                    null // hitlConfig — dynamic sub-agents are not gated; see the
-                         // dynamicAgents.allowCreation escalation flag on the group
-                         // that provisioned this one
+                    null, // hitlConfig — dynamic sub-agents are not gated; see the
+                          // dynamicAgents.allowCreation escalation flag on the group
+                          // that provisioned this one
+                    null // vaultKeyName — a sub-agent inherits the parent's ${vault:...}
+                         // reference through inheritedApiKey above, which is already the
+                         // shared-key case this field exists for
             );
 
             SetupResult result = agentSetupService.setupAgent(request);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -116,6 +116,24 @@ eddi.vault.cache-max-size=1000
 # violation is an ERROR that stops the agent deploying, not a warning.
 eddi.vault.grant-enforcement=enforce
 
+# What the agent setup wizard does with a PLAINTEXT api key the vault already
+# holds under some other name: checksum | never.
+#
+#   checksum (default) - reference the existing entry instead of writing a
+#     second copy, so provisioning ten agents against one provider key leaves
+#     one secret in the vault rather than ten. Matched on the SHA-256 checksum
+#     the vault already stores per entry (nothing is decrypted to decide), and
+#     only entries with allowedAgents unset or ["*"] are candidates - reusing a
+#     narrowed grant would produce a config eddi.vault.grant-enforcement above
+#     rejects at deploy time.
+#   never - every setup writes its own setup.<agent>.<timestamp>.apiKey entry.
+#     Choose this when two agents must be able to rotate the same-valued key
+#     independently.
+#
+# Neither value touches an apiKey that is already a ${vault:...} reference, nor
+# a request carrying an explicit vaultKeyName - those are caller decisions.
+eddi.setup.vault-key-reuse=checksum
+
 # Tenant Quotas — SaaS foundation (per-tenant rate limits + usage metering)
 # Set to -1 for unlimited. Disabled by default — zero impact on existing deployments.
 eddi.tenant.default-id=default

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -132,6 +132,8 @@ eddi.vault.grant-enforcement=enforce
 #
 # Neither value touches an apiKey that is already a ${vault:...} reference, nor
 # a request carrying an explicit vaultKeyName - those are caller decisions.
+# An unrecognised value fails startup rather than degrading (same convention as
+# grant-enforcement above): a typo must not silently switch de-duplication off.
 eddi.setup.vault-key-reuse=checksum
 
 # Tenant Quotas — SaaS foundation (per-tenant rate limits + usage metering)

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpSetupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpSetupToolsTest.java
@@ -863,7 +863,7 @@ class McpSetupToolsTest {
         hitl.setToolApprovals(toolApprovals);
 
         service.createApiAgent(new CreateApiAgentRequest("Agent", "prompt", SIMPLE_SPEC, null, null, "key",
-                null, null, null, null, null, false, null, null, hitl, null, null));
+                null, null, null, null, null, false, null, null, hitl, null, null, null));
 
         var agentCaptor = ArgumentCaptor.forClass(AgentConfiguration.class);
         verify(AgentStore).createAgent(agentCaptor.capture());
@@ -879,7 +879,7 @@ class McpSetupToolsTest {
         stubApiAgentStores();
 
         service.createApiAgent(new CreateApiAgentRequest("Agent", "prompt", SIMPLE_SPEC, null, null, "key",
-                null, null, null, null, null, false, null, null, null, null, null));
+                null, null, null, null, null, false, null, null, null, null, null, null));
 
         var agentCaptor = ArgumentCaptor.forClass(AgentConfiguration.class);
         verify(AgentStore).createAgent(agentCaptor.capture());
@@ -899,7 +899,7 @@ class McpSetupToolsTest {
         stubApiAgentStores();
 
         service.createApiAgent(new CreateApiAgentRequest("Agent", "prompt", SIMPLE_SPEC, null, null, "key",
-                null, null, null, null, null, false, null, null, null, null, 30));
+                null, null, null, null, null, false, null, null, null, null, 30, null));
 
         var llmCaptor = ArgumentCaptor.forClass(LlmConfiguration.class);
         verify(langchainStore).createLlm(llmCaptor.capture());
@@ -911,7 +911,7 @@ class McpSetupToolsTest {
         stubApiAgentStores();
 
         service.createApiAgent(new CreateApiAgentRequest("Agent", "prompt", SIMPLE_SPEC, null, null, "key",
-                null, null, null, null, null, false, null, null, null, null, null));
+                null, null, null, null, null, false, null, null, null, null, null, null));
 
         var llmCaptor = ArgumentCaptor.forClass(LlmConfiguration.class);
         verify(langchainStore).createLlm(llmCaptor.capture());
@@ -929,7 +929,7 @@ class McpSetupToolsTest {
                 .thenReturn(Response.created(URI.create("/mcpcallstore/mcpcalls/mcp-1?version=1")).build());
 
         service.createApiAgent(new CreateApiAgentRequest("Agent", "prompt", SIMPLE_SPEC, null, null, "key",
-                null, null, null, null, null, false, null, null, null, "https://mcp.example.com/sse", null));
+                null, null, null, null, null, false, null, null, null, "https://mcp.example.com/sse", null, null));
 
         var packageCaptor = ArgumentCaptor.forClass(WorkflowConfiguration.class);
         verify(WorkflowStore).createWorkflow(packageCaptor.capture());

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupHardeningTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupHardeningTest.java
@@ -90,7 +90,7 @@ class AgentSetupHardeningTest {
     }
 
     private static SetupAgentRequest request(String name, String prompt) {
-        return new SetupAgentRequest(name, prompt, "ollama", "llama3", null, null, null, null, null, null, null, null, false, null, null);
+        return new SetupAgentRequest(name, prompt, "ollama", "llama3", null, null, null, null, null, null, null, null, false, null, null, null);
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceBranchCoverageTest.java
@@ -87,7 +87,7 @@ class AgentSetupServiceBranchCoverageTest {
         @DisplayName("setupAgent with an unknown environment creates nothing")
         void setupAgentRejectsUnknownEnvironment() {
             var request = new SetupAgentRequest("MyAgent", "You are helpful.", "anthropic", "claude-sonnet-4-6", "sk-test", null, null, false, null,
-                    false, false, null, true, "staging", null);
+                    false, false, null, true, "staging", null, null);
 
             var exception = assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(request));
 
@@ -327,7 +327,7 @@ class AgentSetupServiceBranchCoverageTest {
         @DisplayName("null agent name throws")
         void nullAgentName() {
             var req = new SetupAgentRequest(null, "prompt", "anthropic", "model",
-                    "key", null, null, null, null, null, null, null, null, null, null);
+                    "key", null, null, null, null, null, null, null, null, null, null, null);
             assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(req));
         }
 
@@ -335,7 +335,7 @@ class AgentSetupServiceBranchCoverageTest {
         @DisplayName("blank agent name throws")
         void blankAgentName() {
             var req = new SetupAgentRequest("  ", "prompt", "anthropic", "model",
-                    "key", null, null, null, null, null, null, null, null, null, null);
+                    "key", null, null, null, null, null, null, null, null, null, null, null);
             assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(req));
         }
 
@@ -343,7 +343,7 @@ class AgentSetupServiceBranchCoverageTest {
         @DisplayName("null system prompt throws")
         void nullSystemPrompt() {
             var req = new SetupAgentRequest("Agent", null, "anthropic", "model",
-                    "key", null, null, null, null, null, null, null, null, null, null);
+                    "key", null, null, null, null, null, null, null, null, null, null, null);
             assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(req));
         }
 
@@ -351,7 +351,7 @@ class AgentSetupServiceBranchCoverageTest {
         @DisplayName("blank system prompt throws")
         void blankSystemPrompt() {
             var req = new SetupAgentRequest("Agent", "  ", "anthropic", "model",
-                    "key", null, null, null, null, null, null, null, null, null, null);
+                    "key", null, null, null, null, null, null, null, null, null, null, null);
             assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(req));
         }
 
@@ -359,7 +359,7 @@ class AgentSetupServiceBranchCoverageTest {
         @DisplayName("cloud provider without API key throws")
         void cloudProviderNoApiKey() {
             var req = new SetupAgentRequest("Agent", "prompt", "openai", "gpt-4",
-                    null, null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(req));
         }
 
@@ -367,7 +367,7 @@ class AgentSetupServiceBranchCoverageTest {
         @DisplayName("cloud provider with blank API key throws")
         void cloudProviderBlankApiKey() {
             var req = new SetupAgentRequest("Agent", "prompt", "anthropic", "model",
-                    "  ", null, null, null, null, null, null, null, null, null, null);
+                    "  ", null, null, null, null, null, null, null, null, null, null, null);
             assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(req));
         }
 
@@ -375,7 +375,7 @@ class AgentSetupServiceBranchCoverageTest {
         @DisplayName("local provider (ollama) without API key does NOT throw for validation")
         void localProviderNoApiKeyOk() throws Exception {
             var req = new SetupAgentRequest("Agent", "prompt", "ollama", "llama3",
-                    null, null, null, null, null, null, null, null, false, null, null);
+                    null, null, null, null, null, null, null, null, false, null, null, null);
             // Will fail at REST call, but validation should pass
             when(restInterfaceFactory.get(any())).thenThrow(new RestInterfaceFactory.RestInterfaceFactoryException("mock", new RuntimeException()));
             assertThrows(AgentSetupService.AgentSetupException.class, () -> service.setupAgent(req));

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceBranchCoverageTest.java
@@ -702,9 +702,9 @@ class AgentSetupServiceBranchCoverageTest {
     class VaultApiKey {
 
         private String invokeVaultApiKey(String apiKey, String agentName) throws Exception {
-            var method = AgentSetupService.class.getDeclaredMethod("vaultApiKey", String.class, String.class);
+            var method = AgentSetupService.class.getDeclaredMethod("vaultApiKey", String.class, String.class, String.class, Map.class);
             method.setAccessible(true);
-            return (String) method.invoke(service, apiKey, agentName);
+            return (String) method.invoke(service, apiKey, agentName, null, null);
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceBranchCoverageTest.java
@@ -715,8 +715,8 @@ class AgentSetupServiceBranchCoverageTest {
             String result = invokeVaultApiKey(vaultRef, "MyAgent");
 
             assertEquals(vaultRef, result, "Already-vaulted reference should be returned unchanged");
-            // Should NOT attempt to store anything
-            verifyNoInteractions(secretProvider);
+            // Looked up (so a dangling reference is logged) but never re-vaulted
+            verify(secretProvider, never()).store(any(), anyString(), anyString(), anyList());
         }
 
         @Test
@@ -745,7 +745,8 @@ class AgentSetupServiceBranchCoverageTest {
             String result = invokeVaultApiKey(legacyRef, "LegacyAgent");
 
             assertEquals(legacyRef, result, "Legacy eddivault reference should be returned unchanged");
-            verifyNoInteractions(secretProvider);
+            // Looked up (so a dangling reference is logged) but never re-vaulted
+            verify(secretProvider, never()).store(any(), anyString(), anyString(), anyList());
         }
 
         @Test
@@ -756,7 +757,8 @@ class AgentSetupServiceBranchCoverageTest {
             String result = invokeVaultApiKey(fullRef, "MultiTenantAgent");
 
             assertEquals(fullRef, result, "Full-form vault reference should be returned unchanged");
-            verifyNoInteractions(secretProvider);
+            // Looked up (so a dangling reference is logged) but never re-vaulted
+            verify(secretProvider, never()).store(any(), anyString(), anyString(), anyList());
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceTest.java
@@ -577,7 +577,7 @@ class AgentSetupServiceTest {
         @DisplayName("throws when agent name is null")
         void nullAgentName() {
             var request = new SetupAgentRequest(null, "prompt", "openai", "gpt-4",
-                    "key", null, null, null, null, null, null, null, null, null, null);
+                    "key", null, null, null, null, null, null, null, null, null, null, null);
             assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> service.setupAgent(request));
         }
@@ -586,7 +586,7 @@ class AgentSetupServiceTest {
         @DisplayName("throws when system prompt is blank")
         void blankPrompt() {
             var request = new SetupAgentRequest("Test Agent", "", "openai", "gpt-4",
-                    "key", null, null, null, null, null, null, null, null, null, null);
+                    "key", null, null, null, null, null, null, null, null, null, null, null);
             assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> service.setupAgent(request));
         }
@@ -595,7 +595,7 @@ class AgentSetupServiceTest {
         @DisplayName("throws when cloud provider has no API key")
         void cloudProviderNoApiKey() {
             var request = new SetupAgentRequest("Test Agent", "prompt", "openai", "gpt-4",
-                    null, null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> service.setupAgent(request));
         }
@@ -606,7 +606,7 @@ class AgentSetupServiceTest {
             // ollama doesn't need an API key, but will fail at REST store call
             // — the validation itself should pass
             var request = new SetupAgentRequest("Test Agent", "prompt", "ollama", "llama3",
-                    null, null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             // Will throw AgentSetupException at the REST call level, not validation
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> service.setupAgent(request));
@@ -631,7 +631,7 @@ class AgentSetupServiceTest {
             hitl.setToolApprovals(toolApprovals);
 
             var request = new SetupAgentRequest("Test Agent", "prompt", "openai", "gpt-4",
-                    "key", null, null, null, null, null, null, null, null, null, hitl);
+                    "key", null, null, null, null, null, null, null, null, null, hitl, null);
 
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> guardedService.setupAgent(request));
@@ -655,7 +655,7 @@ class AgentSetupServiceTest {
             hitl.setToolApprovals(toolApprovals);
 
             var request = new SetupAgentRequest("Test Agent", "prompt", "openai", "gpt-4",
-                    "key", null, null, null, null, null, null, null, null, null, hitl);
+                    "key", null, null, null, null, null, null, null, null, null, hitl, null);
 
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> guardedService.setupAgent(request));
@@ -748,7 +748,7 @@ class AgentSetupServiceTest {
             // createAgent, not about deployment, which would need an
             // IRestAgentAdministration mock too.
             var request = new SetupAgentRequest("Billing Agent", "You are helpful.", "anthropic", "claude-sonnet-4-6",
-                    "sk-test", null, null, null, null, null, null, null, false, null, hitl);
+                    "sk-test", null, null, null, null, null, null, null, false, null, hitl, null);
 
             wiredService.setupAgent(request);
 
@@ -768,7 +768,7 @@ class AgentSetupServiceTest {
                     "http://localhost:11434");
 
             var request = new SetupAgentRequest("Billing Agent", "You are helpful.", "anthropic", "claude-sonnet-4-6",
-                    "sk-test", null, null, null, null, null, null, null, false, null, null);
+                    "sk-test", null, null, null, null, null, null, null, false, null, null, null);
 
             wiredService.setupAgent(request);
 
@@ -787,7 +787,7 @@ class AgentSetupServiceTest {
         void nullAgentName() {
             var request = new CreateApiAgentRequest(
                     null, "prompt", "openapi: 3.0", "openai", "gpt-4",
-                    "sk-key", null, null, null, null, null, null, null, null, null, null, null);
+                    "sk-key", null, null, null, null, null, null, null, null, null, null, null, null);
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> service.createApiAgent(request));
             assertTrue(ex.getMessage().contains("Agent name is required"));
@@ -798,7 +798,7 @@ class AgentSetupServiceTest {
         void blankSystemPrompt() {
             var request = new CreateApiAgentRequest(
                     "My Agent", "   ", "openapi: 3.0", "openai", "gpt-4",
-                    "sk-key", null, null, null, null, null, null, null, null, null, null, null);
+                    "sk-key", null, null, null, null, null, null, null, null, null, null, null, null);
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> service.createApiAgent(request));
             assertTrue(ex.getMessage().contains("System prompt is required"));
@@ -809,7 +809,7 @@ class AgentSetupServiceTest {
         void blankOpenApiSpec() {
             var request = new CreateApiAgentRequest(
                     "My Agent", "You are helpful", "", "openai", "gpt-4",
-                    "sk-key", null, null, null, null, null, null, null, null, null, null, null);
+                    "sk-key", null, null, null, null, null, null, null, null, null, null, null, null);
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> service.createApiAgent(request));
             assertTrue(ex.getMessage().contains("OpenAPI spec is required"));
@@ -820,7 +820,7 @@ class AgentSetupServiceTest {
         void cloudProviderNoApiKey() {
             var request = new CreateApiAgentRequest(
                     "My Agent", "You are helpful", "openapi: 3.0", "openai", "gpt-4",
-                    null, null, null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null, null);
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> service.createApiAgent(request));
             assertTrue(ex.getMessage().contains("API key is required"));
@@ -839,7 +839,7 @@ class AgentSetupServiceTest {
             for (int bad : new int[]{0, -1, AgentSetupService.MAX_TOOL_ITERATIONS + 1}) {
                 var request = new CreateApiAgentRequest(
                         "My Agent", "You are helpful", "not-even-openapi", "openai", "gpt-4",
-                        "sk-key", null, null, null, null, null, null, null, null, null, null, bad);
+                        "sk-key", null, null, null, null, null, null, null, null, null, null, bad, null);
                 var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                         () -> service.createApiAgent(request), "value " + bad + " must be rejected");
                 assertTrue(ex.getMessage().contains("maxToolIterations"),
@@ -863,7 +863,7 @@ class AgentSetupServiceTest {
             for (int ok : new int[]{1, AgentSetupService.MAX_TOOL_ITERATIONS}) {
                 var request = new CreateApiAgentRequest(
                         "My Agent", "You are helpful", "not-even-openapi", "openai", "gpt-4",
-                        "sk-key", null, null, null, null, null, null, null, null, null, null, ok);
+                        "sk-key", null, null, null, null, null, null, null, null, null, null, ok, null);
                 var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                         () -> service.createApiAgent(request), "value " + ok + " must reach the spec parse");
                 assertFalse(ex.getMessage().contains("maxToolIterations"),
@@ -891,7 +891,7 @@ class AgentSetupServiceTest {
 
             var request = new CreateApiAgentRequest(
                     "My Agent", "You are helpful", "openapi: 3.0", "openai", "gpt-4",
-                    "sk-key", null, null, null, null, null, null, null, null, hitl, null, null);
+                    "sk-key", null, null, null, null, null, null, null, null, hitl, null, null, null);
 
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> guardedService.createApiAgent(request));
@@ -913,7 +913,7 @@ class AgentSetupServiceTest {
             var request = new CreateApiAgentRequest(
                     "My Agent", "You are helpful", "openapi: 3.0", "openai", "gpt-4",
                     "sk-key", null, null, null, null, null, null, null, null, null,
-                    "https://good.example.com/mcp,ftp://bad.example.com/mcp", null);
+                    "https://good.example.com/mcp,ftp://bad.example.com/mcp", null, null);
 
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> guardedService.createApiAgent(request));
@@ -932,7 +932,7 @@ class AgentSetupServiceTest {
             var request = new CreateApiAgentRequest(
                     "My Agent", "You are helpful", "openapi: 3.0", "openai", "gpt-4",
                     "sk-key", null, null, null, null, null, null, null, null, null,
-                    "https://a.example.com/mcp, https://b.example.com/mcp", null);
+                    "https://a.example.com/mcp, https://b.example.com/mcp", null, null);
 
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> guardedService.createApiAgent(request));
@@ -958,7 +958,7 @@ class AgentSetupServiceTest {
 
             var request = new CreateApiAgentRequest(
                     "My Agent", "You are helpful", "openapi: 3.0", "openai", "gpt-4",
-                    "sk-key", null, null, null, null, null, null, null, null, hitl, null, null);
+                    "sk-key", null, null, null, null, null, null, null, null, hitl, null, null, null);
 
             var ex = assertThrows(AgentSetupService.AgentSetupException.class,
                     () -> guardedService.createApiAgent(request));

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -132,6 +133,10 @@ class AgentSetupVaultKeyReuseTest {
 
             verify(secretProvider).getMetadata(new SecretReference(SecretReference.DEFAULT_TENANT, "typo-key"));
             verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
+            // A log line does not reach the caller. Both this and the restricted-grant
+            // case end in an agent that was created and cannot use its credential.
+            assertTrue(String.valueOf(createdResources.get(AgentSetupService.VAULT_WARNING)).contains("does not exist"),
+                    String.valueOf(createdResources.get(AgentSetupService.VAULT_WARNING)));
         }
 
         /**
@@ -147,7 +152,7 @@ class AgentSetupVaultKeyReuseTest {
 
             assertEquals("${vault:scoped}", vaultApiKey("${vault:scoped}", null));
 
-            String warning = String.valueOf(createdResources.get(AgentSetupService.VAULT_GRANT_WARNING));
+            String warning = String.valueOf(createdResources.get(AgentSetupService.VAULT_WARNING));
             assertTrue(warning.contains("agent-42") && warning.contains("blocked"), warning);
         }
 
@@ -158,7 +163,7 @@ class AgentSetupVaultKeyReuseTest {
 
             vaultApiKey("${vault:open}", null);
 
-            assertFalse(createdResources.containsKey(AgentSetupService.VAULT_GRANT_WARNING));
+            assertFalse(createdResources.containsKey(AgentSetupService.VAULT_WARNING));
         }
 
         @Test
@@ -294,6 +299,24 @@ class AgentSetupVaultKeyReuseTest {
             assertTrue(String.valueOf(createdResources.get(AgentSetupService.VAULTED_SECRET_KEY)).startsWith("setup.my-agent."));
         }
 
+        /**
+         * The timestamp alone did not make the name unique: two setups for agents with
+         * the same name in the same millisecond produced the same key, and store is an
+         * UPSERT, so one silently overwrote the other's credential.
+         */
+        @Test
+        @DisplayName("two same-named agents in the same millisecond get different keys")
+        void generatedNamesDoNotCollide() throws Exception {
+            var names = new HashSet<String>();
+            for (int i = 0; i < 50; i++) {
+                createdResources.clear();
+                service.vaultKeyReuse = AgentSetupService.VAULT_KEY_REUSE_NEVER;
+                names.add(vaultApiKey(KEY, null));
+            }
+
+            assertEquals(50, names.size(), "generated vault key names must be unique: " + names);
+        }
+
         @Test
         @DisplayName("the stored value is trimmed, not the raw paste")
         void storesTheTrimmedKey() throws Exception {
@@ -341,7 +364,7 @@ class AgentSetupVaultKeyReuseTest {
 
             assertEquals("${vault:scoped}", vaultApiKey(null, "scoped"));
 
-            assertTrue(String.valueOf(createdResources.get(AgentSetupService.VAULT_GRANT_WARNING)).contains("agent-42"));
+            assertTrue(String.valueOf(createdResources.get(AgentSetupService.VAULT_WARNING)).contains("agent-42"));
         }
 
         @Test
@@ -453,10 +476,31 @@ class AgentSetupVaultKeyReuseTest {
             assertEquals("openai-prod", ref.getValue().keyName());
         }
 
+        /**
+         * store is an UPSERT and the absent-then-create sequence is not atomic, so two
+         * setups naming one key with different values can both find it missing and both
+         * write. Reading back turns the common interleaving into a loud failure before
+         * any document exists, instead of an agent provisioned against the other
+         * caller's credential.
+         */
+        @Test
+        @DisplayName("a value overwritten concurrently is detected, not accepted")
+        void concurrentOverwriteIsDetected() throws Exception {
+            when(secretProvider.getMetadata(any()))
+                    .thenThrow(new ISecretProvider.SecretNotFoundException("absent"))
+                    .thenReturn(entry("openai-prod", "the-other-callers-key", Instant.EPOCH, List.of("*")));
+
+            var e = assertThrows(AgentSetupService.AgentSetupException.class, () -> vaultApiKey(KEY, "openai-prod"));
+
+            assertTrue(e.getMessage().contains("written concurrently"), e.getMessage());
+        }
+
         @Test
         @DisplayName("a missing entry is created under exactly that name")
         void createsUnderTheGivenName() throws Exception {
-            when(secretProvider.getMetadata(any())).thenThrow(new ISecretProvider.SecretNotFoundException("nope"));
+            when(secretProvider.getMetadata(any()))
+                    .thenThrow(new ISecretProvider.SecretNotFoundException("nope"))
+                    .thenReturn(entry("openai-prod", KEY, Instant.EPOCH, List.of("*")));
 
             assertEquals("${vault:openai-prod}", vaultApiKey(KEY, "openai-prod"));
 

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.setup;
 import ai.labs.eddi.engine.api.IRestAgentAdministration;
 import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
 import ai.labs.eddi.secrets.ISecretProvider;
+import ai.labs.eddi.secrets.SecretResolver;
 import ai.labs.eddi.secrets.crypto.EnvelopeCrypto;
 import ai.labs.eddi.secrets.model.SecretMetadata;
 import ai.labs.eddi.secrets.model.SecretReference;
@@ -36,6 +37,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -68,11 +70,15 @@ class AgentSetupVaultKeyReuseTest {
     private AgentSetupService service;
     private Map<String, Object> createdResources;
 
+    @Mock
+    private SecretResolver secretResolver;
+
     @BeforeEach
     void setUp() throws Exception {
         openMocks(this);
         service = new AgentSetupService(restInterfaceFactory, agentAdmin, secretProvider, "http://localhost:11434");
         service.vaultKeyReuse = AgentSetupService.VAULT_KEY_REUSE_CHECKSUM;
+        service.secretResolver = secretResolver;
         createdResources = new LinkedHashMap<>();
         when(secretProvider.isAvailable()).thenReturn(true);
         when(secretProvider.listKeys(anyString())).thenReturn(List.of());
@@ -315,6 +321,22 @@ class AgentSetupVaultKeyReuseTest {
             }
 
             assertEquals(50, names.size(), "generated vault key names must be unique: " + names);
+        }
+
+        /**
+         * The counter-intuitive half of this: it matters most on CREATION. An agent set
+         * up against a key that did not exist yet — which this service allows, warning
+         * rather than refusing — may already have a cached model holding the unresolved
+         * "${vault:...}" literal as its API key. Filling that key in later without
+         * invalidating leaves it broken until the model cache expires. RestSecretStore
+         * invalidates for exactly this reason; a direct write here has to as well.
+         */
+        @Test
+        @DisplayName("storing a secret invalidates the resolver cache")
+        void storeInvalidatesTheResolverCache() throws Exception {
+            vaultApiKey(KEY, null);
+
+            verify(secretResolver).invalidateCache(any(SecretReference.class));
         }
 
         @Test
@@ -595,6 +617,37 @@ class AgentSetupVaultKeyReuseTest {
                 service.vaultKeyReuse = ok;
                 service.validateVaultKeyReuse();
             }
+        }
+    }
+
+    // ─── ordering against the rest of setup ──────────────────────────────
+
+    @Nested
+    @DisplayName("createApiAgent ordering")
+    class ApiAgentOrdering {
+
+        /**
+         * Key resolution runs ahead of every store call so an unusable vaultKeyName
+         * fails while rollback has nothing to undo. That put it ahead of the OpenAPI
+         * parse too — and the parse is the likeliest way this call fails. Under
+         * vault-key-reuse=never the secret was written first and then leaked, because
+         * createApiAgent's AgentSetupException arm rethrows unwrapped.
+         *
+         * Parsing creates nothing, so it belongs first: an unparseable spec must not
+         * reach the vault at all rather than rely on rollback to undo a write that
+         * should never have happened.
+         */
+        @Test
+        @DisplayName("an unparseable spec never reaches the vault")
+        void invalidSpecDoesNotTouchTheVault() {
+            service.vaultKeyReuse = AgentSetupService.VAULT_KEY_REUSE_NEVER;
+            var request = new CreateApiAgentRequest("Api Agent", "be helpful", "this is not an OpenAPI document", "anthropic",
+                    "claude-sonnet-5", KEY, null, null, null, null, null, false, null, null, null, null, null, null);
+
+            var e = assertThrows(AgentSetupService.AgentSetupException.class, () -> service.createApiAgent(request));
+
+            assertTrue(e.getMessage().contains("OpenAPI"), e.getMessage());
+            verifyNoInteractions(secretProvider);
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.setup;
+
+import ai.labs.eddi.engine.api.IRestAgentAdministration;
+import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
+import ai.labs.eddi.secrets.ISecretProvider;
+import ai.labs.eddi.secrets.crypto.EnvelopeCrypto;
+import ai.labs.eddi.secrets.model.SecretMetadata;
+import ai.labs.eddi.secrets.model.SecretReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+/**
+ * Setting up several agents against ONE provider key must leave ONE secret in
+ * the vault. These tests cover the three ways that is expressed — an existing
+ * {@code ${vault:...}} reference, an explicit {@code vaultKeyName}, and the
+ * same plaintext key pasted twice — plus the two ways it must NOT happen: a
+ * reused entry is never recorded for rollback, and a named entry is never
+ * silently overwritten.
+ */
+@DisplayName("AgentSetupService — vault key reuse")
+class AgentSetupVaultKeyReuseTest {
+
+    private static final String KEY = "sk-live-abcdef0123456789";
+
+    @Mock
+    private IRestInterfaceFactory restInterfaceFactory;
+    @Mock
+    private IRestAgentAdministration agentAdmin;
+    @Mock
+    private ISecretProvider secretProvider;
+
+    private AgentSetupService service;
+    private Map<String, Object> createdResources;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        openMocks(this);
+        service = new AgentSetupService(restInterfaceFactory, agentAdmin, secretProvider, "http://localhost:11434");
+        service.vaultKeyReuse = AgentSetupService.VAULT_KEY_REUSE_CHECKSUM;
+        createdResources = new LinkedHashMap<>();
+        when(secretProvider.isAvailable()).thenReturn(true);
+        when(secretProvider.listKeys(anyString())).thenReturn(List.of());
+    }
+
+    private String vaultApiKey(String apiKey, String vaultKeyName) throws Exception {
+        Method method = AgentSetupService.class.getDeclaredMethod("vaultApiKey", String.class, String.class, String.class, Map.class);
+        method.setAccessible(true);
+        try {
+            return (String) method.invoke(service, apiKey, "My Agent", vaultKeyName, createdResources);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof Exception cause) {
+                throw cause;
+            }
+            throw e;
+        }
+    }
+
+    private static SecretMetadata entry(String keyName, String value, Instant createdAt, List<String> allowedAgents) {
+        return new SecretMetadata(SecretReference.DEFAULT_TENANT, keyName, createdAt, null, null, EnvelopeCrypto.sha256Hex(value),
+                "test", allowedAgents);
+    }
+
+    // ─── an apiKey that is already a reference ───────────────────────────
+
+    @Nested
+    @DisplayName("apiKey is already a vault reference")
+    class AlreadyAReference {
+
+        /**
+         * The regression this whole change starts from. The reference check is a
+         * full-string match, so a value pasted out of a UI list — trailing newline
+         * included — used to miss it and get vaulted as plaintext whose content is a
+         * reference: a brand-new, useless key on every single setup.
+         */
+        @Test
+        @DisplayName("survives the whitespace a paste carries with it")
+        void trimmedBeforeTheReferenceCheck() throws Exception {
+            String result = vaultApiKey("  ${vault:openai-prod}\n", null);
+
+            assertEquals("${vault:openai-prod}", result);
+            verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
+            assertFalse(createdResources.containsKey(AgentSetupService.VAULTED_SECRET_KEY));
+        }
+
+        @Test
+        @DisplayName("a value merely CONTAINING a reference is not one")
+        void embeddedReferenceIsNotAReference() throws Exception {
+            String result = vaultApiKey("Bearer ${vault:openai-prod}", null);
+
+            assertTrue(result.startsWith("${vault:setup.my-agent."), "Expected a freshly vaulted key, got: " + result);
+            verify(secretProvider).store(any(), eq("Bearer ${vault:openai-prod}"), anyString(), any());
+        }
+    }
+
+    // ─── plaintext the vault already holds ───────────────────────────────
+
+    @Nested
+    @DisplayName("plaintext the vault already holds")
+    class ChecksumReuse {
+
+        @Test
+        @DisplayName("references the existing entry instead of storing a second copy")
+        void reusesByChecksum() throws Exception {
+            when(secretProvider.listKeys(SecretReference.DEFAULT_TENANT))
+                    .thenReturn(List.of(entry("setup.first-agent.1.apiKey", KEY, Instant.EPOCH, List.of("*"))));
+
+            assertEquals("${vault:setup.first-agent.1.apiKey}", vaultApiKey(KEY, null));
+            verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
+        }
+
+        /**
+         * Rollback deletes whatever it finds under {@code VAULTED_SECRET_KEY}. A reused
+         * entry belongs to the agent that created it, so recording it here would let
+         * the failure of a LATER agent delete a key the earlier one is still pointing
+         * at.
+         */
+        @Test
+        @DisplayName("a reused entry is never recorded for rollback")
+        void reusedEntryIsNotRollbackFodder() throws Exception {
+            when(secretProvider.listKeys(SecretReference.DEFAULT_TENANT))
+                    .thenReturn(List.of(entry("shared.key", KEY, Instant.EPOCH, null)));
+
+            vaultApiKey(KEY, null);
+
+            assertFalse(createdResources.containsKey(AgentSetupService.VAULTED_SECRET_KEY));
+        }
+
+        /**
+         * A narrowed grant was narrowed deliberately. Referencing it from a new agent
+         * produces a config VaultGrantGate rejects at deploy time — a reuse that
+         * "works" right up until it matters.
+         */
+        @Test
+        @DisplayName("a narrowly granted entry is not a reuse candidate")
+        void skipsRestrictedGrants() throws Exception {
+            when(secretProvider.listKeys(SecretReference.DEFAULT_TENANT))
+                    .thenReturn(List.of(entry("scoped.key", KEY, Instant.EPOCH, List.of("agent-42"))));
+
+            assertTrue(vaultApiKey(KEY, null).startsWith("${vault:setup.my-agent."));
+            verify(secretProvider).store(any(), eq(KEY), anyString(), any());
+        }
+
+        @Test
+        @DisplayName("a different value is not a match")
+        void differentValueIsNotAMatch() throws Exception {
+            when(secretProvider.listKeys(SecretReference.DEFAULT_TENANT))
+                    .thenReturn(List.of(entry("other.key", "sk-some-other-key", Instant.EPOCH, List.of("*"))));
+
+            assertTrue(vaultApiKey(KEY, null).startsWith("${vault:setup.my-agent."));
+        }
+
+        /**
+         * Repeated setups with one key must converge on ONE entry, so the winner cannot
+         * depend on the order the store happens to list in.
+         */
+        @Test
+        @DisplayName("picks the oldest match, whatever order the vault lists in")
+        void deterministicWinner() throws Exception {
+            when(secretProvider.listKeys(SecretReference.DEFAULT_TENANT)).thenReturn(List.of(
+                    entry("newer.key", KEY, Instant.ofEpochSecond(2000), List.of("*")),
+                    entry("older.key", KEY, Instant.ofEpochSecond(1000), List.of("*"))));
+
+            assertEquals("${vault:older.key}", vaultApiKey(KEY, null));
+        }
+
+        @Test
+        @DisplayName("eddi.setup.vault-key-reuse=never restores per-agent keys")
+        void reuseCanBeSwitchedOff() throws Exception {
+            service.vaultKeyReuse = AgentSetupService.VAULT_KEY_REUSE_NEVER;
+            when(secretProvider.listKeys(SecretReference.DEFAULT_TENANT))
+                    .thenReturn(List.of(entry("shared.key", KEY, Instant.EPOCH, List.of("*"))));
+
+            assertTrue(vaultApiKey(KEY, null).startsWith("${vault:setup.my-agent."));
+            verify(secretProvider).store(any(), eq(KEY), anyString(), any());
+        }
+
+        /** A listing failure must not fail the setup — reuse is an optimisation. */
+        @Test
+        @DisplayName("an unlistable vault falls back to storing a new entry")
+        void listFailureDegradesToStore() throws Exception {
+            when(secretProvider.listKeys(SecretReference.DEFAULT_TENANT))
+                    .thenThrow(new ISecretProvider.SecretProviderException("backend down"));
+
+            assertTrue(vaultApiKey(KEY, null).startsWith("${vault:setup.my-agent."));
+        }
+
+        @Test
+        @DisplayName("the stored value is trimmed, not the raw paste")
+        void storesTheTrimmedKey() throws Exception {
+            vaultApiKey("  " + KEY + "\n", null);
+
+            verify(secretProvider).store(any(), eq(KEY), anyString(), any());
+        }
+    }
+
+    // ─── an explicit vaultKeyName ────────────────────────────────────────
+
+    @Nested
+    @DisplayName("explicit vaultKeyName")
+    class NamedKey {
+
+        @Test
+        @DisplayName("names an existing entry, needing no apiKey at all")
+        void reusesExistingWithoutPlaintext() throws Exception {
+            when(secretProvider.getMetadata(new SecretReference(SecretReference.DEFAULT_TENANT, "openai-prod")))
+                    .thenReturn(entry("openai-prod", KEY, Instant.EPOCH, List.of("*")));
+
+            assertEquals("${vault:openai-prod}", vaultApiKey(null, "openai-prod"));
+            verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
+        }
+
+        @Test
+        @DisplayName("accepts the reference form as well as the bare name")
+        void acceptsReferenceForm() throws Exception {
+            when(secretProvider.getMetadata(new SecretReference(SecretReference.DEFAULT_TENANT, "openai-prod")))
+                    .thenReturn(entry("openai-prod", KEY, Instant.EPOCH, List.of("*")));
+
+            assertEquals("${vault:openai-prod}", vaultApiKey(null, "${vault:openai-prod}"));
+        }
+
+        @Test
+        @DisplayName("an existing entry holding the SAME value is reused, not rewritten")
+        void sameValueIsNotRewritten() throws Exception {
+            when(secretProvider.getMetadata(any())).thenReturn(entry("openai-prod", KEY, Instant.EPOCH, List.of("*")));
+
+            assertEquals("${vault:openai-prod}", vaultApiKey(KEY, "openai-prod"));
+            verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
+        }
+
+        /**
+         * Overwriting here would silently rotate the credential of every OTHER agent
+         * already pointing at that name.
+         */
+        @Test
+        @DisplayName("an existing entry holding a DIFFERENT value is refused, not overwritten")
+        void differentValueIsRefused() throws Exception {
+            when(secretProvider.getMetadata(any())).thenReturn(entry("openai-prod", "sk-the-old-one", Instant.EPOCH, List.of("*")));
+
+            var e = assertThrows(AgentSetupService.AgentSetupException.class, () -> vaultApiKey(KEY, "openai-prod"));
+
+            assertTrue(e.getMessage().contains("already holds a different value"), e.getMessage());
+            verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
+        }
+
+        @Test
+        @DisplayName("a missing entry is created under exactly that name")
+        void createsUnderTheGivenName() throws Exception {
+            when(secretProvider.getMetadata(any())).thenThrow(new ISecretProvider.SecretNotFoundException("nope"));
+
+            assertEquals("${vault:openai-prod}", vaultApiKey(KEY, "openai-prod"));
+
+            var ref = ArgumentCaptor.forClass(SecretReference.class);
+            verify(secretProvider).store(ref.capture(), eq(KEY), anyString(), any());
+            assertEquals("openai-prod", ref.getValue().keyName());
+            assertEquals("openai-prod", createdResources.get(AgentSetupService.VAULTED_SECRET_KEY),
+                    "A newly created entry IS this setup's to roll back");
+        }
+
+        @Test
+        @DisplayName("a missing entry with no apiKey to create it from is an error")
+        void missingAndNothingToCreateItFrom() throws Exception {
+            when(secretProvider.getMetadata(any())).thenThrow(new ISecretProvider.SecretNotFoundException("nope"));
+
+            var e = assertThrows(AgentSetupService.AgentSetupException.class, () -> vaultApiKey(null, "openai-prod"));
+
+            assertTrue(e.getMessage().contains("does not exist"), e.getMessage());
+        }
+
+        /**
+         * The generated-name path degrades to plaintext when the vault is off, because
+         * dev mode must keep working. A caller who NAMED a key asked for a specific
+         * shared secret, and silently writing their key in plaintext instead is not a
+         * smaller version of that request.
+         */
+        @Test
+        @DisplayName("fails loudly when the vault is unavailable, rather than degrading to plaintext")
+        void refusesWithoutAVault() throws Exception {
+            when(secretProvider.isAvailable()).thenReturn(false);
+
+            var e = assertThrows(AgentSetupService.AgentSetupException.class, () -> vaultApiKey(KEY, "openai-prod"));
+
+            assertTrue(e.getMessage().contains("vault is unavailable"), e.getMessage());
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
@@ -128,6 +128,33 @@ class AgentSetupVaultKeyReuseTest {
             verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
         }
 
+        /**
+         * A brand-new agent's ID cannot be in any grant list that already exists, so
+         * under enforce the deployment will be blocked. Not a reason to refuse — the
+         * legitimate flow is setup without deploy, widen the grant, deploy — but a
+         * reason to tell the caller in the response, not only in the server log.
+         */
+        @Test
+        @DisplayName("a reference to a narrowly granted key is accepted, with a warning in the result")
+        void restrictedReferenceWarnsInResult() throws Exception {
+            when(secretProvider.getMetadata(any())).thenReturn(entry("scoped", KEY, Instant.EPOCH, List.of("agent-42")));
+
+            assertEquals("${vault:scoped}", vaultApiKey("${vault:scoped}", null));
+
+            String warning = String.valueOf(createdResources.get(AgentSetupService.VAULT_GRANT_WARNING));
+            assertTrue(warning.contains("agent-42") && warning.contains("blocked"), warning);
+        }
+
+        @Test
+        @DisplayName("an unrestricted reference carries no warning")
+        void unrestrictedReferenceIsQuiet() throws Exception {
+            when(secretProvider.getMetadata(any())).thenReturn(entry("open", KEY, Instant.EPOCH, List.of("*")));
+
+            vaultApiKey("${vault:open}", null);
+
+            assertFalse(createdResources.containsKey(AgentSetupService.VAULT_GRANT_WARNING));
+        }
+
         @Test
         @DisplayName("a value merely CONTAINING a reference is not one")
         void embeddedReferenceIsNotAReference() throws Exception {
@@ -230,6 +257,37 @@ class AgentSetupVaultKeyReuseTest {
             assertTrue(vaultApiKey(KEY, null).startsWith("${vault:setup.my-agent."));
         }
 
+        /**
+         * Under checksum reuse a freshly created entry is a shared resource the moment
+         * a second setup with the same key runs — parallel bulk provisioning does
+         * exactly that. Recording it for rollback would let the FIRST agent's failure
+         * delete the key every later one already points at, and the growth rollback
+         * exists to prevent cannot happen here anyway: a retry finds this entry by
+         * value and reuses it.
+         */
+        @Test
+        @DisplayName("under checksum reuse, a fresh entry is NOT registered for rollback")
+        void freshEntryNotRollbackFodderUnderChecksum() throws Exception {
+            vaultApiKey(KEY, null);
+
+            verify(secretProvider).store(any(), eq(KEY), anyString(), any());
+            assertFalse(createdResources.containsKey(AgentSetupService.VAULTED_SECRET_KEY));
+        }
+
+        /**
+         * Under `never` nobody else can find the entry, so the original rollback still
+         * applies.
+         */
+        @Test
+        @DisplayName("under never, a fresh entry IS registered for rollback")
+        void freshEntryIsRollbackFodderUnderNever() throws Exception {
+            service.vaultKeyReuse = AgentSetupService.VAULT_KEY_REUSE_NEVER;
+
+            vaultApiKey(KEY, null);
+
+            assertTrue(String.valueOf(createdResources.get(AgentSetupService.VAULTED_SECRET_KEY)).startsWith("setup.my-agent."));
+        }
+
         @Test
         @DisplayName("the stored value is trimmed, not the raw paste")
         void storesTheTrimmedKey() throws Exception {
@@ -245,6 +303,7 @@ class AgentSetupVaultKeyReuseTest {
         @Test
         @DisplayName("a failed store records nothing for rollback")
         void failedStoreRecordsNothing() throws Exception {
+            service.vaultKeyReuse = AgentSetupService.VAULT_KEY_REUSE_NEVER; // the mode that DOES record on success
             doThrow(new ISecretProvider.SecretProviderException("disk full")).when(secretProvider).store(any(), anyString(), anyString(),
                     any());
 
@@ -267,6 +326,16 @@ class AgentSetupVaultKeyReuseTest {
 
             assertEquals("${vault:openai-prod}", vaultApiKey(null, "openai-prod"));
             verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
+        }
+
+        @Test
+        @DisplayName("naming a narrowly granted key is accepted, with a warning in the result")
+        void restrictedNamedKeyWarnsInResult() throws Exception {
+            when(secretProvider.getMetadata(any())).thenReturn(entry("scoped", KEY, Instant.EPOCH, List.of("agent-42")));
+
+            assertEquals("${vault:scoped}", vaultApiKey(null, "scoped"));
+
+            assertTrue(String.valueOf(createdResources.get(AgentSetupService.VAULT_GRANT_WARNING)).contains("agent-42"));
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
@@ -111,6 +111,23 @@ class AgentSetupVaultKeyReuseTest {
             assertFalse(createdResources.containsKey(AgentSetupService.VAULTED_SECRET_KEY));
         }
 
+        /**
+         * Pass-through has always been accepted as-is and still is — a caller may vault
+         * the key after setup. But the entry is looked up so a typo'd paste is at least
+         * visible in the log rather than surfacing as an agent that deploys and then
+         * fails on its first turn.
+         */
+        @Test
+        @DisplayName("a reference to a missing key is still accepted, and looked up")
+        void danglingReferenceIsAcceptedButChecked() throws Exception {
+            when(secretProvider.getMetadata(any())).thenThrow(new ISecretProvider.SecretNotFoundException("nope"));
+
+            assertEquals("${vault:typo-key}", vaultApiKey("${vault:typo-key}", null));
+
+            verify(secretProvider).getMetadata(new SecretReference(SecretReference.DEFAULT_TENANT, "typo-key"));
+            verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
+        }
+
         @Test
         @DisplayName("a value merely CONTAINING a reference is not one")
         void embeddedReferenceIsNotAReference() throws Exception {
@@ -281,7 +298,7 @@ class AgentSetupVaultKeyReuseTest {
 
             var e = assertThrows(AgentSetupService.AgentSetupException.class, () -> vaultApiKey(KEY, "openai-prod"));
 
-            assertTrue(e.getMessage().contains("already holds a different value"), e.getMessage());
+            assertTrue(e.getMessage().contains("does not match"), e.getMessage());
             verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
         }
 
@@ -340,6 +357,25 @@ class AgentSetupVaultKeyReuseTest {
         @DisplayName("blank vaultKeyName is treated as absent")
         void blankNameIsAbsent() throws Exception {
             assertTrue(vaultApiKey(KEY, "   ").startsWith("${vault:setup.my-agent."));
+        }
+
+        /**
+         * The reference is parsed for its tenant, so the create must honour it too. The
+         * first cut looked the entry up under "acme" and then created it under
+         * "default" — a setup that "worked" and left the agent referencing a secret
+         * that did not exist where it pointed.
+         */
+        @Test
+        @DisplayName("a tenant-qualified name is created in that tenant")
+        void tenantQualifiedNameStaysInItsTenant() throws Exception {
+            when(secretProvider.getMetadata(any())).thenThrow(new ISecretProvider.SecretNotFoundException("nope"));
+
+            assertEquals("${vault:acme/openai-prod}", vaultApiKey(KEY, "${vault:acme/openai-prod}"));
+
+            var ref = ArgumentCaptor.forClass(SecretReference.class);
+            verify(secretProvider).store(ref.capture(), eq(KEY), anyString(), any());
+            assertEquals("acme", ref.getValue().tenantId());
+            assertEquals("openai-prod", ref.getValue().keyName());
         }
 
         @Test
@@ -409,6 +445,37 @@ class AgentSetupVaultKeyReuseTest {
         void neverEchoesPlaintext() throws Exception {
             assertNull(vaultReferenceOrNull(KEY));
             assertNull(vaultReferenceOrNull(null));
+        }
+    }
+
+    // ─── eddi.setup.vault-key-reuse ──────────────────────────────────────
+
+    @Nested
+    @DisplayName("eddi.setup.vault-key-reuse")
+    class ReuseMode {
+
+        /**
+         * Same convention as eddi.vault.grant-enforcement: an unrecognised value fails
+         * startup. Degrading would mean "no reuse" — the original bug back, with every
+         * visible sign saying dedup is on.
+         */
+        @Test
+        @DisplayName("an unrecognised value fails startup instead of silently disabling reuse")
+        void unknownModeFailsFast() {
+            service.vaultKeyReuse = "checksumm";
+
+            var e = assertThrows(IllegalArgumentException.class, service::validateVaultKeyReuse);
+
+            assertTrue(e.getMessage().contains("checksumm"), e.getMessage());
+        }
+
+        @Test
+        @DisplayName("both documented values pass, case-insensitively")
+        void knownModesPass() {
+            for (String ok : List.of("checksum", "never", "CHECKSUM", "Never")) {
+                service.vaultKeyReuse = ok;
+                service.validateVaultKeyReuse();
+            }
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
@@ -26,11 +26,13 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -218,6 +220,20 @@ class AgentSetupVaultKeyReuseTest {
 
             verify(secretProvider).store(any(), eq(KEY), anyString(), any());
         }
+
+        /**
+         * A name recorded before the write would name a secret that does not exist, and
+         * rollback would log a "could not remove" warning chasing it.
+         */
+        @Test
+        @DisplayName("a failed store records nothing for rollback")
+        void failedStoreRecordsNothing() throws Exception {
+            doThrow(new ISecretProvider.SecretProviderException("disk full")).when(secretProvider).store(any(), anyString(), anyString(),
+                    any());
+
+            assertEquals(KEY, vaultApiKey(KEY, null), "falls back to plaintext");
+            assertFalse(createdResources.containsKey(AgentSetupService.VAULTED_SECRET_KEY));
+        }
     }
 
     // ─── an explicit vaultKeyName ────────────────────────────────────────
@@ -269,6 +285,63 @@ class AgentSetupVaultKeyReuseTest {
             verify(secretProvider, never()).store(any(), anyString(), anyString(), any());
         }
 
+        /**
+         * Rollback deletes what it finds under VAULTED_SECRET_KEY. A caller-chosen name
+         * cannot grow the vault on retry (the retry reuses the name), while a
+         * concurrent setup may already have reused the entry — so deleting it is the
+         * riskier of the two options, not the safer one.
+         */
+        @Test
+        @DisplayName("a newly created NAMED entry is left alone by rollback")
+        void namedEntryIsNotRollbackFodder() throws Exception {
+            when(secretProvider.getMetadata(any())).thenThrow(new ISecretProvider.SecretNotFoundException("nope"));
+
+            vaultApiKey(KEY, "openai-prod");
+
+            assertFalse(createdResources.containsKey(AgentSetupService.VAULTED_SECRET_KEY));
+        }
+
+        /**
+         * Honouring the name and dropping the reference silently would deploy the agent
+         * against a credential the caller did not pick.
+         */
+        @Test
+        @DisplayName("apiKey and vaultKeyName naming DIFFERENT keys is refused")
+        void contradictoryNamesAreRefused() throws Exception {
+            var e = assertThrows(AgentSetupService.AgentSetupException.class,
+                    () -> vaultApiKey("${vault:openai-dev}", "openai-prod"));
+
+            assertTrue(e.getMessage().contains("Pass one or the other"), e.getMessage());
+        }
+
+        @Test
+        @DisplayName("apiKey and vaultKeyName naming the SAME key is fine")
+        void agreeingNamesAreAccepted() throws Exception {
+            when(secretProvider.getMetadata(any())).thenReturn(entry("openai-prod", KEY, Instant.EPOCH, List.of("*")));
+
+            assertEquals("${vault:openai-prod}", vaultApiKey("${vault:openai-prod}", "openai-prod"));
+        }
+
+        /**
+         * The name is about to be embedded in "${vault:<tenant>/<key>}". A bare name
+         * containing '/' would re-parse as a tenant separator and a '}' would truncate
+         * the reference, so the agent would resolve a different secret — or none.
+         */
+        @Test
+        @DisplayName("a name that would not survive the reference syntax is refused")
+        void malformedNamesAreRefused() {
+            for (String bad : List.of("tenant/key", "key}", "key with spaces")) {
+                assertThrows(Exception.class, () -> vaultApiKey(KEY, bad), "should have refused: " + bad);
+            }
+        }
+
+        /** An empty field is "not supplied", not a name of zero characters. */
+        @Test
+        @DisplayName("blank vaultKeyName is treated as absent")
+        void blankNameIsAbsent() throws Exception {
+            assertTrue(vaultApiKey(KEY, "   ").startsWith("${vault:setup.my-agent."));
+        }
+
         @Test
         @DisplayName("a missing entry is created under exactly that name")
         void createsUnderTheGivenName() throws Exception {
@@ -279,8 +352,6 @@ class AgentSetupVaultKeyReuseTest {
             var ref = ArgumentCaptor.forClass(SecretReference.class);
             verify(secretProvider).store(ref.capture(), eq(KEY), anyString(), any());
             assertEquals("openai-prod", ref.getValue().keyName());
-            assertEquals("openai-prod", createdResources.get(AgentSetupService.VAULTED_SECRET_KEY),
-                    "A newly created entry IS this setup's to roll back");
         }
 
         @Test
@@ -307,6 +378,37 @@ class AgentSetupVaultKeyReuseTest {
             var e = assertThrows(AgentSetupService.AgentSetupException.class, () -> vaultApiKey(KEY, "openai-prod"));
 
             assertTrue(e.getMessage().contains("vault is unavailable"), e.getMessage());
+        }
+    }
+
+    // ─── what the response body is allowed to carry ──────────────────────
+
+    @Nested
+    @DisplayName("SetupResult.apiKeyVaultReference")
+    class ResultReference {
+
+        private String vaultReferenceOrNull(String effectiveApiKey) throws Exception {
+            Method method = AgentSetupService.class.getDeclaredMethod("vaultReferenceOrNull", String.class);
+            method.setAccessible(true);
+            return (String) method.invoke(null, effectiveApiKey);
+        }
+
+        @Test
+        @DisplayName("hands back the reference, so the next agent can name it")
+        void exposesTheReference() throws Exception {
+            assertEquals("${vault:openai-prod}", vaultReferenceOrNull("${vault:openai-prod}"));
+        }
+
+        /**
+         * With the vault disabled the "effective api key" IS the caller's secret.
+         * Echoing it in a response body would put it through every proxy log between
+         * here and the client.
+         */
+        @Test
+        @DisplayName("never echoes a plaintext key")
+        void neverEchoesPlaintext() throws Exception {
+            assertNull(vaultReferenceOrNull(KEY));
+            assertNull(vaultReferenceOrNull(null));
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java
@@ -49,7 +49,13 @@ import static org.mockito.MockitoAnnotations.openMocks;
 @DisplayName("AgentSetupService — vault key reuse")
 class AgentSetupVaultKeyReuseTest {
 
-    private static final String KEY = "sk-live-abcdef0123456789";
+    /**
+     * Deliberately shaped so it cannot be mistaken for a live credential: a
+     * realistic-looking "sk-live-..." fixture is exactly the pattern a real leaked
+     * key takes, and it tripped the gitleaks generic-api-key rule in CI. Nothing
+     * here depends on the value beyond it being distinct and stable.
+     */
+    private static final String KEY = "test-provider-key-not-a-real-secret";
 
     @Mock
     private IRestInterfaceFactory restInterfaceFactory;
@@ -217,7 +223,7 @@ class AgentSetupVaultKeyReuseTest {
         @DisplayName("a different value is not a match")
         void differentValueIsNotAMatch() throws Exception {
             when(secretProvider.listKeys(SecretReference.DEFAULT_TENANT))
-                    .thenReturn(List.of(entry("other.key", "sk-some-other-key", Instant.EPOCH, List.of("*"))));
+                    .thenReturn(List.of(entry("other.key", "test-a-different-key", Instant.EPOCH, List.of("*"))));
 
             assertTrue(vaultApiKey(KEY, null).startsWith("${vault:setup.my-agent."));
         }
@@ -363,7 +369,7 @@ class AgentSetupVaultKeyReuseTest {
         @Test
         @DisplayName("an existing entry holding a DIFFERENT value is refused, not overwritten")
         void differentValueIsRefused() throws Exception {
-            when(secretProvider.getMetadata(any())).thenReturn(entry("openai-prod", "sk-the-old-one", Instant.EPOCH, List.of("*")));
+            when(secretProvider.getMetadata(any())).thenReturn(entry("openai-prod", "test-the-previously-stored-key", Instant.EPOCH, List.of("*")));
 
             var e = assertThrows(AgentSetupService.AgentSetupException.class, () -> vaultApiKey(KEY, "openai-prod"));
 

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/DynamicAgentToolsTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/DynamicAgentToolsTest.java
@@ -80,7 +80,7 @@ class DynamicAgentToolsTest {
         void createSubAgent_success() throws Exception {
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/DataAnalyst",
-                            "anthropic", "claude-sonnet-4-6", true, "ready", null, null, null, null, null));
+                            "anthropic", "claude-sonnet-4-6", true, "ready", null, null, null, null, null, null));
 
             String result = tool.createSubAgent("DataAnalyst", "You analyze data", "anthropic", "claude-sonnet-4-6", null, null);
 
@@ -156,7 +156,7 @@ class DynamicAgentToolsTest {
             // The tool no longer holds a TenantQuotaService reference at all.
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            null, null, true, "ready", null, null, null, null, null));
+                            null, null, true, "ready", null, null, null, null, null, null));
 
             String result = tool.createSubAgent("Test", "prompt", null, null, null, null);
 
@@ -193,7 +193,7 @@ class DynamicAgentToolsTest {
         void createSubAgent_retainFlag() throws Exception {
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            null, null, true, "ready", null, null, null, null, null));
+                            null, null, true, "ready", null, null, null, null, null, null));
 
             String result = tool.createSubAgent("Test", "prompt", null, null, null, true);
 
@@ -210,7 +210,7 @@ class DynamicAgentToolsTest {
 
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            "openai", "gpt-4o-mini", true, "ready", null, null, null, null, null));
+                            "openai", "gpt-4o-mini", true, "ready", null, null, null, null, null, null));
 
             String result = tool.createSubAgent("Test", "prompt", "openai", "gpt-4o-mini", null, null);
 
@@ -239,7 +239,7 @@ class DynamicAgentToolsTest {
 
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            null, "gpt-4o-mini", true, "ready", null, null, null, null, null));
+                            null, "gpt-4o-mini", true, "ready", null, null, null, null, null, null));
 
             String result = tool.createSubAgent("Test", "prompt", "openai", "gpt-4o-mini", null, null);
 
@@ -317,7 +317,7 @@ class DynamicAgentToolsTest {
         void createSubAgent_withInitialMessage_success() throws Exception {
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            "openai", "gpt-4o-mini", true, "ready", null, null, null, null, null));
+                            "openai", "gpt-4o-mini", true, "ready", null, null, null, null, null, null));
 
             // Stub startConversation
             when(conversationService.startConversation(any(Environment.class), eq("sub-agent-1"), eq("user-1"), anyMap()))
@@ -351,7 +351,7 @@ class DynamicAgentToolsTest {
         void createSubAgent_withInitialMessage_failure() throws Exception {
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            null, null, true, "ready", null, null, null, null, null));
+                            null, null, true, "ready", null, null, null, null, null, null));
 
             // Stub startConversation to throw
             when(conversationService.startConversation(any(Environment.class), eq("sub-agent-1"), eq("user-1"), anyMap()))
@@ -367,7 +367,7 @@ class DynamicAgentToolsTest {
         void createSubAgent_noProviderNoModel_omitsFromResult() throws Exception {
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            null, null, true, "ready", null, null, null, null, null));
+                            null, null, true, "ready", null, null, null, null, null, null));
 
             String result = tool.createSubAgent("Test", "prompt", null, null, null, null);
 
@@ -408,7 +408,7 @@ class DynamicAgentToolsTest {
 
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            "anthropic", null, true, "ready", null, null, null, null, null));
+                            "anthropic", null, true, "ready", null, null, null, null, null, null));
 
             String result = tool.createSubAgent("Test", "prompt", "anthropic", null, null, null);
             assertTrue(result.contains("✅"));
@@ -421,7 +421,7 @@ class DynamicAgentToolsTest {
 
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            null, "any-model", true, "ready", null, null, null, null, null));
+                            null, "any-model", true, "ready", null, null, null, null, null, null));
 
             String result = tool.createSubAgent("Test", "prompt", null, "any-model", null, null);
             assertTrue(result.contains("✅"));
@@ -431,7 +431,7 @@ class DynamicAgentToolsTest {
         void createSubAgent_retainFalse_notTracked() throws Exception {
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            null, null, true, "ready", null, null, null, null, null));
+                            null, null, true, "ready", null, null, null, null, null, null));
 
             String result = tool.createSubAgent("Test", "prompt", null, null, null, false);
 
@@ -444,7 +444,7 @@ class DynamicAgentToolsTest {
         void createSubAgent_withInitialMessage_extractResponseMapFormat() throws Exception {
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            null, null, true, "ready", null, null, null, null, null));
+                            null, null, true, "ready", null, null, null, null, null, null));
 
             when(conversationService.startConversation(any(Environment.class), eq("sub-agent-1"), eq("user-1"), anyMap()))
                     .thenReturn(new ConversationResult("conv-123", null));
@@ -509,7 +509,7 @@ class DynamicAgentToolsTest {
 
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            "openai", "gpt-4o", true, "ready", null, null, null, null, null));
+                            "openai", "gpt-4o", true, "ready", null, null, null, null, null, null));
 
             // Should not NPE — null list is filtered, so model check is skipped
             String result = tool.createSubAgent("Test", "prompt", "openai", "gpt-4o", null, null);
@@ -552,7 +552,7 @@ class DynamicAgentToolsTest {
 
             when(agentSetupService.setupAgent(any(SetupAgentRequest.class)))
                     .thenReturn(new SetupResult("created", "sub-agent-1", "parent-agent-1/Test",
-                            null, null, true, "ready", null, null, null, null, null));
+                            null, null, true, "ready", null, null, null, null, null, null));
 
             // Should not NPE
             String result = toolNullLists.createSubAgent("Test", "prompt", null, null, null, null);


### PR DESCRIPTION
Agent setup minted a **new vault entry per agent**. Provisioning ten agents against one provider key left ten encrypted copies of it under unguessable names (`setup.<agent>.<timestamp>.apiKey`), so rotating that key meant hunting all ten down.

Pasting a `${vault:...}` reference into the wizard's API-key field was supposed to avoid that, and did not.

## Root cause of the reference case

`vaultApiKey()` recognised an existing reference with a **full-string** regex match but never trimmed its input. A reference copied out of a UI list carries surrounding whitespace, so `"${vault:openai-prod}\n"` failed the match, fell through to the "plaintext" branch, and was vaulted **as a secret whose value is a reference** — a brand-new, useless key on every setup. One `trim()` closes it.

## Three ways to share one key

In the order `AgentSetupService.vaultApiKey()` considers them:

| Input | Behaviour |
| --- | --- |
| `vaultKeyName: "openai-prod"` | **New field.** Names the entry. With `apiKey` it creates it under exactly that name; without one, the entry must already exist — so agent #2 needs no credential at all. Never overwrites an entry holding a different value (other agents may point at it) and fails loudly rather than degrading to plaintext when the vault is off. Accepts `${vault:openai-prod}` too, including a tenant. |
| `apiKey: "${vault:openai-prod}"` | Used as-is, never re-vaulted; now whitespace-tolerant. |
| `apiKey: "sk-…"` | Reused if the vault already holds that exact value, otherwise stored under a generated name. |

Plaintext reuse matches on the **SHA-256 checksum `SecretMetadata` already stores** — nothing is decrypted, and the digest compared is one computed from a value the caller just supplied, so it reveals nothing they did not already know. Only entries with `allowedAgents` unset or `["*"]` qualify: referencing a deliberately narrowed grant would produce a config `VaultGrantGate` rejects at deploy time. Ties break oldest-first, so repeated setups converge on one entry rather than depending on listing order.

## Configurable

`eddi.setup.vault-key-reuse=checksum|never` (§4.1 rule 1 — behaviour belongs in config, not hardcoded). `never` restores the previous per-agent behaviour, for deployments where two agents hold the same-valued key today but must rotate independently. Neither value touches rows 1 and 2 above — those are explicit caller decisions. Strict-parsed at startup like `eddi.vault.grant-enforcement`: a typo must not silently switch de-duplication off.

## Rollback safety

The subtlest part of this change, and where two of the review passes landed.

Rollback deletes what it finds under `VAULTED_SECRET_KEY`, which is only safe while **nobody else can be referencing the entry**:

- A **reused** entry — never registered. It belongs to the agent that created it.
- A caller-**named** entry — never registered. A retry reuses the same name, so it cannot cause the unbounded growth rollback exists to prevent; deleting it is the riskier act.
- A **generated** entry under `checksum` — never registered. It becomes shared the moment a second setup with the same key runs (parallel bulk provisioning does exactly that), and a rollback triggered by the *first* agent's later failure would delete the key every later agent already points at. The retry finds it by value anyway.
- A generated entry under `never` — registered, as before. Nobody else can find it.

The record is also written only *after* the store succeeds, so a failed write no longer leaves rollback chasing a secret that never existed.

## Also

- **Key resolution moved ahead of every store call** in both `setupAgent` and `createApiAgent`, and outside the `try` — an unusable `vaultKeyName` fails while rollback still has nothing to undo, and its message reaches the caller unwrapped instead of nested in `Failed to set up agent:`.
- **`SetupResult.apiKeyVaultReference`** returns the reference the created agent points at, whether this call vaulted the key or reused an entry — hand it back as `vaultKeyName` next time. Null when the vault is disabled and the key went in as plaintext: that value *is* the caller's secret, and echoing it in a response body would put it through every proxy log on the way out.
- **`vaultKeyName` is validated** against `[a-zA-Z0-9._-]{1,128}`, the charset `RestSecretStore` already enforces. The value is embedded in `${vault:<tenant>/<key>}`, where a bare name containing `/` silently re-parses as a tenant separator and a `}` truncates the reference — the agent would resolve a *different* secret, or none.
- **A tenant-qualified `vaultKeyName` now creates in that tenant.** It was parsed for the lookup and dropped for the create, so a missing `${vault:acme/key}` produced a setup that reported success and an agent referencing a secret that did not exist where it pointed.
- **Contradictory input is rejected** — `vaultKeyName: "a"` with `apiKey: "${vault:b}"` used to honour `a` and drop `b`, deploying the agent against a credential the caller did not pick.
- **A dangling or narrowly granted reference is surfaced.** Both are still accepted (you may vault the key after setup; setup-without-deploy → widen grant → deploy is a legitimate flow), but a missing key now logs a WARN, and a narrowed grant returns `resources.vaultGrantWarning` — a brand-new agent's ID cannot be on any existing grant list, so under `enforce` that deployment *will* be blocked, and the caller should not have to discover it as `deployed: false`.

## Why `vaultKeyName` is not on the MCP tools

Not to prevent reuse — `apiKey` already accepts a `${vault:...}` reference, so an MCP caller can put an agent on an existing key today. What `vaultKeyName` uniquely adds is choosing the **name** of a newly created entry and a value-must-match check on an existing one. These tools are reachable by `eddi-editor` while REST setup is `eddi-admin`; neither capability is needed to provision an agent, and neither belongs on the lower tier — name-squatting an entry an operator intends to create, and a per-request "does key X hold value V" oracle.

*(An earlier revision of this branch justified the omission on different grounds, which were wrong; the corrected reasoning is in the code comments, `docs/secrets-vault.md`, and the changelog.)*

## Review rounds

CodeRabbit (8 findings) and Copilot (4) both reviewed; all were valid. Two were real bugs this branch had introduced, and both are fixed and mutation-checked:

- **Generated key names could collide.** `setup.<agent>.<timestamp>.apiKey` is not unique for two same-named agents in the same millisecond, and `store` is an upsert — one silently overwrote the other's credential. Now carries a random suffix.
- **An unparseable OpenAPI spec leaked a vault secret.** Moving key resolution to step 0 put it ahead of the spec parse, and `createApiAgent`'s pre-existing `catch (AgentSetupException) { throw e; }` rethrows without rolling back. The parse now runs first (it creates nothing, so a bad spec never reaches the vault), and that arm now rolls back — which also closes the pre-existing document leak on the same path.

Two more were correct and are handled: a direct vault write now invalidates the resolver cache, matching `RestSecretStore` and mattering most on *creation* precisely because this service accepts dangling references and later fills them in; and the dangling-reference warning now reaches the caller instead of only the log, merged with the grant warning into one `resources.vaultWarning`.

Two concurrency findings are **partly addressed and bounded rather than claimed fixed** — the named-key create is read-then-write and the checksum scan is separate from its write. The named path now reads back and fails loudly before anything is created; both javadocs state exactly what stays open, and the atomic create-if-absent is filed as #700 with the full caller inventory (all five `store` sites upsert today) and a per-backend sketch.

Documentation claims that overstated the feature were made conditional rather than left to be discovered: MCP checksum de-duplication depends on `eddi.setup.vault-key-reuse` and on an unrestricted grant, and the `vaultKeyName` charset applies to the parsed tenant/key components rather than the `${vault:…}` wrapper.

## Testing

New `AgentSetupVaultKeyReuseTest` — 40 tests across the trim regression, checksum reuse, grant-scoped skip, deterministic winner, the `never` switch, list-failure degradation, rollback registration in both modes, name-collision uniqueness, cache invalidation, parse-before-vault ordering, and every `vaultKeyName` outcome. Every behavioural fix is **mutation-checked** — reverting the trim, the reuse lookup, the tenant fix, the rollback-registration fix, the random suffix, the read-back, the cache invalidation, and the parse ordering each fails its own test.

369 tests green locally across the setup, MCP, dynamic-agent and repo-wide guard suites. Clean compile, Checkstyle clean (13 pre-existing violations elsewhere, none in touched files). CI is green including **Integration Tests**; `Secret Scanning` is red for a known reason explained [in a comment](https://github.com/labsai/EDDI/pull/699#issuecomment-5330376466) — a renamed test fixture whose `.gitleaksignore` entry only takes effect on merge, because the job deliberately restores that file from the base branch.

## Compatibility

No config migration. Existing agents keep working — nothing rewrites a stored `apiKey`. Old requests that omit `vaultKeyName` behave as before except that a plaintext key the vault already holds is now referenced instead of duplicated; set `eddi.setup.vault-key-reuse=never` to opt out.

Matching Manager PR: labsai/EDDI-Manager#170 — independent, and needs this merged first (against an older backend `apiKeyVaultReference` is simply absent and the block does not render).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vault credential reuse during agent setup through existing references, named entries, or checksum matching.
  * Setup responses now provide reusable vault references without exposing plaintext API keys.
  * Added configuration to enable checksum reuse or always create new credentials.
  * Added validation, warnings, rollback safeguards, and handling for restricted or unavailable vault entries.
  * MCP and dynamic sub-agent setup now support the updated credential behavior.

* **Documentation**
  * Expanded setup and changelog documentation with vault reuse guidance and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->