### PR TITLE
chore(ci): allowlist the AgentSetupVaultKeyReuseTest fixture finding

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -68,3 +68,17 @@ eebfe898b34858918d5cbbe11e60336d1b6a916e:src/test/java/ai/labs/eddi/secrets/sani
 # introduced it stays in history and still needs an entry. Never a real key: it
 # never authenticated against anything.
 96df3c83fa449e02250c08c1aa420a11617f2ebb:src/test/java/ai/labs/eddi/modules/apicalls/impl/ResolvedRequestTest.java:generic-api-key:193
+
+# AgentSetupVaultKeyReuseTest (PR #699): the same mistake as the two entries
+# above, made a third time. The fixture standing in for a provider API key was
+# written as a realistic "sk-live-" + hex literal, which is precisely the shape
+# a real leaked key takes. Renamed in a follow-up commit to a value that reads
+# as a fixture, but gitleaks scans a PR's whole commit range, so the commit that
+# introduced it stays in history and still needs an entry. Never a real key:
+# nothing in those tests authenticates against anything — the value is compared
+# for equality and hashed for a checksum, and any string would do.
+#
+# Landed on main ahead of #699 on purpose. The scan job restores this file from
+# the BASE branch, so an entry added inside the offending PR never applies to
+# that PR — it has to be here first.
+30ff68d1d2eaa568e7399fa24dc6acf7315b30f6:src/test/java/ai/labs/eddi/engine/setup/AgentSetupVaultKeyReuseTest.java:generic-api-key:50


### PR DESCRIPTION
Unblocks the red `Secret Scanning` check on #699. One file, one entry.

## Why this cannot be done inside #699

gitleaks flags `generic-api-key` at `AgentSetupVaultKeyReuseTest.java:50`, in commit `30ff68d1d` — a **test fixture** standing in for a provider API key, written as a realistic `sk-live-` + hex literal. Fair catch: that is exactly the shape a real leaked key takes.

#699 already did both obvious things — renamed the fixture, and added this same entry — and the check stayed red, because two mechanisms combine:

1. The scan job **restores `.gitleaksignore` from the base branch** on every `pull_request` run (`ci.yml`, *"Take the gitleaks config from the base branch"*), deliberately, so a PR cannot allowlist its own secret. An entry added inside #699 is therefore discarded when #699 is scanned.
2. gitleaks scans the **whole PR commit range**, and the fingerprint is anchored to the commit that introduced the line. Renaming it later does not remove it from history, and history is immutable here — force-push is forbidden by AGENTS.md rule 4.

So the entry has to land on `main` first. That is precisely what the guard's own comment describes: *"a config change takes effect once it is merged and reviewed, rather than while it is still being proposed."* This PR is that step, carrying the entry **alone** so it is trivially reviewable and its own scan has nothing to find.

Same path the two entries directly above it took — see `23a6de7e8` (merged in #620) and the `SecretScrubberTest` / `ResolvedRequestTest` entries, which document the identical "the literal is gone but the commit remains" situation.

## Verified

Replicated the CI job locally with the pinned gitleaks 8.30.1 — `.gitleaksignore` restored from `origin/main` (i.e. *without* this entry), then `gitleaks git --log-opts="--no-merges origin/main..HEAD"`: **no leaks found, exit 0**. This PR's own check passes.

After it merges, #699's next run restores a base copy that *does* contain the fingerprint, and its `Secret Scanning` goes green.

## Not a real credential

The fixture never authenticated against anything — it is compared for equality and hashed for a checksum, and any string would do. The justification comment deliberately does not quote the literal, which is what once made an earlier entry match its own file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an exception for a verified historical false positive in secret scanning.
  * Documented the justification for retaining a non-functional test fixture value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->