### PR TITLE
fix(secrets): redact only the value, so a redacted JSON body is still JSON

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,87 @@
 
 
 
+## 🔒 fix(secrets): redaction preserves the JSON it redacts, and stops cutting secrets short (2026-08-19)
+
+**Repo:** EDDI (`fix/redaction-preserves-json`)
+
+`SecretRedactionFilter`'s generic rule ran over the raw request TEXT and matched the key's closing
+quote, the colon **and** the value's opening quote — then replaced all three along with the value
+(`"$1=" + REDACTED`). So an ordinary body came back malformed:
+
+```
+{"modelName":"x","apiKey":"sk-ant-…"}   →   {"modelName":"x","apiKey=<REDACTED>"}
+{"token":12345678,"n":1}                →   {"token=<REDACTED>,"n":1}
+```
+
+— a bare string where a key/value pair was. The `sk-…` and `Bearer …` rules replace only the value
+and leave the document valid; this one did not, and it runs **last**, so it re-mangled what those
+had already redacted correctly.
+
+**Every reader of a redacted body parses it, and both of the Manager's failed silently.** Reported
+from EDDI-Manager PR #173: the approval diff for a gated whole-document `PUT` fell back to comparing
+raw text and rendered every line of the stored config as deleted against the proposed body as one
+added line. Worse, `detectEscalationFlags` runs *every* capability-grant check behind a `JSON.parse`,
+so a request that embedded a credential **and** granted `dynamicAgents.allowCreation` warned about
+the credential alone — and an approver reads "no second warning" as "no capability grant", which is
+the exact false negative that check exists to prevent.
+
+**A second defect, found while fixing the first.** The value class stops at `,`, whitespace, `;`,
+`{`, `}` and `]`, so a secret *containing* one of those was redacted only up to that character and
+the tail survived into the "redacted" output: `"password":"abcdefgh,SURVIVING-TAIL"` became
+`"password=<REDACTED>,SURVIVING-TAIL"`. That is a leak, not a formatting problem.
+
+**The generic rule is now three rules**, replacing the value and nothing else:
+
+| Shape | Rule | Result |
+| --- | --- | --- |
+| `{"apiKey":"sk-…"}` — quoted value | runs to the **closing quote**, keeps both quotes | `{"apiKey":"sk-ant-<REDACTED>"}` |
+| `{"token":12345678}` — no quotes of its own | marker takes the **key's quote style** | `{"token":"<REDACTED>"}` |
+| `?api_key=…`, `password: …` — not JSON | separator put back, no quotes invented | `?api_key=<REDACTED>` |
+
+Design decisions:
+
+- **The quoted rule ends the value at its closing quote, not at the first delimiter.** That is what
+  closes the partial-redaction leak; a secret with a comma or a space in it is now redacted whole.
+- **Two negative lookaheads guard it, and they deliberately use backtracking quantifiers** where the
+  rest of the file is possessive (ReDoS). `(?![^"']*<REDACTED>)` asks "does the marker appear
+  anywhere before the closing quote"; a possessive class there consumes the marker itself, finds
+  nothing left to match, and the guard is silently inert. Both stay bounded by a quote they cannot
+  cross.
+- **That marker guard also fixes a small regression the old rule had all along**: `sk-ant-` and
+  `Bearer ` prefixes say what KIND of credential was found, and the generic rule used to strip them
+  back off every named field. `{"apiKey":"sk-ant-…"}` now keeps `sk-ant-<REDACTED>`.
+- **The vault carve-out is explicit now.** `${vault:…}` survived only as a side effect of the value
+  class excluding `{`/`}`; the quoted rule runs past braces, so it carries
+  `(?!\$\{(?:vault|eddivault):)` as a stated rule instead — which is also what keeps the carve-out
+  from being lost the next time that class is tuned.
+- **`&` is still not a value delimiter, on purpose.** Adding it would make query-string redaction
+  tidier but would cut short every secret containing an `&` in every other context and leak the
+  tail. Over-redacting a raw URL that happens to sit in a log line is the safer trade, and real
+  request URIs never reach the filter whole — `RequestRedactor` scans each query parameter's value
+  on its own. Pinned as a test so the next person does not "fix" it.
+
+**Verified:** `SecretRedactionFilterTest` grows from 15 to 32 cases — three new nested classes
+(`RedactedJsonStaysJson`, which parses every redacted result with Jackson; `ASecretIsRedactedInFull`,
+parameterised over all six delimiters; `AlreadyRedactedValuesKeepTheirPrefix`) plus idempotency, the
+8-char floor, and a neighbouring-field-not-swallowed case. `RequestRedactorTest`, `ResolvedRequestTest`,
+the three `ApiCallExecutor*` suites, `ConversationMemoryUtilitiesHitlTest`,
+`LifecycleManagerErrorClassificationTest`, `SlackToolPauseNotificationTest` and
+`RestAgentEngineToolPauseDetailsTest` all pass unchanged.
+
+Full `./mvnw test` locally reports failures in `WebSearchToolTest`, `SafeHttpClientTest`,
+`SlackWebApiClientTest` (loopback sockets — the documented sandbox limitation in AGENTS.md) and
+`DocumentationLinksTest` (scans an untracked local `.history/` folder). **Confirmed pre-existing**:
+the same classes fail identically with these changes stashed. CI is the source of truth for those.
+
+**Manager side:** EDDI-Manager PR #173 shipped a client-side repair (`src/lib/redacted-json.ts`) that
+reconstructs the mangled shape before parsing. It stays — it is the tolerance layer for bodies
+arriving from backends that predate this fix — and becomes a no-op against a backend with it, since
+a body that already parses is returned untouched.
+
+---
+
+
 ## 🔒 fix(docker): bump UBI9 base digest for CVE-2026-11940 (python3 tarfile filter bypass) (2026-08-17)
 
 **Repo:** EDDI (`fix/trivy-cve-2026-11940-base-image`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -67,7 +67,31 @@ Design decisions:
   request URIs never reach the filter whole — `RequestRedactor` scans each query parameter's value
   on its own. Pinned as a test so the next person does not "fix" it.
 
-**Verified:** `SecretRedactionFilterTest` grows from 15 to 32 cases — three new nested classes
+**A review pass before pushing found four more leaks in the first draft of this fix**, all in the
+same two decisions, all now pinned as regression tests:
+
+- **The closing quote was "any quote", not the opening one.** `"password":"abcdefgh'xyz"` terminated
+  at the apostrophe and published the tail; `"password":"it's-a-secret"` was cut to `it` at that same
+  apostrophe, fell under the 8-character floor, and was not redacted **at all**. The closing quote is
+  now a backreference to the opening one, which also lets the value class admit the *other* quote
+  character — that is what makes both cases whole.
+- **The "already redacted" guard asked whether the marker appeared ANYWHERE in the value.** It reads
+  as the more cautious rule and is the leakier one: it skipped
+  `"secret":"the key sk-ant-<REDACTED> is here"`, leaving the text around the marker unredacted under
+  a key that says it is a secret — and it handed anyone who knows the marker a **bypass**, since a
+  value of `my<REDACTED>pass` passed through untouched. The guard is now anchored to the START of the
+  value, which is the condition actually meant and the narrow one.
+
+Both were reasoned about while writing the first draft and dismissed as theoretical. They are not:
+a throwaway probe printing the filter's actual output for a dozen shapes found all four in one run.
+
+**Pinned as a known limit, not fixed:** an escaped quote INSIDE a value ends it early
+(`"he said \"x\" done"` redacts up to the `\"`). `\"` is a terminator in an escaped-JSON body and a
+literal in a plain one and the filter cannot tell which it is looking at; resolved in favour of the
+escaped body, because the other reading runs the match past the real end of the field and eats the
+document. Still an improvement — the old rule stopped at the first space and redacted nothing there.
+
+**Verified:** `SecretRedactionFilterTest` grows from 14 to 40 cases — three new nested classes
 (`RedactedJsonStaysJson`, which parses every redacted result with Jackson; `ASecretIsRedactedInFull`,
 parameterised over all six delimiters; `AlreadyRedactedValuesKeepTheirPrefix`) plus idempotency, the
 8-char floor, and a neighbouring-field-not-swallowed case. `RequestRedactorTest`, `ResolvedRequestTest`,

--- a/src/main/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilter.java
+++ b/src/main/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilter.java
@@ -26,6 +26,12 @@ public final class SecretRedactionFilter {
     // string end), so a correct match never needs to give characters back — the
     // possessive form yields identical results while running in linear time on
     // adversarial inputs (e.g. long repetitions of "${vault:").
+    //
+    // The two negative lookaheads are the deliberate exception: they must be free
+    // to backtrack, because they ask "does the marker appear ANYWHERE before the
+    // closing quote". A possessive class there consumes the marker itself and then
+    // finds nothing left to match, so the lookahead never fires and the guard is
+    // silently inert. They stay bounded by the quote they cannot cross.
     private static final List<RedactionRule> RULES = List.of(
             // Anthropic API keys: sk-ant-... — underscores INCLUDED. Real keys carry
             // them, and a class without '_' stopped matching at the first one: a full
@@ -44,15 +50,52 @@ public final class SecretRedactionFilter {
             new RedactionRule(Pattern.compile("Bearer\\s++[A-Za-z0-9\\-_.+/=]{20,}+"),
                     "Bearer " + REDACTED),
 
-            // Generic API key patterns: key=... or apikey=... in query strings AND in
-            // JSON — including JSON nested as an ESCAPED string ("apiKey\": \"..."),
-            // the exact shape of a tool call whose requestBody argument is itself a
-            // JSON document. The optional backslash-tolerant quote groups are what
-            // see through that escaping; without them the separator never matched
-            // inside escaped bodies. Quantifiers stay possessive (ReDoS).
+            // A credential named by its key, with a QUOTED value — the JSON shape,
+            // including JSON nested as an ESCAPED string ("apiKey\": \"..."), which
+            // is what a tool call whose requestBody argument is itself a JSON
+            // document looks like. The backslash-tolerant quote groups are what see
+            // through that escaping; without them the separator never matches inside
+            // escaped bodies.
+            //
+            // Only the VALUE is replaced. The rule this one replaces matched the
+            // key's closing quote, the colon and the value's opening quote and threw
+            // all three away ("$1=" + REDACTED), so `{"apiKey":"sk-…"}` came back as
+            // `{"apiKey=<REDACTED>"}` — a bare string where a key/value pair was, and
+            // not parseable JSON. Both readers of a redacted body then failed
+            // silently on it: the Manager's approval diff fell back to comparing raw
+            // text and reported the whole stored document as deleted, and its
+            // capability-grant checks sit behind a JSON.parse, so a request that
+            // embedded a credential AND granted dynamic agent creation warned about
+            // the credential alone.
+            //
+            // The value runs to its closing quote rather than to the first
+            // delimiter, which also closes a leak: the loose rule's class stops at
+            // ',', whitespace, ';', '{', '}' and ']', so a secret containing any of
+            // those was only redacted up to that character and the tail survived.
             new RedactionRule(Pattern.compile(
-                    "(?i)(api[_-]?key|token|secret|password|authorization)(?:\\\\*+[\"'])?+\\s*+[=:]\\s*+(?:\\\\*+[\"'])?+[^'\"\\\\\\s,;}{\\]]{8,}+"),
-                    "$1=" + REDACTED));
+                    "(?i)(api[_-]?key|token|secret|password|authorization)((?:\\\\*+[\"'])?+\\s*+[=:]\\s*+)(\\\\*+[\"'])"
+                            + "(?!\\$\\{(?:vault|eddivault):)(?![^\"']*" + REDACTED + ")"
+                            + "(?:[^\"'\\\\]|\\\\(?![\"'])){8,}+(\\\\*+[\"'])"),
+                    "$1$2$3" + REDACTED + "$4"),
+
+            // The same, for a JSON value that carries no quotes of its own — a
+            // number, or a bare literal. The marker is a string, so it is given the
+            // key's own quote style (group 2 and 3, escaped or not) to keep the
+            // document parseable: `{"token":12345678}` → `{"token":"<REDACTED>"}`.
+            new RedactionRule(Pattern.compile(
+                    "(?i)(api[_-]?key|token|secret|password|authorization)(\\\\*+)([\"'])(\\s*+:\\s*+)"
+                            + "(?!\\\\*+[\"'])(?![^\\s,;}{\\]\"']*" + REDACTED + ")"
+                            + "[^\\s,;}{\\]\"'\\\\]{8,}+"),
+                    "$1$2$3$4$2$3" + REDACTED + "$2$3"),
+
+            // Everything that is not JSON: query strings (?api_key=…), log lines
+            // ("password: …"). No quotes to preserve, so the separator is put back
+            // and the value replaced.
+            new RedactionRule(Pattern.compile(
+                    "(?i)(api[_-]?key|token|secret|password|authorization)((?:\\\\*+[\"'])?+\\s*+[=:]\\s*+(?:\\\\*+[\"'])?+)"
+                            + "(?![^\\s,;}{\\]\"']*" + REDACTED + ")"
+                            + "[^'\"\\\\\\s,;}{\\]]{8,}+"),
+                    "$1$2" + REDACTED));
 
     // A `${vault:...}` reference is DELIBERATELY NOT redacted. It is a pointer to
     // a secret — the correct, encouraged alternative to writing one down — and the
@@ -70,9 +113,15 @@ public final class SecretRedactionFilter {
     //
     // A resolved secret does not look like a vault reference (it is the raw value,
     // caught by the rules above), so nothing is weakened by leaving the pointer
-    // legible. The generic key=value rule above cannot match one either: its value
-    // class excludes `{`/`}`, so `apiKey: "${vault:x}"` never reaches its 8-char
-    // minimum.
+    // legible.
+    //
+    // Two of the rules above are kept off it by their value class, which excludes
+    // `{`/`}` so `apiKey: "${vault:x}"` never reaches the 8-char minimum. The
+    // quoted-value rule runs to the closing quote instead and would happily consume
+    // a reference, so it carries an explicit `(?!\$\{(?:vault|eddivault):)` — the
+    // carve-out is a stated rule there rather than a side effect of a character
+    // class, which is also what keeps it from being lost the next time that class
+    // is tuned.
 
     private SecretRedactionFilter() {
         // Utility class

--- a/src/main/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilter.java
+++ b/src/main/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilter.java
@@ -17,21 +17,39 @@ public final class SecretRedactionFilter {
     private static final String REDACTED = "<REDACTED>";
 
     /**
+     * Do not re-redact a value an earlier rule has already replaced.
+     * <p>
+     * Those rules say WHAT KIND of credential was found —
+     * {@code sk-ant-<REDACTED>}, {@code Bearer <REDACTED>} — and an approver uses
+     * that. Without this guard the name-based rules below strip the prefix straight
+     * back off, which is what the rule they replace did to every named field.
+     * <p>
+     * Anchored to the START of the value, deliberately. A "does the marker appear
+     * anywhere in this value" guard reads as more thorough and is strictly worse:
+     * it skips {@code "secret":"the key sk-ant-<REDACTED> is here"}, leaving the
+     * text around the marker unredacted under a key that says it is a secret — and
+     * it hands anyone who knows the marker a bypass, since a value of
+     * {@code my<REDACTED>pass} then passes through untouched. Beginning with a
+     * redacted form is the condition actually meant, and it is the narrow one.
+     * <p>
+     * The optional prefix is the one non-possessive quantifier in this file: it has
+     * to be free to try {@code sk-ant-}, then {@code sk-}, then nothing, and it is
+     * bounded by three short literal alternatives, so it is no ReDoS surface.
+     */
+    private static final String NOT_ALREADY_REDACTED = "(?!(?:sk-ant-|sk-|Bearer\\s)?" + REDACTED + ")";
+
+    /**
      * Ordered list of redaction patterns. Each pattern has a compiled regex and a
      * replacement strategy.
      */
     // Quantifiers below are POSSESSIVE (++, *+, {n,}+) to eliminate ReDoS
     // backtracking. This is behavior-preserving here: every quantified class is
-    // followed by a literal that is NOT a member of the class (a '.', '}', or the
-    // string end), so a correct match never needs to give characters back — the
-    // possessive form yields identical results while running in linear time on
-    // adversarial inputs (e.g. long repetitions of "${vault:").
-    //
-    // The two negative lookaheads are the deliberate exception: they must be free
-    // to backtrack, because they ask "does the marker appear ANYWHERE before the
-    // closing quote". A possessive class there consumes the marker itself and then
-    // finds nothing left to match, so the lookahead never fires and the guard is
-    // silently inert. They stay bounded by the quote they cannot cross.
+    // followed by a literal that is NOT a member of the class (a '.', '}', a quote,
+    // or the string end), so a correct match never needs to give characters back —
+    // the possessive form yields identical results while running in linear time on
+    // adversarial inputs (e.g. long repetitions of "${vault:"). The single
+    // exception is the optional prefix inside NOT_ALREADY_REDACTED, documented
+    // there.
     private static final List<RedactionRule> RULES = List.of(
             // Anthropic API keys: sk-ant-... — underscores INCLUDED. Real keys carry
             // them, and a class without '_' stopped matching at the first one: a full
@@ -72,11 +90,26 @@ public final class SecretRedactionFilter {
             // delimiter, which also closes a leak: the loose rule's class stops at
             // ',', whitespace, ';', '{', '}' and ']', so a secret containing any of
             // those was only redacted up to that character and the tail survived.
+            //
+            // The closing quote is a BACKREFERENCE to the opening one (\4), not
+            // "any quote". Accepting either let the wrong quote end the value:
+            // `"password":"abcdefgh'xyz"` terminated at the apostrophe and published
+            // the rest, and `"password":"it's-a-secret"` fell under the 8-character
+            // floor at that same apostrophe and was not redacted at all. Tying the
+            // pair together also lets the value class admit the OTHER quote
+            // character, which is what makes both of those whole again.
+            //
+            // Known limit: an escaped quote INSIDE a value ends it early
+            // (`"he said \"x\" done"` redacts up to `\"`). That is the same
+            // ambiguity the backslash tolerance exists for — `\"` is a terminator in
+            // an escaped-JSON body and a literal in a plain one — and it is resolved
+            // in favour of the escaped body, because reading it the other way runs
+            // the match past the real end of the field and eats the document.
             new RedactionRule(Pattern.compile(
-                    "(?i)(api[_-]?key|token|secret|password|authorization)((?:\\\\*+[\"'])?+\\s*+[=:]\\s*+)(\\\\*+[\"'])"
-                            + "(?!\\$\\{(?:vault|eddivault):)(?![^\"']*" + REDACTED + ")"
-                            + "(?:[^\"'\\\\]|\\\\(?![\"'])){8,}+(\\\\*+[\"'])"),
-                    "$1$2$3" + REDACTED + "$4"),
+                    "(?i)(api[_-]?key|token|secret|password|authorization)((?:\\\\*+[\"'])?+\\s*+[=:]\\s*+)(\\\\*+)([\"'])"
+                            + "(?!\\$\\{(?:vault|eddivault):)" + NOT_ALREADY_REDACTED
+                            + "(?:(?!\\4)[^\\\\]|\\\\(?!\\4)){8,}+(\\\\*+)\\4"),
+                    "$1$2$3$4" + REDACTED + "$5$4"),
 
             // The same, for a JSON value that carries no quotes of its own — a
             // number, or a bare literal. The marker is a string, so it is given the
@@ -84,7 +117,7 @@ public final class SecretRedactionFilter {
             // document parseable: `{"token":12345678}` → `{"token":"<REDACTED>"}`.
             new RedactionRule(Pattern.compile(
                     "(?i)(api[_-]?key|token|secret|password|authorization)(\\\\*+)([\"'])(\\s*+:\\s*+)"
-                            + "(?!\\\\*+[\"'])(?![^\\s,;}{\\]\"']*" + REDACTED + ")"
+                            + "(?!\\\\*+[\"'])" + NOT_ALREADY_REDACTED
                             + "[^\\s,;}{\\]\"'\\\\]{8,}+"),
                     "$1$2$3$4$2$3" + REDACTED + "$2$3"),
 
@@ -93,7 +126,7 @@ public final class SecretRedactionFilter {
             // and the value replaced.
             new RedactionRule(Pattern.compile(
                     "(?i)(api[_-]?key|token|secret|password|authorization)((?:\\\\*+[\"'])?+\\s*+[=:]\\s*+(?:\\\\*+[\"'])?+)"
-                            + "(?![^\\s,;}{\\]\"']*" + REDACTED + ")"
+                            + NOT_ALREADY_REDACTED
                             + "[^'\"\\\\\\s,;}{\\]]{8,}+"),
                     "$1$2" + REDACTED));
 

--- a/src/test/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilterTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilterTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class SecretRedactionFilterTest {
 
     private static final String ANTHROPIC_KEY = "sk-ant-api03-CeIJ4onq59Mf_oN4mICgfgScyJO5bfxFSS3Sdvo1Zgo2F7zUfEvx";
+    private static final String REDACTED_MARKER = "<REDACTED>";
 
     @Test
     void redact_openaiKey() {
@@ -290,6 +291,62 @@ class SecretRedactionFilterTest {
             String input = "{\"password\":\"abc\",\"note\":\"nothing secret here\"}";
             assertEquals(input, SecretRedactionFilter.redact(input));
         }
+
+        @Test
+        void theWrongQuoteCharacterCannotEndTheValue() {
+            // Found in review. Accepting "any quote" as the terminator let an
+            // apostrophe close a double-quoted value: everything after it was
+            // published.
+            String result = SecretRedactionFilter.redact("{\"password\":\"abcdefgh'SURVIVING-TAIL\",\"n\":1}");
+
+            assertFalse(result.contains("SURVIVING-TAIL"), result);
+            assertEquals("{\"password\":\"<REDACTED>\",\"n\":1}", result);
+        }
+
+        @Test
+        void anApostropheEarlyInAValueDoesNotPutItUnderTheLengthFloor() {
+            // Same root cause, worse symptom: the value was cut to "it" — two
+            // characters, under the 8-char floor — so nothing matched at all and the
+            // whole password went out in the clear.
+            String result = SecretRedactionFilter.redact("{\"password\":\"it's-a-secret-value\",\"n\":1}");
+
+            assertFalse(result.contains("secret-value"), result);
+            assertEquals("{\"password\":\"<REDACTED>\",\"n\":1}", result);
+        }
+
+        @Test
+        void aSingleQuotedValueMayContainDoubleQuotes() {
+            // The mirror image, which the backreference gets for free.
+            String result = SecretRedactionFilter.redact("password='abcdefgh\"SURVIVING-TAIL'");
+
+            assertFalse(result.contains("SURVIVING-TAIL"), result);
+            assertEquals("password='<REDACTED>'", result);
+        }
+
+        @Test
+        void anUnterminatedValueIsStillRedacted() {
+            // A truncated body has no closing quote, so the quoted rule cannot fire.
+            // The loose rule is the safety net and must still catch it — a body cut
+            // short is exactly when a leak would go unnoticed.
+            String result = SecretRedactionFilter.redact("{\"apiKey\": \"unterminated-secret-value");
+
+            assertFalse(result.contains("unterminated-secret"), result);
+            assertTrue(result.contains(REDACTED_MARKER), result);
+        }
+
+        @Test
+        void anEscapedQuoteInsideAValueEndsItEarly() {
+            // A pinned LIMIT, not an aspiration. `\"` is a terminator in an
+            // escaped-JSON body and a literal inside a plain one, and the filter
+            // cannot tell which it is looking at. Resolved in favour of the escaped
+            // body: reading it the other way runs the match past the real end of the
+            // field and eats the rest of the document. Still an improvement — the
+            // old rule stopped at the first space and redacted nothing here.
+            String result = SecretRedactionFilter.redact("{\"password\":\"he said \\\"x\\\" done\",\"n\":1}");
+
+            assertFalse(result.contains("he said"), result);
+            assertTrue(result.startsWith("{\"password\":\"<REDACTED>"), result);
+        }
     }
 
     /**
@@ -311,6 +368,28 @@ class SecretRedactionFilterTest {
         void aBearerTokenKeepsItsPrefixInsideAJsonField() {
             String input = "{\"Authorization\":\"Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature\"}";
             assertEquals("{\"Authorization\":\"Bearer <REDACTED>\"}", SecretRedactionFilter.redact(input));
+        }
+
+        /**
+         * The guard is anchored to the start of the value. Both cases below passed
+         * through untouched while it asked whether the marker appeared ANYWHERE — which
+         * reads as the more cautious rule and is the leakier one.
+         */
+        @Test
+        void aValueMerelyCONTAININGARedactedFragmentIsStillRedacted() {
+            String input = "{\"secret\":\"the key sk-ant-<REDACTED> is SURVIVING-TAIL\",\"n\":1}";
+            String result = SecretRedactionFilter.redact(input);
+
+            assertFalse(result.contains("SURVIVING-TAIL"), result);
+            assertEquals("{\"secret\":\"<REDACTED>\",\"n\":1}", result);
+        }
+
+        @Test
+        void writingTheMarkerIntoYourOwnSecretIsNotABypass() {
+            String result = SecretRedactionFilter.redact("{\"password\":\"my<REDACTED>SURVIVING-TAIL\",\"n\":1}");
+
+            assertFalse(result.contains("SURVIVING-TAIL"), result);
+            assertEquals("{\"password\":\"<REDACTED>\",\"n\":1}", result);
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilterTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/sanitize/SecretRedactionFilterTest.java
@@ -4,11 +4,17 @@
  */
 package ai.labs.eddi.secrets.sanitize;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class SecretRedactionFilterTest {
+
+    private static final String ANTHROPIC_KEY = "sk-ant-api03-CeIJ4onq59Mf_oN4mICgfgScyJO5bfxFSS3Sdvo1Zgo2F7zUfEvx";
 
     @Test
     void redact_openaiKey() {
@@ -144,5 +150,167 @@ class SecretRedactionFilterTest {
     void redact_safeMessages() {
         String safe = "User said hello, Agent responded with greeting";
         assertEquals(safe, SecretRedactionFilter.redact(safe));
+    }
+
+    /**
+     * Redacting a JSON body must leave JSON behind.
+     * <p>
+     * The rule these replace matched the key's closing quote, the colon AND the
+     * value's opening quote, then threw all three away — so
+     * {@code {"apiKey":"sk-…"}} came back as {@code {"apiKey=<REDACTED>"}}: a bare
+     * string where a key/value pair was. Every reader of a redacted body parses it,
+     * and both of the Manager's failed silently on that — the approval diff fell
+     * back to comparing raw text and reported the whole stored document as deleted,
+     * and the capability-grant checks sit behind a {@code JSON.parse}, so a request
+     * that embedded a credential AND granted dynamic agent creation warned about
+     * the credential alone.
+     */
+    @Nested
+    class RedactedJsonStaysJson {
+
+        @Test
+        void aStringValueKeepsItsQuotesAndItsSiblings() {
+            String input = "{\"modelName\":\"claude-sonnet-5\",\"apiKey\":\"" + ANTHROPIC_KEY + "\",\"threshold\":9}";
+            String result = SecretRedactionFilter.redact(input);
+
+            assertFalse(result.contains("CeIJ4onq59Mf"), result);
+            assertEquals("{\"modelName\":\"claude-sonnet-5\",\"apiKey\":\"sk-ant-<REDACTED>\",\"threshold\":9}", result);
+            assertValidJson(result);
+        }
+
+        @Test
+        void aNonStringValueGetsTheKeysQuoteStyleSoTheDocumentStillParses() {
+            // Nothing to preserve here — the value had no quotes — so the marker
+            // brings its own, or the document ends up with a bare <REDACTED> token.
+            String result = SecretRedactionFilter.redact("{\"token\":123456789012,\"n\":1}");
+
+            assertFalse(result.contains("123456789012"), result);
+            assertEquals("{\"token\":\"<REDACTED>\",\"n\":1}", result);
+            assertValidJson(result);
+        }
+
+        @Test
+        void aNestedValueStillParses() {
+            String result = SecretRedactionFilter.redact("{\"llm\":{\"apiKey\":\"abcdefghij\"},\"n\":1}");
+
+            assertEquals("{\"llm\":{\"apiKey\":\"<REDACTED>\"},\"n\":1}", result);
+            assertValidJson(result);
+        }
+
+        @Test
+        void anEscapedJsonBodyStaysEscapedJson() {
+            // A tool call whose requestBody argument is itself a JSON document: every
+            // quote arrives backslashed, and the backslashes have to come back out.
+            String input = "{\"requestBody\": \"{\\\"llm\\\": {\\\"apiKey\\\": \\\"" + ANTHROPIC_KEY + "\\\"}}\"}";
+            String result = SecretRedactionFilter.redact(input);
+
+            assertFalse(result.contains("CeIJ4onq59Mf"), result);
+            assertTrue(result.contains("\\\"apiKey\\\": \\\"sk-ant-<REDACTED>\\\""), result);
+            assertValidJson(result);
+        }
+
+        @Test
+        void severalCredentialFieldsAllParse() {
+            String result = SecretRedactionFilter
+                    .redact("{\"apiKey\":\"abcdefghij\",\"password\":\"klmnopqrst\",\"n\":1}");
+
+            assertEquals("{\"apiKey\":\"<REDACTED>\",\"password\":\"<REDACTED>\",\"n\":1}", result);
+            assertValidJson(result);
+        }
+
+        @Test
+        void redactingTwiceChangesNothingTheSecondTime() {
+            String once = SecretRedactionFilter.redact("{\"apiKey\":\"" + ANTHROPIC_KEY + "\",\"n\":1}");
+            assertEquals(once, SecretRedactionFilter.redact(once));
+        }
+
+        @Test
+        void aQueryStringIsNotGivenQuotesItNeverHad() {
+            // The JSON rules must not fire outside JSON: there is no key quote here,
+            // so quoting the marker would corrupt the URI.
+            assertEquals("https://x/y?api_key=<REDACTED>",
+                    SecretRedactionFilter.redact("https://x/y?api_key=abcdefghijklmnop"));
+        }
+
+        @Test
+        void aTrailingQueryParamIsSwallowedRatherThanRiskingALeak() {
+            // Pinning a deliberate non-fix. '&' is NOT in the value class, so the
+            // scan runs past it and the rest of the query goes with the secret.
+            // Adding it would cut short every secret CONTAINING an '&' in every
+            // other context and leak the tail — over-redacting a raw URL that
+            // happens to sit in a log line is the safer trade. Real request URIs
+            // never reach here whole: RequestRedactor scans each query parameter's
+            // value on its own, where there is no '&' left to meet.
+            assertEquals("https://x/y?api_key=<REDACTED>",
+                    SecretRedactionFilter.redact("https://x/y?api_key=abcdefghijklmnop&z=1"));
+        }
+
+        @Test
+        void aPlainLogLineIsNotGivenQuotesEither() {
+            assertEquals("password: <REDACTED>", SecretRedactionFilter.redact("password: hunter2butlonger"));
+        }
+
+        private void assertValidJson(String value) {
+            assertDoesNotThrow(() -> new ObjectMapper().readTree(value),
+                    () -> "redaction produced something that is no longer JSON: " + value);
+        }
+    }
+
+    /**
+     * The value class stops at ',', whitespace, ';', '{', '}' and ']', so a secret
+     * containing any of them was redacted only up to that character and the tail
+     * survived into the "redacted" output. A quoted value ends at its closing
+     * quote, not at the first delimiter.
+     */
+    @Nested
+    class ASecretIsRedactedInFull {
+
+        @ParameterizedTest(name = "a secret cut short at [{0}]")
+        @ValueSource(strings = {",", " ", ";", "{", "}", "]"})
+        void aSecretIsNotCutShortAtADelimiter(String delimiter) {
+            String secret = "abcdefgh" + delimiter + "SURVIVING-TAIL";
+            String result = SecretRedactionFilter.redact("{\"password\":\"" + secret + "\",\"n\":1}");
+
+            assertFalse(result.contains("SURVIVING-TAIL"), result);
+            assertEquals("{\"password\":\"<REDACTED>\",\"n\":1}", result);
+        }
+
+        @Test
+        void aShortValueIsStillLeftAlone() {
+            // The 8-char floor is what keeps benign values legible; running to the
+            // closing quote must not quietly lower it.
+            String input = "{\"password\":\"short\",\"n\":1}";
+            assertEquals(input, SecretRedactionFilter.redact(input));
+        }
+
+        @Test
+        void aNeighbouringFieldIsNotSwallowed() {
+            // The value class cannot cross a quote, so a short value must fail to
+            // match rather than reaching into the next field for its 8 characters.
+            String input = "{\"password\":\"abc\",\"note\":\"nothing secret here\"}";
+            assertEquals(input, SecretRedactionFilter.redact(input));
+        }
+    }
+
+    /**
+     * An earlier rule's replacement says WHAT KIND of credential was found —
+     * {@code sk-ant-<REDACTED>}, {@code Bearer <REDACTED>} — and that is
+     * information an approver uses. The later rules must not strip it back off,
+     * which the old generic rule did to every named field.
+     */
+    @Nested
+    class AlreadyRedactedValuesKeepTheirPrefix {
+
+        @Test
+        void anAnthropicKeyKeepsItsPrefixInsideAJsonField() {
+            String result = SecretRedactionFilter.redact("{\"apiKey\":\"" + ANTHROPIC_KEY + "\"}");
+            assertEquals("{\"apiKey\":\"sk-ant-<REDACTED>\"}", result);
+        }
+
+        @Test
+        void aBearerTokenKeepsItsPrefixInsideAJsonField() {
+            String input = "{\"Authorization\":\"Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature\"}";
+            assertEquals("{\"Authorization\":\"Bearer <REDACTED>\"}", SecretRedactionFilter.redact(input));
+        }
     }
 }


### PR DESCRIPTION
`SecretRedactionFilter`'s generic rule runs over the raw request **text**, and it matched the key's closing quote, the colon **and** the value's opening quote — then replaced all three along with the value (`"$1=" + REDACTED`). An ordinary body came back malformed:

```
{"modelName":"x","apiKey":"sk-ant-…"}   →   {"modelName":"x","apiKey=<REDACTED>"}
{"token":12345678,"n":1}                →   {"token=<REDACTED>,"n":1}
```

A bare string where a key/value pair was. The `sk-…` and `Bearer …` rules replace only the value and leave the document valid; this one did not — and it runs **last**, so it re-mangled what those had already redacted correctly.

## Why it matters

Every reader of a redacted body parses it, and both of the Manager's failed silently. Surfaced from [EDDI-Manager#173](https://github.com/labsai/EDDI-Manager/pull/173):

- the approval diff for a gated whole-document `PUT` fell back to comparing raw text and rendered **every line of the stored config as deleted** against the proposed body as one added line;
- worse, `detectEscalationFlags` runs *every* capability-grant check behind a `JSON.parse`. So a request that embedded a credential **and** granted `dynamicAgents.allowCreation` warned about the credential alone — and an approver reads "no second warning" as "no capability grant", which is the exact false negative that check exists to prevent.

The Manager shipped a client-side repair for the mangled shape. This is the fix at the source; that repair stays as tolerance for older backends and goes inert against a fixed one.

## Three defects, not one

**1. The output isn't JSON** — above.

**2. A secret containing a delimiter was only redacted up to it.** The value class stops at `,`, whitespace, `;`, `{`, `}` and `]`, so the tail survived into the "redacted" output:

```
{"password":"abcdefgh,SURVIVING-TAIL"}  →  {"password=<REDACTED>,SURVIVING-TAIL"}
```

**3. Found by a review pass on this branch, after a first draft.** A throwaway probe printing the filter's real output for a dozen shapes found four more leaks in my own fix — two decisions I had reasoned about and dismissed as theoretical:

| Input | First draft | Defect |
|---|---|---|
| `"password":"abcdefgh'xyz"` | `"<REDACTED>'xyz"` | closing quote needn't match the opening one |
| `"password":"it's-a-secret"` | *unchanged* | apostrophe cut it to 2 chars, under the 8-char floor |
| `"secret":"the key sk-ant-<REDACTED> is here"` | *unchanged* | "marker anywhere" guard skipped it |
| `"password":"my<REDACTED>pass"` | *unchanged* | same guard — a **bypass** for anyone who knows the marker |

## The fix

The generic rule becomes three, each replacing the value and nothing else:

| Shape | Rule | Result |
|---|---|---|
| `{"apiKey":"sk-…"}` | quoted value, runs to its **closing quote** | `{"apiKey":"sk-ant-<REDACTED>"}` |
| `{"token":12345678}` | no quotes of its own → marker takes the key's quote style | `{"token":"<REDACTED>"}` |
| `?api_key=…`, `password: …` | not JSON → separator preserved, no quotes invented | `?api_key=<REDACTED>` |

- **The closing quote is a backreference to the opening one** (`\4`), not "any quote". That fixes rows 1–2 above, and lets the value class admit the *other* quote character — a single-quoted value containing `"` gets the mirror fix free.
- **`NOT_ALREADY_REDACTED` is anchored to the start of the value**, fixing rows 3–4. It exists so the later rules don't strip the `sk-ant-` / `Bearer ` prefix an earlier rule deliberately kept — information an approver uses, and something the old rule destroyed on every named field.
- **The `${vault:…}` carve-out is now explicit.** It survived only as a side effect of the value class excluding braces; the quoted rule runs past braces, so it carries `(?!\$\{(?:vault|eddivault):)` as a stated rule — which also keeps it from being lost the next time that class is tuned.

## Deliberately not changed

- **`&` is still not a value delimiter.** It would tidy query-string redaction but would cut short every secret *containing* `&` in every other context and leak the tail. Over-redacting a raw URL that happens to sit in a log line is the safer trade, and real request URIs never reach the filter whole — `RequestRedactor` scans each query parameter's value on its own. Pinned as a test so nobody "fixes" it.
- **An escaped quote inside a value ends it early.** `\"` is a terminator in an escaped-JSON body and a literal in a plain one, and the filter cannot tell which it is reading. Resolved in favour of the escaped body — the other reading runs past the real end of the field and eats the document. Pinned as a known limit; still an improvement, since the old rule stopped at the first space and redacted nothing there.

## Verification

- `SecretRedactionFilterTest` **14 → 40** cases. Three new nested classes: `RedactedJsonStaysJson` (parses every redacted result with Jackson), `ASecretIsRedactedInFull` (parameterised over all six delimiters, plus the quote-pairing and truncated-body cases), `AlreadyRedactedValuesKeepTheirPrefix` (including both guard-bypass regressions). Plus idempotency, the 8-char floor, and neighbouring-field-not-swallowed.
- `RequestRedactorTest`, `ResolvedRequestTest`, the three `ApiCallExecutor*` suites, `ConversationMemoryUtilitiesHitlTest`, `LifecycleManagerErrorClassificationTest`, `SlackToolPauseNotificationTest`, `RestAgentEngineToolPauseDetailsTest` — all pass unchanged.
- `./mvnw validate` (Checkstyle) and `./mvnw compile` clean.

**Local full-suite caveat:** `./mvnw test` reports failures in `WebSearchToolTest`, `SafeHttpClientTest`, `SlackWebApiClientTest` (loopback sockets — the sandbox limitation AGENTS.md documents) and `DocumentationLinksTest` (it scans an untracked local `.history/` folder). Confirmed pre-existing by stashing these changes and re-running those classes: identical failures. CI is the source of truth for them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret redaction across JSON and non-JSON content.
  * Preserved valid JSON structure while fully masking secrets containing delimiters.
  * Retained credential prefixes and vault placeholders where applicable.
  * Improved handling of quoted, unquoted, escaped, and already-redacted values.
  * Prevented masking from crossing quote boundaries or altering unrelated content.

* **Documentation**
  * Added a changelog entry describing the redaction improvements, compatibility updates, known limitations, and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->