### PR TITLE
fix: address defects from the run-0820a

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,18 @@ jobs:
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high
+          # deny-licenses is deprecated upstream (dependency-review-action#997) in
+          # favour of allow-lists, but migrating means enumerating every licence
+          # this project accepts — a repo-wide policy decision, not a mechanical
+          # swap. Kept deliberately until the maintainers make that call; the
+          # pinned v4 keeps honouring it, and removal would arrive with a major
+          # bump that gets reviewed here anyway.
           deny-licenses: GPL-3.0, AGPL-3.0
+          # BOM-managed dependencies carry no <version> in the pom, so the action
+          # cannot resolve their metadata and reports "unknown licence" on every
+          # PR that touches the manifest. Caffeine is Apache-2.0 — verified against
+          # its own POM on Maven Central (3.2.4, the version the Quarkus BOM
+          # resolves) — and already shipped transitively via quarkus-caffeine
+          # before it was ever declared, so nothing new is being licensed here.
+          allow-dependencies-licenses: pkg:maven/com.github.ben-manes.caffeine/caffeine
           comment-summary-in-pr: always

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -813,8 +813,10 @@ Matcher:      "actions" : "ask_for_model"
 #### Qute template safety in HTTP call bodies
 
 When embedding `{properties.x}` in HTTP call body templates, be aware:
-- `quarkus.qute.strict-rendering=false` renders missing properties as empty strings (no error). This is set once in `application.properties` and applies to **every profile** — there is deliberately no `%prod` override, so dev, test and production all render leniently and fail identically. (Earlier releases turned strict rendering **on** in prod only, which meant a missing property rendered blank in dev but leaked the raw `{properties.x}` literal to the end user in production.)
-- Do NOT use `.orEmpty` on properties — it's for Qute iterables, not strings, and fails on `NOT_FOUND`
+- A missing property renders as an **empty string**, in every profile. This takes *two* settings in `application.properties`, and both are deliberate:
+  - `quarkus.qute.strict-rendering=false` stops the render from throwing. There is no `%prod` override — dev, test and production must fail identically. (Earlier releases turned strict rendering **on** in prod only, which meant a missing property rendered blank in dev but leaked the raw `{properties.x}` literal to the end user in production.)
+  - `quarkus.qute.property-not-found-strategy=NOOP` decides what is written instead. Without it a missing value resolves to Qute's NotFound sentinel and the **literal string `NOT_FOUND`** reaches the output — system prompts, HTTP call bodies and user-visible replies alike ("Your favourite programming language is: NOT_FOUND."). Dev mode defaults to throwing instead, so the two did not even agree. This was a live defect, not a hypothetical.
+- Do NOT use `.orEmpty` on properties — it's for Qute iterables, not strings, and fails on `NOT_FOUND`. If you want an explicit fallback in the template itself, the Qute idiom is the elvis operator: `{properties.x ?: 'unknown'}`
 - User-entered text containing `{` or `}` will be interpreted as Qute expressions, potentially eating content
 
 #### Calling an API as the signed-in user

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,47 @@
 
 
 
+## 🔍 fix(review): findings from reviewing the run-0820a sweep itself (2026-08-20)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+A critical pass over the sweep's own fixes turned up four things worth their own note.
+
+**The audit timestamp fix was still one rounding away from failing.** Signing milliseconds is not
+sufficient on its own: PostgreSQL's `timestamp(6)` **rounds** to the nearest microsecond rather than
+truncating, so an instant whose nanoseconds land in the last half-microsecond of a millisecond rounds
+its microsecond count up across the millisecond boundary and reads back one millisecond later than it
+was signed — roughly one row in two thousand, reported as tampered for no reason. `AuditLedgerService`
+now floors the timestamp *before* signing (`AuditHmac.withStorablePrecision`), so the row that lands
+in the database is the row that was signed and there is nothing left to round. It also makes the two
+backends agree on the ledger's timestamp resolution instead of differing by a factor of a thousand.
+
+**The D3 fix did not reach the caller that mattered most.** `ConversationHistoryBuilder` pre-checked
+`output instanceof List && !isEmpty()` before calling the extractor — the same "decide the shape from
+the outside" mistake, one level up. A turn whose output was written with
+`addConversationOutputString("output", …)` holds a plain String, so it stayed missing from the
+model's own chat history while the rolling summary and the recall tool, which call the extractor
+directly, kept it. Guard removed; the extractor already returns null when there is nothing to say.
+
+**D12's parity sweep missed two call sites.** `create_channel_integration` and
+`update_channel_integration` deserialise `ChannelIntegrationConfiguration` — a first-party config
+model that REST *is* strict about — with the lenient mapper, so the same divergence existed there.
+Both now go through `StrictConfigurationParser`. Agent triggers were checked and deliberately left
+alone: `AgentTriggerConfiguration` lives outside `configs.*.model`, so REST is lenient about it too
+and making MCP stricter would create the asymmetry in the opposite direction.
+
+**An over-claim in the rerun fix.** The comment asserted that a rerun never re-fires external side
+effects. True for the standard workflow layout (http/mcp calls precede the LLM step) but not an
+invariant — a workflow that places `httpcalls` after its LLM step will re-run them. Reworded to say
+what actually holds.
+
+Also added: a 404 regression test for the missing-export-archive path, and tests proving A2A Agent
+Cards use the descriptor's name and fall back to the id form when there is none.
+
+---
+
+
+
 ## 🧩 fix(engine): the rest of the run-0820a sweep — memory, validation parity, error hygiene (2026-08-20)
 
 **Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
@@ -183,9 +224,12 @@ empty result, and no second `ai.labs.llm`.
 
 The cleared set and the restart set are now separate and stated to agree: clear
 `{output, quickReplies}`, restart at `{langchain, output, quickReplies}`. Restarting at `langchain`
-re-runs the model and everything after it while parser, behavior rules, property setters and HTTP
-calls keep their results — a retry does not re-fire external side effects. A rule-based agent has no
-`langchain` task and still restarts at `output`, exactly as before. Separately, `/rerun` required an
+re-runs the model and everything after it; whatever precedes it keeps its results, which in the
+standard workflow layout (parser → behavior → property → http/mcp calls → llm → output) means a retry
+does not re-fire those external calls. That is the layout rather than an invariant — a workflow that
+places `httpcalls` after its LLM step will re-run them, which is what "re-execute the last step" has
+always meant for anything after the restart point. A rule-based agent has no `langchain` task and
+still restarts at `output`, exactly as before. Separately, `/rerun` required an
 undocumented `?language=` or returned 400; it is now optional, matching `say()`, and the endpoint
 description says what a rerun actually does.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,56 @@
 
 
 
+## 🔐 fix(audit): the compliance ledger reported every entry as forged (2026-08-20)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+From the run-0820a live sweep (D7, D7b). The audit ledger's tamper-evidence was non-functional on
+both supported backends:
+
+```text
+signingEnabled=true  entriesChecked=78  valid=0  invalid=78  unsigned=0  chainStatus=INTACT
+```
+
+Entries seconds old failed alongside everything else, so this was neither key rotation nor legacy
+data. `chainStatus: INTACT` ruled out the sequence, leaving one field.
+
+**The signed timestamp had a precision no backend can store.** `buildCanonicalStringV3` signed the
+raw `Instant`, which on a Linux container carries nanoseconds. PostgreSQL's `TIMESTAMPTZ` keeps
+microseconds; MongoDB's `Date` keeps milliseconds. The entry read back was therefore never the entry
+that was signed, and the digest could not match. An operator running verify could not distinguish a
+forged row from a healthy one — the control emitted no signal at all, in either direction.
+
+**Fixed forward with a v4 canonical form**, per the class's own "frozen once written" rule: identical
+to v3 except `ts` is the millisecond epoch value. Milliseconds is the coarsest backend floor, so a v4
+signature round-trips through either; signing the epoch rather than `Instant.toString()` also removes
+its trailing-zero variance from the digest.
+
+**Existing v3 rows are recovered, not re-signed.** The stored HMAC is intact — only the
+sub-storage-precision digits of the timestamp are gone, and the signature still identifies them.
+Verification completes a v3 row by trying each candidate: at most 999 for a microsecond-floored
+(PostgreSQL) row, and 999 more for a millisecond-floored (MongoDB) row from a microsecond clock — a
+couple of milliseconds per row. A match proves integrity as strongly as a direct one, since producing
+a completion without the key is as hard as forging the digest. Blind re-signing was rejected
+deliberately: resealing without verifying would launder any tampering that had already happened.
+Recovered rows report as `VALID_RECOVERED` and are counted in a new `recovered` field on
+`/auditstore/verify`, so the count also tells an operator how much of the ledger predates v4. Switch
+it off with `eddi.audit.verify.recover-legacy=false`.
+
+**D7b — Ed25519 signatures were separately discarded on PostgreSQL.**
+`eddi.audit.agent-signing-enabled` defaults to true and signatures were duly computed, but
+`audit_ledger` had no `agent_signature` column and the row-mapper hard-coded `null`. The
+non-repudiation half of the ledger was inert on one backend while the other had it. The column is
+added through the same `ADD COLUMN IF NOT EXISTS` upgrade pattern as `sequence`, and is written and
+read.
+
+Regression tests do what the ledger's own tests never did: sign an entry, apply each backend's
+truncation, and verify what comes back. Reverting the v4 form fails them.
+
+---
+
+
+
 ## 🧾 fix(memory): conversation turns that were destroyed while reporting success (2026-08-20)
 
 **Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,43 @@
 
 
 
+## 🎯 test(sweep): close the two verdict caveats — legacy triage + stubbed-LLM validation (2026-08-21)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+The final double-check ended with two stated caveats. Both are now addressed with fixes rather than
+disclaimers.
+
+**Caveat 1 — legacy INVALIDs were indistinguishable from real tampering.** A verify sweep reports
+both a freshly tampered v4 row and an unrecoverable legacy row (payload signed over live Java
+objects; nothing can reconstruct it) as INVALID — and those demand opposite reactions. Each
+`EntryProblem` now carries `hmacVersion` (`v1`–`v4`, from the stored HMAC's own prefix via
+`AuditHmac.versionOf`), so an operator sweeping an old ledger can separate the expected pre-v4
+residue from the alarm: an INVALID on `v4` means something touched a row this release wrote. Additive
+JSON field; wiring pinned in `RestAuditStoreTest`.
+
+**Caveat 2 — the LLM-involving fixes had never run against a model.** `LlmAgentEngineIT` already had
+a WireMock-backed fake OpenAI endpoint (the sweep's Tier-3 recommendation, shipped and forgotten);
+two tests now ride it:
+
+- **D11 end to end:** say → scripted "ALPHA.", then `POST /rerun` (deliberately without
+  `?language=`, pinning that fix live) → the body must contain "BRAVO." and must NOT contain
+  "ALPHA.", and WireMock must have been called exactly twice. Only a genuinely re-executed model can
+  produce the second answer; a rerun that merely cleared (the defect) or a cached answer both fail.
+- **D10 end to end:** an agent with `enableMemoryTools: true` and deliberately NO `userMemoryConfig`
+  (the defaults fallback carries it) receives a scripted `rememberFact` tool call on a *say* turn —
+  the turn on which the tool used to be silently absent — and
+  `GET /usermemorystore/memories/{userId}` must show the fact landed. This exercises the whole
+  broken conjunction: config survives past init, defaults fall back, the tool assembles, executes,
+  and writes.
+
+Both are ITs and gate in CI, where the audit-verify IT has already proven this class of test earns
+its keep — it caught the POJO-payload defect that every mock-based test had been green through.
+
+---
+
+
+
 ## 🔏 fix(audit): sign the payload the database actually stores (2026-08-21)
 
 **Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,9 +39,12 @@ lenient mapper, and its error path returned `e.getMessage()`, which for a respon
 `describe()`, so the known-fields message reaches the MCP caller. (`update_agent` takes only
 name/description parameters — checked, no gap.)
 
-**The memory/built-ins WARN is now once per agent**, not per turn — a busy misconfigured agent would
-have flooded the log with the same sentence, which trains operators to ignore it. The set is static
-because `AgentOrchestrator` constructs the provider per call.
+**The memory/built-ins WARN is now at most once per agent per day**, not per turn — a busy
+misconfigured agent would have flooded the log with the same sentence, which trains operators to
+ignore it. The cache is static because `AgentOrchestrator` constructs the provider per call, and
+bounded/expiring (Caffeine, 10k / 24h) rather than a plain set — "the number of distinct agents" is
+not a fixed bound on a platform that creates dynamic and ephemeral agents at runtime, so a plain set
+would grow for the JVM lifetime under churn (review catch on the first version of this fix).
 
 **Verified clean, for the record:** the D6 Qute strategy genuinely reaches production rendering
 (`TemplatingEngine` injects the CDI `Engine` that `EngineProducer` builds from config — not a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,61 @@
 
 
 
+## 🧪 test(sweep): regression nets for every behavioural fix on the branch (2026-08-21)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+A coverage audit of the whole branch: for each behavioural change, does a test exist that fails if it
+regresses — and are the *wiring* paths pinned, not just the units? Eleven additions, three of them
+load-bearing.
+
+**The audit signature is now proven against a real PostgreSQL container**
+(`PostgresAuditHmacRoundTripTest`, Testcontainers). The original defect was a cross-layer mismatch no
+mock could see — a live ledger reported `valid=0 invalid=78` while every unit test was green — and
+the unit tests that cover the fix *simulate* storage truncation. The new class runs the shipped
+pipeline (floor → sign → store → read → verify) and the v3 recovery search against whatever the real
+server and JDBC driver actually do. Mutation against the live container settled the rounding question
+empirically: making the recovery search forward-only fails the legacy-row test, because **the real
+PostgreSQL pipeline rounds a 789ns remainder up** — the stored value sits above the signed one, where
+a forward search can never reach it. The deep-pass bidirectional fix is therefore load-bearing on
+real infrastructure, not just in simulation. The same exercise showed the layering honestly: a
+canonical-form regression alone passes this class (flooring makes even v3 round-trip) and is pinned
+instead by `AuditHmacTimestampPrecisionTest` (signs raw nanos) and `AuditLedgerServiceTest` (catches
+flooring removal) — now stated in the class javadoc so nobody mistakes one net for all three.
+
+**`/auditstore/verify` gets its end-to-end CI net** (`AuditAndSecurityIT`): every earlier test in that
+class read an *empty* conversation's trail — precisely why broken verification could ship. The new
+ordered test deploys the minimal rule-based agent, drives a real turn, polls until the async flush
+lands, and asserts `valid == entriesChecked`, `invalid == 0`, `unsigned == 0`, `recovered == 0`,
+`recoverySkipped == 0`, `chainStatus INTACT` — the sweep's own definition of done, failing on every
+pre-v4 EDDI.
+
+**The D3 pin turned out to cover the wrong path — caught by its own mutation check.** The
+`skipSteps > 0` (rolling-summary) branch of `ConversationHistoryBuilder` has its *own* render loop,
+and my first caller-level test exercised only the generator branch: re-adding the removed
+`instanceof List` guard passed it. A rolling summary is exactly where losing a turn hurts most — the
+summarized prefix is gone by design, so a dropped turn has no other copy in the prompt. Both branches
+are pinned now, and the mutation fails.
+
+**The rest:** multi-entry redo preserves order and outputs (a flipped cache would restore the *wrong*
+turn's answer); `VALID_RECOVERED` wiring (counts as valid + recovered, never a problem entry) and
+`recoverySkipped` read off the sweep's actual budget (a literal 0 would fail nothing else); the
+submit path floors a nano-precise timestamp deterministically (host-clock-independent);
+`create_resource` propagates the strict known-fields message to the MCP caller end-to-end; the
+user-memory tool's enablement conjunction pinned in both directions at `contribute()` level
+(assembles when both switches agree, and built-ins-off *wins* — the restrictive half is a security
+posture); runtime delegation pins for the rules and dictionary listings (the source sweep can't see a
+derivation bug); the rerun list restarts at a `langchain` task placed before `output`; plaintext
+channel secrets warn but must never reject (a "hardening" to 400 would brick every existing
+integration on update); and `/rerun` without a language proceeds.
+
+Full local suite after the additions: 19,648 tests (+48), failures at the exact environmental
+baseline (8/294 loopback/selector, none in touched code).
+
+---
+
+
+
 ## 🔬 fix(audit): deep-pass findings — recovery direction, precision caps, null timestamps (2026-08-20)
 
 **Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,16 @@ are signed with".
 **`MeterRegistry`** was declared by fully-qualified name in three signatures (AGENTS.md §4.7).
 `ImportStyleTest` does not cover `io.micrometer`, so nothing failed — replaced with an import.
 
+**Second round, two more.** Rows left unsearched by the recovery budget were still counted by
+`tamperingSuspected()`, so a page large enough to exhaust the budget would have raised a compliance
+alarm without a single HMAC having been disproven — the same "reported as proven when it is not"
+shape as the defects this release fixes, pointed the other way. Those rows establish nothing either
+way (failing the direct check is the *expected* outcome for a pre-v4 row), so they no longer count as
+tampering, and a new `disproven()` gives alerting the number to key on. They still defeat `intact()`:
+a sweep that could not finish checking is not a clean bill of health. Also corrected two Javadocs
+left stale by the v4 switch — `V3_PREFIX` still called itself the form `computeHmac` writes, and the
+v1 canonicalizer still pointed new entries at v2.
+
 ---
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,61 @@
 
 
 
+## 🔬 fix(audit): deep-pass findings — recovery direction, precision caps, null timestamps (2026-08-20)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+A final adversarial pass over the whole branch. Four fixes and a set of verified-clean checks.
+
+**The v3 recovery search missed roughly half of all PostgreSQL legacy rows.** Storage does not only
+floor: Java's `truncatedTo`/`toEpochMilli` floor, but PostgreSQL's `timestamp(6)` — and the JDBC
+driver's nanos-to-micros conversion — round to *nearest*, so a value whose lost digits were in the
+upper half is stored **above** the signed one. The forward-only search could never reach it. The
+search now runs in both directions.
+
+**…and is capped to exactly the precision each row lost**, read off the stored value itself. The
+searched window is, unavoidably, also the window within which a *moved* stored timestamp is
+indistinguishable from a truncated one — recovery proves the signed instant exactly, and proves the
+stored value lies within the destroyed precision of it, never more. A row with sub-millisecond
+digits present came through a microsecond store, so only ±999ns is searched; only a
+millisecond-aligned row gets the ±999µs tier. Without the cap, going bidirectional would have turned
+a recovery aid into ±1ms timestamp tamper-tolerance. A test pins the cap with a whole-µs shift that
+the µs tier *would* absorb — the cap is the only thing between that edit and `VALID_RECOVERED`.
+
+**A null-timestamped entry could never verify on PostgreSQL.** v4 signs the empty string for a null
+timestamp, but `PostgresAuditStore` substitutes `now()` on write — so the row read back carried a
+timestamp the signature never covered, permanently INVALID, on that backend only (MongoDB stores the
+field as absent, which round-trips). The service now stamps a missing timestamp *before* signing.
+
+**`update_group` was a third D12 site.** It parsed `AgentGroupConfiguration` — REST-strict — with the
+lenient mapper, and its error path returned `e.getMessage()`, which for a response-built
+`BadRequestException` is just "HTTP 400 Bad Request". Now parses strictly and reports through
+`describe()`, so the known-fields message reaches the MCP caller. (`update_agent` takes only
+name/description parameters — checked, no gap.)
+
+**The memory/built-ins WARN is now once per agent**, not per turn — a busy misconfigured agent would
+have flooded the log with the same sentence, which trains operators to ignore it. The set is static
+because `AgentOrchestrator` constructs the provider per call.
+
+**Verified clean, for the record:** the D6 Qute strategy genuinely reaches production rendering
+(`TemplatingEngine` injects the CDI `Engine` that `EngineProducer` builds from config — not a
+hand-built one); `LlmTask` has no step-data idempotency guard that could defeat the rerun fix (its
+only gates are the actions data, which rerun preserves, and HITL resume mode, which requires a
+pending batch *and* a decision); every `PostgresAuditStore` row query selects `agent_signature`; and
+one worthwhile nuance of the D10 fallback — a memory-enabled agent with no `userMemoryConfig` now
+loads at the config default of 50 recall entries rather than the legacy no-config fallback of 1000,
+which is the documented default for agents that opted into memory.
+
+Tidy-ups: inline `java.io.IOException` FQNs in five test helpers replaced with imports (the
+ImportStyle sweep does not cover `java.io`, so nothing failed — AGENTS.md §4.7 applies anyway); a
+vestigial alias in `ConversationOutputExtractor`; the budget javadoc's cost figures updated for the
+bidirectional search. All three behavioural fixes mutation-checked: removing the minus branch, the
+precision cap, or the timestamp stamping each fails its test.
+
+---
+
+
+
 ## 🧹 fix(audit): review round on PR #707 (2026-08-20)
 
 **Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,7 +44,11 @@ misconfigured agent would have flooded the log with the same sentence, which tra
 ignore it. The cache is static because `AgentOrchestrator` constructs the provider per call, and
 bounded/expiring (Caffeine, 10k / 24h) rather than a plain set — "the number of distinct agents" is
 not a fixed bound on a platform that creates dynamic and ephemeral agents at runtime, so a plain set
-would grow for the JVM lifetime under churn (review catch on the first version of this fix).
+would grow for the JVM lifetime under churn (review catch on the first version of this fix). A second
+review round tightened it further: a null agent id bypassed deduplication entirely — making the
+defensive path the one case that logged on every turn — and now maps to a stable fallback key; and
+the "once per day" claim was softened to what a bounded cache can honestly promise (suppression
+while the entry remains cached). Both mutation-checked.
 
 **Verified clean, for the record:** the D6 Qute strategy genuinely reaches production rendering
 (`TemplatingEngine` injects the CDI `Engine` that `EngineProducer` builds from config — not a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,13 @@ lands, and asserts `valid == entriesChecked`, `invalid == 0`, `unsigned == 0`, `
 `recoverySkipped == 0`, `chainStatus INTACT` — the sweep's own definition of done, failing on every
 pre-v4 EDDI.
 
+Its first CI run failed, usefully: the audit collector is attached in `ConversationService.say()`, so
+a conversation that has only been *started* produces no entries at all, and the test had asserted on
+one. It now drives a real user turn. The count assertion was also rewritten as an invariant
+(`valid == entriesChecked`) rather than a comparison against a count polled moments earlier — the
+flush is asynchronous, so entries can land between the two calls; the invariant is both stronger and
+race-free.
+
 **The D3 pin turned out to cover the wrong path — caught by its own mutation check.** The
 `skipSteps > 0` (rolling-summary) branch of `ConversationHistoryBuilder` has its *own* render loop,
 and my first caller-level test exercised only the generator branch: re-adding the removed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,50 @@
 
 
 
+## 🔏 fix(audit): sign the payload the database actually stores (2026-08-21)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+**The v4 timestamp fix was necessary but not sufficient, and the new end-to-end IT proved it in CI**
+before a human ever ran the branch: a plain rule-based turn reported `entriesChecked=5 valid=2`. Three
+of five entries still failed verification, on **both** backends.
+
+The sweep's own report suspected this — *"a row failing the search is either tampered or hit a second
+lossy field"* — and the cause is now identified. The ledger signs an entry whose payload maps hold
+**live Java objects**: a turn's `output` is a list of `TextOutputItem` POJOs, not of Maps.
+Verification later runs over what JSON gave back. The two canonicalize completely differently — a
+POJO as `s:<toString()>`, its round-tripped form as `m{…}`. Measured against a real PostgreSQL
+container:
+
+```text
+signed: {output=[Hi there!]}
+stored: {output=[{text=Hi there!, type=text, delay=0}]}   → verifies=false
+```
+
+That accounts for the 2/5 exactly: parser and behavior run before any output exists and verified;
+output, templating and property all had rendered output in scope and did not.
+
+**Same defect class as the nanosecond timestamp, same cure: normalise first, then sign.**
+`AuditLedgerService` now reduces `input`/`output`/`llmDetail`/`toolCalls` to their JSON-native shape
+before signing, so the row that lands in the database is byte-for-byte the row that was signed. It is
+deliberately non-fatal — an audit write must never break the turn it records, so a value the mapper
+cannot convert keeps its original form, logs a warning, and shows up in the ledger's own verify
+report rather than throwing.
+
+Pinned by `pojoPayloadSurvivesTheDatabase`, which drives the real submit path (normalise → floor →
+sign → queue → flush → store) against a live PostgreSQL container; removing the normalisation call
+fails it.
+
+**Note for legacy rows.** A pre-v4 row whose payload carried POJOs was signed over objects that no
+longer exist in that form; the timestamp-completion search cannot recover it, and nothing can. Those
+rows report INVALID permanently. That is a property of how they were written, not of this fix — but
+it means an operator sweeping an old ledger should expect them, and it is the honest reason the
+recovery path was never sold as universal.
+
+---
+
+
+
 ## 🧪 test(sweep): regression nets for every behavioural fix on the branch (2026-08-21)
 
 **Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,40 @@
 
 
 
+## 🔎 fix(configs): three descriptor listings could never return anything (2026-08-20)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+From the run-0820a live sweep (D1). `GET /rulestore/rulesets/descriptors` and
+`GET /apicallstore/apicalls/descriptors` returned `[]` on an instance holding 10 ruleset and 22
+apicall descriptors. Direct `GET` of a ruleset returned 200 with real content, so nothing was lost —
+only listing was blind. A third case, dictionaries, was found while fixing it.
+
+`DescriptorStore.readDescriptors` filters by regex-matching the stored resource URI against
+`"eddi://" + type + ".*"`, so `type` has to be the URI's namespace segment. Three stores restated it
+as a legacy literal that no URI has ever carried:
+
+```text
+?type=ai.labs.rules      → 10      ?type=ai.labs.behavior          → 0
+?type=ai.labs.apicalls   → 22      ?type=ai.labs.httpcalls         → 0
+?type=ai.labs.dictionary →  1      ?type=ai.labs.regulardictionary → 0
+```
+
+This is the legacy-file-name vs v6-URI-name split of AGENTS.md §5.5 leaking into a runtime query,
+and it fails *silently* — an empty list, never an error. Anything browsing behavior rules, HTTP
+calls or dictionaries, the Manager included, saw nothing.
+
+**Fixed structurally rather than by three string edits.** `RestUtilities.extractDescriptorType`
+derives the type from the store's own `resourceURI`, and a new
+`RestVersionInfo.readDescriptors(filter, index, limit)` overload uses it; all 14 REST stores now call
+that instead of naming a type. A store can no longer query a namespace it does not write to.
+`DescriptorTypeConsistencyTest` sweeps the sources and fails on any hard-coded type that disagrees
+with its store's `resourceURI` — verified by reverting the fix. Two existing tests had pinned the
+wrong value (`ai.labs.httpcalls`) and were corrected.
+
+---
+
+
 ## 🛑 fix(ci): the Red Hat certify workflow would have overwritten the signed release (2026-08-20)
 
 **Repo:** EDDI (`fix/preflight-version-1-20-0`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,52 @@
 
 
 
+## 🧹 fix(audit): review round on PR #707 (2026-08-20)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+Six findings from CodeQL and CodeRabbit, five applied as reported and one applied in part.
+
+**Bounded the legacy-recovery work per sweep, not only per row (the substantive one).** Each pre-v4
+row that fails its direct check costs about 2,000 HMAC computations. Per row that is a couple of
+milliseconds; per *sweep* nothing bounded it, and `/auditstore/verify` accepts a limit of 10,000
+entries and verifies inline on the request thread — so a page where nothing can be recovered would
+spend roughly twenty million HMACs before answering. "Nothing can be recovered" is not exotic: it is
+what a ledger verified with the wrong key looks like, so the case where an operator most wants a
+prompt answer was the slowest. `AuditRecoveryBudget` is now created once per sweep
+(`eddi.audit.verify.recover-legacy-max-rows`, default 500) and spent only on rows whose direct check
+already failed. Rows past the budget report INVALID and are counted in a new `recoverySkipped` field
+— a non-zero value says that verdict is "not proven" rather than "disproven", which is the
+distinction this whole release is about.
+
+**MCP error detail: applied in part, with reasoning.** The suggestion was to return only the prefix
+and no exception detail. Returning only the prefix would undo two things this PR fixed — the
+`"Failed to chat with agent: null"` responses, and D12's parity, whose entire point is that the MCP
+client sees `Unknown field 'setProperties' … Known fields: [setOnActions]`. Message exposure is also
+not new: the pre-existing code already concatenated `e.getMessage()`. What *was* new is unwrapping
+JAX-RS response entities, so that is now scoped to `ClientErrorException` (4xx) only. A 4xx entity is
+a message this codebase authored *for* the caller; a 5xx entity is not written to that contract and
+may name endpoints or datastores, so it is never lifted verbatim.
+
+**Log injection (CodeQL alerts 498/499).** `agentId` in the A2A descriptor-lookup fallback and the
+group name in the cost-ceiling diagnostic now go through `LogSanitizer.sanitize`, as does the
+adjacent non-positive-ceiling warning that shared the defect.
+
+**Two orphaned Javadoc blocks** — inserting `withStorablePrecision` and `buildCanonicalStringV4`
+directly above existing methods left `computeHmac` and `buildCanonicalStringV3` documented by the
+block above their neighbour. Reattached; v3's text also no longer claims to be "the form new entries
+are signed with".
+
+**`AuditEntry.withTimestamp`'s Javadoc** said it is never used on the write path. Adding
+`withStorablePrecision` made that false on the same day it was written. Corrected.
+
+**`MeterRegistry`** was declared by fully-qualified name in three signatures (AGENTS.md §4.7).
+`ImportStyleTest` does not cover `io.micrometer`, so nothing failed — replaced with an import.
+
+---
+
+
+
 ## 🔍 fix(review): findings from reviewing the run-0820a sweep itself (2026-08-20)
 
 **Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,62 @@
 
 
 
+## 🧾 fix(memory): conversation turns that were destroyed while reporting success (2026-08-20)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+Three defects from the run-0820a sweep that share one shape: the API returns 200 and the turn's
+content is gone.
+
+**D3 — HITL-gated turns vanished from the log and from the agent's own history.** The Platform
+Operator was asked to create a group; it paused, a human approved, the group *was* created — and on
+the next turn it stated "the group was never created". `GET /agents/{id}/log` returned
+`user, assistant, user, user`.
+
+`ConversationOutputUtils.extractOutputText` decided the shape of the whole output list from
+`outputList.getFirst() instanceof Map`, and `ConversationLogGenerator` did the same. A HITL turn
+writes its pre-pause announcements through `addConversationOutputString(...)`, so its stored list
+reads `STRING, STRING, OBJECT` where an ordinary turn's reads `OBJECT`. The guard failed and the
+entire turn was discarded, later Maps included. Both now delegate to
+`ConversationOutputExtractor`, which already handled Strings, Maps, `TextOutputItem`s and mixed
+lists; it grew an `extractText(ConversationOutput, delimiter)` entry point so each caller keeps its
+own joining convention (space for LLM history, newline for the snapshot path). Fixing the extractor
+fixes `ConversationHistoryBuilder`, `ConversationSummarizer`, `ConversationRecallTool` and the REST
+log at once. Two existing tests had pinned the defect — a list of plain Strings asserted `null` —
+and now assert the text.
+
+**D2 — redo silently destroyed the turn it restored.** After undo → redo the step came back with
+`outputs[n] == {}`, and asking the agent what word it had just said returned its greeting, so the
+model lost the turn too. Undo/redo in live memory was always correct; serialisation was not.
+`iterateConversationStep` stored only `workflows/lifecycleTasks`, so `iterateRedoCache` rehydrated
+each entry as `new ConversationStep(new ConversationOutput())` and `redoLastStep()` pushed that empty
+output over the answer. Every request reloads memory from the store, so this fired on every real
+redo. `ConversationStepSnapshot` gained a nullable `conversationOutput`, populated only for redo
+entries (ordinary steps keep their output in `conversationOutputs` — duplicating it would double the
+document). Null-tolerant on read, so documents written before the field load unchanged.
+
+**D11 — rerun destroyed the answer and never regenerated it.** Root cause: a rerun cleared results
+it would not re-run. `Conversation.rerun` discarded the `output` and `quickReplies` results and then
+restarted selective execution at the first task matching those types — the *output* task. On an LLM
+agent the answer is stored under `output` but written by the `langchain` task, which sits earlier in
+the pipeline, so the answer was wiped, `ai.labs.llm` never re-ran, and the output task alone had
+nothing to render. The audit trail showed it exactly: a second `ai.labs.output` entry at 0ms with an
+empty result, and no second `ai.labs.llm`.
+
+The cleared set and the restart set are now separate and stated to agree: clear
+`{output, quickReplies}`, restart at `{langchain, output, quickReplies}`. Restarting at `langchain`
+re-runs the model and everything after it while parser, behavior rules, property setters and HTTP
+calls keep their results — a retry does not re-fire external side effects. A rule-based agent has no
+`langchain` task and still restarts at `output`, exactly as before. Separately, `/rerun` required an
+undocumented `?language=` or returned 400; it is now optional, matching `say()`, and the endpoint
+description says what a rerun actually does.
+
+Every fix here has a regression test that was confirmed to fail when the fix is reverted.
+
+---
+
+
+
 ## 🔎 fix(configs): three descriptor listings could never return anything (2026-08-20)
 
 **Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,88 @@
 
 
 
+## 🧩 fix(engine): the rest of the run-0820a sweep — memory, validation parity, error hygiene (2026-08-20)
+
+**Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)
+
+**D10 — agent-facing persistent memory never attached, and the model invented success.** With all
+three required conditions verified on a live agent (`enableMemoryTools: true`, a populated
+`userMemoryConfig`, the LLM task's `enableBuiltInTools: true`), `UserMemoryTool` was still never
+assembled: no `[MEMORY]` log line on any turn, memory count stayed 0. The calculator built-in ran on
+the same turn, so tool assembly worked — only memory was missing. Given no tool the model
+confabulated: *"I've saved that you're allergic to peanuts"*, and on a second attempt leaked raw
+`<invoke name="memory_write">` pseudo-XML into user-visible output.
+
+`ContextualToolsProvider` gates on `memory.getUserMemoryConfig()`, whose only assignment was
+`Conversation.init()`. The field is not part of the persisted snapshot and every request rebuilds
+memory from the store, so it was present for the CONVERSATION_START turn and null for every turn a
+user could actually talk to. Now applied in the `Conversation` constructor — the one point `say`,
+`resume` and `rerun` all pass through. Two related traps closed: `AgentStoreClientLibrary` required
+`userMemoryConfig` to be non-null alongside `enableMemoryTools`, though every field of that config
+has a working default, so an agent that enabled memory and tuned nothing got nothing — it now falls
+back to the defaults; and the remaining `enableBuiltInTools` conjunction, kept deliberately (a
+task-level "no built-in capability" should win over an agent-level opt-in for a cross-conversation
+*write*), now logs a WARN naming the missing switch instead of skipping in silence.
+
+**D12 — MCP resource writes bypassed the validation REST enforces.** The same payload:
+`create_resource(propertysetter, {"setProperties":[…]})` returned `201 created` and stored
+`{"setOnActions":[]}`, while the identical REST body returned `400 Unknown field 'setProperties' …
+Known fields: [setOnActions]`. `update_resource` then reported `newVersion: 2` for the hollow object.
+The strictness lived in a JAX-RS `ReaderInterceptor`, which only fires on a real inbound HTTP body —
+MCP calls the same stores in-process. Extracted to `StrictConfigurationParser`, used by both, so
+there is one implementation and one message. MCP errors also now surface a JAX-RS response entity
+rather than "HTTP 400 Bad Request".
+
+**D8 — validation messages never reached the client.** `throw new BadRequestException("…")` yields a
+400 with an empty body unless an ExceptionMapper attaches one; `POST /channelstore/channels` alone
+throws four distinct, well-written messages and delivered none of them. A `ClientErrorExceptionMapper`
+copies a 4xx message into the response entity — 4xx only, and never over an entity that already
+exists, so no 5xx internal ever leaks. This one defect caused four false findings during the sweep.
+
+**D4 / D5 — `PATCH /descriptorstore/descriptors/{id}`.** "Partial update" was a full replace: sending
+only `description` wiped `name` and returned 204, after which the agent rendered as unnamed in every
+listing. SET now merges non-null fields; DELETE clears exactly the fields the patch names (or both,
+as before, when it names none). A body that is not the `PatchInstruction` wrapper NPE'd into a 500 —
+now a 400 stating the expected shape.
+
+**D6 — missing properties rendered the literal `NOT_FOUND` to end users.**
+`quarkus.qute.strict-rendering=false` only stops the throw; the value still resolves to Qute's
+NotFound sentinel, whose default mapper writes `NOT_FOUND` into the output — reproduced live and
+through `POST /administration/preview/template`. Added
+`quarkus.qute.property-not-found-strategy=NOOP`, which renders nothing, in every profile (dev
+defaulted to throwing, so the two did not even agree). AGENTS.md §5.4 claimed the empty-string
+behaviour already held; corrected, with `{properties.x ?: ''}` documented as the in-template fallback
+since `.orEmpty` is for iterables and fails on NotFound.
+
+**D9 — "cascade-delete member conversations" only ends them.** `GroupLifecycleOps` calls
+`endConversation`, verified on both surfaces; artifacts and ephemeral agents *are* deleted. The
+promise is corrected on both the MCP tool and the REST operation rather than the behaviour changed:
+a member conversation holds an agent's own transcript and GDPR erasure is the path meant to destroy
+it. The inconsistency is now stated in the code. **Maintainer decision still open** — the report's
+Option A (truly delete) remains available for a minor release.
+
+**Minors.** `GET /backup/export/{unknown}` returned an unlogged 500 via `sneakyThrow`, now a 404 —
+easy to hit, since export and download share the path and differ only by method. `pauseDetails.actions`
+reported `["CONVERSATION_START"]` on every rule pause: the lookup walked forward from index 0 while
+believing `getConversationSteps()` was reverse-chronological. It is chronological — the countdown in
+`convertConversationMemory` indexes a `ConversationStepStack` whose own `get(i)` already counts back,
+so the inversions cancel. Verified against a real memory round-trip, not read off the loop; an
+existing test had encoded the same wrong premise and passed because the code shared it. MCP error
+paths rendered `"…: null"` for exceptions with no message (54 call sites). A2A Agent Cards announced
+"EDDI Agent &lt;uuid&gt;" instead of the descriptor's name. `create_group` omitted NEGOTIATION and
+CUSTOM; `read_group_conversation` said "decision record" without naming the `decision` field; team
+cadence cron is 5-field Unix, now documented.
+
+**O1/O2.** A `maxCostPerDiscussion` is inert unless members carry `inputPricePer1M`/`outputPricePer1M`
+— EDDI ships no price table by design — so the group store now says so when a ceiling is saved.
+Channel `platformConfig` credentials are stored and returned verbatim; `ChannelTargetRouter` already
+resolves `${vault:...}` at send time, so a write-time WARN points operators at the vault rather than
+rejecting configurations that work today.
+
+---
+
+
+
 ## 🔐 fix(audit): the compliance ledger reported every entry as forged (2026-08-20)
 
 **Repo:** EDDI (`fix/sweep-0820a-integrity-defects`)

--- a/docs/group-conversations.md
+++ b/docs/group-conversations.md
@@ -420,6 +420,10 @@ POST /groupstore/groups/{groupId}/workspace/cadences  {"cronExpression": "0 9 * 
 GET  /groupstore/groups/{groupId}/workspace
 ```
 
+`cronExpression` is a **5-field Unix cron** (`min hour day month weekday`), not
+6-field Quartz — `"0 0 3 * * ?"` is rejected. The error message says so, but the
+example above is the one to copy.
+
 MCP: `add_team_task`, `list_team_backlog`. The backlog caps at 200 with an
 actionable error — it is a working set, not an archive.
 
@@ -963,7 +967,7 @@ summarizer's.
 | `POST` | `/groups/{groupId}/conversations` | Start discussion |
 | `GET` | `/groups/{groupId}/conversations/{id}` | Read transcript |
 | `GET` | `/groups/{groupId}/conversations` | List conversations |
-| `DELETE` | `/groups/{groupId}/conversations/{id}` | Delete + cascade |
+| `DELETE` | `/groups/{groupId}/conversations/{id}` | Delete (artifacts + ephemeral agents; members **ended**) |
 | `GET` | `/groupstore/groups/jsonSchema` | JSON schema for the group config |
 | `POST` | `/groups/{groupId}/conversations/stream` | Start discussion, stream events over SSE |
 | `POST` | `/groups/{groupId}/conversations/{id}/followup` | Ask one member a follow-up |
@@ -1032,7 +1036,7 @@ split is internal.
 | `read_group_conversation` | Read conversation transcript |
 | `list_group_conversations`  | List past discussions for a group, with state and timestamps                                                                         |
 | `start_group_discussion`    | Start a discussion asynchronously (returns immediately). Poll with `read_group_conversation`                                         |
-| `delete_group_conversation` | Delete a group conversation and cascade-delete all member conversations                                                              |
+| `delete_group_conversation` | Delete a group conversation. Artifacts and ephemeral agents are deleted; member conversations are **ended**, not deleted |
 | `followup_with_member` | Ask a single member a follow-up on a finished discussion |
 | `continue_group_discussion` | Continue a discussion with a new question |
 | `close_group_conversation` | Close a conversation to further rounds |

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,18 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-cache</artifactId>
         </dependency>
+        <!-- Caffeine is used DIRECTLY (Caffeine.newBuilder()) by ten classes — the
+             cache factory, the prompt-snippet and global-variable caches, the model
+             registries, and the tool-assembly warning cache. It arrives transitively
+             via quarkus-cache -> quarkus-caffeine, so the build works today by
+             accident: a Quarkus upgrade that reshapes that extension's own
+             dependencies would break compilation in classes that never mention
+             Quarkus. Declared explicitly, version left to the Quarkus BOM so it
+             cannot drift from the one the extension expects. -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
         <!-- Bean Validation (Jakarta Validation / Hibernate Validator). Enables
              declarative constraints on JAX-RS request bodies so an invalid body is
              rejected at the boundary with a field-level 400 instead of being carried

--- a/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
@@ -36,6 +36,7 @@ import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
@@ -138,7 +139,12 @@ public class RestExportService extends AbstractBackupService implements IRestExp
 
             return Response.ok(new BufferedInputStream(new FileInputStream(zipFilePath.toFile()))).build();
         } catch (FileNotFoundException e) {
-            throw sneakyThrow(e);
+            // An archive that is not there is a 404, not a 500. sneakyThrow'ing the
+            // FileNotFoundException produced an unlogged 500 error page — easy to hit,
+            // since export and download share this path and differ only by method, so
+            // a mistyped or expired filename looked like a server fault.
+            throw new NotFoundException("No exported archive named '" + agentFilename
+                    + "'. Archives are produced by POST on this path and are not kept indefinitely.");
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -106,7 +106,7 @@ public class RestAgentStore implements IRestAgentStore {
 
     @Override
     public List<DocumentDescriptor> readAgentDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.agent", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStore.java
+++ b/src/main/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStore.java
@@ -53,7 +53,7 @@ public class RestApiCallsStore implements IRestApiCallsStore {
 
     @Override
     public List<DocumentDescriptor> readApiCallsDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.httpcalls", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
@@ -61,7 +61,7 @@ public class RestChannelIntegrationStore implements IRestChannelIntegrationStore
 
     @Override
     public List<DocumentDescriptor> readChannelDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.channel", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
+
 /**
  * REST implementation for channel integration configuration CRUD. Includes
  * validation for trigger uniqueness, default target, and channel type.
@@ -140,10 +142,54 @@ public class RestChannelIntegrationStore implements IRestChannelIntegrationStore
     // ─── Validation ────────────────────────────────────────────────────────────
 
     // Visible for testing
+    /**
+     * {@code platformConfig} keys that hold credentials.
+     * <p>
+     * A channel's bot token or signing secret is stored, and returned by
+     * {@code GET /channelstore/channels/&#123;id&#125;}, exactly as it was written
+     * — so a plaintext value is readable by anyone who can read the configuration,
+     * and lands in ZIP exports and backups too. {@code ChannelTargetRouter}
+     * resolves {@code ${vault:...}} references at send time, so the vault is
+     * available here; nothing was telling operators to use it.
+     */
+    private static final Set<String> SECRET_PLATFORM_CONFIG_KEYS = Set.of(
+            "bottoken", "signingsecret", "clientsecret", "apikey", "apisecret", "token",
+            "password", "webhooksecret", "appsecret", "verificationtoken");
+
+    /**
+     * Warns — rather than rejects — when a credential is written in plaintext.
+     * <p>
+     * Rejecting would break every existing integration on its next update, and
+     * whether a value is a secret is a guess based on its key name. A log line at
+     * write time is the honest amount of certainty: it names the key, points at the
+     * vault, and leaves the operator's configuration working.
+     */
+    private void warnOnPlaintextSecrets(ChannelIntegrationConfiguration config) {
+        var platformConfig = config.getPlatformConfig();
+        if (platformConfig == null || platformConfig.isEmpty()) {
+            return;
+        }
+        for (var entry : platformConfig.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (key == null || !(value instanceof String text) || text.isBlank()) {
+                continue;
+            }
+            if (SECRET_PLATFORM_CONFIG_KEYS.contains(key.toLowerCase(Locale.ROOT)) && !text.contains("${vault:")) {
+                LOG.warnf("Channel integration '%s' stores platformConfig.%s in plaintext — it is returned verbatim by "
+                        + "GET /channelstore/channels/{id} and included in backups. Store it in the secrets vault and "
+                        + "reference it as ${vault:<key>} instead; the router resolves that at send time.",
+                        sanitize(config.getName()), sanitize(key));
+            }
+        }
+    }
+
     void validateConfiguration(ChannelIntegrationConfiguration config) {
         if (config.getName() == null || config.getName().isBlank()) {
             throw new BadRequestException("Channel integration name is required.");
         }
+
+        warnOnPlaintextSecrets(config);
 
         // Channel type must be a registered adapter
         String channelType = config.getChannelType();

--- a/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
@@ -15,6 +15,7 @@ import org.jboss.logging.Logger;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
@@ -64,18 +65,54 @@ public class RestDocumentDescriptorStore implements IRestDocumentDescriptorStore
         return new SimpleDocumentDescriptor(documentDescriptor.getName(), documentDescriptor.getDescription());
     }
 
+    /**
+     * Applies a partial update to a descriptor.
+     * <p>
+     * <b>SET merges.</b> Only the fields the patch actually carries are written;
+     * everything else is left alone. This endpoint calls itself "Partial update"
+     * and used to assign both fields unconditionally, so a caller sending just
+     * {@code description} — exactly what the documentation describes — wiped the
+     * descriptor's {@code name} and got a 204 for it. The agent then rendered as
+     * unnamed everywhere it was listed, and recovering it meant knowing to re-send
+     * both fields.
+     * <p>
+     * <b>DELETE clears.</b> With no document, or one naming no fields, it clears
+     * both, as before; when the document names fields, it clears exactly those.
+     */
     @Override
     public void patchDescriptor(String id, Integer version, PatchInstruction<DocumentDescriptor> patchInstruction) {
+        // A body that is not the PatchInstruction wrapper deserialises to an
+        // instruction
+        // with a null operation, which used to be dereferenced — a client-side shape
+        // error surfaced as a 500 error page naming a line of Java. Say what was
+        // expected instead.
+        if (patchInstruction == null || patchInstruction.getOperation() == null) {
+            throw new BadRequestException("A patch body must be a PatchInstruction: "
+                    + "{\"operation\":\"SET|DELETE\",\"document\":{\"name\":\"…\",\"description\":\"…\"}}");
+        }
+
         try {
             DocumentDescriptor documentDescriptor = documentDescriptorStore.readDescriptor(id, version);
-            DocumentDescriptor simpleDescriptor = patchInstruction.getDocument();
+            DocumentDescriptor patch = patchInstruction.getDocument();
 
-            if (patchInstruction.getOperation().equals(PatchInstruction.PatchOperation.SET)) {
-                documentDescriptor.setName(simpleDescriptor.getName());
-                documentDescriptor.setDescription(simpleDescriptor.getDescription());
+            if (patchInstruction.getOperation() == PatchInstruction.PatchOperation.SET) {
+                if (patch == null) {
+                    throw new BadRequestException("A SET patch must carry a 'document' with the fields to update.");
+                }
+                if (patch.getName() != null) {
+                    documentDescriptor.setName(patch.getName());
+                }
+                if (patch.getDescription() != null) {
+                    documentDescriptor.setDescription(patch.getDescription());
+                }
             } else {
-                documentDescriptor.setName("");
-                documentDescriptor.setDescription("");
+                boolean namesFields = patch != null && (patch.getName() != null || patch.getDescription() != null);
+                if (!namesFields || patch.getName() != null) {
+                    documentDescriptor.setName("");
+                }
+                if (!namesFields || patch.getDescription() != null) {
+                    documentDescriptor.setDescription("");
+                }
             }
 
             documentDescriptorStore.setDescriptor(id, version, documentDescriptor);

--- a/src/main/java/ai/labs/eddi/configs/dictionary/rest/RestDictionaryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/dictionary/rest/RestDictionaryStore.java
@@ -51,7 +51,7 @@ public class RestDictionaryStore implements IRestDictionaryStore {
 
     @Override
     public List<DocumentDescriptor> readRegularDictionaryDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.regulardictionary", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
@@ -377,7 +377,7 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
             return;
         }
         LOGGER.warnf("Group '%s' has maxCostPerDiscussion=%s (not positive) — treating as unlimited",
-                groupConfiguration.getName(), protocol.maxCostPerDiscussion());
+                LogSanitizer.sanitize(groupConfiguration.getName()), protocol.maxCostPerDiscussion());
         groupConfiguration.setProtocol(new AgentGroupConfiguration.ProtocolConfig(
                 protocol.agentTimeoutSeconds(), protocol.onAgentFailure(), protocol.maxRetries(),
                 protocol.onMemberUnavailable(), protocol.maxTurns(), null, protocol.onCostExceeded()));
@@ -408,6 +408,6 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
         LOGGER.infof("Group '%s' sets maxCostPerDiscussion=%s. This only takes effect for members whose LLM task "
                 + "defines inputPricePer1M/outputPricePer1M — EDDI ships no provider price table, so unpriced "
                 + "members contribute $0 and the ceiling never fires.",
-                groupConfiguration.getName(), protocol.maxCostPerDiscussion());
+                LogSanitizer.sanitize(groupConfiguration.getName()), protocol.maxCostPerDiscussion());
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/mongo/AgentGroupStore.java
@@ -52,6 +52,7 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
         validateFacilitator(groupConfiguration);
         ArtifactValidators.requireValidSpecs(groupConfiguration.getArtifactConfig());
         normalizeNonPositiveCostCeiling(groupConfiguration);
+        warnCostCeilingNeedsPricedMembers(groupConfiguration);
         warnOnModeratorlessPhases(groupConfiguration);
         warnOnSummarizerlessWindow(groupConfiguration);
         return super.create(groupConfiguration);
@@ -68,6 +69,7 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
         validateFacilitator(groupConfiguration);
         ArtifactValidators.requireValidSpecs(groupConfiguration.getArtifactConfig());
         normalizeNonPositiveCostCeiling(groupConfiguration);
+        warnCostCeilingNeedsPricedMembers(groupConfiguration);
         warnOnModeratorlessPhases(groupConfiguration);
         warnOnSummarizerlessWindow(groupConfiguration);
         return super.update(id, version, groupConfiguration);
@@ -379,5 +381,33 @@ public class AgentGroupStore extends AbstractResourceStore<AgentGroupConfigurati
         groupConfiguration.setProtocol(new AgentGroupConfiguration.ProtocolConfig(
                 protocol.agentTimeoutSeconds(), protocol.onAgentFailure(), protocol.maxRetries(),
                 protocol.onMemberUnavailable(), protocol.maxTurns(), null, protocol.onCostExceeded()));
+    }
+
+    /**
+     * A dollar ceiling only binds if something is priced.
+     * <p>
+     * {@code TokenPricing} ships no provider price table by design, so a member
+     * whose LLM task carries no {@code inputPricePer1M}/{@code outputPricePer1M}
+     * contributes exactly $0 and {@code totalCost} stays at 0 for the whole
+     * discussion — the ceiling can never fire. That is deliberate, but it is also
+     * invisible: the group reports {@code totalCost: 0}, {@code onCostExceeded}
+     * never runs, and a template advertising a "dollar ceiling" appears to be
+     * working. {@code setup_agent} exposes no pricing fields at all, so every agent
+     * it builds lands in exactly this state.
+     * <p>
+     * Whether the members are priced cannot be answered here without resolving each
+     * member agent's LLM configuration — a cross-resource read on the save path.
+     * The prerequisite is stated once, at the moment someone configures the
+     * ceiling, which is where it is actionable.
+     */
+    private void warnCostCeilingNeedsPricedMembers(AgentGroupConfiguration groupConfiguration) {
+        var protocol = groupConfiguration.getProtocol();
+        if (protocol == null || protocol.maxCostPerDiscussion() == null || protocol.maxCostPerDiscussion() <= 0) {
+            return;
+        }
+        LOGGER.infof("Group '%s' sets maxCostPerDiscussion=%s. This only takes effect for members whose LLM task "
+                + "defines inputPricePer1M/outputPricePer1M — EDDI ships no provider price table, so unpriced "
+                + "members contribute $0 and the ceiling never fires.",
+                groupConfiguration.getName(), protocol.maxCostPerDiscussion());
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
@@ -96,7 +96,7 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
 
     @Override
     public List<DocumentDescriptor> readGroupDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.group", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/llm/rest/RestLlmStore.java
+++ b/src/main/java/ai/labs/eddi/configs/llm/rest/RestLlmStore.java
@@ -47,7 +47,7 @@ public class RestLlmStore implements IRestLlmStore {
 
     @Override
     public List<DocumentDescriptor> readLlmDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.llm", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStore.java
+++ b/src/main/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStore.java
@@ -61,7 +61,7 @@ public class RestMcpCallsStore implements IRestMcpCallsStore {
 
     @Override
     public List<DocumentDescriptor> readMcpCallsDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.mcpcalls", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/output/rest/RestOutputStore.java
+++ b/src/main/java/ai/labs/eddi/configs/output/rest/RestOutputStore.java
@@ -50,7 +50,7 @@ public class RestOutputStore implements IRestOutputStore {
 
     @Override
     public List<DocumentDescriptor> readOutputDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.output", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/parser/rest/RestParserStore.java
+++ b/src/main/java/ai/labs/eddi/configs/parser/rest/RestParserStore.java
@@ -33,7 +33,7 @@ public class RestParserStore implements IRestParserStore {
 
     @Override
     public List<DocumentDescriptor> readParserDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.parser", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/propertysetter/rest/RestPropertySetterStore.java
+++ b/src/main/java/ai/labs/eddi/configs/propertysetter/rest/RestPropertySetterStore.java
@@ -48,7 +48,7 @@ public class RestPropertySetterStore implements IRestPropertySetterStore {
 
     @Override
     public List<DocumentDescriptor> readPropertySetterDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.property", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/rag/rest/RestRagStore.java
+++ b/src/main/java/ai/labs/eddi/configs/rag/rest/RestRagStore.java
@@ -53,7 +53,7 @@ public class RestRagStore implements IRestRagStore {
 
     @Override
     public List<DocumentDescriptor> readRagDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.rag", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
@@ -31,6 +31,17 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
         this.documentDescriptorStore = documentDescriptorStore;
     }
 
+    /**
+     * The descriptors of the resources <em>this</em> store owns.
+     * <p>
+     * Prefer this over {@link #readDescriptors(String, String, Integer, Integer)}:
+     * the descriptor type is derived from the store's own {@code resourceURI}, so a
+     * listing can never silently query a namespace the store does not write to.
+     */
+    public List<DocumentDescriptor> readDescriptors(String filter, Integer index, Integer limit) {
+        return readDescriptors(RestUtilities.extractDescriptorType(resourceURI), filter, index, limit);
+    }
+
     public List<DocumentDescriptor> readDescriptors(String type, String filter, Integer index, Integer limit) {
         try {
             return documentDescriptorStore.readDescriptors(type, filter, index, limit, false);

--- a/src/main/java/ai/labs/eddi/configs/rest/StrictConfigurationBodyInterceptor.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/StrictConfigurationBodyInterceptor.java
@@ -4,24 +4,16 @@
  */
 package ai.labs.eddi.configs.rest;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-
 import jakarta.inject.Inject;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 /**
  * Rejects a configuration document that carries a field the model does not
@@ -67,9 +59,17 @@ import java.util.stream.Collectors;
  * </p>
  *
  * <p>
- * Only {@link UnrecognizedPropertyException} is translated. Every other parse
- * failure is left to the regular message-body reader, so no existing error
- * response changes shape.
+ * Only an unrecognised property is translated. Every other parse failure is
+ * left to the regular message-body reader, so no existing error response
+ * changes shape.
+ * </p>
+ *
+ * <p>
+ * The check itself lives in {@link StrictConfigurationParser}, because it
+ * belongs to <em>writing a configuration</em> rather than to reading an HTTP
+ * body: a {@code ReaderInterceptor} never fires for MCP's {@code
+ * create_resource}, which calls the same stores in-process, so that surface has
+ * to invoke the parser directly to get the same answer.
  * </p>
  */
 @Provider
@@ -86,13 +86,11 @@ public class StrictConfigurationBodyInterceptor implements ReaderInterceptor {
 
     private static final String JSON_SUBTYPE = "json";
 
-    private final ObjectMapper strictMapper;
+    private final StrictConfigurationParser parser;
 
     @Inject
-    public StrictConfigurationBodyInterceptor(ObjectMapper restMapper) {
-        // copy() so the injected mapper — shared with the REST client and with every
-        // service that parses third-party JSON — keeps its lenient behaviour.
-        this.strictMapper = restMapper.copy().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    public StrictConfigurationBodyInterceptor(StrictConfigurationParser parser) {
+        this.parser = parser;
     }
 
     @Override
@@ -114,42 +112,9 @@ public class StrictConfigurationBodyInterceptor implements ReaderInterceptor {
         }
 
         context.setInputStream(new ByteArrayInputStream(body));
-        rejectUnknownFields(context.getType(), body);
+        parser.rejectUnknownFields(body, context.getType());
 
         return context.proceed();
-    }
-
-    private void rejectUnknownFields(Class<?> type, byte[] body) {
-        try {
-            strictMapper.readValue(body, type);
-        } catch (UnrecognizedPropertyException e) {
-            throw badRequest(describe(e, type));
-        } catch (IOException e) {
-            // Malformed JSON, wrong value type, etc. — not this interceptor's business.
-            // Proceeding lets the regular reader produce the response it always has.
-        }
-    }
-
-    private static BadRequestException badRequest(String message) {
-        return new BadRequestException(Response.status(Response.Status.BAD_REQUEST).entity(message).type(MediaType.TEXT_PLAIN_TYPE).build());
-    }
-
-    private static String describe(UnrecognizedPropertyException e, Class<?> type) {
-        var message = new StringBuilder("Unknown field '").append(e.getPropertyName()).append("' in ").append(type.getSimpleName());
-
-        String path = e.getPathReference();
-        if (path != null && !path.isBlank()) {
-            message.append(" at ").append(path);
-        }
-
-        Collection<Object> known = e.getKnownPropertyIds();
-        if (known != null && !known.isEmpty()) {
-            message.append(". Known fields: ")
-                    .append(known.stream().map(String::valueOf).sorted().collect(Collectors.joining(", ", "[", "]")));
-        }
-
-        return message.append(". The field was rejected instead of being silently discarded — "
-                + "a dropped key looks like a successful save but changes nothing.").toString();
     }
 
     static boolean isConfigurationModel(Class<?> type) {

--- a/src/main/java/ai/labs/eddi/configs/rest/StrictConfigurationParser.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/StrictConfigurationParser.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.rest;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * Parses a first-party configuration document, rejecting any field the model
+ * does not declare.
+ * <p>
+ * EDDI is a config-driven engine: a typo'd key in {@code behavior.json} or
+ * {@code langchain.json} is a behavioural bug, and silently discarding it is
+ * the worst possible failure mode — the author is told the save succeeded, a
+ * subsequent read no longer shows the key, and the agent misbehaves with no
+ * signal anywhere.
+ * <p>
+ * This lives apart from {@link StrictConfigurationBodyInterceptor} because the
+ * check belongs to <em>writing a configuration</em>, not to reading an HTTP
+ * body. A {@code ReaderInterceptor} only fires on a real inbound request, so
+ * MCP's {@code create_resource} — which calls the same REST store in-process
+ * with its own lenient parse — bypassed it entirely. The same payload therefore
+ * had opposite outcomes on the two surfaces: REST answered
+ * {@code 400 Unknown field 'setProperties' … Known fields: [setOnActions]},
+ * while MCP answered {@code 201 created} and stored {@code {"setOnActions":[]}}
+ * — an empty configuration that then read back happily and did nothing. That
+ * path is reachable by every MCP client, including the Platform Operator agent,
+ * which creates resources this way.
+ *
+ * @see StrictConfigurationBodyInterceptor
+ */
+@ApplicationScoped
+public class StrictConfigurationParser {
+
+    private final ObjectMapper strictMapper;
+
+    @Inject
+    public StrictConfigurationParser(ObjectMapper restMapper) {
+        // copy() so the injected mapper — shared with the REST client and with every
+        // service that parses third-party JSON — keeps its lenient behaviour. Flipping
+        // FAIL_ON_UNKNOWN_PROPERTIES on a shared mapper would also make MongoDB reads
+        // and ZIP imports strict, which must stay schema-evolution-tolerant.
+        this.strictMapper = restMapper.copy().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    /**
+     * Deserialises a configuration document strictly.
+     *
+     * @param json
+     *            the configuration body
+     * @param type
+     *            the configuration model to read it into
+     * @return the parsed configuration
+     * @throws BadRequestException
+     *             if the body names a field the model does not declare; the message
+     *             names the field and lists the legal ones
+     * @throws IOException
+     *             for every other parse failure, so callers keep whatever error
+     *             they already produced for malformed JSON
+     */
+    public <T> T parse(String json, Class<T> type) throws IOException {
+        try {
+            return strictMapper.readValue(json, type);
+        } catch (UnrecognizedPropertyException e) {
+            throw badRequest(describe(e, type));
+        }
+    }
+
+    /**
+     * Checks a body for unknown fields without taking its parse result. Used where
+     * the caller already has a deserialised object and only wants the rejection.
+     *
+     * @throws BadRequestException
+     *             if the body names an undeclared field
+     */
+    public void rejectUnknownFields(byte[] body, Class<?> type) {
+        try {
+            strictMapper.readValue(body, type);
+        } catch (UnrecognizedPropertyException e) {
+            throw badRequest(describe(e, type));
+        } catch (IOException e) {
+            // Malformed JSON, wrong value type, etc. — not this class's business.
+            // Proceeding lets the regular reader produce the response it always has.
+        }
+    }
+
+    private static BadRequestException badRequest(String message) {
+        return new BadRequestException(Response.status(Response.Status.BAD_REQUEST)
+                .entity(message).type(MediaType.TEXT_PLAIN_TYPE).build());
+    }
+
+    private static String describe(UnrecognizedPropertyException e, Class<?> type) {
+        var message = new StringBuilder("Unknown field '").append(e.getPropertyName()).append("' in ").append(type.getSimpleName());
+
+        String path = e.getPathReference();
+        if (path != null && !path.isBlank()) {
+            message.append(" at ").append(path);
+        }
+
+        Collection<Object> known = e.getKnownPropertyIds();
+        if (known != null && !known.isEmpty()) {
+            message.append(". Known fields: ")
+                    .append(known.stream().map(String::valueOf).sorted().collect(Collectors.joining(", ", "[", "]")));
+        }
+
+        return message.append(". The field was rejected instead of being silently discarded — "
+                + "a dropped key looks like a successful save but changes nothing.").toString();
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/rules/rest/RestRuleSetStore.java
+++ b/src/main/java/ai/labs/eddi/configs/rules/rest/RestRuleSetStore.java
@@ -47,7 +47,7 @@ public class RestRuleSetStore implements IRestRuleSetStore {
 
     @Override
     public List<DocumentDescriptor> readBehaviorDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.behavior", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/snippets/rest/RestPromptSnippetStore.java
+++ b/src/main/java/ai/labs/eddi/configs/snippets/rest/RestPromptSnippetStore.java
@@ -43,7 +43,7 @@ public class RestPromptSnippetStore implements IRestPromptSnippetStore {
 
     @Override
     public List<DocumentDescriptor> readSnippetDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.snippet", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
@@ -65,7 +65,7 @@ public class RestWorkflowStore implements IRestWorkflowStore {
 
     @Override
     public List<DocumentDescriptor> readWorkflowDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors("ai.labs.workflow", filter, index, limit);
+        return restVersionInfo.readDescriptors(filter, index, limit);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresAuditStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresAuditStore.java
@@ -49,6 +49,7 @@ public class PostgresAuditStore implements IAuditStore {
                 duration_ms BIGINT NOT NULL,
                 cost DOUBLE PRECISION NOT NULL DEFAULT 0,
                 hmac TEXT,
+                agent_signature TEXT,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 sequence BIGINT NOT NULL DEFAULT -1,
                 data JSONB NOT NULL
@@ -65,6 +66,19 @@ public class PostgresAuditStore implements IAuditStore {
      */
     private static final String ADD_SEQUENCE_COLUMN = "ALTER TABLE audit_ledger ADD COLUMN IF NOT EXISTS sequence BIGINT NOT NULL DEFAULT -1";
 
+    /**
+     * Adds {@code agent_signature} to ledgers created before it existed.
+     * <p>
+     * {@code eddi.audit.agent-signing-enabled} defaults to true and the Ed25519
+     * signature was duly computed for every entry — but this backend had no column
+     * to put it in and its row-mapper hard-coded {@code null}, so the signature was
+     * discarded on write and read back absent. The second, non-repudiation half of
+     * the ledger's integrity story was silently inert on PostgreSQL while MongoDB
+     * deployments had it. Nullable, because rows written before this column existed
+     * genuinely have no signature to record.
+     */
+    private static final String ADD_AGENT_SIGNATURE_COLUMN = "ALTER TABLE audit_ledger ADD COLUMN IF NOT EXISTS agent_signature TEXT";
+
     private static final String CREATE_INDEX_CONV = "CREATE INDEX IF NOT EXISTS idx_audit_conv ON audit_ledger (conversation_id)";
     /** Chain verification reads a conversation's entries in sequence order. */
     private static final String CREATE_INDEX_CONV_SEQ = "CREATE INDEX IF NOT EXISTS idx_audit_conv_seq ON audit_ledger (conversation_id, sequence)";
@@ -75,14 +89,15 @@ public class PostgresAuditStore implements IAuditStore {
     private static final String INSERT_SQL = """
             INSERT INTO audit_ledger
                 (id, conversation_id, AGENT_ID, AGENT_VERSION, user_id, environment,
-                 step_index, task_id, task_type, task_index, duration_ms, cost, hmac, created_at, data, sequence)
-            VALUES (?::uuid, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?)
+                 step_index, task_id, task_type, task_index, duration_ms, cost, hmac, created_at, data, sequence,
+                 agent_signature)
+            VALUES (?::uuid, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?)
             """;
 
     private static final String SELECT_ALL = """
             id, conversation_id, AGENT_ID, AGENT_VERSION, user_id, environment,
             step_index, task_id, task_type, task_index, duration_ms, cost, hmac, created_at, data,
-            sequence
+            sequence, agent_signature
             """;
 
     private final Instance<DataSource> dataSourceInstance;
@@ -100,7 +115,8 @@ public class PostgresAuditStore implements IAuditStore {
             return;
         try (Connection conn = dataSourceInstance.get().getConnection(); Statement stmt = conn.createStatement()) {
             stmt.execute(CREATE_TABLE);
-            stmt.execute(ADD_SEQUENCE_COLUMN); // idempotent upgrade for pre-existing ledgers
+            stmt.execute(ADD_SEQUENCE_COLUMN); // idempotent upgrades for pre-existing ledgers
+            stmt.execute(ADD_AGENT_SIGNATURE_COLUMN);
             stmt.execute(CREATE_INDEX_CONV);
             stmt.execute(CREATE_INDEX_CONV_SEQ);
             stmt.execute(CREATE_INDEX_AGENT);
@@ -221,6 +237,7 @@ public class PostgresAuditStore implements IAuditStore {
         ps.setTimestamp(14, entry.timestamp() != null ? Timestamp.from(entry.timestamp()) : Timestamp.from(Instant.now()));
         ps.setString(15, jsonSerialization.serialize(data));
         ps.setLong(16, entry.sequence());
+        ps.setString(17, entry.agentSignature());
     }
 
     private List<AuditEntry> queryEntries(String sql, String param, int limit, int skip) {
@@ -254,7 +271,7 @@ public class PostgresAuditStore implements IAuditStore {
                 rs.getInt("task_index"), rs.getLong("duration_ms"), (Map<String, Object>) data.get("input"), (Map<String, Object>) data.get("output"),
                 (Map<String, Object>) data.get("llmDetail"), (Map<String, Object>) data.get("toolCalls"),
                 data.get("actions") instanceof List<?> list ? (List<String>) list : null, rs.getDouble("cost"), ts != null ? ts.toInstant() : null,
-                rs.getString("hmac"), null, rs.getLong("sequence"));
+                rs.getString("hmac"), rs.getString("agent_signature"), rs.getLong("sequence"));
     }
     /**
      * PostgreSQL persists the per-conversation sequence, so the chain continuity

--- a/src/main/java/ai/labs/eddi/engine/a2a/AgentCardService.java
+++ b/src/main/java/ai/labs/eddi/engine/a2a/AgentCardService.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.engine.a2a;
 
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.engine.a2a.A2AModels.AgentAuthentication;
 import ai.labs.eddi.engine.a2a.A2AModels.AgentCapabilities;
@@ -34,16 +35,18 @@ public class AgentCardService {
     private static final Logger LOGGER = Logger.getLogger(AgentCardService.class);
 
     private final IRestAgentStore restAgentStore;
+    private final IDocumentDescriptorStore documentDescriptorStore;
     private final String baseUrl;
     private final boolean authEnabled;
     private final String oidcAuthServerUrl;
 
     @Inject
-    public AgentCardService(IRestAgentStore restAgentStore,
+    public AgentCardService(IRestAgentStore restAgentStore, IDocumentDescriptorStore documentDescriptorStore,
             @ConfigProperty(name = "eddi.a2a.base-url", defaultValue = "http://localhost:7070") String baseUrl,
             @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authEnabled,
             @ConfigProperty(name = "quarkus.oidc.auth-server-url") Optional<String> oidcAuthServerUrl) {
         this.restAgentStore = restAgentStore;
+        this.documentDescriptorStore = documentDescriptorStore;
         this.baseUrl = baseUrl;
         this.authEnabled = authEnabled;
         this.oidcAuthServerUrl = oidcAuthServerUrl.orElse(null);
@@ -119,8 +122,30 @@ public class AgentCardService {
     /**
      * Build an AgentCard from an agent configuration.
      */
+    /**
+     * The agent's human name, as its descriptor records it.
+     * <p>
+     * A2A Agent Cards are how other systems discover what an agent <em>is</em>, and
+     * every card announced "EDDI Agent 6a1f…" — the raw id, for every agent. The
+     * name an operator gave the agent lives on its {@link DocumentDescriptor}, not
+     * on {@link AgentConfiguration}, which is why it was never reached for. Falls
+     * back to the old form when the descriptor is missing or unnamed, so a card is
+     * still served rather than dropped.
+     */
+    private String agentDisplayName(String agentId, Integer version) {
+        try {
+            DocumentDescriptor descriptor = documentDescriptorStore.readDescriptor(agentId, version);
+            if (descriptor != null && !isNullOrEmpty(descriptor.getName())) {
+                return descriptor.getName();
+            }
+        } catch (Exception e) {
+            LOGGER.debugf("No descriptor name for A2A agent %s: %s", agentId, e.getMessage());
+        }
+        return "EDDI Agent " + agentId;
+    }
+
     AgentCard buildAgentCard(String agentId, AgentConfiguration config, Integer version) {
-        String name = "EDDI Agent " + agentId;
+        String name = agentDisplayName(agentId, version);
 
         String description = !isNullOrEmpty(config.getDescription()) ? config.getDescription() : "EDDI conversational AI agent";
 

--- a/src/main/java/ai/labs/eddi/engine/a2a/AgentCardService.java
+++ b/src/main/java/ai/labs/eddi/engine/a2a/AgentCardService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
  * Generates A2A Agent Cards from deployed EDDI agent configurations.
@@ -139,7 +140,7 @@ public class AgentCardService {
                 return descriptor.getName();
             }
         } catch (Exception e) {
-            LOGGER.debugf("No descriptor name for A2A agent %s: %s", agentId, e.getMessage());
+            LOGGER.debugf("No descriptor name for A2A agent %s: %s", sanitize(agentId), e.getMessage());
         }
         return "EDDI Agent " + agentId;
     }

--- a/src/main/java/ai/labs/eddi/engine/api/IRestAgentEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IRestAgentEngine.java
@@ -121,9 +121,14 @@ public interface IRestAgentEngine {
     @POST
     @Path("/{conversationId}/rerun")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Rerun last conversation step", description = "Re-executes the last conversation step, useful for retrying after errors.")
+    @Operation(summary = "Rerun last conversation step", description = "Re-executes the last conversation step, "
+            + "useful for retrying after errors. The step's rendered answer and quick replies are discarded and "
+            + "regenerated: on an LLM agent the model is called again, while the tasks that ran before it — parser, "
+            + "behavior rules, property setters, HTTP calls — keep their results, so external side effects are not "
+            + "repeated.")
     void rerunLastConversationStep(@PathParam("conversationId") String conversationId,
-                                   @Parameter(description = "Language code for NLP processing.")
+                                   @Parameter(description = "Optional language code for NLP processing. "
+                                           + "Omitted, the turn carries no language context, as with a normal message.")
                                    @QueryParam("language") String language,
                                    @QueryParam("returnDetailed")
                                    @DefaultValue("false") Boolean returnDetailed,

--- a/src/main/java/ai/labs/eddi/engine/api/IRestGroupConversation.java
+++ b/src/main/java/ai/labs/eddi/engine/api/IRestGroupConversation.java
@@ -119,7 +119,9 @@ public interface IRestGroupConversation {
 
     @DELETE
     @Path("/{groupId}/conversations/{groupConversationId}")
-    @Operation(summary = "Delete a group conversation", description = "Deletes a group conversation and its member conversations.")
+    @Operation(summary = "Delete a group conversation", description = "Deletes the group conversation, its shared "
+            + "artifacts and any ephemeral agents created for it. The members' own conversations are ENDED, not "
+            + "deleted, and stay readable afterwards.")
     @APIResponse(responseCode = "200", description = "Group conversation deleted.")
     @APIResponse(responseCode = "404", description = "Group conversation not found.")
     @APIResponse(responseCode = "409", description = "Another operation (follow-up / continue / close) is in progress — retry.")

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
@@ -181,14 +181,44 @@ public final class AuditHmac {
 
     /**
      * Compute HMAC-SHA256 over all audit entry fields (excluding the hmac field
-     * itself), using the v3 canonical form.
+     * itself), using the v4 canonical form.
+     * <p>
+     * Pass the entry through {@link #withStorablePrecision} first: v4 signs the
+     * timestamp at millisecond precision, and the entry that is stored has to carry
+     * the same value, or the database's own rounding can move it.
      *
      * @param entry
      *            the audit entry (hmac field is ignored)
      * @param hmacKey
      *            the 32-byte HMAC key
-     * @return version-tagged, hex-encoded HMAC string ({@code v3:<64 hex chars>})
+     * @return version-tagged, hex-encoded HMAC string ({@code v4:<64 hex chars>})
      */
+    /**
+     * The entry as it should be <em>stored</em>: its timestamp floored to the
+     * precision {@link #SIGNED_TIMESTAMP_PRECISION} signs.
+     * <p>
+     * Signing a millisecond value is not enough on its own. PostgreSQL's
+     * {@code timestamp(6)} <em>rounds</em> to the nearest microsecond rather than
+     * truncating, so an instant whose nanoseconds fall in the last half-microsecond
+     * of a millisecond rounds its microsecond count up across the millisecond
+     * boundary and reads back one millisecond later than it was signed — about one
+     * row in two thousand, reported as tampered for no reason. Storing what was
+     * signed leaves the database nothing to round, and makes the two backends agree
+     * on the ledger's timestamp resolution instead of differing by a factor of a
+     * thousand.
+     *
+     * @param entry
+     *            the entry about to be signed and stored
+     * @return the same entry with a storage-safe timestamp, or unchanged when it
+     *         carries none
+     */
+    public static AuditEntry withStorablePrecision(AuditEntry entry) {
+        if (entry == null || entry.timestamp() == null) {
+            return entry;
+        }
+        return entry.withTimestamp(entry.timestamp().truncatedTo(SIGNED_TIMESTAMP_PRECISION));
+    }
+
     public static String computeHmac(AuditEntry entry, byte[] hmacKey) {
         return V4_PREFIX + hmacSha256(buildCanonicalStringV4(entry), hmacKey);
     }

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
@@ -55,10 +55,11 @@ public final class AuditHmac {
     static final String V2_PREFIX = "v2:";
 
     /**
-     * Marker for the <strong>v3</strong> canonical form — the one
-     * {@link #computeHmac} writes today. v3 differs from v2 in exactly two places:
-     * the user identifier is signed through {@link #identityToken} rather than
-     * verbatim, and the per-conversation {@code sequence} joins the signed payload.
+     * Marker for the <strong>v3</strong> canonical form. No longer produced — see
+     * {@link #V4_PREFIX} — but still selected by {@link #verify} for rows written
+     * while v3 was current. v3 differs from v2 in exactly two places: the user
+     * identifier is signed through {@link #identityToken} rather than verbatim, and
+     * the per-conversation {@code sequence} joins the signed payload.
      *
      * @see #buildCanonicalStringV3
      */
@@ -600,7 +601,7 @@ public final class AuditHmac {
      * existed carries a bare hex HMAC over exactly these bytes, and
      * {@link #verifyHmac} still recomputes it for those rows. Changing this method
      * by a single byte makes every historical ledger row read as tampered. New
-     * entries are signed with {@link #buildCanonicalStringV2}.
+     * entries are signed with {@link #buildCanonicalStringV4}.
      */
     static String buildCanonicalString(AuditEntry entry) {
         StringBuilder sb = new StringBuilder(512);

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
@@ -12,6 +12,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -61,6 +63,38 @@ public final class AuditHmac {
      * @see #buildCanonicalStringV3
      */
     static final String V3_PREFIX = "v3:";
+
+    /**
+     * Marker for the <strong>v4</strong> canonical form — the one
+     * {@link #computeHmac} writes today. v4 differs from v3 in exactly one place:
+     * the timestamp is signed as {@code epoch-millis}, not as the raw
+     * {@link Instant}.
+     * <p>
+     * That single field made tamper-evidence non-functional on both supported
+     * backends. v3 signed {@code Instant.toString()} at whatever precision the JVM
+     * clock produced — nanoseconds on a Linux container — but no backend stores
+     * that: PostgreSQL's {@code TIMESTAMPTZ} keeps microseconds and MongoDB's
+     * {@code Date} keeps milliseconds. The entry read back therefore never carried
+     * the value that was signed, so the recomputed digest never matched. A live
+     * ledger reported {@code valid=0 invalid=78} on entries written seconds
+     * earlier: an operator running verify could not tell a forged row from a
+     * healthy one, because the control emitted no signal at all.
+     * <p>
+     * Milliseconds is the coarsest floor of the two backends, so a v4 signature
+     * round-trips through either without loss. Signing the epoch value rather than
+     * the text also removes {@code Instant.toString()}'s trailing-zero variance
+     * ({@code …:00Z} vs {@code …:00.000Z}) from the digest.
+     *
+     * @see #buildCanonicalStringV4
+     */
+    static final String V4_PREFIX = "v4:";
+
+    /**
+     * The storage floor every supported backend can represent: PostgreSQL keeps
+     * microseconds, MongoDB milliseconds, so a signed timestamp must be truncated
+     * to the coarser of the two before it is signed.
+     */
+    static final ChronoUnit SIGNED_TIMESTAMP_PRECISION = ChronoUnit.MILLIS;
 
     /**
      * Prefix of a GDPR-pseudonymised user identifier. Shared with the erasure
@@ -156,7 +190,7 @@ public final class AuditHmac {
      * @return version-tagged, hex-encoded HMAC string ({@code v3:<64 hex chars>})
      */
     public static String computeHmac(AuditEntry entry, byte[] hmacKey) {
-        return V3_PREFIX + hmacSha256(buildCanonicalStringV3(entry), hmacKey);
+        return V4_PREFIX + hmacSha256(buildCanonicalStringV4(entry), hmacKey);
     }
 
     /**
@@ -188,15 +222,80 @@ public final class AuditHmac {
      * @return true if the HMAC is valid, false if tampered
      */
     public static boolean verifyHmac(AuditEntry entry, byte[] hmacKey) {
+        return verify(entry, hmacKey, false) != VerificationOutcome.MISMATCH;
+    }
+
+    /**
+     * The outcome of re-checking one entry, distinguishing a plain match from one
+     * that needed the v3 timestamp-completion search.
+     */
+    public enum VerificationOutcome {
+        /** The stored digest matched a straight recomputation. */
+        MATCH,
+
+        /**
+         * A v3 row that matched only once the timestamp digits its backend could not
+         * store were reconstructed. Proof of integrity, not a weaker result — see
+         * {@link #verify}.
+         */
+        MATCH_RECOVERED,
+
+        /** No recomputation matched. The entry was altered, or signed elsewhere. */
+        MISMATCH
+    }
+
+    /**
+     * Verify an entry, optionally recovering the timestamp precision v3 rows lost
+     * on the way into storage.
+     * <p>
+     * v3 signed the timestamp at the JVM clock's precision while the backends store
+     * less of it, so a v3 row's stored fields are not the fields that were signed
+     * and it can never verify as written. The <em>signature itself</em> still
+     * carries the missing digits, though: appending each candidate sub-precision
+     * completion to the stored timestamp and recomputing costs one HMAC per
+     * candidate, and a match identifies the original value. There are at most 999
+     * of them for a microsecond-floored row (PostgreSQL) and, for a
+     * millisecond-floored one (MongoDB) written by a microsecond-resolution clock,
+     * at most 999 more — a couple of milliseconds of work per row.
+     * <p>
+     * This is not a weakening. Producing a completion that matches without holding
+     * the key is exactly as hard as forging the digest outright; the search only
+     * re-derives a value the writer knew and storage discarded. It is also why
+     * legacy rows must never be re-signed in place: resealing without verifying
+     * would launder any tampering that already happened, whereas recovering proves
+     * the row is the one that was written.
+     * <p>
+     * About one v3 row in a thousand verifies with no search at all — its clock
+     * happened to land on a whole unit. That is expected, not a special case.
+     *
+     * @param entry
+     *            the audit entry with its hmac field populated
+     * @param hmacKey
+     *            the 32-byte HMAC key
+     * @param recoverLegacyTimestamps
+     *            run the completion search for v3 rows that do not match as stored
+     * @return whether, and how, the entry verified
+     */
+    public static VerificationOutcome verify(AuditEntry entry, byte[] hmacKey, boolean recoverLegacyTimestamps) {
         String stored = entry.hmac();
         if (stored == null)
-            return false;
+            return VerificationOutcome.MISMATCH;
 
         String expectedDigest;
         String storedDigest;
-        if (stored.startsWith(V3_PREFIX)) {
-            expectedDigest = hmacSha256(buildCanonicalStringV3(entry), hmacKey);
-            storedDigest = stored.substring(V3_PREFIX.length());
+        if (stored.startsWith(V4_PREFIX)) {
+            expectedDigest = hmacSha256(buildCanonicalStringV4(entry), hmacKey);
+            storedDigest = stored.substring(V4_PREFIX.length());
+        } else if (stored.startsWith(V3_PREFIX)) {
+            byte[] storedV3 = decodeHexOrNull(stored.substring(V3_PREFIX.length()));
+            if (storedV3 == null)
+                return VerificationOutcome.MISMATCH;
+            if (MessageDigest.isEqual(decodeHexOrNull(hmacSha256(buildCanonicalStringV3(entry), hmacKey)), storedV3)) {
+                return VerificationOutcome.MATCH;
+            }
+            return recoverLegacyTimestamps && recoverV3Timestamp(entry, hmacKey, storedV3)
+                    ? VerificationOutcome.MATCH_RECOVERED
+                    : VerificationOutcome.MISMATCH;
         } else if (stored.startsWith(V2_PREFIX)) {
             expectedDigest = hmacSha256(buildCanonicalStringV2(entry), hmacKey);
             storedDigest = stored.substring(V2_PREFIX.length());
@@ -208,9 +307,50 @@ public final class AuditHmac {
 
         byte[] storedBytes = decodeHexOrNull(storedDigest);
         if (storedBytes == null)
-            return false;
+            return VerificationOutcome.MISMATCH;
 
-        return MessageDigest.isEqual(decodeHexOrNull(expectedDigest), storedBytes);
+        return MessageDigest.isEqual(decodeHexOrNull(expectedDigest), storedBytes)
+                ? VerificationOutcome.MATCH
+                : VerificationOutcome.MISMATCH;
+    }
+
+    /**
+     * Candidate sub-precision completions for a v3 timestamp, in the order they are
+     * tried: first the nanoseconds a microsecond-floored row (PostgreSQL) dropped,
+     * then the microseconds a millisecond-floored row (MongoDB) dropped from a
+     * clock that ticked in microseconds.
+     * <p>
+     * A millisecond-floored row written by a nanosecond-resolution clock would need
+     * the full million and is deliberately not searched: that costs about a second
+     * per row on a bulk sweep, and such a row simply reports as it did before.
+     * Recovery is a courtesy to existing ledgers, not a load-bearing path — every
+     * row written from now on is v4 and verifies directly.
+     */
+    private static final int[] RECOVERY_NANO_STEPS = {1, 1_000};
+
+    /** Completions tried per step: a whole unit would be the next unit up. */
+    private static final int RECOVERY_CANDIDATES_PER_STEP = 999;
+
+    /**
+     * Searches for the sub-precision timestamp digits a v3 row lost in storage.
+     *
+     * @return true when the digits that reproduce the stored digest were found
+     */
+    private static boolean recoverV3Timestamp(AuditEntry entry, byte[] hmacKey, byte[] storedDigest) {
+        Instant storedTimestamp = entry.timestamp();
+        if (storedTimestamp == null) {
+            // Nothing was truncated, so there is nothing to complete.
+            return false;
+        }
+        for (int step : RECOVERY_NANO_STEPS) {
+            for (int k = 1; k <= RECOVERY_CANDIDATES_PER_STEP; k++) {
+                AuditEntry candidate = entry.withTimestamp(storedTimestamp.plusNanos((long) k * step));
+                if (MessageDigest.isEqual(decodeHexOrNull(hmacSha256(buildCanonicalStringV3(candidate), hmacKey)), storedDigest)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -244,6 +384,51 @@ public final class AuditHmac {
      * <strong>Frozen once written.</strong> Same rule as v1/v2: changing a byte
      * here makes every v3 row read as tampered. Add a v4 instead.
      */
+    /**
+     * Build the <strong>v4</strong> canonical string — the form new entries are
+     * signed with.
+     * <p>
+     * Byte-for-byte v3 apart from the version tag and {@code ts}, which is the
+     * millisecond epoch value of the timestamp rather than its
+     * {@link Instant#toString()}. See {@link #V4_PREFIX} for why that one field
+     * broke verification everywhere.
+     * <p>
+     * <strong>Frozen once written.</strong> Same rule as v1/v2/v3: changing a byte
+     * here makes every v4 row read as tampered. Add a v5 instead.
+     */
+    static String buildCanonicalStringV4(AuditEntry entry) {
+        StringBuilder sb = new StringBuilder(512);
+        sb.append("v4");
+        sb.append("|id=").append(escape(entry.id()));
+        sb.append("|cid=").append(escape(entry.conversationId()));
+        sb.append("|bid=").append(escape(entry.agentId()));
+        sb.append("|bv=").append(entry.agentVersion());
+        sb.append("|uid=").append(escape(identityToken(entry.userId())));
+        sb.append("|env=").append(escape(entry.environment()));
+        sb.append("|si=").append(entry.stepIndex());
+        sb.append("|tid=").append(escape(entry.taskId()));
+        sb.append("|tt=").append(escape(entry.taskType()));
+        sb.append("|ti=").append(entry.taskIndex());
+        sb.append("|seq=").append(entry.sequence());
+        sb.append("|dur=").append(entry.durationMs());
+        sb.append("|in=").append(canonicalValueV2(entry.input()));
+        sb.append("|out=").append(canonicalValueV2(entry.output()));
+        sb.append("|llm=").append(canonicalValueV2(entry.llmDetail()));
+        sb.append("|tools=").append(canonicalValueV2(entry.toolCalls()));
+        sb.append("|actions=").append(canonicalValueV2(entry.actions()));
+        sb.append("|cost=").append(entry.cost());
+        sb.append("|ts=").append(signedTimestamp(entry.timestamp()));
+        return sb.toString();
+    }
+
+    /**
+     * The timestamp as v4 signs it: epoch milliseconds, or the empty string when
+     * the entry carries no timestamp at all.
+     */
+    private static String signedTimestamp(Instant timestamp) {
+        return timestamp == null ? "" : Long.toString(timestamp.truncatedTo(SIGNED_TIMESTAMP_PRECISION).toEpochMilli());
+    }
+
     static String buildCanonicalStringV3(AuditEntry entry) {
         StringBuilder sb = new StringBuilder(512);
         sb.append("v3");

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
@@ -282,12 +282,13 @@ public final class AuditHmac {
      * v3 signed the timestamp at the JVM clock's precision while the backends store
      * less of it, so a v3 row's stored fields are not the fields that were signed
      * and it can never verify as written. The <em>signature itself</em> still
-     * carries the missing digits, though: appending each candidate sub-precision
-     * completion to the stored timestamp and recomputing costs one HMAC per
-     * candidate, and a match identifies the original value. There are at most 999
-     * of them for a microsecond-floored row (PostgreSQL) and, for a
-     * millisecond-floored one (MongoDB) written by a microsecond-resolution clock,
-     * at most 999 more — a couple of milliseconds of work per row.
+     * carries the missing digits, though: trying each candidate sub-precision
+     * completion of the stored timestamp and recomputing costs one HMAC per
+     * candidate, and a match identifies the original value. The search covers both
+     * directions (storage floors <em>or</em> rounds to nearest, depending on the
+     * backend) and is capped to the precision the row demonstrably lost — a few
+     * thousand candidates and a few milliseconds of work per row; see
+     * {@link #recoverV3Timestamp}.
      * <p>
      * This is not a weakening. Producing a completion that matches without holding
      * the key is exactly as hard as forging the digest outright; the search only
@@ -367,24 +368,38 @@ public final class AuditHmac {
     }
 
     /**
-     * Candidate sub-precision completions for a v3 timestamp, in the order they are
-     * tried: first the nanoseconds a microsecond-floored row (PostgreSQL) dropped,
-     * then the microseconds a millisecond-floored row (MongoDB) dropped from a
-     * clock that ticked in microseconds.
+     * Completions tried per tier and direction: a whole unit would be the next unit
+     * up.
+     */
+    private static final int RECOVERY_CANDIDATES_PER_STEP = 999;
+
+    /**
+     * Searches for the sub-precision timestamp digits a v3 row lost in storage.
+     * <p>
+     * <b>The search runs in both directions</b>, because storage does not only
+     * floor. Java's {@code truncatedTo}/{@code toEpochMilli} floor, but
+     * PostgreSQL's {@code timestamp(6)} — and the JDBC driver's nanos-to-micros
+     * conversion — round to <em>nearest</em>, so a value whose lost digits were in
+     * the upper half is stored <em>above</em> the signed one. A forward-only search
+     * missed every such row: roughly half of all PostgreSQL legacy rows.
+     * <p>
+     * <b>The search is capped to exactly the precision the row lost</b>, read off
+     * the stored value itself. A row with sub-millisecond digits present came
+     * through a microsecond-precision store, so only sub-microsecond digits are
+     * unknowable and only ±999ns is searched. A millisecond-aligned row may be a
+     * millisecond-floored (MongoDB) one, so the ±999µs tier applies as well. The
+     * cap matters because the searched window is, unavoidably, also the window
+     * within which a <em>moved</em> stored timestamp is indistinguishable from a
+     * truncated one: recovery proves the signed instant exactly, and proves the
+     * stored value lies within the destroyed precision of it — never more. Widening
+     * the window beyond what storage destroyed would turn a recovery aid into
+     * timestamp tamper-tolerance, so it is derived, not configured.
      * <p>
      * A millisecond-floored row written by a nanosecond-resolution clock would need
      * the full million and is deliberately not searched: that costs about a second
      * per row on a bulk sweep, and such a row simply reports as it did before.
      * Recovery is a courtesy to existing ledgers, not a load-bearing path — every
      * row written from now on is v4 and verifies directly.
-     */
-    private static final int[] RECOVERY_NANO_STEPS = {1, 1_000};
-
-    /** Completions tried per step: a whole unit would be the next unit up. */
-    private static final int RECOVERY_CANDIDATES_PER_STEP = 999;
-
-    /**
-     * Searches for the sub-precision timestamp digits a v3 row lost in storage.
      *
      * @return true when the digits that reproduce the stored digest were found
      */
@@ -394,15 +409,30 @@ public final class AuditHmac {
             // Nothing was truncated, so there is nothing to complete.
             return false;
         }
-        for (int step : RECOVERY_NANO_STEPS) {
+        // Sub-millisecond digits present ⇒ a µs-precision store wrote this row and
+        // only the nanosecond tier was lost. Only a ms-aligned row can be ms-floored.
+        boolean millisecondAligned = storedTimestamp.getNano() % 1_000_000 == 0;
+        int[] nanoSteps = millisecondAligned ? new int[]{1, 1_000} : new int[]{1};
+
+        for (int step : nanoSteps) {
             for (int k = 1; k <= RECOVERY_CANDIDATES_PER_STEP; k++) {
-                AuditEntry candidate = entry.withTimestamp(storedTimestamp.plusNanos((long) k * step));
-                if (MessageDigest.isEqual(decodeHexOrNull(hmacSha256(buildCanonicalStringV3(candidate), hmacKey)), storedDigest)) {
+                long offsetNanos = (long) k * step;
+                if (signedAt(entry, storedTimestamp.plusNanos(offsetNanos), hmacKey, storedDigest)
+                        || signedAt(entry, storedTimestamp.minusNanos(offsetNanos), hmacKey, storedDigest)) {
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    /**
+     * True when the v3 digest over the entry at {@code candidate} matches the
+     * stored one.
+     */
+    private static boolean signedAt(AuditEntry entry, Instant candidate, byte[] hmacKey, byte[] storedDigest) {
+        String recomputed = hmacSha256(buildCanonicalStringV3(entry.withTimestamp(candidate)), hmacKey);
+        return MessageDigest.isEqual(decodeHexOrNull(recomputed), storedDigest);
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
@@ -252,6 +252,36 @@ public final class AuditHmac {
      *            the 32-byte HMAC key
      * @return true if the HMAC is valid, false if tampered
      */
+    /**
+     * The canonical-form version a stored HMAC names: {@code "v4"}, {@code "v3"},
+     * {@code "v2"}, {@code "v1"} for a bare pre-tag digest, or {@code null} for an
+     * unsigned value.
+     * <p>
+     * Exists for triage, not verification. A verify sweep reports both a freshly
+     * tampered v4 row and an unrecoverable legacy row as INVALID, and those demand
+     * opposite reactions: a v4 failure means something touched a row this release
+     * wrote and is an alarm, while a pre-v4 failure is usually a row whose payload
+     * held live Java objects when it was signed — a form nothing can reconstruct,
+     * so no recovery search will ever clear it. Without the version on the problem
+     * entry, an operator sweeping an old ledger cannot tell the expected residue
+     * from the emergency.
+     */
+    public static String versionOf(String storedHmac) {
+        if (storedHmac == null || storedHmac.isBlank()) {
+            return null;
+        }
+        if (storedHmac.startsWith(V4_PREFIX)) {
+            return "v4";
+        }
+        if (storedHmac.startsWith(V3_PREFIX)) {
+            return "v3";
+        }
+        if (storedHmac.startsWith(V2_PREFIX)) {
+            return "v2";
+        }
+        return "v1";
+    }
+
     public static boolean verifyHmac(AuditEntry entry, byte[] hmacKey) {
         return verify(entry, hmacKey, false) != VerificationOutcome.MISMATCH;
     }

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
@@ -180,20 +180,6 @@ public final class AuditHmac {
     }
 
     /**
-     * Compute HMAC-SHA256 over all audit entry fields (excluding the hmac field
-     * itself), using the v4 canonical form.
-     * <p>
-     * Pass the entry through {@link #withStorablePrecision} first: v4 signs the
-     * timestamp at millisecond precision, and the entry that is stored has to carry
-     * the same value, or the database's own rounding can move it.
-     *
-     * @param entry
-     *            the audit entry (hmac field is ignored)
-     * @param hmacKey
-     *            the 32-byte HMAC key
-     * @return version-tagged, hex-encoded HMAC string ({@code v4:<64 hex chars>})
-     */
-    /**
      * The entry as it should be <em>stored</em>: its timestamp floored to the
      * precision {@link #SIGNED_TIMESTAMP_PRECISION} signs.
      * <p>
@@ -219,6 +205,20 @@ public final class AuditHmac {
         return entry.withTimestamp(entry.timestamp().truncatedTo(SIGNED_TIMESTAMP_PRECISION));
     }
 
+    /**
+     * Compute HMAC-SHA256 over all audit entry fields (excluding the hmac field
+     * itself), using the v4 canonical form.
+     * <p>
+     * Pass the entry through {@link #withStorablePrecision} first: v4 signs the
+     * timestamp at millisecond precision, and the entry that is stored has to carry
+     * the same value, or the database's own rounding can move it.
+     *
+     * @param entry
+     *            the audit entry (hmac field is ignored)
+     * @param hmacKey
+     *            the 32-byte HMAC key
+     * @return version-tagged, hex-encoded HMAC string ({@code v4:<64 hex chars>})
+     */
     public static String computeHmac(AuditEntry entry, byte[] hmacKey) {
         return V4_PREFIX + hmacSha256(buildCanonicalStringV4(entry), hmacKey);
     }
@@ -307,6 +307,25 @@ public final class AuditHmac {
      * @return whether, and how, the entry verified
      */
     public static VerificationOutcome verify(AuditEntry entry, byte[] hmacKey, boolean recoverLegacyTimestamps) {
+        return verify(entry, hmacKey, recoverLegacyTimestamps ? new AuditRecoveryBudget(1) : AuditRecoveryBudget.none());
+    }
+
+    /**
+     * Verify an entry, spending recovery searches from a budget the whole sweep
+     * shares.
+     * <p>
+     * The per-row search is bounded; without this the per-<em>sweep</em> work is
+     * not. See {@link AuditRecoveryBudget}.
+     *
+     * @param entry
+     *            the audit entry with its hmac field populated
+     * @param hmacKey
+     *            the 32-byte HMAC key
+     * @param recoveryBudget
+     *            consumed once per legacy row that fails the direct check
+     * @return whether, and how, the entry verified
+     */
+    public static VerificationOutcome verify(AuditEntry entry, byte[] hmacKey, AuditRecoveryBudget recoveryBudget) {
         String stored = entry.hmac();
         if (stored == null)
             return VerificationOutcome.MISMATCH;
@@ -323,7 +342,9 @@ public final class AuditHmac {
             if (MessageDigest.isEqual(decodeHexOrNull(hmacSha256(buildCanonicalStringV3(entry), hmacKey)), storedV3)) {
                 return VerificationOutcome.MATCH;
             }
-            return recoverLegacyTimestamps && recoverV3Timestamp(entry, hmacKey, storedV3)
+            // tryConsume() is called only once the direct check has already failed, so a
+            // healthy legacy ledger spends none of the budget.
+            return recoveryBudget != null && recoveryBudget.tryConsume() && recoverV3Timestamp(entry, hmacKey, storedV3)
                     ? VerificationOutcome.MATCH_RECOVERED
                     : VerificationOutcome.MISMATCH;
         } else if (stored.startsWith(V2_PREFIX)) {
@@ -398,23 +419,6 @@ public final class AuditHmac {
     }
 
     /**
-     * Build the <strong>v3</strong> canonical string — the form new entries are
-     * signed with.
-     * <p>
-     * Same escaping and type-tagging as {@link #buildCanonicalStringV2}, with two
-     * changes:
-     * <ul>
-     * <li>{@code uid} is the {@link #identityToken}, not the raw identifier, so a
-     * GDPR pseudonymisation no longer invalidates the signature it had.</li>
-     * <li>{@code seq} — the entry's position in its conversation — is signed, so an
-     * entry cannot be renumbered and a deletion leaves a gap that verification can
-     * see. A per-entry HMAC on its own only detects in-place edits.</li>
-     * </ul>
-     * <p>
-     * <strong>Frozen once written.</strong> Same rule as v1/v2: changing a byte
-     * here makes every v3 row read as tampered. Add a v4 instead.
-     */
-    /**
      * Build the <strong>v4</strong> canonical string — the form new entries are
      * signed with.
      * <p>
@@ -459,6 +463,25 @@ public final class AuditHmac {
         return timestamp == null ? "" : Long.toString(timestamp.truncatedTo(SIGNED_TIMESTAMP_PRECISION).toEpochMilli());
     }
 
+    /**
+     * Build the <strong>v3</strong> canonical string — the form written before
+     * {@link #buildCanonicalStringV4}, still selected by {@link #verify} for rows
+     * signed while it was current.
+     * <p>
+     * Same escaping and type-tagging as {@link #buildCanonicalStringV2}, with two
+     * changes:
+     * <ul>
+     * <li>{@code uid} is the {@link #identityToken}, not the raw identifier, so a
+     * GDPR pseudonymisation no longer invalidates the signature it had.</li>
+     * <li>{@code seq} — the entry's position in its conversation — is signed, so an
+     * entry cannot be renumbered and a deletion leaves a gap that verification can
+     * see. A per-entry HMAC on its own only detects in-place edits.</li>
+     * </ul>
+     * <p>
+     * <strong>Frozen once written.</strong> Same rule as v1/v2: changing a byte
+     * here makes every v3 row read as tampered — which is why the timestamp defect
+     * became v4 rather than an edit to this method.
+     */
     static String buildCanonicalStringV3(AuditEntry entry) {
         StringBuilder sb = new StringBuilder(512);
         sb.append("v3");

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
@@ -280,6 +280,11 @@ public class AuditLedgerService {
             // impossible to close by renumbering its neighbours.
             scrubbed = scrubbed.withSequence(nextSequence(scrubbed.conversationId()));
 
+            // Floor the timestamp to what the signature covers and the backends can
+            // store, BEFORE signing — so the row that lands in the database is
+            // byte-for-byte the row that was signed and nothing downstream can round it.
+            scrubbed = AuditHmac.withStorablePrecision(scrubbed);
+
             // Compute HMAC if key is available
             AuditEntry signed;
             if (hmacKey != null) {

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
@@ -30,6 +30,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.nio.file.*;
 import java.time.Instant;
 import java.nio.charset.StandardCharsets;
+import com.fasterxml.jackson.core.type.TypeReference;
+import ai.labs.eddi.utils.LogSanitizer;
+import java.util.Map;
 
 /**
  * Async batch writer for the immutable audit ledger.
@@ -113,6 +116,10 @@ public class AuditLedgerService {
     private final String defaultTenantId;
     private final AgentSigningService agentSigningService;
     private final ObjectMapper objectMapper;
+
+    /** Target shape for {@link #normalizePayloadsForStorage}. */
+    private static final TypeReference<Map<String, Object>> MAP_OF_OBJECT = new TypeReference<>() {
+    };
     private final int maxQueueSize;
 
     private byte[] hmacKey;
@@ -291,6 +298,10 @@ public class AuditLedgerService {
             // part of the signed payload, which is what makes a deleted entry's gap
             // impossible to close by renumbering its neighbours.
             scrubbed = scrubbed.withSequence(nextSequence(scrubbed.conversationId()));
+
+            // Payload maps must be reduced to their STORED shape before signing, for
+            // exactly the same reason as the timestamp below: sign what is stored.
+            scrubbed = normalizePayloadsForStorage(scrubbed);
 
             // A null timestamp must be stamped BEFORE signing, not by the store. v4
             // signs the empty string for null, but PostgresAuditStore substitutes
@@ -668,6 +679,62 @@ public class AuditLedgerService {
      */
     public AuditRecoveryBudget newRecoveryBudget() {
         return recoverLegacyTimestamps ? new AuditRecoveryBudget(recoverLegacyMaxRows) : AuditRecoveryBudget.none();
+    }
+
+    /**
+     * Reduces an entry's payload maps to the JSON-native shape the stores persist.
+     * <p>
+     * The pipeline hands this service <em>live Java objects</em>: a turn's
+     * {@code output} is a list of {@code TextOutputItem} POJOs, not of Maps. The
+     * signature was computed over those objects while verification later ran over
+     * whatever JSON gave back — and the two canonicalize completely differently, a
+     * POJO as {@code s:<toString()>} and its round-tripped form as
+     * {@code m&#123;…&#125;}. Verified against a real PostgreSQL container, a
+     * single output item signed as {@code {output=[Hi there!]}} came back as
+     * {@code {output=[{text=Hi there!, type=text, delay=0}]}} and could never
+     * verify.
+     * <p>
+     * This is the same defect class as the nanosecond timestamp, and it takes the
+     * same cure: normalise first, then sign, so the row that lands in the database
+     * is byte-for-byte the row that was signed. Fixing only the timestamp left
+     * every entry carrying rendered output — on a rule-based turn, the majority of
+     * them — still reporting as tampered.
+     * <p>
+     * Deliberately non-fatal: an audit write must never break the turn it records.
+     * A value the mapper cannot convert keeps its original form, which verifies no
+     * worse than it did before and is visible in the ledger's own verify report.
+     */
+    private AuditEntry normalizePayloadsForStorage(AuditEntry entry) {
+        Map<String, Object> input = normalizeMap(entry.input(), entry.id());
+        Map<String, Object> output = normalizeMap(entry.output(), entry.id());
+        Map<String, Object> llmDetail = normalizeMap(entry.llmDetail(), entry.id());
+        Map<String, Object> toolCalls = normalizeMap(entry.toolCalls(), entry.id());
+
+        if (input == entry.input() && output == entry.output()
+                && llmDetail == entry.llmDetail() && toolCalls == entry.toolCalls()) {
+            return entry;
+        }
+        return new AuditEntry(entry.id(), entry.conversationId(), entry.agentId(), entry.agentVersion(),
+                entry.userId(), entry.environment(), entry.stepIndex(), entry.taskId(), entry.taskType(),
+                entry.taskIndex(), entry.durationMs(), input, output, llmDetail, toolCalls, entry.actions(),
+                entry.cost(), entry.timestamp(), entry.hmac(), entry.agentSignature(), entry.sequence());
+    }
+
+    /**
+     * @return the JSON-native form of {@code map}, or {@code map} itself if it
+     *         cannot be converted
+     */
+    private Map<String, Object> normalizeMap(Map<String, Object> map, String entryId) {
+        if (map == null || map.isEmpty()) {
+            return map;
+        }
+        try {
+            return objectMapper.convertValue(map, MAP_OF_OBJECT);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warnf("Audit entry %s carries a payload value that cannot be normalised (%s); "
+                    + "it is stored as-is and will not verify.", LogSanitizer.sanitize(entryId), e.getMessage());
+            return map;
+        }
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.audit;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import ai.labs.eddi.configs.agents.AgentSigningService;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
 import ai.labs.eddi.secrets.sanitize.SecretRedactionFilter;
@@ -93,6 +94,15 @@ public class AuditLedgerService {
      * literal stored form.
      */
     private final boolean recoverLegacyTimestamps;
+
+    /**
+     * How many legacy rows one sweep may search before it stops trying. A search is
+     * only spent on a row whose direct check already failed, so a healthy ledger
+     * never touches this; a ledger verified with the wrong key would otherwise
+     * spend one on every row. 500 bounds the worst case at a second or two of HMAC
+     * work per request.
+     */
+    private final int recoverLegacyMaxRows;
     private final boolean enabled;
     private final int flushIntervalSeconds;
     private final Optional<String> masterKeyConfig;
@@ -162,9 +172,11 @@ public class AuditLedgerService {
             @ConfigProperty(name = "eddi.tenant.default-id", defaultValue = "default") String defaultTenantId,
             @ConfigProperty(name = "eddi.audit.max-queue-size", defaultValue = "100000") int maxQueueSize,
             @ConfigProperty(name = "eddi.audit.verify.recover-legacy", defaultValue = "true") boolean recoverLegacyTimestamps,
-            io.micrometer.core.instrument.MeterRegistry meterRegistry, Instance<Connection> natsConnectionInstance,
+            @ConfigProperty(name = "eddi.audit.verify.recover-legacy-max-rows", defaultValue = "500") int recoverLegacyMaxRows,
+            MeterRegistry meterRegistry, Instance<Connection> natsConnectionInstance,
             AgentSigningService agentSigningService, ObjectMapper objectMapper) {
         this.recoverLegacyTimestamps = recoverLegacyTimestamps;
+        this.recoverLegacyMaxRows = recoverLegacyMaxRows;
         this.auditStore = auditStore;
         this.enabled = enabled;
         this.flushIntervalSeconds = flushIntervalSeconds;
@@ -184,7 +196,7 @@ public class AuditLedgerService {
      * {@link #init()} after construction.
      */
     static AuditLedgerService createForTesting(IAuditStore auditStore, boolean enabled, int flushIntervalSeconds, String masterKeyConfig,
-                                               io.micrometer.core.instrument.MeterRegistry meterRegistry) {
+                                               MeterRegistry meterRegistry) {
         return createForTesting(auditStore, enabled, flushIntervalSeconds, masterKeyConfig, meterRegistry, DEFAULT_MAX_QUEUE_SIZE);
     }
 
@@ -192,9 +204,9 @@ public class AuditLedgerService {
      * Factory method for unit testing with an explicit queue bound.
      */
     static AuditLedgerService createForTesting(IAuditStore auditStore, boolean enabled, int flushIntervalSeconds, String masterKeyConfig,
-                                               io.micrometer.core.instrument.MeterRegistry meterRegistry, int maxQueueSize) {
+                                               MeterRegistry meterRegistry, int maxQueueSize) {
         return new AuditLedgerService(auditStore, enabled, flushIntervalSeconds, Optional.ofNullable(masterKeyConfig), "eddi-audit-deadletter.jsonl",
-                false, "default", maxQueueSize, true, meterRegistry, null, null, new ObjectMapper());
+                false, "default", maxQueueSize, true, 500, meterRegistry, null, null, new ObjectMapper());
     }
 
     @PostConstruct
@@ -609,6 +621,20 @@ public class AuditLedgerService {
      * @return the verification outcome for that entry
      */
     public AuditVerificationStatus verifyEntry(AuditEntry entry) {
+        return verifyEntry(entry, newRecoveryBudget());
+    }
+
+    /**
+     * Re-check a stored entry, spending legacy-recovery searches from a budget the
+     * caller's whole sweep shares.
+     *
+     * @param entry
+     *            a stored entry, as read back from {@link IAuditStore}
+     * @param recoveryBudget
+     *            from {@link #newRecoveryBudget()}, created once per sweep
+     * @return the verification outcome for that entry
+     */
+    public AuditVerificationStatus verifyEntry(AuditEntry entry, AuditRecoveryBudget recoveryBudget) {
         if (entry == null) {
             return AuditVerificationStatus.INVALID;
         }
@@ -618,11 +644,19 @@ public class AuditLedgerService {
         if (entry.hmac() == null || entry.hmac().isBlank()) {
             return AuditVerificationStatus.UNSIGNED;
         }
-        return switch (AuditHmac.verify(entry, hmacKey, recoverLegacyTimestamps)) {
+        return switch (AuditHmac.verify(entry, hmacKey, recoveryBudget)) {
             case MATCH -> AuditVerificationStatus.VALID;
             case MATCH_RECOVERED -> AuditVerificationStatus.VALID_RECOVERED;
             case MISMATCH -> AuditVerificationStatus.INVALID;
         };
+    }
+
+    /**
+     * A recovery budget for one verification sweep, sized by
+     * {@code eddi.audit.verify.recover-legacy-max-rows}.
+     */
+    public AuditRecoveryBudget newRecoveryBudget() {
+        return recoverLegacyTimestamps ? new AuditRecoveryBudget(recoverLegacyMaxRows) : AuditRecoveryBudget.none();
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
@@ -83,6 +83,16 @@ public class AuditLedgerService {
     static final int MAX_TRACKED_UNDELIVERED = 10_000;
 
     private final IAuditStore auditStore;
+
+    /**
+     * Whether verification reconstructs the timestamp precision pre-v4 rows lost in
+     * storage. On by default: without it every entry written before the v4
+     * canonical form reports INVALID, which is what made the ledger's
+     * tamper-evidence emit no usable signal at all. Set
+     * {@code eddi.audit.verify.recover-legacy=false} to hold legacy rows to their
+     * literal stored form.
+     */
+    private final boolean recoverLegacyTimestamps;
     private final boolean enabled;
     private final int flushIntervalSeconds;
     private final Optional<String> masterKeyConfig;
@@ -151,8 +161,10 @@ public class AuditLedgerService {
             @ConfigProperty(name = "eddi.audit.agent-signing-enabled", defaultValue = "true") boolean agentSigningEnabled,
             @ConfigProperty(name = "eddi.tenant.default-id", defaultValue = "default") String defaultTenantId,
             @ConfigProperty(name = "eddi.audit.max-queue-size", defaultValue = "100000") int maxQueueSize,
+            @ConfigProperty(name = "eddi.audit.verify.recover-legacy", defaultValue = "true") boolean recoverLegacyTimestamps,
             io.micrometer.core.instrument.MeterRegistry meterRegistry, Instance<Connection> natsConnectionInstance,
             AgentSigningService agentSigningService, ObjectMapper objectMapper) {
+        this.recoverLegacyTimestamps = recoverLegacyTimestamps;
         this.auditStore = auditStore;
         this.enabled = enabled;
         this.flushIntervalSeconds = flushIntervalSeconds;
@@ -182,7 +194,7 @@ public class AuditLedgerService {
     static AuditLedgerService createForTesting(IAuditStore auditStore, boolean enabled, int flushIntervalSeconds, String masterKeyConfig,
                                                io.micrometer.core.instrument.MeterRegistry meterRegistry, int maxQueueSize) {
         return new AuditLedgerService(auditStore, enabled, flushIntervalSeconds, Optional.ofNullable(masterKeyConfig), "eddi-audit-deadletter.jsonl",
-                false, "default", maxQueueSize, meterRegistry, null, null, new ObjectMapper());
+                false, "default", maxQueueSize, true, meterRegistry, null, null, new ObjectMapper());
     }
 
     @PostConstruct
@@ -601,7 +613,11 @@ public class AuditLedgerService {
         if (entry.hmac() == null || entry.hmac().isBlank()) {
             return AuditVerificationStatus.UNSIGNED;
         }
-        return AuditHmac.verifyHmac(entry, hmacKey) ? AuditVerificationStatus.VALID : AuditVerificationStatus.INVALID;
+        return switch (AuditHmac.verify(entry, hmacKey, recoverLegacyTimestamps)) {
+            case MATCH -> AuditVerificationStatus.VALID;
+            case MATCH_RECOVERED -> AuditVerificationStatus.VALID_RECOVERED;
+            case MISMATCH -> AuditVerificationStatus.INVALID;
+        };
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
@@ -292,6 +292,17 @@ public class AuditLedgerService {
             // impossible to close by renumbering its neighbours.
             scrubbed = scrubbed.withSequence(nextSequence(scrubbed.conversationId()));
 
+            // A null timestamp must be stamped BEFORE signing, not by the store. v4
+            // signs the empty string for null, but PostgresAuditStore substitutes
+            // now() on write — so a null-timestamped entry read back would carry a
+            // timestamp the signature never covered and report INVALID forever.
+            // (MongoDB stores the field as absent, which round-trips; only the
+            // Postgres fallback diverges.) Stamping here makes the two agree and the
+            // signature honest.
+            if (scrubbed.timestamp() == null) {
+                scrubbed = scrubbed.withTimestamp(Instant.now());
+            }
+
             // Floor the timestamp to what the signature covers and the backends can
             // store, BEFORE signing — so the row that lands in the database is
             // byte-for-byte the row that was signed and nothing downstream can round it.

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditRecoveryBudget.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditRecoveryBudget.java
@@ -7,13 +7,13 @@ package ai.labs.eddi.engine.audit;
 /**
  * How much legacy-timestamp recovery one verification sweep may spend.
  * <p>
- * A pre-v4 row that fails the direct check triggers a completion search worth
- * about two thousand HMAC computations. Per row that is a couple of
- * milliseconds and entirely reasonable. Per <em>sweep</em> it is not bounded at
- * all by the per-row limit: {@code /auditstore/verify} accepts a limit of ten
- * thousand entries and runs verification inline on the request thread, so a
- * page where nothing can be recovered would spend roughly twenty million HMACs
- * before answering.
+ * A pre-v4 row that fails the direct check triggers a completion search worth a
+ * few thousand HMAC computations. Per row that is a few milliseconds and
+ * entirely reasonable. Per <em>sweep</em> it is not bounded at all by the
+ * per-row limit: {@code /auditstore/verify} accepts a limit of ten thousand
+ * entries and runs verification inline on the request thread, so a page where
+ * nothing can be recovered would spend tens of millions of HMACs before
+ * answering.
  * <p>
  * "Nothing can be recovered" is not a rare case, either — it is what a ledger
  * verified with the wrong key looks like, and what genuinely tampered rows look

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditRecoveryBudget.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditRecoveryBudget.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.audit;
+
+/**
+ * How much legacy-timestamp recovery one verification sweep may spend.
+ * <p>
+ * A pre-v4 row that fails the direct check triggers a completion search worth
+ * about two thousand HMAC computations. Per row that is a couple of
+ * milliseconds and entirely reasonable. Per <em>sweep</em> it is not bounded at
+ * all by the per-row limit: {@code /auditstore/verify} accepts a limit of ten
+ * thousand entries and runs verification inline on the request thread, so a
+ * page where nothing can be recovered would spend roughly twenty million HMACs
+ * before answering.
+ * <p>
+ * "Nothing can be recovered" is not a rare case, either — it is what a ledger
+ * verified with the wrong key looks like, and what genuinely tampered rows look
+ * like. Exactly the situations where an operator most wants a prompt answer are
+ * the ones that would take longest.
+ * <p>
+ * So the budget is per sweep, and rows past it are verified without the search:
+ * they report {@code INVALID}, and the count of rows that went unsearched is
+ * reported alongside so the result is never quietly less thorough than it
+ * looks. Not thread-safe; one instance belongs to one sweep on one thread.
+ *
+ * @since 6.3.1
+ */
+public final class AuditRecoveryBudget {
+
+    /**
+     * A budget that permits no searching at all — for callers verifying a single
+     * entry outside a sweep, and for deployments with recovery switched off.
+     */
+    public static AuditRecoveryBudget none() {
+        return new AuditRecoveryBudget(0);
+    }
+
+    private final int maxSearches;
+    private int searchesUsed;
+    private int searchesSkipped;
+
+    public AuditRecoveryBudget(int maxSearches) {
+        this.maxSearches = Math.max(maxSearches, 0);
+    }
+
+    /**
+     * Claims one recovery search.
+     *
+     * @return {@code true} when the sweep may still search; {@code false} once the
+     *         budget is spent, counting this row as unsearched
+     */
+    public boolean tryConsume() {
+        if (searchesUsed >= maxSearches) {
+            searchesSkipped++;
+            return false;
+        }
+        searchesUsed++;
+        return true;
+    }
+
+    /** Rows that failed the direct check and were not searched. */
+    public int searchesSkipped() {
+        return searchesSkipped;
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditVerificationStatus.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditVerificationStatus.java
@@ -15,6 +15,17 @@ public enum AuditVerificationStatus {
     VALID,
 
     /**
+     * A pre-v4 entry that verified only after the timestamp precision its backend
+     * could not store was reconstructed from the signature itself.
+     * <p>
+     * Integrity is proven exactly as strongly as {@link #VALID} — finding a
+     * completion that reproduces the digest without the key is as hard as forging
+     * it. Reported separately because it also says something operational: the row
+     * predates the v4 canonical form, and only rows written before it need this.
+     */
+    VALID_RECOVERED,
+
+    /**
      * The stored HMAC does not match — the entry was altered after it was written,
      * or it was signed with a different key.
      */

--- a/src/main/java/ai/labs/eddi/engine/audit/model/AuditEntry.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/model/AuditEntry.java
@@ -125,6 +125,18 @@ public record AuditEntry(String id, String conversationId, String agentId, Integ
     }
 
     /**
+     * Return a copy of this entry with a different timestamp. Used only by the v3
+     * legacy-recovery search in {@code AuditHmac}, which reconstructs the
+     * sub-precision digits a backend truncated away so that an old row can still
+     * prove it is the one that was written. Never used on the write path — an entry
+     * is timestamped once.
+     */
+    public AuditEntry withTimestamp(Instant newTimestamp) {
+        return new AuditEntry(id, conversationId, agentId, agentVersion, userId, environment, stepIndex, taskId, taskType, taskIndex, durationMs,
+                input, output, llmDetail, toolCalls, actions, cost, newTimestamp, hmac, agentSignature, sequence);
+    }
+
+    /**
      * Return a copy of this entry with the agent signature set. Used by
      * AuditLedgerService when agent signing is configured.
      */

--- a/src/main/java/ai/labs/eddi/engine/audit/model/AuditEntry.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/model/AuditEntry.java
@@ -125,11 +125,18 @@ public record AuditEntry(String id, String conversationId, String agentId, Integ
     }
 
     /**
-     * Return a copy of this entry with a different timestamp. Used only by the v3
-     * legacy-recovery search in {@code AuditHmac}, which reconstructs the
-     * sub-precision digits a backend truncated away so that an old row can still
-     * prove it is the one that was written. Never used on the write path — an entry
-     * is timestamped once.
+     * Return a copy of this entry with a different timestamp.
+     * <p>
+     * Two callers, both in {@code AuditHmac}. On the write path,
+     * {@code withStorablePrecision} floors the timestamp to the precision the
+     * signature covers and the backends can store, so the row that is signed is the
+     * row that is stored. On the read path, the v3 legacy-recovery search
+     * reconstructs the sub-precision digits a backend truncated away, so an old row
+     * can still prove it is the one that was written.
+     * <p>
+     * Not a general-purpose setter: an entry's timestamp records when the event
+     * happened, and moving it after the fact is exactly what the signature exists
+     * to detect.
      */
     public AuditEntry withTimestamp(Instant newTimestamp) {
         return new AuditEntry(id, conversationId, agentId, agentVersion, userId, environment, stepIndex, taskId, taskType, taskIndex, durationMs,

--- a/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
@@ -53,6 +53,13 @@ import java.util.List;
  *            not store was reconstructed from the signature. Integrity is
  *            proven just as strongly; the count is reported separately because
  *            it dates the rows
+ * @param recoverySkipped
+ *            pre-v4 entries that failed the direct check and were <em>not</em>
+ *            searched, because the sweep's recovery budget
+ *            ({@code eddi.audit.verify.recover-legacy-max-rows}) was spent.
+ *            They are counted in {@code invalid}; a non-zero value here says
+ *            that verdict is "not proven" rather than "disproven", and that a
+ *            narrower page or a larger budget would say more
  * @param invalid
  *            entries whose HMAC did not match — tampering, or a key change
  * @param unsigned
@@ -79,8 +86,8 @@ import java.util.List;
  * @since 6.2.0
  */
 public record AuditVerificationReport(String scope, String scopeId, boolean signingEnabled, int entriesChecked, int valid, int recovered,
-        int invalid, int unsigned, ChainStatus chainStatus, List<Long> missingSequences, List<Long> undeliveredSequences,
-        List<Long> duplicateSequences, List<EntryProblem> problems, Instant verifiedAt) {
+        int recoverySkipped, int invalid, int unsigned, ChainStatus chainStatus, List<Long> missingSequences,
+        List<Long> undeliveredSequences, List<Long> duplicateSequences, List<EntryProblem> problems, Instant verifiedAt) {
 
     /**
      * Whether the sweep found nothing wrong. False whenever an entry failed

--- a/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
@@ -45,7 +45,14 @@ import java.util.List;
  * @param entriesChecked
  *            number of entries examined
  * @param valid
- *            entries whose HMAC recomputed correctly
+ *            entries whose HMAC recomputed correctly, including the
+ *            {@code recovered} ones
+ * @param recovered
+ *            of those, entries written before the v4 canonical form that
+ *            verified only after the timestamp precision their backend could
+ *            not store was reconstructed from the signature. Integrity is
+ *            proven just as strongly; the count is reported separately because
+ *            it dates the rows
  * @param invalid
  *            entries whose HMAC did not match — tampering, or a key change
  * @param unsigned
@@ -71,9 +78,9 @@ import java.util.List;
  *            when the sweep ran
  * @since 6.2.0
  */
-public record AuditVerificationReport(String scope, String scopeId, boolean signingEnabled, int entriesChecked, int valid, int invalid, int unsigned,
-        ChainStatus chainStatus, List<Long> missingSequences, List<Long> undeliveredSequences, List<Long> duplicateSequences,
-        List<EntryProblem> problems, Instant verifiedAt) {
+public record AuditVerificationReport(String scope, String scopeId, boolean signingEnabled, int entriesChecked, int valid, int recovered,
+        int invalid, int unsigned, ChainStatus chainStatus, List<Long> missingSequences, List<Long> undeliveredSequences,
+        List<Long> duplicateSequences, List<EntryProblem> problems, Instant verifiedAt) {
 
     /**
      * Whether the sweep found nothing wrong. False whenever an entry failed

--- a/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
@@ -183,6 +183,20 @@ public record AuditVerificationReport(String scope, String scopeId, boolean sign
      * @param status
      *            why it is listed here
      */
-    public record EntryProblem(String entryId, String conversationId, long sequence, Instant timestamp, AuditVerificationStatus status) {
+    /**
+     * One entry the sweep could not mark VALID.
+     *
+     * @param hmacVersion
+     *            which canonical form the stored HMAC names ({@code v1}–{@code v4},
+     *            or {@code null} for UNSIGNED). This is the triage field: an
+     *            INVALID on {@code v4} means something touched a row this release
+     *            wrote — an alarm — while an INVALID on a pre-v4 version is usually
+     *            a legacy row whose payload held live Java objects when it was
+     *            signed, a form nothing can reconstruct and no recovery search will
+     *            ever clear. The two deserve opposite reactions, and without this
+     *            field they are indistinguishable in the report.
+     */
+    public record EntryProblem(String entryId, String conversationId, long sequence, Instant timestamp, AuditVerificationStatus status,
+            String hmacVersion) {
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
@@ -117,9 +117,28 @@ public record AuditVerificationReport(String scope, String scopeId, boolean sign
      * whose HMAC no longer recomputes, or a gap this deployment cannot account for.
      * An {@code INCOMPLETE} chain (the ledger dropped those entries itself) and a
      * missing signing key are explicitly not tampering.
+     * <p>
+     * Nor is {@link #recoverySkipped}. Those rows failed their direct check and
+     * were then <em>not searched</em>, because the sweep's recovery budget was
+     * spent — so nothing about them was established either way, and a pre-v4 row
+     * failing its direct check is the expected outcome rather than evidence.
+     * Counting them would make a large enough page raise a tampering alarm purely
+     * by exhausting a budget, which is the same "reports something as proven when
+     * it is not" failure this release exists to remove. They still defeat
+     * {@link #intact()}: a sweep that could not finish checking is not a clean bill
+     * of health.
      */
     public boolean tamperingSuspected() {
-        return invalid > 0 || chainStatus == ChainStatus.BROKEN;
+        return (invalid - Math.min(recoverySkipped, invalid)) > 0 || chainStatus == ChainStatus.BROKEN;
+    }
+
+    /**
+     * Entries whose HMAC was actually shown not to recompute — {@link #invalid}
+     * minus the rows that went unsearched. This is the number an alert should key
+     * on.
+     */
+    public int disproven() {
+        return invalid - Math.min(recoverySkipped, invalid);
     }
 
     /** Continuity of the per-conversation sequence chain. */

--- a/src/main/java/ai/labs/eddi/engine/audit/rest/RestAuditStore.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/rest/RestAuditStore.java
@@ -108,6 +108,7 @@ public class RestAuditStore implements IRestAuditStore {
                                            boolean expectRunFromOrigin) {
         boolean signingEnabled = auditLedgerService.isSigningEnabled();
         int valid = 0;
+        int recovered = 0;
         int invalid = 0;
         int unsigned = 0;
         var problems = new ArrayList<EntryProblem>();
@@ -116,13 +117,19 @@ public class RestAuditStore implements IRestAuditStore {
             AuditVerificationStatus status = auditLedgerService.verifyEntry(entry);
             switch (status) {
                 case VALID -> valid++;
+                // A recovered entry is intact — it counts as valid, and is also counted
+                // on its own so an operator can see how much of the ledger predates v4.
+                case VALID_RECOVERED -> {
+                    valid++;
+                    recovered++;
+                }
                 case INVALID -> invalid++;
                 case UNSIGNED -> unsigned++;
                 case SIGNING_DISABLED -> {
                     // counted only as a problem — nothing was actually checked
                 }
             }
-            if (status != AuditVerificationStatus.VALID) {
+            if (status != AuditVerificationStatus.VALID && status != AuditVerificationStatus.VALID_RECOVERED) {
                 problems.add(new EntryProblem(entry.id(), entry.conversationId(), entry.sequence(), entry.timestamp(), status));
             }
         }
@@ -134,8 +141,8 @@ public class RestAuditStore implements IRestAuditStore {
                 ? checkChain(entries, missing, undelivered, duplicates, expectRunFromOrigin, undeliveredFor(scopeId))
                 : ChainStatus.NOT_APPLICABLE;
 
-        return new AuditVerificationReport(scope, scopeId, signingEnabled, entries.size(), valid, invalid, unsigned, chainStatus, missing,
-                undelivered, duplicates, problems, Instant.now());
+        return new AuditVerificationReport(scope, scopeId, signingEnabled, entries.size(), valid, recovered, invalid, unsigned, chainStatus,
+                missing, undelivered, duplicates, problems, Instant.now());
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/audit/rest/RestAuditStore.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/rest/RestAuditStore.java
@@ -112,9 +112,12 @@ public class RestAuditStore implements IRestAuditStore {
         int invalid = 0;
         int unsigned = 0;
         var problems = new ArrayList<EntryProblem>();
+        // One budget for the whole sweep — see AuditRecoveryBudget. Spent only on
+        // rows whose direct check already failed.
+        var recoveryBudget = auditLedgerService.newRecoveryBudget();
 
         for (AuditEntry entry : entries) {
-            AuditVerificationStatus status = auditLedgerService.verifyEntry(entry);
+            AuditVerificationStatus status = auditLedgerService.verifyEntry(entry, recoveryBudget);
             switch (status) {
                 case VALID -> valid++;
                 // A recovered entry is intact — it counts as valid, and is also counted
@@ -141,8 +144,8 @@ public class RestAuditStore implements IRestAuditStore {
                 ? checkChain(entries, missing, undelivered, duplicates, expectRunFromOrigin, undeliveredFor(scopeId))
                 : ChainStatus.NOT_APPLICABLE;
 
-        return new AuditVerificationReport(scope, scopeId, signingEnabled, entries.size(), valid, recovered, invalid, unsigned, chainStatus,
-                missing, undelivered, duplicates, problems, Instant.now());
+        return new AuditVerificationReport(scope, scopeId, signingEnabled, entries.size(), valid, recovered,
+                recoveryBudget.searchesSkipped(), invalid, unsigned, chainStatus, missing, undelivered, duplicates, problems, Instant.now());
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/audit/rest/RestAuditStore.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/rest/RestAuditStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.audit.rest;
 
 import ai.labs.eddi.engine.audit.AuditLedgerService;
+import ai.labs.eddi.engine.audit.AuditHmac;
 import ai.labs.eddi.engine.audit.AuditVerificationStatus;
 import ai.labs.eddi.engine.audit.IAuditStore;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
@@ -133,7 +134,8 @@ public class RestAuditStore implements IRestAuditStore {
                 }
             }
             if (status != AuditVerificationStatus.VALID && status != AuditVerificationStatus.VALID_RECOVERED) {
-                problems.add(new EntryProblem(entry.id(), entry.conversationId(), entry.sequence(), entry.timestamp(), status));
+                problems.add(new EntryProblem(entry.id(), entry.conversationId(), entry.sequence(), entry.timestamp(), status,
+                        AuditHmac.versionOf(entry.hmac())));
             }
         }
 

--- a/src/main/java/ai/labs/eddi/engine/exception/ClientErrorExceptionMapper.java
+++ b/src/main/java/ai/labs/eddi/engine/exception/ClientErrorExceptionMapper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.exception;
+
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Puts a 4xx exception's message into its response body.
+ * <p>
+ * {@code throw new BadRequestException("Channel integration name is required.")}
+ * produces a 400 with an <em>empty</em> body: JAX-RS builds the response from
+ * the status alone unless the exception was constructed with an entity. The
+ * validation code across this codebase is written as though the message were
+ * delivered — {@code POST /channelstore/channels} alone throws four distinct,
+ * well-written messages, none of which ever reached a client. On a live sweep
+ * that made channel integrations impossible to create through the API without
+ * reading the Java source to find out which rule was being violated, and it
+ * produced four false findings whose only cause was a call shape nothing would
+ * explain.
+ * <p>
+ * Deliberately scoped to {@link ClientErrorException}: a 4xx message describes
+ * what the <em>caller</em> did wrong and is safe to return. Server-side
+ * exceptions are left alone, so no internal detail is copied into a 5xx body.
+ * An exception that already carries an entity is passed through untouched.
+ */
+@Provider
+public class ClientErrorExceptionMapper implements ExceptionMapper<ClientErrorException> {
+
+    @Override
+    public Response toResponse(ClientErrorException exception) {
+        Response original = exception.getResponse();
+        if (original.hasEntity()) {
+            return original;
+        }
+
+        String message = exception.getLocalizedMessage();
+        if (message == null || message.isBlank()) {
+            return original;
+        }
+
+        return Response.fromResponse(original)
+                .type(MediaType.TEXT_PLAIN)
+                .entity(message)
+                .build();
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
@@ -56,7 +56,7 @@ import java.util.concurrent.TimeUnit;
 
 import static ai.labs.eddi.engine.internal.RestAgentManagement.KEY_LANG;
 import static ai.labs.eddi.engine.model.Context.ContextType.string;
-import static ai.labs.eddi.utils.RuntimeUtilities.checkNotEmpty;
+import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
 import static ai.labs.eddi.utils.RuntimeUtilities.checkNotNull;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 
@@ -172,11 +172,18 @@ public class RestAgentEngine implements IRestAgentEngine {
     public void rerunLastConversationStep(String conversationId, String language, Boolean returnDetailed, Boolean returnCurrentStepOnly,
                                           List<String> returningFields, final AsyncResponse response) {
         checkNotNull(conversationId, "conversationId");
-        checkNotEmpty(language, "language");
         validateConversationOwnership(conversationId);
 
+        // language is optional, as it is on say(). Requiring it here 400'd every
+        // rerun call that followed the endpoint's own description, which never
+        // mentioned it. Absent, the turn simply carries no language context —
+        // exactly what say() does.
+        var contexts = isNullOrEmpty(language)
+                ? Map.<String, Context>of()
+                : Map.of(KEY_LANG, new Context(string, language));
+
         sayInternal(conversationId, returnDetailed, returnCurrentStepOnly, returningFields,
-                new InputData("", Map.of(KEY_LANG, new Context(string, language))), true, response);
+                new InputData("", contexts), true, response);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
@@ -597,12 +597,21 @@ public class RestAgentEngine implements IRestAgentEngine {
      * The ACTIONS data of the most recent (paused) conversation step — read-time
      * lookup over the snapshot's step history, no new persistence.
      * <p>
-     * {@code ConversationMemorySnapshot.getConversationSteps()} is built by
-     * {@code ConversationMemoryUtilities.convertConversationMemory} in
-     * REVERSE-chronological order (index 0 = most recent step), each holding a
-     * single {@code WorkflowRunSnapshot} whose {@code lifecycleTasks} preserve the
-     * original insertion order — so within that step, the LAST matching "actions"
-     * entry is the most recent one (same semantics as
+     * {@code ConversationMemorySnapshot.getConversationSteps()} is CHRONOLOGICAL,
+     * index 0 being the oldest step. {@code convertConversationMemory} does count
+     * down from {@code size() - 1}, which reads as a reversal — but it indexes a
+     * {@code ConversationStepStack}, whose own {@code get(i)} already counts from
+     * the most recent, so the two inversions cancel. {@code
+     * convertConversationMemorySnapshot} relies on that too, pairing steps with the
+     * chronological {@code conversationOutputs} by index.
+     * <p>
+     * Walking forward from index 0 therefore returned the FIRST step's actions, and
+     * step 0 is the CONVERSATION_START turn — so a paused conversation reported
+     * {@code ["CONVERSATION_START"]} as the actions that caused the pause, on every
+     * rule pause, no matter which rule fired.
+     * <p>
+     * Within a step, {@code lifecycleTasks} preserve insertion order, so the LAST
+     * matching "actions" entry is the most recent one (same semantics as
      * {@code IConversationStep.getLatestData}).
      */
     private List<String> findPausedStepActions(ConversationMemorySnapshot snapshot) {
@@ -610,9 +619,9 @@ public class RestAgentEngine implements IRestAgentEngine {
         if (steps == null || steps.isEmpty()) {
             return List.of();
         }
-        for (ConversationStepSnapshot step : steps) {
+        for (int i = steps.size() - 1; i >= 0; i--) {
             List<String> latestActionsInStep = null;
-            for (WorkflowRunSnapshot workflow : step.getWorkflows()) {
+            for (WorkflowRunSnapshot workflow : steps.get(i).getWorkflows()) {
                 for (ResultSnapshot data : workflow.getLifecycleTasks()) {
                     if ("actions".equals(data.getKey()) && data.getResult() instanceof List<?> actions) {
                         @SuppressWarnings("unchecked")

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOps.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/GroupLifecycleOps.java
@@ -151,6 +151,15 @@ public class GroupLifecycleOps {
                 groupConversationService.deleteGroupHitlTimeoutSchedule(groupConversationId);
                 groupConversationService.cleanupAfterTerminalState(gc);
             }
+            // Member conversations are ENDED, not deleted — deliberately, and the tool
+            // description and docs now say so. They were previously advertised as
+            // cascade-DELETED while this loop only ended them, which left every deleted
+            // discussion with N readable documents behind and no one expecting them.
+            // Making them actually disappear is a separate, irreversible behaviour
+            // change: a member conversation holds the agent's own transcript, and GDPR
+            // erasure (which does delete conversations) is the path that is meant to
+            // destroy it. Note the inconsistency this leaves — artifacts and ephemeral
+            // agents below ARE deleted.
             for (String privateConvId : gc.getMemberConversationIds().values()) {
                 try {
                     conversationService.endConversation(privateConvId);

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpAdminTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpAdminTools.java
@@ -1250,8 +1250,11 @@ public class McpAdminTools {
         if (config == null || config.isBlank())
             return errorJson("config is required");
         try {
-            var channelConfig = jsonSerialization.deserialize(config,
-                    ChannelIntegrationConfiguration.class);
+            // Same strictness as POST/PUT /channelstore/channels —
+            // ChannelIntegrationConfiguration
+            // is a first-party config model, so a typo'd key must be rejected here too
+            // rather than dropped into a silently different integration.
+            var channelConfig = configParser.parse(config, ChannelIntegrationConfiguration.class);
             var channelStore = getRestStore(
                     IRestChannelIntegrationStore.class);
             Response response = channelStore.createChannel(channelConfig);
@@ -1283,8 +1286,11 @@ public class McpAdminTools {
             return errorJson("config is required");
         try {
             int ver = version != null ? version : 1;
-            var channelConfig = jsonSerialization.deserialize(config,
-                    ChannelIntegrationConfiguration.class);
+            // Same strictness as POST/PUT /channelstore/channels —
+            // ChannelIntegrationConfiguration
+            // is a first-party config model, so a typo'd key must be rejected here too
+            // rather than dropped into a silently different integration.
+            var channelConfig = configParser.parse(config, ChannelIntegrationConfiguration.class);
             var channelStore = getRestStore(
                     IRestChannelIntegrationStore.class);
             Response response = channelStore.updateChannel(resourceId, ver, channelConfig);

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpAdminTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpAdminTools.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.mcp;
 
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 import ai.labs.eddi.configs.rules.IRestRuleSetStore;
 import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.engine.triggermanagement.IRestAgentTriggerStore;
@@ -80,6 +81,16 @@ public class McpAdminTools {
     private final IRestInterfaceFactory restInterfaceFactory;
     private final IRestAgentAdministration agentAdmin;
     private final IJsonSerialization jsonSerialization;
+
+    /**
+     * Deserialises resource configurations with the same strictness the REST
+     * surface applies. {@code StrictConfigurationBodyInterceptor} is a JAX-RS
+     * {@code ReaderInterceptor}, so it only fires on a real inbound HTTP body —
+     * these tools call the very same stores in-process and were therefore parsing
+     * leniently, accepting payloads REST rejects and storing the emptied result as
+     * a success.
+     */
+    private final StrictConfigurationParser configParser;
     private final IScheduleStore scheduleStore;
     private final ScheduleFireExecutor scheduleFireExecutor;
     private final SchedulePollerService schedulePollerService;
@@ -88,11 +99,13 @@ public class McpAdminTools {
 
     @Inject
     public McpAdminTools(IRestInterfaceFactory restInterfaceFactory, IRestAgentAdministration agentAdmin, IJsonSerialization jsonSerialization,
-            IScheduleStore scheduleStore, ScheduleFireExecutor scheduleFireExecutor, SchedulePollerService schedulePollerService,
-            SecurityIdentity identity, @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authEnabled) {
+            StrictConfigurationParser configParser, IScheduleStore scheduleStore, ScheduleFireExecutor scheduleFireExecutor,
+            SchedulePollerService schedulePollerService, SecurityIdentity identity,
+            @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authEnabled) {
         this.restInterfaceFactory = restInterfaceFactory;
         this.agentAdmin = agentAdmin;
         this.jsonSerialization = jsonSerialization;
+        this.configParser = configParser;
         this.scheduleStore = scheduleStore;
         this.scheduleFireExecutor = scheduleFireExecutor;
         this.schedulePollerService = schedulePollerService;
@@ -172,7 +185,7 @@ public class McpAdminTools {
                     "status", response.getStatus()));
         } catch (Exception e) {
             LOGGER.error("MCP undeploy_agent failed for Agent " + agentId, e);
-            return errorJson("Failed to undeploy agent: " + e.getMessage());
+            return errorJson("Failed to undeploy agent", e);
         }
     }
 
@@ -192,7 +205,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(entity);
         } catch (Exception e) {
             LOGGER.error("MCP get_deployment_status failed for Agent " + agentId, e);
-            return errorJson("Failed to get deployment status: " + e.getMessage());
+            return errorJson("Failed to get deployment status", e);
         }
     }
 
@@ -208,7 +221,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(descriptors);
         } catch (Exception e) {
             LOGGER.error("MCP list_workflows failed", e);
-            return errorJson("Failed to list workflows: " + e.getMessage());
+            return errorJson("Failed to list workflows", e);
         }
     }
 
@@ -262,7 +275,7 @@ public class McpAdminTools {
                     description != null ? description : "", "location", location != null ? location : "unknown", "status", response.getStatus()));
         } catch (Exception e) {
             LOGGER.error("MCP create_agent failed", e);
-            return errorJson("Failed to create agent: " + e.getMessage());
+            return errorJson("Failed to create agent", e);
         }
     }
 
@@ -281,7 +294,7 @@ public class McpAdminTools {
                     Map.of("agentId", agentId, "version", ver, "permanent", isPermanent, "cascade", isCascade, "status", response.getStatus()));
         } catch (Exception e) {
             LOGGER.error("MCP delete_agent failed for Agent " + agentId, e);
-            return errorJson("Failed to delete agent: " + e.getMessage());
+            return errorJson("Failed to delete agent", e);
         }
     }
 
@@ -336,7 +349,7 @@ public class McpAdminTools {
             return resultJson("updated", result);
         } catch (Exception e) {
             LOGGER.error("MCP update_agent failed for Agent " + agentId, e);
-            return errorJson("Failed to update agent: " + e.getMessage());
+            return errorJson("Failed to update agent", e);
         }
     }
 
@@ -363,7 +376,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP read_workflow failed for workflow " + workflowId, e);
-            return errorJson("Failed to read workflow: " + e.getMessage());
+            return errorJson("Failed to read workflow", e);
         }
     }
 
@@ -395,7 +408,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP read_resource failed for " + resourceType + "/" + resourceId, e);
-            return errorJson("Failed to read resource: " + e.getMessage());
+            return errorJson("Failed to read resource", e);
         }
     }
 
@@ -454,7 +467,7 @@ public class McpAdminTools {
             return resultJson("updated", result);
         } catch (Exception e) {
             LOGGER.error("MCP update_resource failed for " + resourceType + "/" + resourceId, e);
-            return errorJson("Failed to update resource: " + e.getMessage());
+            return errorJson("Failed to update resource", e);
         }
     }
 
@@ -487,7 +500,7 @@ public class McpAdminTools {
             return resultJson("created", result);
         } catch (Exception e) {
             LOGGER.error("MCP create_resource failed for " + resourceType, e);
-            return errorJson("Failed to create resource: " + e.getMessage());
+            return errorJson("Failed to create resource", e);
         }
     }
 
@@ -515,7 +528,7 @@ public class McpAdminTools {
                     Map.of("resourceType", type, "resourceId", resourceId, "version", ver, "permanent", isPermanent, "status", response.getStatus()));
         } catch (Exception e) {
             LOGGER.error("MCP delete_resource failed for " + resourceType + "/" + resourceId, e);
-            return errorJson("Failed to delete resource: " + e.getMessage());
+            return errorJson("Failed to delete resource", e);
         }
     }
 
@@ -642,7 +655,7 @@ public class McpAdminTools {
             return resultJson("cascaded", result);
         } catch (Exception e) {
             LOGGER.error("MCP apply_agent_changes failed for Agent " + agentId, e);
-            return errorJson("Failed to apply Agent changes: " + e.getMessage());
+            return errorJson("Failed to apply Agent changes", e);
         }
     }
 
@@ -729,7 +742,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP list_agent_resources failed for Agent " + agentId, e);
-            return errorJson("Failed to list Agent resources: " + e.getMessage());
+            return errorJson("Failed to list Agent resources", e);
         }
     }
 
@@ -741,19 +754,19 @@ public class McpAdminTools {
     private Response updateResourceByType(String type, String id, int version, String configJson) throws IOException {
         return switch (type) {
             case "behavior" -> getRestStore(IRestRuleSetStore.class).updateRuleSet(id, version,
-                    jsonSerialization.deserialize(configJson, RuleSetConfiguration.class));
+                    configParser.parse(configJson, RuleSetConfiguration.class));
             case "langchain" ->
-                getRestStore(IRestLlmStore.class).updateLlm(id, version, jsonSerialization.deserialize(configJson, LlmConfiguration.class));
+                getRestStore(IRestLlmStore.class).updateLlm(id, version, configParser.parse(configJson, LlmConfiguration.class));
             case "httpcalls" -> getRestStore(IRestApiCallsStore.class).updateApiCalls(id, version,
-                    jsonSerialization.deserialize(configJson, ApiCallsConfiguration.class));
+                    configParser.parse(configJson, ApiCallsConfiguration.class));
             case "mcpcalls" -> getRestStore(IRestMcpCallsStore.class).updateMcpCalls(id, version,
-                    jsonSerialization.deserialize(configJson, McpCallsConfiguration.class));
+                    configParser.parse(configJson, McpCallsConfiguration.class));
             case "output" -> getRestStore(IRestOutputStore.class).updateOutputSet(id, version,
-                    jsonSerialization.deserialize(configJson, OutputConfigurationSet.class));
+                    configParser.parse(configJson, OutputConfigurationSet.class));
             case "propertysetter" -> getRestStore(IRestPropertySetterStore.class).updatePropertySetter(id, version,
-                    jsonSerialization.deserialize(configJson, PropertySetterConfiguration.class));
+                    configParser.parse(configJson, PropertySetterConfiguration.class));
             case "dictionaries" -> getRestStore(IRestDictionaryStore.class).updateRegularDictionary(id, version,
-                    jsonSerialization.deserialize(configJson, DictionaryConfiguration.class));
+                    configParser.parse(configJson, DictionaryConfiguration.class));
             default -> throw new IllegalArgumentException(
                     "Unknown resource type: " + type + ". Supported: behavior, langchain, httpcalls, mcpcalls, output, propertysetter, dictionaries");
         };
@@ -765,18 +778,18 @@ public class McpAdminTools {
     private Response createResourceByType(String type, String configJson) throws IOException {
         return switch (type) {
             case "behavior" ->
-                getRestStore(IRestRuleSetStore.class).createRuleSet(jsonSerialization.deserialize(configJson, RuleSetConfiguration.class));
-            case "langchain" -> getRestStore(IRestLlmStore.class).createLlm(jsonSerialization.deserialize(configJson, LlmConfiguration.class));
+                getRestStore(IRestRuleSetStore.class).createRuleSet(configParser.parse(configJson, RuleSetConfiguration.class));
+            case "langchain" -> getRestStore(IRestLlmStore.class).createLlm(configParser.parse(configJson, LlmConfiguration.class));
             case "httpcalls" ->
-                getRestStore(IRestApiCallsStore.class).createApiCalls(jsonSerialization.deserialize(configJson, ApiCallsConfiguration.class));
+                getRestStore(IRestApiCallsStore.class).createApiCalls(configParser.parse(configJson, ApiCallsConfiguration.class));
             case "mcpcalls" ->
-                getRestStore(IRestMcpCallsStore.class).createMcpCalls(jsonSerialization.deserialize(configJson, McpCallsConfiguration.class));
+                getRestStore(IRestMcpCallsStore.class).createMcpCalls(configParser.parse(configJson, McpCallsConfiguration.class));
             case "output" ->
-                getRestStore(IRestOutputStore.class).createOutputSet(jsonSerialization.deserialize(configJson, OutputConfigurationSet.class));
+                getRestStore(IRestOutputStore.class).createOutputSet(configParser.parse(configJson, OutputConfigurationSet.class));
             case "propertysetter" -> getRestStore(IRestPropertySetterStore.class)
-                    .createPropertySetter(jsonSerialization.deserialize(configJson, PropertySetterConfiguration.class));
+                    .createPropertySetter(configParser.parse(configJson, PropertySetterConfiguration.class));
             case "dictionaries" -> getRestStore(IRestDictionaryStore.class)
-                    .createRegularDictionary(jsonSerialization.deserialize(configJson, DictionaryConfiguration.class));
+                    .createRegularDictionary(configParser.parse(configJson, DictionaryConfiguration.class));
             default -> throw new IllegalArgumentException(
                     "Unknown resource type: " + type + ". Supported: behavior, langchain, httpcalls, mcpcalls, output, propertysetter, dictionaries");
         };
@@ -857,7 +870,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP list_agent_triggers failed", e);
-            return errorJson("Failed to list Agent triggers: " + e.getMessage());
+            return errorJson("Failed to list Agent triggers", e);
         }
     }
 
@@ -885,7 +898,7 @@ public class McpAdminTools {
             return resultJson("created", result);
         } catch (Exception e) {
             LOGGER.error("MCP create_agent_trigger failed", e);
-            return errorJson("Failed to create Agent trigger: " + e.getMessage());
+            return errorJson("Failed to create Agent trigger", e);
         }
     }
 
@@ -911,7 +924,7 @@ public class McpAdminTools {
             return resultJson("updated", result);
         } catch (Exception e) {
             LOGGER.error("MCP update_agent_trigger failed for intent " + intent, e);
-            return errorJson("Failed to update Agent trigger: " + e.getMessage());
+            return errorJson("Failed to update Agent trigger", e);
         }
     }
 
@@ -930,7 +943,7 @@ public class McpAdminTools {
             return resultJson("deleted", result);
         } catch (Exception e) {
             LOGGER.error("MCP delete_agent_trigger failed for intent " + intent, e);
-            return errorJson("Failed to delete Agent trigger: " + e.getMessage());
+            return errorJson("Failed to delete Agent trigger", e);
         }
     }
 
@@ -1030,10 +1043,10 @@ public class McpAdminTools {
             result.put("environment", schedule.getEnvironment());
             return resultJson("schedule_created", result);
         } catch (IllegalArgumentException e) {
-            return errorJson("Invalid schedule: " + e.getMessage());
+            return errorJson("Invalid schedule", e);
         } catch (Exception e) {
             LOGGER.error("MCP create_schedule failed", e);
-            return errorJson("Failed to create schedule: " + e.getMessage());
+            return errorJson("Failed to create schedule", e);
         }
     }
 
@@ -1079,7 +1092,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP list_schedules failed", e);
-            return errorJson("Failed to list schedules: " + e.getMessage());
+            return errorJson("Failed to list schedules", e);
         }
     }
 
@@ -1119,7 +1132,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP read_schedule failed for " + scheduleId, e);
-            return errorJson("Failed to read schedule: " + e.getMessage());
+            return errorJson("Failed to read schedule", e);
         }
     }
 
@@ -1133,7 +1146,7 @@ public class McpAdminTools {
             return resultJson("schedule_deleted", Map.of("scheduleId", scheduleId));
         } catch (Exception e) {
             LOGGER.error("MCP delete_schedule failed for " + scheduleId, e);
-            return errorJson("Failed to delete schedule: " + e.getMessage());
+            return errorJson("Failed to delete schedule", e);
         }
     }
 
@@ -1162,7 +1175,7 @@ public class McpAdminTools {
             return resultJson("schedule_fired", result);
         } catch (Exception e) {
             LOGGER.error("MCP fire_schedule_now failed for " + scheduleId, e);
-            return errorJson("Failed to fire schedule: " + e.getMessage());
+            return errorJson("Failed to fire schedule", e);
         }
     }
 
@@ -1178,7 +1191,7 @@ public class McpAdminTools {
                     Map.of("scheduleId", scheduleId, "status", "PENDING", "message", "Schedule requeued for next poll cycle"));
         } catch (Exception e) {
             LOGGER.error("MCP retry_failed_schedule failed for " + scheduleId, e);
-            return errorJson("Failed to retry schedule: " + e.getMessage());
+            return errorJson("Failed to retry schedule", e);
         }
     }
 
@@ -1199,7 +1212,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(descriptors);
         } catch (Exception e) {
             LOGGER.error("MCP list_channel_integrations failed", e);
-            return errorJson("Failed to list channel integrations: " + e.getMessage());
+            return errorJson("Failed to list channel integrations", e);
         }
     }
 
@@ -1224,7 +1237,7 @@ public class McpAdminTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP read_channel_integration failed for " + resourceId, e);
-            return errorJson("Failed to read channel integration: " + e.getMessage());
+            return errorJson("Failed to read channel integration", e);
         }
     }
 
@@ -1254,7 +1267,7 @@ public class McpAdminTools {
                     "status", response.getStatus()));
         } catch (Exception e) {
             LOGGER.error("MCP create_channel_integration failed", e);
-            return errorJson("Failed to create channel integration: " + e.getMessage());
+            return errorJson("Failed to create channel integration", e);
         }
     }
 
@@ -1285,7 +1298,7 @@ public class McpAdminTools {
                     "status", response.getStatus()));
         } catch (Exception e) {
             LOGGER.error("MCP update_channel_integration failed for " + resourceId, e);
-            return errorJson("Failed to update channel integration: " + e.getMessage());
+            return errorJson("Failed to update channel integration", e);
         }
     }
 
@@ -1311,7 +1324,7 @@ public class McpAdminTools {
                     "status", response.getStatus()));
         } catch (Exception e) {
             LOGGER.error("MCP delete_channel_integration failed for " + resourceId, e);
-            return errorJson("Failed to delete channel integration: " + e.getMessage());
+            return errorJson("Failed to delete channel integration", e);
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpConversationTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpConversationTools.java
@@ -135,7 +135,7 @@ public class McpConversationTools {
             return jsonSerialization.serialize(statuses);
         } catch (Exception e) {
             LOGGER.error("MCP list_agents failed", e);
-            return errorJson("Failed to list agents: " + e.getMessage());
+            return errorJson("Failed to list agents", e);
         }
     }
 
@@ -151,7 +151,7 @@ public class McpConversationTools {
             return jsonSerialization.serialize(descriptors);
         } catch (Exception e) {
             LOGGER.error("MCP list_agent_configs failed", e);
-            return errorJson("Failed to list Agent configs: " + e.getMessage());
+            return errorJson("Failed to list Agent configs", e);
         }
     }
 
@@ -175,7 +175,7 @@ public class McpConversationTools {
                     result.conversationUri().toString(), "agentId", agentId, "environment", env.name()));
         } catch (Exception e) {
             LOGGER.error("MCP create_conversation failed for Agent " + agentId, e);
-            return errorJson("Failed to create conversation: " + e.getMessage());
+            return errorJson("Failed to create conversation", e);
         }
     }
 
@@ -225,7 +225,7 @@ public class McpConversationTools {
             return skippedResultJson(conversationId, e.state());
         } catch (Exception e) {
             LOGGER.error("MCP talk_to_agent failed for Agent " + agentId + " conversation " + conversationId, e);
-            return errorJson("Failed to talk to agent: " + e.getMessage());
+            return errorJson("Failed to talk to agent", e);
         }
     }
 
@@ -292,7 +292,7 @@ public class McpConversationTools {
             return skippedResultJson(convId, e.state());
         } catch (Exception e) {
             LOGGER.error("MCP chat_with_agent failed for Agent " + agentId, e);
-            return errorJson("Failed to chat with agent: " + e.getMessage());
+            return errorJson("Failed to chat with agent", e);
         }
     }
 
@@ -352,7 +352,7 @@ public class McpConversationTools {
             return accessDenied("read_conversation", conversationId);
         } catch (Exception e) {
             LOGGER.error("MCP read_conversation failed for conversation " + conversationId, e);
-            return errorJson("Failed to read conversation: " + e.getMessage());
+            return errorJson("Failed to read conversation", e);
         }
     }
 
@@ -371,7 +371,7 @@ public class McpConversationTools {
             return accessDenied("read_conversation_log", conversationId);
         } catch (Exception e) {
             LOGGER.error("MCP read_conversation_log failed for conversation " + conversationId, e);
-            return errorJson("Failed to read conversation log: " + e.getMessage());
+            return errorJson("Failed to read conversation log", e);
         }
     }
 
@@ -404,7 +404,7 @@ public class McpConversationTools {
             try {
                 convStore = restInterfaceFactory.get(IRestConversationStore.class);
             } catch (RestInterfaceFactory.RestInterfaceFactoryException e) {
-                return errorJson("Failed to get conversation store: " + e.getMessage());
+                return errorJson("Failed to get conversation store", e);
             }
 
             // Ownership filtering is enforced by the conversation store itself:
@@ -424,7 +424,7 @@ public class McpConversationTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP list_conversations failed for Agent " + agentId, e);
-            return errorJson("Failed to list conversations: " + e.getMessage());
+            return errorJson("Failed to list conversations", e);
         }
     }
 
@@ -460,7 +460,7 @@ public class McpConversationTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP get_agent failed for Agent " + agentId, e);
-            return errorJson("Failed to get agent: " + e.getMessage());
+            return errorJson("Failed to get agent", e);
         }
     }
 
@@ -518,7 +518,7 @@ public class McpConversationTools {
             return accessDenied("read_agent_logs", conversationId);
         } catch (Exception e) {
             LOGGER.error("MCP read_agent_logs failed", e);
-            return errorJson("Failed to read Agent logs: " + e.getMessage());
+            return errorJson("Failed to read Agent logs", e);
         }
     }
 
@@ -548,7 +548,7 @@ public class McpConversationTools {
             return accessDenied("read_audit_trail", conversationId);
         } catch (Exception e) {
             LOGGER.error("MCP read_audit_trail failed for conversation " + conversationId, e);
-            return errorJson("Failed to read audit trail: " + e.getMessage());
+            return errorJson("Failed to read audit trail", e);
         }
     }
 
@@ -613,7 +613,7 @@ public class McpConversationTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP discover_agents failed", e);
-            return errorJson("Failed to discover agents: " + e.getMessage());
+            return errorJson("Failed to discover agents", e);
         }
     }
 
@@ -692,7 +692,7 @@ public class McpConversationTools {
             return errorJson("Access denied: you do not own this managed conversation");
         } catch (Exception e) {
             LOGGER.errorv("MCP chat_managed failed for intent={0}, userId={1}: {2}", intent, userId, e.getMessage());
-            return errorJson("Failed to chat via managed agent: " + e.getMessage());
+            return errorJson("Failed to chat via managed agent", e);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.mcp;
 
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
@@ -59,6 +60,13 @@ public class McpGroupTools {
     private final IRestAgentGroupStore groupStore;
     private final IGroupConversationService groupConversationService;
     private final IJsonSerialization jsonSerialization;
+
+    /**
+     * Strict deserialisation for the config bodies this surface accepts — the same
+     * check REST's {@code StrictConfigurationBodyInterceptor} applies, which never
+     * fires for these in-process calls. See {@code StrictConfigurationParser}.
+     */
+    private final StrictConfigurationParser configParser;
     private final SecurityIdentity identity;
     private final OwnershipValidator ownershipValidator;
     private final IGroupWorkspaceStore workspaceStore;
@@ -67,9 +75,10 @@ public class McpGroupTools {
 
     @Inject
     public McpGroupTools(IRestAgentGroupStore groupStore, IGroupConversationService groupConversationService, IJsonSerialization jsonSerialization,
-            SecurityIdentity identity, OwnershipValidator ownershipValidator, IGroupWorkspaceStore workspaceStore,
-            GroupTemplateService templateService,
+            StrictConfigurationParser configParser, SecurityIdentity identity, OwnershipValidator ownershipValidator,
+            IGroupWorkspaceStore workspaceStore, GroupTemplateService templateService,
             @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authEnabled) {
+        this.configParser = configParser;
         this.groupStore = groupStore;
         this.groupConversationService = groupConversationService;
         this.jsonSerialization = jsonSerialization;
@@ -336,12 +345,17 @@ public class McpGroupTools {
         requireRole(identity, authEnabled, "eddi-editor");
         try {
             int ver = parseIntOrDefault(version, 0);
-            AgentGroupConfiguration config = jsonSerialization.deserialize(configJson, AgentGroupConfiguration.class);
+            // Same strictness as PUT /groupstore/groups — AgentGroupConfiguration is a
+            // first-party config model, so a typo'd key must be rejected here too
+            // rather than dropped into a silently different group.
+            AgentGroupConfiguration config = configParser.parse(configJson, AgentGroupConfiguration.class);
             groupStore.updateGroup(groupId, ver, config);
             return "Updated group " + groupId;
         } catch (Exception e) {
             LOGGER.errorf("update_group failed: %s", e.getMessage());
-            return errorJson(e.getMessage());
+            // describe(), not getMessage(): the strict parser's rejection travels as a
+            // response entity, and getMessage() on that is just "HTTP 400 Bad Request".
+            return errorJson("Failed to update group", e);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGroupTools.java
@@ -244,7 +244,8 @@ public class McpGroupTools {
                                        + "(default) or GROUP for nested groups (optional)") String memberTypes,
                                @ToolArg(description = "Moderator agent ID (optional)") String moderatorAgentId,
                                @ToolArg(description = "Discussion style: ROUND_TABLE, PEER_REVIEW, "
-                                       + "DEVIL_ADVOCATE, DELPHI, DEBATE, TASK_FORCE (default ROUND_TABLE)") String style,
+                                       + "DEVIL_ADVOCATE, DELPHI, DEBATE, TASK_FORCE, NEGOTIATION, CUSTOM "
+                                       + "(default ROUND_TABLE). All eight work; see describe_discussion_styles") String style,
                                @ToolArg(description = "Max rounds (default 2)") String maxRounds,
                                @ToolArg(description = "Maximum total agent turns across all phases (default 50). "
                                        + "Safety cap to prevent runaway discussions.") String maxTurns,
@@ -300,7 +301,7 @@ public class McpGroupTools {
                     TaskDefinition[] taskArray = jsonSerialization.deserialize(tasks, TaskDefinition[].class);
                     config.setTasks(List.of(taskArray));
                 } catch (Exception ex) {
-                    return errorJson("Invalid tasks JSON: " + ex.getMessage());
+                    return errorJson("Invalid tasks JSON", ex);
                 }
             }
 
@@ -387,7 +388,8 @@ public class McpGroupTools {
     @Tool(description = "Read a group conversation including its full transcript, task list "
             + "(for TASK_FORCE discussions with per-task status, assignments, and results), "
             + "dynamic agent tracking (createdAgentIds, retainedAgentIds), synthesized answer, "
-            + "structured decision record (verdict/vote/agreement/award, if one was reached), "
+            + "the structured decision record in the 'decision' field "
+            + "(verdict/vote/agreement/award, if one was reached), "
             + "and conversation state. Use this to poll for completion after start_group_discussion, "
             + "or to inspect task-level results after a TASK_FORCE discussion.")
     public String read_group_conversation(
@@ -464,8 +466,9 @@ public class McpGroupTools {
         }
     }
 
-    @Tool(description = "Delete a group conversation and cascade-delete all member "
-            + "conversations created during the discussion.")
+    @Tool(description = "Delete a group conversation. Its shared artifacts and any ephemeral agents "
+            + "created for it are deleted; the members' own conversations are ENDED, not deleted, and "
+            + "remain readable afterwards.")
     public String delete_group_conversation(
                                             @ToolArg(description = "Group conversation ID to delete") String groupConversationId) {
         requireRole(identity, authEnabled, "eddi-editor");

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpMemoryTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpMemoryTools.java
@@ -79,7 +79,7 @@ public class McpMemoryTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP list_user_memories failed for user: " + userId, e);
-            return errorJson("Failed to list memories: " + e.getMessage());
+            return errorJson("Failed to list memories", e);
         }
     }
 
@@ -112,7 +112,7 @@ public class McpMemoryTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP get_visible_memories failed", e);
-            return errorJson("Failed to get visible memories: " + e.getMessage());
+            return errorJson("Failed to get visible memories", e);
         }
     }
 
@@ -136,7 +136,7 @@ public class McpMemoryTools {
             return jsonSerialization.serialize(result);
         } catch (Exception e) {
             LOGGER.error("MCP search_user_memories failed", e);
-            return errorJson("Failed to search memories: " + e.getMessage());
+            return errorJson("Failed to search memories", e);
         }
     }
 
@@ -158,7 +158,7 @@ public class McpMemoryTools {
             }
         } catch (Exception e) {
             LOGGER.error("MCP get_memory_by_key failed", e);
-            return errorJson("Failed to get memory: " + e.getMessage());
+            return errorJson("Failed to get memory", e);
         }
     }
 
@@ -191,7 +191,7 @@ public class McpMemoryTools {
             return errorJson("Invalid visibility value. Use: self, group, or global");
         } catch (Exception e) {
             LOGGER.error("MCP upsert_user_memory failed", e);
-            return errorJson("Failed to upsert memory: " + e.getMessage());
+            return errorJson("Failed to upsert memory", e);
         }
     }
 
@@ -205,7 +205,7 @@ public class McpMemoryTools {
             return jsonSerialization.serialize(Map.of("entryId", entryId, "status", "deleted"));
         } catch (Exception e) {
             LOGGER.error("MCP delete_user_memory failed", e);
-            return errorJson("Failed to delete memory: " + e.getMessage());
+            return errorJson("Failed to delete memory", e);
         }
     }
 
@@ -225,7 +225,7 @@ public class McpMemoryTools {
             return jsonSerialization.serialize(Map.of("userId", userId, "entriesDeleted", count, "status", "deleted"));
         } catch (Exception e) {
             LOGGER.error("MCP delete_all_user_memories failed", e);
-            return errorJson("Failed to delete memories: " + e.getMessage());
+            return errorJson("Failed to delete memories", e);
         }
     }
 
@@ -240,7 +240,7 @@ public class McpMemoryTools {
             return jsonSerialization.serialize(Map.of("userId", userId, "count", count));
         } catch (Exception e) {
             LOGGER.error("MCP count_user_memories failed", e);
-            return errorJson("Failed to count memories: " + e.getMessage());
+            return errorJson("Failed to count memories", e);
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpSetupTools.java
@@ -112,7 +112,7 @@ public class McpSetupTools {
             return errorJson(e.getMessage());
         } catch (Exception e) {
             LOGGER.error("MCP setup_agent failed", e);
-            return errorJson("Failed to set up agent: " + e.getMessage());
+            return errorJson("Failed to set up agent", e);
         }
     }
 
@@ -164,7 +164,7 @@ public class McpSetupTools {
             return errorJson(e.getMessage());
         } catch (Exception e) {
             LOGGER.error("MCP create_api_agent failed", e);
-            return errorJson("Failed to create API agent: " + e.getMessage());
+            return errorJson("Failed to create API agent", e);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpToolUtils.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpToolUtils.java
@@ -12,7 +12,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 
 import java.util.Collection;
 import java.util.Map;
-import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ClientErrorException;
 
 /**
  * Shared utility methods for MCP tool implementations.
@@ -177,19 +177,28 @@ final class McpToolUtils {
     /**
      * A throwable's message, or its class's simple name when it has none.
      * <p>
-     * A {@link WebApplicationException} is unwrapped to its response entity first.
-     * These tools call EDDI's own REST stores in-process, and a JAX-RS exception
-     * built from a {@code Response} carries the useful text in that entity while
-     * {@code getMessage()} returns only the status line — so a precise "Unknown
-     * field 'setProperties' … Known fields: [setOnActions]" would otherwise reach
-     * the MCP client as "HTTP 400 Bad Request".
+     * A <strong>client error</strong> ({@link ClientErrorException}, i.e. 4xx) is
+     * unwrapped to its response entity first. These tools call EDDI's own REST
+     * stores in-process, and a JAX-RS exception built from a {@code Response}
+     * carries the useful text in that entity while {@code getMessage()} returns
+     * only the status line — so a precise "Unknown field 'setProperties' … Known
+     * fields: [setOnActions]" would otherwise reach the MCP client as "HTTP 400 Bad
+     * Request", which is exactly the MCP/REST parity this exists to preserve.
+     * <p>
+     * Only 4xx. A 4xx entity is a message this codebase authored <em>for</em> the
+     * caller, describing what the caller got wrong. A 5xx entity is not written to
+     * that contract and can carry endpoint, datastore or configuration detail, so
+     * it falls through to the message below and is never lifted verbatim. Every MCP
+     * tool that reaches this point is already behind {@code requireRole}, but "the
+     * caller is an admin" is a reason to answer usefully, not a reason to stop
+     * distinguishing the two.
      */
     static String describe(Throwable cause) {
         if (cause == null) {
             return "unknown cause";
         }
-        if (cause instanceof WebApplicationException wae) {
-            var response = wae.getResponse();
+        if (cause instanceof ClientErrorException clientError) {
+            var response = clientError.getResponse();
             if (response != null && response.hasEntity() && response.getEntity() instanceof String entity && !entity.isBlank()) {
                 return entity;
             }

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpToolUtils.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpToolUtils.java
@@ -12,6 +12,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 
 import java.util.Collection;
 import java.util.Map;
+import jakarta.ws.rs.WebApplicationException;
 
 /**
  * Shared utility methods for MCP tool implementations.
@@ -156,6 +157,45 @@ final class McpToolUtils {
      */
     static String errorJson(String message) {
         return "{\"error\":\"" + escapeJsonString(message) + "\"}";
+    }
+
+    /**
+     * Build an error JSON response describing a failure, from a caller-supplied
+     * prefix and the exception that caused it.
+     * <p>
+     * Prefer this over {@code errorJson(prefix + ": " + e.getMessage())}: plenty of
+     * exceptions carry no message, and the concatenation then renders literally as
+     * {@code "Failed to chat with agent: null"} — an error that says a call failed
+     * and nothing whatsoever about why. The class name is not a diagnosis either,
+     * but it is the difference between "something threw" and "a
+     * ResourceNotFoundException threw".
+     */
+    static String errorJson(String prefix, Throwable cause) {
+        return errorJson(prefix + ": " + describe(cause));
+    }
+
+    /**
+     * A throwable's message, or its class's simple name when it has none.
+     * <p>
+     * A {@link WebApplicationException} is unwrapped to its response entity first.
+     * These tools call EDDI's own REST stores in-process, and a JAX-RS exception
+     * built from a {@code Response} carries the useful text in that entity while
+     * {@code getMessage()} returns only the status line — so a precise "Unknown
+     * field 'setProperties' … Known fields: [setOnActions]" would otherwise reach
+     * the MCP client as "HTTP 400 Bad Request".
+     */
+    static String describe(Throwable cause) {
+        if (cause == null) {
+            return "unknown cause";
+        }
+        if (cause instanceof WebApplicationException wae) {
+            var response = wae.getResponse();
+            if (response != null && response.hasEntity() && response.getEntity() instanceof String entity && !entity.isBlank()) {
+                return entity;
+            }
+        }
+        String message = cause.getLocalizedMessage();
+        return message == null || message.isBlank() ? cause.getClass().getSimpleName() : message;
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationLogGenerator.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationLogGenerator.java
@@ -9,14 +9,11 @@ import ai.labs.eddi.engine.memory.model.ConversationLog.ConversationPart;
 import ai.labs.eddi.engine.memory.model.ConversationLog.ConversationPart.Content;
 import ai.labs.eddi.engine.memory.model.ConversationLog.ConversationPart.ContentType;
 import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
-import ai.labs.eddi.modules.output.model.types.TextOutputItem;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static ai.labs.eddi.engine.memory.model.ConversationLog.ConversationPart.ContentType.*;
 import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
@@ -26,9 +23,7 @@ public class ConversationLogGenerator {
     private static final String KEY_ROLE_ASSISTANT = "assistant";
     private static final Object OUTPUT_KEY_CONTEXT = "context";
     private static final String OUTPUT_KEY_INPUT = "input";
-    private static final String OUTPUT_KEY_OUTPUT = "output";
     private static final String KEY_INPUT_FILES = "inputFiles";
-    private static final String KEY_TEXT = "text";
     private static final String KEY_TYPE = "type";
     private static final String KEY_URL = "url";
 
@@ -112,33 +107,18 @@ public class ConversationLogGenerator {
                     conversationLog.getMessages().add(new ConversationPart(KEY_ROLE_USER, inputs));
                 }
 
-                var output = conversationOutput.get(OUTPUT_KEY_OUTPUT);
-                if (output instanceof List<?> outputList) {
-                    if (!outputList.isEmpty()) {
-                        var outputContentList = new LinkedList<Content>();
-                        var content = new Content();
-                        outputContentList.add(content);
-                        if (outputList.getFirst() instanceof Map) {
-                            @SuppressWarnings("unchecked")
-                            var mapList = (List<Map<String, Object>>) outputList;
-                            var joinedOutput = mapList.stream()
-                                    .map(item -> item.get(KEY_TEXT))
-                                    .filter(Objects::nonNull)
-                                    .map(Object::toString)
-                                    .collect(Collectors.joining(" "));
-                            content.setType(text);
-                            content.setValue(joinedOutput);
-                            conversationLog.getMessages().add(new ConversationPart(KEY_ROLE_ASSISTANT, outputContentList));
-
-                        } else if (outputList.getFirst() instanceof TextOutputItem) {
-                            @SuppressWarnings("unchecked")
-                            var textOutputList = (List<TextOutputItem>) outputList;
-                            var joinedOutput = textOutputList.stream().map(TextOutputItem::getText).collect(Collectors.joining(" "));
-                            content.setType(text);
-                            content.setValue(joinedOutput);
-                            conversationLog.getMessages().add(new ConversationPart(KEY_ROLE_ASSISTANT, outputContentList));
-                        }
-                    }
+                // Every item is inspected, whatever its type. Deciding the list's shape
+                // from element zero dropped the assistant turn entirely whenever the list
+                // began with a String — which is what a HITL-gated turn writes via
+                // addConversationOutputString, so approved turns went missing from the log.
+                var joinedOutput = ConversationOutputExtractor.extractText(conversationOutput, " ");
+                if (joinedOutput != null) {
+                    var content = new Content();
+                    content.setType(text);
+                    content.setValue(joinedOutput);
+                    var outputContentList = new LinkedList<Content>();
+                    outputContentList.add(content);
+                    conversationLog.getMessages().add(new ConversationPart(KEY_ROLE_ASSISTANT, outputContentList));
                 }
             }
 

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilities.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryUtilities.java
@@ -43,6 +43,9 @@ public class ConversationMemoryUtilities {
 
         for (var redoStep : conversationMemory.getRedoCache()) {
             var redoStepSnapshot = iterateConversationStep(redoStep);
+            // A redo entry's output is not in snapshot.conversationOutputs — undo popped
+            // it. Carry it on the step itself, or redo restores an empty turn.
+            redoStepSnapshot.setConversationOutput(redoStep.getConversationOutput());
             snapshot.getRedoCache().push(redoStepSnapshot);
         }
 
@@ -111,7 +114,10 @@ public class ConversationMemoryUtilities {
     private static List<IConversationStep> iterateRedoCache(List<ConversationStepSnapshot> redoSteps) {
         List<IConversationStep> conversationSteps = new LinkedList<>();
         for (var redoStep : redoSteps) {
-            IWritableConversationStep conversationStep = new ConversationStep(new ConversationOutput());
+            // Null for documents written before the output was carried here; an empty
+            // output then behaves exactly as it did before.
+            var storedOutput = redoStep.getConversationOutput();
+            IWritableConversationStep conversationStep = new ConversationStep(storedOutput != null ? storedOutput : new ConversationOutput());
             conversationSteps.add(conversationStep);
             for (var packageRunSnapshot : redoStep.getWorkflows()) {
                 for (var resultSnapshot : packageRunSnapshot.getLifecycleTasks()) {

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
@@ -38,6 +38,9 @@ public final class ConversationOutputExtractor {
 
     private static final Logger LOGGER = Logger.getLogger(ConversationOutputExtractor.class);
 
+    /** The delimiter the snapshot-level extraction has always used. */
+    private static final String LINE_DELIMITER = "\n";
+
     private ConversationOutputExtractor() {
         // Utility class
     }
@@ -56,7 +59,45 @@ public final class ConversationOutputExtractor {
             return null;
         }
         List<ConversationOutput> outputs = snapshot.getConversationOutputs();
-        ConversationOutput lastOutput = outputs.get(outputs.size() - 1);
+        return extractText(outputs.get(outputs.size() - 1), LINE_DELIMITER);
+    }
+
+    /**
+     * Extracts the human-readable text from a single {@link ConversationOutput},
+     * joining multiple output items with a newline.
+     *
+     * @param output
+     *            the output to extract from (may be null)
+     * @return the extracted text, or {@code null} if no meaningful output is found
+     */
+    public static String extractText(ConversationOutput output) {
+        return extractText(output, LINE_DELIMITER);
+    }
+
+    /**
+     * Extracts the human-readable text from a single {@link ConversationOutput}.
+     * <p>
+     * Every item of the {@code output} list is inspected, whatever its runtime type
+     * — a turn's output list is heterogeneous. A turn gated by HITL, for instance,
+     * writes its pre-pause announcement through
+     * {@code addConversationOutputString(...)}, so its list reads
+     * {@code [String, String, Map]} where an ordinary turn's reads {@code [Map]}.
+     * Deciding the shape of the whole list from its first element — the bug this
+     * method replaces — discarded every such turn in full, which is why an approved
+     * HITL turn vanished from {@code GET /agents/&#123;id&#125;/log}, from the
+     * rolling summary, from the recall tool, and from the agent's own chat history:
+     * the Platform Operator went on to state that a group a human had approved "was
+     * never created".
+     *
+     * @param output
+     *            the output to extract from (may be null)
+     * @param delimiter
+     *            joins multiple output items; callers differ, see
+     *            {@code ConversationOutputUtils}
+     * @return the extracted text, or {@code null} if no meaningful output is found
+     */
+    public static String extractText(ConversationOutput output, String delimiter) {
+        ConversationOutput lastOutput = output;
         if (lastOutput == null) {
             return null;
         }
@@ -77,7 +118,7 @@ public final class ConversationOutputExtractor {
                 }
             }
             if (!texts.isEmpty()) {
-                return String.join("\n", texts);
+                return String.join(delimiter, texts);
             }
         } else if (outputValue instanceof String s && hasText(s)) {
             // Plain string written via addConversationOutputString("output", ...)
@@ -109,7 +150,7 @@ public final class ConversationOutputExtractor {
         }
 
         if (!texts.isEmpty()) {
-            return String.join("\n", texts);
+            return String.join(delimiter, texts);
         }
 
         // Format 3: "reply" key — used by some task extensions
@@ -122,7 +163,7 @@ public final class ConversationOutputExtractor {
                     texts.add(s);
             }
             if (!texts.isEmpty()) {
-                return String.join("\n", texts);
+                return String.join(delimiter, texts);
             }
         }
 

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationOutputExtractor.java
@@ -89,15 +89,14 @@ public final class ConversationOutputExtractor {
      * the Platform Operator went on to state that a group a human had approved "was
      * never created".
      *
-     * @param output
+     * @param lastOutput
      *            the output to extract from (may be null)
      * @param delimiter
      *            joins multiple output items; callers differ, see
      *            {@code ConversationOutputUtils}
      * @return the extracted text, or {@code null} if no meaningful output is found
      */
-    public static String extractText(ConversationOutput output, String delimiter) {
-        ConversationOutput lastOutput = output;
+    public static String extractText(ConversationOutput lastOutput, String delimiter) {
         if (lastOutput == null) {
             return null;
         }

--- a/src/main/java/ai/labs/eddi/engine/memory/model/ConversationMemorySnapshot.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/model/ConversationMemorySnapshot.java
@@ -127,6 +127,25 @@ public class ConversationMemorySnapshot {
     public static class ConversationStepSnapshot {
         private List<WorkflowRunSnapshot> packages = new LinkedList<>();
 
+        /**
+         * The step's rendered output — populated only for redo-cache entries, and
+         * {@code null} for the ordinary {@code conversationSteps}, whose outputs are
+         * stored once in {@link ConversationMemorySnapshot#conversationOutputs}.
+         * <p>
+         * Undo/redo in live memory always kept the output, because the step object
+         * carries it. Serialisation did not: a redo entry rehydrated as
+         * {@code new ConversationStep(new ConversationOutput())}, so
+         * {@code redoLastStep()} pushed an <em>empty</em> output over the answer it was
+         * supposed to restore. Since every request reloads memory from the store, that
+         * always fired in practice — redo returned 200 while destroying the turn, and
+         * the model lost it too, because {@code conversationOutputs} is what
+         * {@code ConversationHistoryBuilder} reads.
+         * <p>
+         * Absent in documents written before this field existed; those deserialize to
+         * {@code null} and load exactly as they did before.
+         */
+        private ConversationOutput conversationOutput;
+
         @Override
         public boolean equals(Object o) {
             if (this == o)
@@ -136,12 +155,13 @@ public class ConversationMemorySnapshot {
 
             ConversationStepSnapshot that = (ConversationStepSnapshot) o;
 
-            return Objects.equals(packages, that.packages);
+            return Objects.equals(packages, that.packages)
+                    && Objects.equals(conversationOutput, that.conversationOutput);
         }
 
         @Override
         public int hashCode() {
-            return packages != null ? packages.hashCode() : 0;
+            return Objects.hash(packages, conversationOutput);
         }
 
         public List<WorkflowRunSnapshot> getWorkflows() {
@@ -150,6 +170,14 @@ public class ConversationMemorySnapshot {
 
         public void setWorkflows(List<WorkflowRunSnapshot> packages) {
             this.packages = packages;
+        }
+
+        public ConversationOutput getConversationOutput() {
+            return conversationOutput;
+        }
+
+        public void setConversationOutput(ConversationOutput conversationOutput) {
+            this.conversationOutput = conversationOutput;
         }
 
     }

--- a/src/main/java/ai/labs/eddi/engine/runtime/client/agents/AgentStoreClientLibrary.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/client/agents/AgentStoreClientLibrary.java
@@ -51,9 +51,16 @@ public class AgentStoreClientLibrary implements IAgentStoreClientLibrary {
             }
         }
 
-        // Persistent User Memory (Phase 11a)
-        if (agentConfig.isEnableMemoryTools() && agentConfig.getUserMemoryConfig() != null) {
-            ((Agent) agent).setUserMemoryConfig(agentConfig.getUserMemoryConfig());
+        // Persistent User Memory (Phase 11a).
+        //
+        // enableMemoryTools is the opt-in; userMemoryConfig is tuning on top of it,
+        // and every one of its fields already has a working default. Requiring both
+        // made the second a hidden second switch: an agent that set enableMemoryTools
+        // and nothing else got no memory tool and no explanation, because the skip is
+        // silent. Fall back to the defaults instead.
+        if (agentConfig.isEnableMemoryTools()) {
+            var memoryConfig = agentConfig.getUserMemoryConfig();
+            ((Agent) agent).setUserMemoryConfig(memoryConfig != null ? memoryConfig : new AgentConfiguration.UserMemoryConfig());
         }
 
         // Memory Policy (Phase A: Strict Write Discipline)

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -254,17 +254,54 @@ public class Conversation implements IConversation {
         return this.conversationMemory.getConversationState();
     }
 
+    /**
+     * The step results a rerun discards before re-executing: the rendered answer
+     * and its quick replies.
+     */
+    private static final List<String> RERUN_CLEARED_RESULT_TYPES = List.of("output", "quickReplies");
+
+    /**
+     * Where a rerun restarts the pipeline — the earliest task type that can
+     * <em>produce</em> what {@link #RERUN_CLEARED_RESULT_TYPES} discards.
+     * <p>
+     * Selective execution runs the suffix of the pipeline from the first task
+     * matching any of these types, so this set and the cleared set have to agree: a
+     * rerun must never clear a result it will not regenerate. Restarting at
+     * {@code output} alone did exactly that on any LLM agent. The model's answer is
+     * stored under {@code output} but is written by the {@code langchain} task,
+     * which sits <em>before</em> the output task — so the answer was wiped,
+     * {@code ai.labs.llm} never re-ran, and the output task alone had nothing left
+     * to render. The turn came back 200 with {@code conversationOutputs[n].output}
+     * an empty array, destroying the reply instead of retrying it — and taking it
+     * out of the model's own history with it.
+     * <p>
+     * Restarting at {@code langchain} re-runs only the model and everything after
+     * it. Tasks before it — parser, behavior rules, property setters, HTTP calls —
+     * keep their results, so a retry does not re-fire external side effects. A
+     * rule-based agent has no {@code langchain} task, so it still restarts at
+     * {@code output} and behaves exactly as before.
+     */
+    private static final List<String> RERUN_RESTART_TASK_TYPES = List.of("langchain", "output", "quickReplies");
+
     @Override
     public void rerun(final Map<String, Context> contexts) throws ConversationNotReadyException, LifecycleException {
-        runStep("", contexts, false, Arrays.asList("output", "quickReplies"));
+        runStep("", contexts, false, RERUN_CLEARED_RESULT_TYPES, RERUN_RESTART_TASK_TYPES);
     }
 
     @Override
     public void say(final String message, final Map<String, Context> contexts) throws LifecycleException, ConversationNotReadyException {
-        runStep(message, contexts, true, new LinkedList<>());
+        runStep(message, contexts, true, new LinkedList<>(), new LinkedList<>());
     }
 
-    private void runStep(String message, Map<String, Context> contexts, boolean startNewStep, List<String> lifecycleTaskTypes)
+    /**
+     * @param clearedResultTypes
+     *            task-type results to drop from the current step before executing
+     * @param restartTaskTypes
+     *            the pipeline restarts at the first task matching one of these;
+     *            empty means "run every task"
+     */
+    private void runStep(String message, Map<String, Context> contexts, boolean startNewStep,
+                         List<String> clearedResultTypes, List<String> restartTaskTypes)
             throws ConversationNotReadyException, LifecycleException {
 
         // Auto-recover from transient interrupted state
@@ -283,8 +320,8 @@ public class Conversation implements IConversation {
                 startNextStep();
             }
 
-            var lifecycleData = prepareLifecycleData(message, contexts, lifecycleTaskTypes);
-            executeConversationStep(lifecycleData, lifecycleTaskTypes);
+            var lifecycleData = prepareLifecycleData(message, contexts, clearedResultTypes);
+            executeConversationStep(lifecycleData, restartTaskTypes);
 
         } catch (LifecycleException.LifecycleInterruptedException e) {
             setConversationState(ConversationState.EXECUTION_INTERRUPTED);

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -297,10 +297,16 @@ public class Conversation implements IConversation {
      * an empty array, destroying the reply instead of retrying it — and taking it
      * out of the model's own history with it.
      * <p>
-     * Restarting at {@code langchain} re-runs only the model and everything after
-     * it. Tasks before it — parser, behavior rules, property setters, HTTP calls —
-     * keep their results, so a retry does not re-fire external side effects. A
-     * rule-based agent has no {@code langchain} task, so it still restarts at
+     * Restarting at {@code langchain} re-runs the model and every task after it.
+     * Whatever precedes it keeps its results — in the standard workflow layout
+     * ({@code AgentSetupService#createWorkflowConfig}) that is parser, behavior
+     * rules, property setters and HTTP/MCP calls, so a retry does not re-fire those
+     * external side effects. That is the layout, not an invariant: a workflow that
+     * deliberately places {@code httpcalls} <em>after</em> its LLM step will re-run
+     * those calls on a rerun, which is the same thing "re-execute the last step"
+     * has always meant for whatever follows the restart point.
+     * <p>
+     * A rule-based agent has no {@code langchain} task, so it still restarts at
      * {@code output} and behaves exactly as before.
      */
     private static final List<String> RERUN_RESTART_TASK_TYPES = List.of("langchain", "output", "quickReplies");

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/Conversation.java
@@ -83,7 +83,32 @@ public class Conversation implements IConversation {
         this.conversationMemory = conversationMemory;
         this.propertiesHandler = propertiesHandler;
         this.outputProvider = outputProvider;
+        applyUserMemoryConfig();
         captureRestoredLongTermBaseline();
+    }
+
+    /**
+     * Carries the agent's user-memory configuration onto this turn's memory object.
+     * <p>
+     * This has to happen per turn, not per conversation. The field is not part of
+     * the persisted snapshot, and every request rebuilds memory from the store — so
+     * setting it only in {@link #init()} meant it was present for the
+     * CONVERSATION_START turn and null for every turn after it. The gate in
+     * {@code ContextualToolsProvider.addUserMemoryToolIfEnabled} reads exactly that
+     * field, so the {@code UserMemoryTool} was never assembled on a turn a user
+     * could actually talk to. An agent with memory fully enabled could not write a
+     * single memory, silently: no error, no log line, the store simply stayed at
+     * zero — and the model, handed no tool, went on to state that it had saved
+     * things it had not, once leaking raw tool-call syntax into user-visible
+     * output. The constructor is the one point every path goes through
+     * ({@code Agent#continueConversation} builds a Conversation for say, resume and
+     * rerun alike).
+     */
+    private void applyUserMemoryConfig() {
+        AgentConfiguration.UserMemoryConfig memoryConfig = propertiesHandler.getUserMemoryConfig();
+        if (memoryConfig != null) {
+            conversationMemory.setUserMemoryConfig(memoryConfig);
+        }
     }
 
     /**
@@ -170,11 +195,8 @@ public class Conversation implements IConversation {
 
         addConversationStartAction(conversationMemory.getCurrentStep());
 
-        // Set UserMemoryConfig on the memory (if advanced tools are enabled)
-        AgentConfiguration.UserMemoryConfig memoryConfig = propertiesHandler.getUserMemoryConfig();
-        if (memoryConfig != null) {
-            conversationMemory.setUserMemoryConfig(memoryConfig);
-        }
+        // The config is applied in the constructor, which every turn goes through —
+        // init() is only the first of them. Re-applying is harmless but pointless.
 
         // Load all user properties from usermemories (always, regardless of
         // enableMemoryTools)

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProvider.java
@@ -27,9 +27,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.Collections;
 
 /**
  * The three conversation-context-dependent tool sources — persistent user
@@ -64,12 +66,19 @@ class ContextualToolsProvider implements ToolSourceProvider {
     private final AttachmentTextExtractor attachmentTextExtractor;
 
     /**
-     * Agents already warned about the memory/built-ins conflict. Static because
+     * Agents already warned about the memory/built-ins conflict — see
+     * {@link #warnIfMemoryEnabledButBuiltInsAreOff}. Static because
      * {@code AgentOrchestrator} constructs this provider per call, so an instance
-     * field would debounce nothing; bounded by the number of distinct agents. — see
-     * {@link #warnIfMemoryEnabledButBuiltInsAreOff}.
+     * field would debounce nothing. Bounded and expiring rather than a plain set:
+     * "the number of distinct agents" is not a fixed bound on this platform —
+     * dynamic and ephemeral agents are created at runtime with fresh ids, so a
+     * long-lived deployment with churn would otherwise accumulate entries for the
+     * JVM lifetime. Expiry also means a standing misconfiguration re-announces
+     * itself daily instead of exactly once per process.
      */
-    private static final Set<String> MEMORY_MISCONFIGURATION_WARNED = ConcurrentHashMap.newKeySet();
+    private static final Set<String> MEMORY_MISCONFIGURATION_WARNED = Collections.newSetFromMap(
+            Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofHours(24))
+                    .<String, Boolean>build().asMap());
 
     ContextualToolsProvider(IUserMemoryStore userMemoryStore, IAttachmentStore attachmentStore,
             AttachmentTextExtractor attachmentTextExtractor) {
@@ -161,7 +170,7 @@ class ContextualToolsProvider implements ToolSourceProvider {
         }
         LOGGER.warnf("[MEMORY] Agent '%s' has persistent user memory enabled, but this LLM task has "
                 + "enableBuiltInTools=%s — UserMemoryTool is NOT attached and the agent cannot write memories. "
-                + "Set enableBuiltInTools: true on the task (conversation='%s'). Logged once per agent.",
+                + "Set enableBuiltInTools: true on the task (conversation='%s'). Logged at most once per agent per day.",
                 sanitize(agentId), ctx.task().getEnableBuiltInTools(),
                 sanitize(ctx.memory().getConversationId()));
     }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProvider.java
@@ -85,7 +85,9 @@ class ContextualToolsProvider implements ToolSourceProvider {
      * {@code readAttachment}. Null means disabled, and null is the default. User
      * memory is a persistent cross-conversation <em>write</em> capability, so
      * handing it to an agent with built-ins off would be a real privilege
-     * escalation, not a cosmetic difference.</li>
+     * escalation, not a cosmetic difference. An agent that enabled memory and lands
+     * here is warned about rather than skipped silently — see
+     * {@link #warnIfMemoryEnabledButBuiltInsAreOff}.</li>
      * <li>a whitelist is configured ⇒ user memory only on {@code "usermemory"},
      * recall only on {@code "conversationRecall"}.</li>
      * <li>no whitelist ⇒ both, as today.</li>
@@ -105,6 +107,8 @@ class ContextualToolsProvider implements ToolSourceProvider {
             if (ctx.hasNoWhitelist() || ctx.isWhitelisted("conversationRecall")) {
                 addConversationRecallToolIfEnabled(tools, ctx.task(), ctx.memory());
             }
+        } else {
+            warnIfMemoryEnabledButBuiltInsAreOff(ctx);
         }
         // readAttachment is NOT contributed here — see AttachmentToolsProvider. It
         // has to be assembled after the dynamic-agent tools to keep the pre-SPI spec
@@ -116,6 +120,31 @@ class ContextualToolsProvider implements ToolSourceProvider {
         var reflected = ToolObjectReflector.reflect(tools);
         return new ToolContribution(reflected.specs(), reflected.executors(), reflected.toolSources(), Map.of(),
                 List.of(), reflected.toolCanonicalNames());
+    }
+
+    /**
+     * Says out loud that an agent asked for persistent memory and this task will
+     * not give it any.
+     * <p>
+     * Attaching {@code UserMemoryTool} is a three-way conjunction across two
+     * configuration files — the agent's {@code enableMemoryTools}, its
+     * {@code userMemoryConfig}, and this task's {@code enableBuiltInTools} — and
+     * failing any part produced no output at all. An agent designer who enabled
+     * memory and got none had nothing to read: no error, no log line, and a model
+     * that cheerfully claimed to have saved things it had not. The conflict is
+     * resolved the restrictive way on purpose ({@code enableBuiltInTools: false} is
+     * a task-level statement that this task gets no built-in capability, and user
+     * memory is a cross-conversation write), but it must be visible.
+     */
+    private void warnIfMemoryEnabledButBuiltInsAreOff(ToolAssemblyContext ctx) {
+        if (ctx.memory().getUserMemoryConfig() == null || userMemoryStore == null) {
+            return;
+        }
+        LOGGER.warnf("[MEMORY] Agent '%s' has persistent user memory enabled, but this LLM task has "
+                + "enableBuiltInTools=%s — UserMemoryTool is NOT attached and the agent cannot write memories. "
+                + "Set enableBuiltInTools: true on the task (conversation='%s').",
+                sanitize(ctx.memory().getAgentId()), ctx.task().getEnableBuiltInTools(),
+                sanitize(ctx.memory().getConversationId()));
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProvider.java
@@ -73,8 +73,9 @@ class ContextualToolsProvider implements ToolSourceProvider {
      * "the number of distinct agents" is not a fixed bound on this platform —
      * dynamic and ephemeral agents are created at runtime with fresh ids, so a
      * long-lived deployment with churn would otherwise accumulate entries for the
-     * JVM lifetime. Expiry also means a standing misconfiguration re-announces
-     * itself daily instead of exactly once per process.
+     * JVM lifetime. Expiry means a standing misconfiguration re-announces itself
+     * periodically instead of exactly once per process; suppression is therefore
+     * best-effort, holding only while the entry remains cached.
      */
     private static final Set<String> MEMORY_MISCONFIGURATION_WARNED = Collections.newSetFromMap(
             Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofHours(24))
@@ -155,22 +156,36 @@ class ContextualToolsProvider implements ToolSourceProvider {
      * a task-level statement that this task gets no built-in capability, and user
      * memory is a cross-conversation write), but it must be visible.
      */
+    /**
+     * Whether the memory-misconfiguration warning should be emitted for this agent.
+     * <p>
+     * A missing agent id maps to a stable fallback key rather than bypassing
+     * deduplication — the bypass meant the defensive null path was the one case
+     * that logged on every turn, the exact flood the cache exists to prevent.
+     * Suppression holds while the cache entry remains present (size- and
+     * TTL-bounded), so a repeat is possible after expiry or under heavy churn; that
+     * is the right trade for a log-hygiene cache, and it means a standing
+     * misconfiguration re-announces itself rather than going silent forever.
+     */
+    static boolean shouldWarnAboutMemoryMisconfiguration(String agentId) {
+        return MEMORY_MISCONFIGURATION_WARNED.add(agentId != null ? agentId : "<no-agent-id>");
+    }
+
     private void warnIfMemoryEnabledButBuiltInsAreOff(ToolAssemblyContext ctx) {
         if (ctx.memory().getUserMemoryConfig() == null || userMemoryStore == null) {
             return;
         }
-        // Once per agent, not per turn: this fires on every turn of a misconfigured
-        // agent, and a busy production agent would otherwise flood the log with the
-        // same sentence thousands of times — which trains operators to ignore it.
-        // Bounded by the number of distinct agents this instance serves; a redeploy
-        // that fixes the config makes the stale entry harmless.
+        // Suppressed per agent, not per turn: this fires on every turn of a
+        // misconfigured agent, and a busy production agent would otherwise flood the
+        // log with the same sentence thousands of times — which trains operators to
+        // ignore it.
         String agentId = ctx.memory().getAgentId();
-        if (agentId != null && !MEMORY_MISCONFIGURATION_WARNED.add(agentId)) {
+        if (!shouldWarnAboutMemoryMisconfiguration(agentId)) {
             return;
         }
         LOGGER.warnf("[MEMORY] Agent '%s' has persistent user memory enabled, but this LLM task has "
                 + "enableBuiltInTools=%s — UserMemoryTool is NOT attached and the agent cannot write memories. "
-                + "Set enableBuiltInTools: true on the task (conversation='%s'). Logged at most once per agent per day.",
+                + "Set enableBuiltInTools: true on the task (conversation='%s'). Repeats of this warning are suppressed.",
                 sanitize(agentId), ctx.task().getEnableBuiltInTools(),
                 sanitize(ctx.memory().getConversationId()));
     }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProvider.java
@@ -26,6 +26,8 @@ import org.jboss.logging.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
@@ -60,6 +62,14 @@ class ContextualToolsProvider implements ToolSourceProvider {
     private final IUserMemoryStore userMemoryStore;
     private final IAttachmentStore attachmentStore;
     private final AttachmentTextExtractor attachmentTextExtractor;
+
+    /**
+     * Agents already warned about the memory/built-ins conflict. Static because
+     * {@code AgentOrchestrator} constructs this provider per call, so an instance
+     * field would debounce nothing; bounded by the number of distinct agents. — see
+     * {@link #warnIfMemoryEnabledButBuiltInsAreOff}.
+     */
+    private static final Set<String> MEMORY_MISCONFIGURATION_WARNED = ConcurrentHashMap.newKeySet();
 
     ContextualToolsProvider(IUserMemoryStore userMemoryStore, IAttachmentStore attachmentStore,
             AttachmentTextExtractor attachmentTextExtractor) {
@@ -140,10 +150,19 @@ class ContextualToolsProvider implements ToolSourceProvider {
         if (ctx.memory().getUserMemoryConfig() == null || userMemoryStore == null) {
             return;
         }
+        // Once per agent, not per turn: this fires on every turn of a misconfigured
+        // agent, and a busy production agent would otherwise flood the log with the
+        // same sentence thousands of times — which trains operators to ignore it.
+        // Bounded by the number of distinct agents this instance serves; a redeploy
+        // that fixes the config makes the stale entry harmless.
+        String agentId = ctx.memory().getAgentId();
+        if (agentId != null && !MEMORY_MISCONFIGURATION_WARNED.add(agentId)) {
+            return;
+        }
         LOGGER.warnf("[MEMORY] Agent '%s' has persistent user memory enabled, but this LLM task has "
                 + "enableBuiltInTools=%s — UserMemoryTool is NOT attached and the agent cannot write memories. "
-                + "Set enableBuiltInTools: true on the task (conversation='%s').",
-                sanitize(ctx.memory().getAgentId()), ctx.task().getEnableBuiltInTools(),
+                + "Set enableBuiltInTools: true on the task (conversation='%s'). Logged once per agent.",
+                sanitize(agentId), ctx.task().getEnableBuiltInTools(),
                 sanitize(ctx.memory().getConversationId()));
     }
 

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ConversationHistoryBuilder.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ConversationHistoryBuilder.java
@@ -380,12 +380,16 @@ class ConversationHistoryBuilder {
                 result.add(UserMessage.from(ConversationLogGenerator.withAttachmentExtracts(allSteps, i, input)));
             }
 
-            Object outputObj = output.get("output");
-            if (outputObj instanceof List<?> outputList && !outputList.isEmpty()) {
-                String text = ConversationOutputUtils.extractOutputText(output);
-                if (text != null && !text.isEmpty()) {
-                    result.add(AiMessage.from(text));
-                }
+            // No pre-check on the shape of "output": deciding here that a turn is only
+            // renderable when that value is a non-empty List is the same mistake the
+            // extractor was just fixed for, one level up. A turn whose output was
+            // written with addConversationOutputString("output", …) holds a plain
+            // String, and this guard dropped it from the model's own history while the
+            // rolling summary and the recall tool — which call the extractor directly —
+            // kept it. The extractor already returns null when there is nothing to say.
+            String text = ConversationOutputUtils.extractOutputText(output);
+            if (text != null && !text.isEmpty()) {
+                result.add(AiMessage.from(text));
             }
         }
 

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ConversationOutputUtils.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ConversationOutputUtils.java
@@ -4,11 +4,8 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
+import ai.labs.eddi.engine.memory.ConversationOutputExtractor;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
-
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Shared utility for extracting text from conversation outputs.
@@ -22,6 +19,13 @@ import java.util.stream.Collectors;
  */
 public final class ConversationOutputUtils {
 
+    /**
+     * Multiple output items become one line of history, so they are joined with a
+     * space rather than the newline {@link ConversationOutputExtractor} uses for
+     * its own callers.
+     */
+    private static final String ITEM_DELIMITER = " ";
+
     private ConversationOutputUtils() {
         // utility class
     }
@@ -29,24 +33,17 @@ public final class ConversationOutputUtils {
     /**
      * Extract the agent's output text from a ConversationOutput map.
      * <p>
-     * Handles the standard output format: a List of Maps with "text" keys. Multiple
-     * text entries are joined with a single space.
+     * Every item in the output list is inspected, not just the first: a turn gated
+     * by HITL starts its list with a plain String, and reading the list's shape
+     * from element zero used to discard such turns wholesale — removing them from
+     * the agent's own chat history, the rolling summary, the recall tool and the
+     * REST log. Multiple text entries are joined with a single space.
      *
      * @param output
      *            the conversation output to extract from
      * @return the joined text, or null if no output is present
      */
-    @SuppressWarnings("unchecked")
     public static String extractOutputText(ConversationOutput output) {
-        Object outputObj = output.get("output");
-        if (outputObj instanceof List<?> outputList && !outputList.isEmpty()) {
-            if (outputList.getFirst() instanceof Map) {
-                var mapList = (List<Map<String, Object>>) outputList;
-                String result = mapList.stream().filter(m -> m.get("text") != null).map(m -> m.get("text").toString())
-                        .collect(Collectors.joining(" "));
-                return result.isEmpty() ? null : result;
-            }
-        }
-        return null;
+        return ConversationOutputExtractor.extractText(output, ITEM_DELIMITER);
     }
 }

--- a/src/main/java/ai/labs/eddi/utils/RestUtilities.java
+++ b/src/main/java/ai/labs/eddi/utils/RestUtilities.java
@@ -20,6 +20,8 @@ import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
  * @author ginccc
  */
 public class RestUtilities {
+    private static final String EDDI_SCHEME = "eddi://";
+
     private static final String versionQueryParam = "?version=";
 
     public static WebApplicationException createConflictException(String containerUri, IResourceStore.IResourceId currentId) {
@@ -150,6 +152,40 @@ public class RestUtilities {
         }
 
         return true;
+    }
+
+    /**
+     * The descriptor {@code type} that matches the resources a store emits, derived
+     * from that store's own {@code resourceURI} constant.
+     * <p>
+     * {@link ai.labs.eddi.datastore.serialization.IDescriptorStore#readDescriptors}
+     * filters descriptors by regex-matching the stored resource URI against
+     * {@code "eddi://" + type + ".*"}, so {@code type} must be the URI's namespace
+     * segment and nothing else. Hard-coding it at each call site is what let three
+     * stores (rules, apicalls, dictionary) ship a legacy name —
+     * {@code ai.labs.behavior} against {@code eddi://ai.labs.rules/…} — which can
+     * never match, so their listings always returned an empty list while the
+     * resources existed and read back fine individually. Derive it here instead of
+     * restating it.
+     *
+     * @param resourceURI
+     *            a store's resource URI, e.g.
+     *            {@code eddi://ai.labs.rules/rulestore/rulesets/}
+     * @return the namespace segment, e.g. {@code ai.labs.rules}
+     */
+    public static String extractDescriptorType(String resourceURI) {
+        RuntimeUtilities.checkNotNull(resourceURI, "resourceURI");
+
+        String remainder = resourceURI.startsWith(EDDI_SCHEME)
+                ? resourceURI.substring(EDDI_SCHEME.length())
+                : resourceURI;
+        int pathStart = remainder.indexOf('/');
+        String type = pathStart < 0 ? remainder : remainder.substring(0, pathStart);
+        if (type.isBlank()) {
+            throw new IllegalArgumentException(
+                    "resourceURI '" + resourceURI + "' carries no namespace segment to derive a descriptor type from.");
+        }
+        return type;
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,6 +45,14 @@ eddi.migration.v6-qute.enabled=false
 # write time, not to the middle of a user's turn; OutputTemplateTask logs any
 # render failure and substitutes an empty string (its FAILED_TEMPLATE_SUBSTITUTE).
 quarkus.qute.strict-rendering=false
+# ...and "as an empty string" has to be stated, because strict-rendering=false
+# only stops the THROW. A missing value still resolves to Qute's NotFound
+# sentinel, whose default mapper writes the literal "NOT_FOUND" into the output —
+# so a template referencing an optional property emitted
+# "Your favourite language is: NOT_FOUND." into system prompts, HTTP call bodies
+# and user-visible replies. (In dev mode the default is THROW_EXCEPTION instead,
+# so dev and prod did not even agree.) NOOP renders nothing, in every profile.
+quarkus.qute.property-not-found-strategy=NOOP
 
 # Datastore — database backend for configuration and conversation storage
 # Options: mongodb (default), postgres

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceBranchTest.java
@@ -25,6 +25,7 @@ import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.secrets.sanitize.SecretScrubber;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -373,6 +374,22 @@ class RestExportServiceBranchTest {
         void emptyFilename() {
             assertThrows(BadRequestException.class,
                     () -> exportService.getAgentZipArchive(""));
+        }
+
+        /**
+         * A well-formed name for an archive that is not there used to sneakyThrow the
+         * FileNotFoundException, which surfaced as an unlogged 500 error page. Easy to
+         * hit: export and download share this path and differ only by method, so a
+         * mistyped or expired filename read as a server fault.
+         */
+        @Test
+        @DisplayName("a well-formed name for a missing archive is a 404, not a 500")
+        void missingArchiveIsNotFound() {
+            var notFound = assertThrows(NotFoundException.class,
+                    () -> exportService.getAgentZipArchive("no-such-export.zip"));
+
+            assertTrue(notFound.getMessage().contains("no-such-export.zip"),
+                    "the message must name the archive the caller asked for");
         }
     }
 

--- a/src/test/java/ai/labs/eddi/configs/DescriptorListingDelegationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/DescriptorListingDelegationTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.dictionary.IDictionaryStore;
+import ai.labs.eddi.configs.dictionary.rest.RestDictionaryStore;
+import ai.labs.eddi.configs.rules.IRuleSetStore;
+import ai.labs.eddi.configs.rules.rest.RestRuleSetStore;
+import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The runtime half of the D1 regression net: the descriptor store must be
+ * queried with the store's own URI namespace, not a legacy name.
+ * <p>
+ * {@code DescriptorTypeConsistencyTest} sweeps the <em>sources</em>, which
+ * kills hard-coded literals — but it cannot see a bug in the derivation itself,
+ * and it proves nothing about what reaches the descriptor store at runtime.
+ * These two stores are the ones that shipped broken (queried
+ * {@code ai.labs.behavior} and {@code ai.labs.regulardictionary}, matched
+ * nothing, and listed {@code []} forever while their resources existed); the
+ * apicalls store — the third — has this same pin in
+ * {@code RestApiCallsStoreDelegationTest}.
+ */
+@DisplayName("descriptor listings query the derived namespace at runtime")
+class DescriptorListingDelegationTest {
+
+    @Test
+    @DisplayName("rulesets list under ai.labs.rules — the namespace their URIs actually carry")
+    void ruleSetListingUsesTheRulesNamespace() throws Exception {
+        var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        var store = new RestRuleSetStore(mock(IRuleSetStore.class), documentDescriptorStore, mock(IJsonSchemaCreator.class));
+        List<DocumentDescriptor> expected = List.of(new DocumentDescriptor());
+        doReturn(expected).when(documentDescriptorStore).readDescriptors("ai.labs.rules", "f", 0, 10, false);
+
+        assertEquals(expected, store.readBehaviorDescriptors("f", 0, 10),
+                "querying any other namespace returns an empty list forever, with no error");
+    }
+
+    @Test
+    @DisplayName("dictionaries list under ai.labs.dictionary")
+    void dictionaryListingUsesTheDictionaryNamespace() throws Exception {
+        var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        var store = new RestDictionaryStore(mock(IDictionaryStore.class), documentDescriptorStore,
+                mock(IJsonSchemaCreator.class));
+        List<DocumentDescriptor> expected = List.of(new DocumentDescriptor());
+        doReturn(expected).when(documentDescriptorStore).readDescriptors("ai.labs.dictionary", "f", 0, 10, false);
+
+        assertEquals(expected, store.readRegularDictionaryDescriptors("f", 0, 10));
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/DescriptorTypeConsistencyTest.java
+++ b/src/test/java/ai/labs/eddi/configs/DescriptorTypeConsistencyTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs;
+
+import ai.labs.eddi.utils.RestUtilities;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every {@code read*Descriptors} listing must query the namespace its own store
+ * actually writes to.
+ * <p>
+ * {@code DescriptorStore.readDescriptors} filters by regex-matching the stored
+ * resource URI against {@code "eddi://" + type + ".*"}, so a {@code type} that
+ * is not the URI's namespace segment matches nothing — and matches nothing
+ * <em>silently</em>, returning an empty list rather than an error. Three stores
+ * shipped exactly that: rulesets queried {@code ai.labs.behavior} against
+ * {@code eddi://ai.labs.rules/…}, api calls {@code ai.labs.httpcalls} against
+ * {@code eddi://ai.labs.apicalls/…}, and dictionaries
+ * {@code ai.labs.regulardictionary} against
+ * {@code eddi://ai.labs.dictionary/…}. Ten ruleset and twenty-two apicall
+ * descriptors existed on a live instance while their listings returned
+ * {@code []}, so anything browsing behavior rules, HTTP calls or dictionaries —
+ * the Manager included — saw nothing at all.
+ * <p>
+ * The mismatch is possible because the legacy config-file names and the v6 URI
+ * names differ (AGENTS.md §5.5) and each store restated its type as a literal.
+ * The fix derives the type from the store's own {@code resourceURI}; this test
+ * guards the remaining freedom to hard-code one anyway, by reading the sources
+ * rather than the runtime — nothing else fails when the two drift apart.
+ */
+@DisplayName("descriptor type matches the store's own URI namespace")
+class DescriptorTypeConsistencyTest {
+
+    /**
+     * {@code String resourceBaseType = "eddi://ai.labs.x";} in an IRest*Store
+     * interface.
+     */
+    private static final Pattern BASE_TYPE = Pattern.compile(
+            "String\\s+resourceBaseType\\s*=\\s*\"([^\"]+)\"");
+
+    /**
+     * {@code String resourceURI = "eddi://…";} or {@code = resourceBaseType + "…";}
+     */
+    private static final Pattern RESOURCE_URI = Pattern.compile(
+            "String\\s+resourceURI\\s*=\\s*(?:resourceBaseType\\s*\\+\\s*)?\"([^\"]+)\"");
+
+    /**
+     * A hard-coded descriptor type handed to any {@code readDescriptors} overload.
+     */
+    private static final Pattern HARDCODED_TYPE = Pattern.compile(
+            "readDescriptors\\(\\s*(?:eq\\(\\s*)?\"(ai\\.labs\\.[A-Za-z]+)\"");
+
+    private static Path repoRoot() {
+        Path root = Path.of("").toAbsolutePath();
+        assertTrue(Files.isRegularFile(root.resolve("pom.xml")),
+                "expected the working directory to be the project root, was " + root);
+        return root;
+    }
+
+    private static List<Path> javaFilesUnder(Path dir) {
+        try (Stream<Path> paths = Files.walk(dir)) {
+            return paths.filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().endsWith(".java"))
+                    .toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String read(Path file) {
+        try {
+            return Files.readString(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Maps a store package (e.g. {@code configs/rules}) to the descriptor type its
+     * {@code resourceURI} implies.
+     */
+    private static Map<String, String> declaredTypesByPackage(Path mainJava) {
+        Map<String, String> byPackage = new LinkedHashMap<>();
+        for (Path file : javaFilesUnder(mainJava)) {
+            String name = file.getFileName().toString();
+            if (!name.startsWith("IRest") || !name.endsWith("Store.java")) {
+                continue;
+            }
+            String source = read(file);
+            Matcher uri = RESOURCE_URI.matcher(source);
+            if (!uri.find()) {
+                continue;
+            }
+            String resourceURI = uri.group(1);
+            if (!resourceURI.startsWith("eddi://")) {
+                Matcher base = BASE_TYPE.matcher(source);
+                if (!base.find()) {
+                    continue;
+                }
+                resourceURI = base.group(1) + resourceURI;
+            }
+            byPackage.put(file.getParent().toString().replace('\\', '/'),
+                    RestUtilities.extractDescriptorType(resourceURI));
+        }
+        return byPackage;
+    }
+
+    @Test
+    @DisplayName("no REST store queries a descriptor type outside its own namespace")
+    void restStoresQueryTheirOwnNamespace() {
+        Path root = repoRoot();
+        Path mainJava = root.resolve("src/main/java");
+        Map<String, String> expectedByPackage = declaredTypesByPackage(mainJava);
+
+        assertTrue(expectedByPackage.size() >= 10,
+                "expected to discover the IRest*Store interfaces, found " + expectedByPackage);
+
+        List<String> offenders = new ArrayList<>();
+        for (Path file : javaFilesUnder(mainJava)) {
+            String dir = file.getParent().toString().replace('\\', '/');
+            // A REST implementation lives in <storePackage>/rest.
+            if (!dir.endsWith("/rest")) {
+                continue;
+            }
+            String expected = expectedByPackage.get(dir.substring(0, dir.length() - "/rest".length()));
+            if (expected == null) {
+                continue;
+            }
+            Matcher m = HARDCODED_TYPE.matcher(read(file));
+            while (m.find()) {
+                if (!expected.equals(m.group(1))) {
+                    offenders.add(root.relativize(file).toString().replace('\\', '/')
+                            + " queries \"" + m.group(1) + "\" but its resourceURI namespace is \"" + expected + "\"");
+                }
+            }
+        }
+
+        assertEquals(List.of(), offenders,
+                "A descriptor listing that names a namespace its store does not write to returns an empty "
+                        + "list forever, with no error. Call readDescriptors(filter, index, limit) — the overload "
+                        + "that derives the type from resourceURI — instead of restating it.\n  "
+                        + String.join("\n  ", offenders));
+    }
+
+    @Test
+    @DisplayName("extractDescriptorType reads the namespace segment, not the path")
+    void extractsNamespaceSegment() {
+        assertEquals("ai.labs.rules",
+                RestUtilities.extractDescriptorType("eddi://ai.labs.rules/rulestore/rulesets/"));
+        assertEquals("ai.labs.apicalls",
+                RestUtilities.extractDescriptorType("eddi://ai.labs.apicalls/apicallstore/apicalls/"));
+        assertEquals("ai.labs.dictionary",
+                RestUtilities.extractDescriptorType("eddi://ai.labs.dictionary/dictionarystore/dictionaries/"));
+        // Tolerates a bare namespace and a missing scheme rather than returning "".
+        assertEquals("ai.labs.agent", RestUtilities.extractDescriptorType("eddi://ai.labs.agent"));
+        assertEquals("ai.labs.agent", RestUtilities.extractDescriptorType("ai.labs.agent/agentstore/agents/"));
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreBranchTest.java
+++ b/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreBranchTest.java
@@ -74,7 +74,7 @@ class RestApiCallsStoreBranchTest {
         @DisplayName("returns descriptors list")
         void returnsDescriptors() throws Exception {
             var desc = new DocumentDescriptor();
-            when(documentDescriptorStore.readDescriptors(eq("ai.labs.httpcalls"), anyString(), anyInt(), anyInt(), eq(false)))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.apicalls"), anyString(), anyInt(), anyInt(), eq(false)))
                     .thenReturn(List.of(desc));
 
             List<DocumentDescriptor> result = restApiCallsStore.readApiCallsDescriptors("", 0, 10);

--- a/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreDelegationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreDelegationTest.java
@@ -73,7 +73,7 @@ class RestApiCallsStoreDelegationTest {
         void delegatesCorrectly() throws Exception {
             List<DocumentDescriptor> expected = List.of(new DocumentDescriptor());
             doReturn(expected).when(documentDescriptorStore)
-                    .readDescriptors("ai.labs.httpcalls", "myFilter", 0, 10, false);
+                    .readDescriptors("ai.labs.apicalls", "myFilter", 0, 10, false);
 
             List<DocumentDescriptor> result = store.readApiCallsDescriptors("myFilter", 0, 10);
 
@@ -85,7 +85,7 @@ class RestApiCallsStoreDelegationTest {
         void emptyFilter() throws Exception {
             List<DocumentDescriptor> expected = List.of();
             doReturn(expected).when(documentDescriptorStore)
-                    .readDescriptors("ai.labs.httpcalls", "", 0, 20, false);
+                    .readDescriptors("ai.labs.apicalls", "", 0, 20, false);
 
             List<DocumentDescriptor> result = store.readApiCallsDescriptors("", 0, 20);
 

--- a/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreCrudTest.java
+++ b/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreCrudTest.java
@@ -425,4 +425,37 @@ class RestChannelIntegrationStoreCrudTest {
             assertDoesNotThrow(() -> sut.createChannel(config));
         }
     }
+
+    // ==================== O2: plaintext secrets warn, never reject
+    // ====================
+
+    /**
+     * A plaintext {@code botToken} produces a WARN pointing at the vault — it must
+     * never become a rejection. Every existing integration stores its credentials
+     * this way; a well-meaning "hardening" that turns the warning into a 400 would
+     * brick them all on their next update, which is why the non-throwing half of
+     * this behaviour is pinned and not just the log line.
+     */
+    @Nested
+    @DisplayName("plaintext platformConfig secrets")
+    class PlaintextSecretWarning {
+
+        @Test
+        @DisplayName("a plaintext botToken passes validation — warn, don't reject")
+        void plaintextTokenIsNotRejected() {
+            var config = validConfig();
+            config.setPlatformConfig(Map.of("botToken", "xoxb-plaintext-not-a-vault-ref"));
+
+            assertDoesNotThrow(() -> sut.validateConfiguration(config));
+        }
+
+        @Test
+        @DisplayName("a vault reference passes validation too")
+        void vaultReferencePasses() {
+            var config = validConfig();
+            config.setPlatformConfig(Map.of("botToken", "${vault:slack-bot-token}"));
+
+            assertDoesNotThrow(() -> sut.validateConfiguration(config));
+        }
+    }
 }

--- a/src/test/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStoreTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
@@ -151,6 +152,103 @@ class RestDocumentDescriptorStoreTest {
         verify(documentDescriptorStore).setDescriptor("id1", 1, existing);
         assertEquals("", existing.getName());
         assertEquals("", existing.getDescription());
+    }
+
+    /**
+     * The endpoint calls itself "Partial update" and used to assign both fields
+     * unconditionally, so a caller sending only {@code description} — exactly what
+     * the documentation describes — wiped the descriptor's {@code name} and got a
+     * 204 for it. The agent then rendered as unnamed in every listing, and
+     * recovering it meant knowing to re-send both fields.
+     */
+    @Test
+    @DisplayName("patchDescriptor — SET with only a description leaves the name alone")
+    void patchDescriptorSetMergesRatherThanReplaces() throws Exception {
+        var existing = new DocumentDescriptor();
+        existing.setName("Support Agent");
+        existing.setDescription("old desc");
+        when(documentDescriptorStore.readDescriptor("id1", 1)).thenReturn(existing);
+
+        var patch = new DocumentDescriptor();
+        patch.setDescription("new desc");
+        var instruction = new PatchInstruction<DocumentDescriptor>();
+        instruction.setDocument(patch);
+        instruction.setOperation(PatchInstruction.PatchOperation.SET);
+
+        restStore.patchDescriptor("id1", 1, instruction);
+
+        assertEquals("Support Agent", existing.getName(), "a partial update must not destroy the fields it omits");
+        assertEquals("new desc", existing.getDescription());
+    }
+
+    @Test
+    @DisplayName("patchDescriptor — SET with only a name leaves the description alone")
+    void patchDescriptorSetNameOnly() throws Exception {
+        var existing = new DocumentDescriptor();
+        existing.setName("old");
+        existing.setDescription("Handles refunds");
+        when(documentDescriptorStore.readDescriptor("id1", 1)).thenReturn(existing);
+
+        var patch = new DocumentDescriptor();
+        patch.setName("Refund Agent");
+        var instruction = new PatchInstruction<DocumentDescriptor>();
+        instruction.setDocument(patch);
+        instruction.setOperation(PatchInstruction.PatchOperation.SET);
+
+        restStore.patchDescriptor("id1", 1, instruction);
+
+        assertEquals("Refund Agent", existing.getName());
+        assertEquals("Handles refunds", existing.getDescription());
+    }
+
+    @Test
+    @DisplayName("patchDescriptor — DELETE naming one field clears only that field")
+    void patchDescriptorDeleteIsFieldSelective() throws Exception {
+        var existing = new DocumentDescriptor();
+        existing.setName("Support Agent");
+        existing.setDescription("old desc");
+        when(documentDescriptorStore.readDescriptor("id1", 1)).thenReturn(existing);
+
+        var patch = new DocumentDescriptor();
+        patch.setDescription("old desc");
+        var instruction = new PatchInstruction<DocumentDescriptor>();
+        instruction.setDocument(patch);
+        instruction.setOperation(PatchInstruction.PatchOperation.DELETE);
+
+        restStore.patchDescriptor("id1", 1, instruction);
+
+        assertEquals("Support Agent", existing.getName());
+        assertEquals("", existing.getDescription());
+    }
+
+    /**
+     * A body that is not the wrapper deserialises to an instruction with a null
+     * operation, which used to be dereferenced — so a client-side shape error came
+     * back as a 500 error page and an NPE in the container log.
+     */
+    @Test
+    @DisplayName("patchDescriptor — a body that is not a PatchInstruction is a 400, not a 500")
+    void patchDescriptorRejectsMalformedBody() {
+        var noOperation = new PatchInstruction<DocumentDescriptor>();
+        noOperation.setDocument(new DocumentDescriptor());
+
+        var badRequest = assertThrows(BadRequestException.class,
+                () -> restStore.patchDescriptor("id1", 1, noOperation));
+        assertTrue(badRequest.getMessage().contains("PatchInstruction"),
+                "the message must name the shape the caller should have sent");
+
+        assertThrows(BadRequestException.class, () -> restStore.patchDescriptor("id1", 1, null));
+    }
+
+    @Test
+    @DisplayName("patchDescriptor — SET without a document is a 400")
+    void patchDescriptorSetWithoutDocument() throws Exception {
+        when(documentDescriptorStore.readDescriptor("id1", 1)).thenReturn(new DocumentDescriptor());
+
+        var instruction = new PatchInstruction<DocumentDescriptor>();
+        instruction.setOperation(PatchInstruction.PatchOperation.SET);
+
+        assertThrows(BadRequestException.class, () -> restStore.patchDescriptor("id1", 1, instruction));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/rest/StrictConfigurationBodyInterceptorTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rest/StrictConfigurationBodyInterceptorTest.java
@@ -55,7 +55,7 @@ class StrictConfigurationBodyInterceptorTest {
     @BeforeEach
     void setUp() {
         restMapper = SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false);
-        interceptor = new StrictConfigurationBodyInterceptor(restMapper);
+        interceptor = new StrictConfigurationBodyInterceptor(new StrictConfigurationParser(restMapper));
     }
 
     private static ReaderInterceptorContext context(Class<?> type, String body) {

--- a/src/test/java/ai/labs/eddi/configs/rest/StrictConfigurationParserTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rest/StrictConfigurationParserTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.rest;
+
+import ai.labs.eddi.configs.propertysetter.model.PropertySetterConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Both write surfaces must answer the same payload the same way.
+ * <p>
+ * The strictness used to live inside a JAX-RS {@code ReaderInterceptor}, which
+ * only fires on a real inbound HTTP body. MCP's {@code create_resource} calls
+ * the very same REST stores in-process with its own lenient parse, so the same
+ * document had opposite outcomes: REST returned
+ * {@code 400 Unknown field 'setProperties' … Known fields: [setOnActions]},
+ * while MCP returned {@code 201 created} and stored {@code {"setOnActions":[]}}
+ * — an emptied configuration that then read back happily and did nothing at
+ * runtime. {@code update_resource} went on to report {@code newVersion: 2} for
+ * it. That path is reachable by every MCP client, the Platform Operator agent
+ * included.
+ */
+@DisplayName("configuration writes are strict on every surface")
+class StrictConfigurationParserTest {
+
+    private final StrictConfigurationParser parser = new StrictConfigurationParser(new ObjectMapper());
+
+    /** The exact payload from the sweep: a plausible but undeclared field name. */
+    private static final String UNKNOWN_FIELD_PAYLOAD = "{\"setProperties\":[{\"name\":\"x\",\"valueString\":\"y\"}]}";
+
+    @Test
+    @DisplayName("an undeclared field is rejected, not dropped")
+    void unknownFieldIsRejected() {
+        var rejected = assertThrows(BadRequestException.class,
+                () -> parser.parse(UNKNOWN_FIELD_PAYLOAD, PropertySetterConfiguration.class));
+
+        String body = String.valueOf(rejected.getResponse().getEntity());
+        assertTrue(body.contains("setProperties"), "the message must name the offending field: " + body);
+        assertTrue(body.contains("setOnActions"), "the message must list the legal fields: " + body);
+    }
+
+    @Test
+    @DisplayName("rejectUnknownFields agrees with parse — one implementation, two entry points")
+    void byteEntryPointAgrees() {
+        assertThrows(BadRequestException.class,
+                () -> parser.rejectUnknownFields(UNKNOWN_FIELD_PAYLOAD.getBytes(), PropertySetterConfiguration.class));
+    }
+
+    @Test
+    @DisplayName("a valid document parses")
+    void validDocumentParses() {
+        var config = assertDoesNotThrow(
+                () -> parser.parse("{\"setOnActions\":[]}", PropertySetterConfiguration.class));
+
+        assertNotNull(config);
+    }
+
+    @Test
+    @DisplayName("malformed JSON is left to the caller's existing error path")
+    void malformedJsonIsNotThisClassesBusiness() {
+        // parse() propagates the IOException; rejectUnknownFields() swallows it so the
+        // regular message-body reader still produces the response it always has.
+        assertThrows(Exception.class, () -> parser.parse("{not json", PropertySetterConfiguration.class));
+        assertDoesNotThrow(() -> parser.rejectUnknownFields("{not json".getBytes(), PropertySetterConfiguration.class));
+    }
+}

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreTest.java
@@ -301,4 +301,5 @@ class PostgresAuditStoreTest extends PostgresTestBase {
                 null, null, null, null, null, 0.0,
                 Instant.now(), null, null);
     }
+
 }

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreUnitTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreUnitTest.java
@@ -85,6 +85,36 @@ class PostgresAuditStoreUnitTest {
         verify(preparedStatement).setLong(16, 7L);
     }
 
+    /**
+     * {@code eddi.audit.agent-signing-enabled} defaults to true and the Ed25519
+     * signature was computed for every entry — but this backend had no column for
+     * it and its row-mapper hard-coded null, so the signature was discarded on
+     * write and read back absent. The non-repudiation half of the ledger was
+     * silently inert on PostgreSQL while MongoDB deployments had it.
+     */
+    @Test
+    void appendEntry_persistsTheAgentSignature() throws Exception {
+        AuditEntry entry = new AuditEntry("id-1", "conv-1", "agent-1", 1, "user-1", "production",
+                0, "task-1", "langchain", 0, 100L, null, null, null, null, null, 0.0, Instant.now(), "hmac", "ed25519-signature", 7L);
+        when(jsonSerialization.serialize(any())).thenReturn("{}");
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        store.appendEntry(entry);
+
+        verify(preparedStatement).setString(17, "ed25519-signature");
+    }
+
+    @Test
+    void ensureSchema_addsTheAgentSignatureColumnToExistingLedgers() throws Exception {
+        AuditEntry entry = createEntry();
+        when(jsonSerialization.serialize(any())).thenReturn("{}");
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        store.appendEntry(entry);
+
+        verify(statement).execute("ALTER TABLE audit_ledger ADD COLUMN IF NOT EXISTS agent_signature TEXT");
+    }
+
     @Test
     void supportsSequence_isTrueSoTheChainIsActuallyChecked() {
         assertTrue(store.supportsSequence(),

--- a/src/test/java/ai/labs/eddi/engine/a2a/AgentCardServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/a2a/AgentCardServiceTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.a2a;
 
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
@@ -22,13 +23,16 @@ import static org.mockito.Mockito.*;
 class AgentCardServiceTest {
 
     private IRestAgentStore restAgentStore;
+    private IDocumentDescriptorStore documentDescriptorStore;
     private AgentCardService service;
 
     @BeforeEach
     void setUp() {
         restAgentStore = mock(IRestAgentStore.class);
+        documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         service = new AgentCardService(
                 restAgentStore,
+                documentDescriptorStore,
                 "http://localhost:7070",
                 false,
                 Optional.empty());
@@ -155,6 +159,7 @@ class AgentCardServiceTest {
         void withAuth_whenEnabled() {
             var authService = new AgentCardService(
                     restAgentStore,
+                    documentDescriptorStore,
                     "http://localhost:7070",
                     true,
                     Optional.of("http://keycloak:8080/realms/eddi"));

--- a/src/test/java/ai/labs/eddi/engine/a2a/AgentCardServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/a2a/AgentCardServiceTest.java
@@ -105,10 +105,67 @@ class AgentCardServiceTest {
 
             var card = service.getAgentCard("agent-1");
             assertNotNull(card);
+            // No descriptor for this id, so the card falls back to the id form.
             assertEquals("EDDI Agent agent-1", card.name());
             assertEquals("My agent", card.description());
             assertTrue(card.url().contains("agent-1"));
             assertEquals("EDDI", card.provider());
+        }
+
+        /**
+         * A2A Agent Cards are how other systems discover what an agent <em>is</em>, and
+         * every card announced "EDDI Agent &lt;uuid&gt;" — the raw id, for every agent.
+         * The operator-given name lives on the DocumentDescriptor, not on
+         * AgentConfiguration, which is why it was never reached for.
+         */
+        @Test
+        void usesTheDescriptorName_whenTheAgentHasOne() throws Exception {
+            var config = new AgentConfiguration();
+            config.setA2aEnabled(true);
+            config.setDescription("My agent");
+
+            var resourceId = new IResourceStore.IResourceId() {
+                @Override
+                public String getId() {
+                    return "agent-1";
+                }
+
+                @Override
+                public Integer getVersion() {
+                    return 1;
+                }
+            };
+            when(restAgentStore.getCurrentResourceId("agent-1")).thenReturn(resourceId);
+            when(restAgentStore.readAgent("agent-1", 1)).thenReturn(config);
+
+            var descriptor = new DocumentDescriptor();
+            descriptor.setName("Refund Specialist");
+            when(documentDescriptorStore.readDescriptor("agent-1", 1)).thenReturn(descriptor);
+
+            assertEquals("Refund Specialist", service.getAgentCard("agent-1").name());
+        }
+
+        @Test
+        void fallsBackToTheIdForm_whenTheDescriptorIsUnnamed() throws Exception {
+            var config = new AgentConfiguration();
+            config.setA2aEnabled(true);
+
+            var resourceId = new IResourceStore.IResourceId() {
+                @Override
+                public String getId() {
+                    return "agent-2";
+                }
+
+                @Override
+                public Integer getVersion() {
+                    return 1;
+                }
+            };
+            when(restAgentStore.getCurrentResourceId("agent-2")).thenReturn(resourceId);
+            when(restAgentStore.readAgent("agent-2", 1)).thenReturn(config);
+            when(documentDescriptorStore.readDescriptor("agent-2", 1)).thenReturn(new DocumentDescriptor());
+
+            assertEquals("EDDI Agent agent-2", service.getAgentCard("agent-2").name());
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTest.java
@@ -91,11 +91,11 @@ class AuditHmacTest {
         void producesHex() {
             String hmac = AuditHmac.computeHmac(createTestEntry(), hmacKey);
             assertNotNull(hmac);
-            assertTrue(hmac.startsWith("v3:"),
+            assertTrue(hmac.startsWith("v4:"),
                     "the stored value must name its canonical form, or verification cannot pick a canonicalizer");
             // Hex string should be 64 chars (32 bytes) after the version tag
-            assertEquals(64, hmac.substring("v3:".length()).length());
-            assertTrue(hmac.substring("v3:".length()).matches("[0-9a-f]{64}"));
+            assertEquals(64, hmac.substring("v4:".length()).length());
+            assertTrue(hmac.substring("v4:".length()).matches("[0-9a-f]{64}"));
         }
 
         @Test
@@ -174,25 +174,28 @@ class AuditHmacTest {
          * string; a v2 row carries {@code v2:} + a digest over the v2 form.
          */
         @Test
-        @DisplayName("v1, v2 and v3 rows all verify, and any of them tampered is rejected")
+        @DisplayName("v1 through v4 rows all verify, and any of them tampered is rejected")
         void allVersionsVerifyAndAllRejectTampering() {
             AuditEntry entry = createTestEntry();
 
             String v1Hmac = legacySignV1(AuditHmac.buildCanonicalString(entry));
             String v2Hmac = "v2:" + legacySignV1(AuditHmac.buildCanonicalStringV2(entry));
-            String v3Hmac = AuditHmac.computeHmac(entry, hmacKey);
+            String v3Hmac = "v3:" + legacySignV1(AuditHmac.buildCanonicalStringV3(entry));
+            String v4Hmac = AuditHmac.computeHmac(entry, hmacKey);
 
             assertFalse(v1Hmac.startsWith("v"), "precondition: the v1 row carries no version tag");
-            assertTrue(v3Hmac.startsWith("v3:"), "precondition: the current row names its canonical form");
+            assertTrue(v4Hmac.startsWith("v4:"), "precondition: the current row names its canonical form");
 
             assertTrue(AuditHmac.verifyHmac(entry.withHmac(v1Hmac), hmacKey), "a pre-v2 ledger row must still verify");
             assertTrue(AuditHmac.verifyHmac(entry.withHmac(v2Hmac), hmacKey), "a v2 ledger row must verify");
             assertTrue(AuditHmac.verifyHmac(entry.withHmac(v3Hmac), hmacKey), "a v3 ledger row must verify");
+            assertTrue(AuditHmac.verifyHmac(entry.withHmac(v4Hmac), hmacKey), "a v4 ledger row must verify");
 
             AuditEntry tampered = entry.withEnvironment("TAMPERED");
             assertFalse(AuditHmac.verifyHmac(tampered.withHmac(v1Hmac), hmacKey), "a tampered v1 row must be rejected");
             assertFalse(AuditHmac.verifyHmac(tampered.withHmac(v2Hmac), hmacKey), "a tampered v2 row must be rejected");
             assertFalse(AuditHmac.verifyHmac(tampered.withHmac(v3Hmac), hmacKey), "a tampered v3 row must be rejected");
+            assertFalse(AuditHmac.verifyHmac(tampered.withHmac(v4Hmac), hmacKey), "a tampered v4 row must be rejected");
         }
 
         /**

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTestSupport.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTestSupport.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.audit;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+/**
+ * Signs a canonical string the way the ledger's writer does, so a test can
+ * plant a row in an older canonical form without {@link AuditHmac} having to
+ * expose a way to write one. Production code only ever writes the current form.
+ */
+final class AuditHmacTestSupport {
+
+    private AuditHmacTestSupport() {
+        // Test helper
+    }
+
+    static String hmacHex(String canonical, byte[] hmacKey) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(hmacKey, "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(canonical.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to sign canonical string for test", e);
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
@@ -201,6 +201,44 @@ class AuditHmacTimestampPrecisionTest {
             assertEquals(VerificationOutcome.MISMATCH, AuditHmac.verify(tampered, hmacKey, true));
         }
 
+        /**
+         * The per-row search is bounded; the per-sweep work was not. A page of ten
+         * thousand rows that cannot be recovered — which is what a ledger verified with
+         * the wrong key looks like — would have spent about twenty million HMACs on one
+         * request thread before answering.
+         */
+        @Test
+        @DisplayName("a sweep stops searching once its budget is spent")
+        void budgetBoundsTheSweepNotJustTheRow() {
+            AuditEntry original = entryAt(NANO_PRECISE);
+            AuditEntry stored = asStoredByPostgres(original).withHmac(signV3(original));
+
+            var budget = new AuditRecoveryBudget(1);
+
+            assertEquals(VerificationOutcome.MATCH_RECOVERED, AuditHmac.verify(stored, hmacKey, budget),
+                    "the first row is within budget");
+            assertEquals(VerificationOutcome.MISMATCH, AuditHmac.verify(stored, hmacKey, budget),
+                    "the second is not searched, so it reports as it stands");
+            assertEquals(1, budget.searchesSkipped(),
+                    "an unsearched row must be counted, or the sweep looks more thorough than it was");
+        }
+
+        @Test
+        @DisplayName("a row that verifies directly spends none of the budget")
+        void healthyRowsDoNotConsumeBudget() {
+            AuditEntry original = entryAt(Instant.parse("2026-08-20T10:15:30Z"));
+            AuditEntry stored = asStoredByPostgres(original).withHmac(signV3(original));
+
+            var budget = new AuditRecoveryBudget(1);
+            assertEquals(VerificationOutcome.MATCH, AuditHmac.verify(stored, hmacKey, budget));
+
+            // The one search is still available for a row that actually needs it.
+            AuditEntry needsSearch = entryAt(NANO_PRECISE);
+            assertEquals(VerificationOutcome.MATCH_RECOVERED, AuditHmac.verify(
+                    asStoredByPostgres(needsSearch).withHmac(signV3(needsSearch)), hmacKey, budget));
+            assertEquals(0, budget.searchesSkipped());
+        }
+
         @Test
         @DisplayName("recovery can be switched off")
         void recoveryIsOptional() {

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -93,6 +94,36 @@ class AuditHmacTimestampPrecisionTest {
 
             assertEquals(VerificationOutcome.MISMATCH, AuditHmac.verify(moved, hmacKey, true),
                     "tolerating sub-millisecond loss must not tolerate an actual edit");
+        }
+
+        /**
+         * Signing milliseconds is not enough on its own: {@code timestamp(6)} ROUNDS to
+         * the nearest microsecond, so an instant in the last half-microsecond of a
+         * millisecond rounds up across the boundary and reads back a millisecond late.
+         * Storing what was signed leaves nothing to round.
+         */
+        @Test
+        @DisplayName("the stored timestamp is floored first, so PostgreSQL rounding cannot move it")
+        void storedPrecisionDefeatsDatabaseRounding() {
+            Instant lastHalfMicrosecond = Instant.parse("2026-08-20T10:15:30Z").plusNanos(123_999_600L);
+            AuditEntry storable = AuditHmac.withStorablePrecision(entryAt(lastHalfMicrosecond));
+
+            assertEquals(0, storable.timestamp().getNano() % 1_000_000,
+                    "a millisecond-floored instant has no sub-millisecond digits for a database to round");
+
+            AuditEntry signed = storable.withHmac(AuditHmac.computeHmac(storable, hmacKey));
+            // PostgreSQL rounding this value is a no-op, because there is nothing below
+            // the millisecond left to round.
+            assertTrue(AuditHmac.verifyHmac(asStoredByPostgres(signed), hmacKey));
+            assertTrue(AuditHmac.verifyHmac(asStoredByMongo(signed), hmacKey));
+        }
+
+        @Test
+        @DisplayName("withStorablePrecision tolerates a null entry and a null timestamp")
+        void storablePrecisionIsNullTolerant() {
+            assertNull(AuditHmac.withStorablePrecision(null));
+            AuditEntry noTimestamp = entryAt(null);
+            assertEquals(noTimestamp, AuditHmac.withStorablePrecision(noTimestamp));
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.audit;
+
+import ai.labs.eddi.engine.audit.AuditHmac.VerificationOutcome;
+import ai.labs.eddi.engine.audit.model.AuditEntry;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A signature has to survive the trip through storage.
+ * <p>
+ * The v3 canonical form signed the raw {@link Instant}, which on a Linux
+ * container carries nanoseconds — but PostgreSQL's {@code TIMESTAMPTZ} keeps
+ * microseconds and MongoDB's {@code Date} keeps milliseconds. The entry read
+ * back was therefore never the entry that was signed, and verification failed
+ * for effectively every row on both supported backends: a live ledger reported
+ * {@code valid=0 invalid=78} on entries written seconds earlier. Nothing was
+ * tampered with; the control simply had no signal in it, so an operator could
+ * not tell a forged row from a healthy one.
+ * <p>
+ * These tests do what the ledger's own tests never did: sign an entry, apply
+ * each backend's truncation, and verify what comes back.
+ */
+@DisplayName("audit HMAC survives each backend's timestamp precision")
+class AuditHmacTimestampPrecisionTest {
+
+    private static byte[] hmacKey;
+
+    @BeforeAll
+    static void deriveKey() {
+        hmacKey = AuditHmac.deriveHmacKey("test-master-key");
+    }
+
+    /** An instant with digits below every storage floor: 123456789 nanos. */
+    private static final Instant NANO_PRECISE = Instant.parse("2026-08-20T10:15:30Z").plusNanos(123_456_789L);
+
+    private static AuditEntry entryAt(Instant timestamp) {
+        return new AuditEntry("id-1", "conv-1", "agent-1", 1, "alice", "prod", 0, "ai.labs.llm", "langchain", 2, 780L,
+                Map.of("input", "hello"), Map.of("output", "ALPHA."), null, null, List.of("greet"), 0.0, timestamp, null, null, 7L);
+    }
+
+    /** What PostgreSQL's {@code TIMESTAMPTZ} (precision 6) hands back. */
+    private static AuditEntry asStoredByPostgres(AuditEntry entry) {
+        return entry.withTimestamp(entry.timestamp().truncatedTo(ChronoUnit.MICROS));
+    }
+
+    /** What MongoDB's {@code Date} hands back. */
+    private static AuditEntry asStoredByMongo(AuditEntry entry) {
+        return entry.withTimestamp(entry.timestamp().truncatedTo(ChronoUnit.MILLIS));
+    }
+
+    @Nested
+    @DisplayName("v4, the form written today")
+    class V4 {
+
+        @Test
+        @DisplayName("verifies after a PostgreSQL round-trip")
+        void survivesMicrosecondTruncation() {
+            AuditEntry signed = entryAt(NANO_PRECISE).withHmac(AuditHmac.computeHmac(entryAt(NANO_PRECISE), hmacKey));
+
+            assertTrue(AuditHmac.verifyHmac(asStoredByPostgres(signed), hmacKey),
+                    "a row read back from TIMESTAMPTZ must still verify");
+        }
+
+        @Test
+        @DisplayName("verifies after a MongoDB round-trip")
+        void survivesMillisecondTruncation() {
+            AuditEntry signed = entryAt(NANO_PRECISE).withHmac(AuditHmac.computeHmac(entryAt(NANO_PRECISE), hmacKey));
+
+            assertTrue(AuditHmac.verifyHmac(asStoredByMongo(signed), hmacKey),
+                    "a row read back from a BSON Date must still verify");
+        }
+
+        @Test
+        @DisplayName("still rejects a timestamp moved by a whole millisecond")
+        void rejectsRealTimestampTampering() {
+            AuditEntry signed = entryAt(NANO_PRECISE).withHmac(AuditHmac.computeHmac(entryAt(NANO_PRECISE), hmacKey));
+            AuditEntry moved = signed.withTimestamp(signed.timestamp().plusMillis(1));
+
+            assertEquals(VerificationOutcome.MISMATCH, AuditHmac.verify(moved, hmacKey, true),
+                    "tolerating sub-millisecond loss must not tolerate an actual edit");
+        }
+
+        @Test
+        @DisplayName("signs the epoch value, so toString's trailing-zero variance cannot matter")
+        void signsEpochNotText() {
+            // "…:30Z" and "…:30.000Z" are the same instant but different text.
+            Instant whole = Instant.parse("2026-08-20T10:15:30Z");
+            Instant sameWithExplicitMillis = Instant.ofEpochMilli(whole.toEpochMilli());
+
+            assertEquals(AuditHmac.buildCanonicalStringV4(entryAt(whole)),
+                    AuditHmac.buildCanonicalStringV4(entryAt(sameWithExplicitMillis)));
+        }
+    }
+
+    @Nested
+    @DisplayName("v3 rows already in the ledger")
+    class V3Recovery {
+
+        private static String signV3(AuditEntry entry) {
+            return "v3:" + AuditHmacTestSupport.hmacHex(AuditHmac.buildCanonicalStringV3(entry), hmacKey);
+        }
+
+        @Test
+        @DisplayName("a PostgreSQL-truncated row cannot verify as stored")
+        void demonstratesTheDefect() {
+            AuditEntry original = entryAt(NANO_PRECISE);
+            AuditEntry stored = asStoredByPostgres(original).withHmac(signV3(original));
+
+            assertNotEquals(original.timestamp(), stored.timestamp(),
+                    "precondition: storage really did drop digits");
+            assertEquals(VerificationOutcome.MISMATCH, AuditHmac.verify(stored, hmacKey, false),
+                    "this is what made every entry report INVALID");
+        }
+
+        @Test
+        @DisplayName("recovery reconstructs the nanoseconds PostgreSQL dropped")
+        void recoversMicrosecondFlooredRow() {
+            AuditEntry original = entryAt(NANO_PRECISE);
+            AuditEntry stored = asStoredByPostgres(original).withHmac(signV3(original));
+
+            assertEquals(VerificationOutcome.MATCH_RECOVERED, AuditHmac.verify(stored, hmacKey, true),
+                    "the missing digits are recoverable from the signature itself");
+        }
+
+        @Test
+        @DisplayName("recovery reconstructs the microseconds MongoDB dropped")
+        void recoversMillisecondFlooredRow() {
+            // A microsecond-resolution clock, which is what a JVM Date-backed row has.
+            AuditEntry original = entryAt(Instant.parse("2026-08-20T10:15:30Z").plusNanos(123_456_000L));
+            AuditEntry stored = asStoredByMongo(original).withHmac(signV3(original));
+
+            assertEquals(VerificationOutcome.MATCH_RECOVERED, AuditHmac.verify(stored, hmacKey, true));
+        }
+
+        @Test
+        @DisplayName("a v3 row whose clock landed on a whole millisecond verifies with no search")
+        void exactRowNeedsNoRecovery() {
+            AuditEntry original = entryAt(Instant.parse("2026-08-20T10:15:30Z"));
+            AuditEntry stored = asStoredByPostgres(original).withHmac(signV3(original));
+
+            assertEquals(VerificationOutcome.MATCH, AuditHmac.verify(stored, hmacKey, true));
+        }
+
+        /**
+         * The point of recovery is that it proves integrity rather than assuming it.
+         * Re-signing legacy rows in place would have laundered exactly this case.
+         */
+        @Test
+        @DisplayName("recovery does not rescue a genuinely tampered row")
+        void tamperedRowStaysInvalid() {
+            AuditEntry original = entryAt(NANO_PRECISE);
+            AuditEntry stored = asStoredByPostgres(original).withHmac(signV3(original));
+            AuditEntry tampered = stored.withEnvironment("TAMPERED");
+
+            assertEquals(VerificationOutcome.MISMATCH, AuditHmac.verify(tampered, hmacKey, true));
+        }
+
+        @Test
+        @DisplayName("recovery can be switched off")
+        void recoveryIsOptional() {
+            AuditEntry original = entryAt(NANO_PRECISE);
+            AuditEntry stored = asStoredByPostgres(original).withHmac(signV3(original));
+
+            assertEquals(VerificationOutcome.MISMATCH, AuditHmac.verify(stored, hmacKey, false));
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
@@ -139,6 +139,22 @@ class AuditHmacTimestampPrecisionTest {
     }
 
     @Nested
+    @DisplayName("versionOf — the triage field")
+    class VersionOf {
+
+        @Test
+        @DisplayName("names each canonical form, bare digests as v1, unsigned as null")
+        void namesEveryForm() {
+            assertEquals("v4", AuditHmac.versionOf("v4:" + "0".repeat(64)));
+            assertEquals("v3", AuditHmac.versionOf("v3:" + "0".repeat(64)));
+            assertEquals("v2", AuditHmac.versionOf("v2:" + "0".repeat(64)));
+            assertEquals("v1", AuditHmac.versionOf("0".repeat(64)));
+            assertNull(AuditHmac.versionOf(null));
+            assertNull(AuditHmac.versionOf(""));
+        }
+    }
+
+    @Nested
     @DisplayName("v3 rows already in the ledger")
     class V3Recovery {
 

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditHmacTimestampPrecisionTest.java
@@ -178,6 +178,48 @@ class AuditHmacTimestampPrecisionTest {
             assertEquals(VerificationOutcome.MATCH_RECOVERED, AuditHmac.verify(stored, hmacKey, true));
         }
 
+        /**
+         * Storage does not only floor. PostgreSQL's {@code timestamp(6)} — and the JDBC
+         * driver's nanos-to-micros conversion — round to NEAREST, so a value whose lost
+         * digits were in the upper half is stored ABOVE the signed one. A forward-only
+         * search missed every such row: roughly half of all PostgreSQL legacy rows.
+         */
+        @Test
+        @DisplayName("recovery also finds a timestamp PostgreSQL rounded UP")
+        void recoversRoundedUpRow() {
+            // 789ns remainder ≥ 500 → rounds up to the next microsecond: the stored
+            // value sits 211ns ABOVE the signed one.
+            AuditEntry original = entryAt(NANO_PRECISE);
+            Instant roundedUp = original.timestamp().truncatedTo(ChronoUnit.MICROS).plusNanos(1_000);
+            AuditEntry stored = original.withTimestamp(roundedUp).withHmac(signV3(original));
+
+            assertTrue(roundedUp.isAfter(original.timestamp()), "precondition: rounding moved the value up");
+            assertEquals(VerificationOutcome.MATCH_RECOVERED, AuditHmac.verify(stored, hmacKey, true),
+                    "a rounded-up stored value sits above the signed one, so the search must look down too");
+        }
+
+        /**
+         * The searched window is, unavoidably, also the window within which a MOVED
+         * stored timestamp is indistinguishable from a truncated one — so it must be
+         * capped to exactly the precision the row demonstrably lost. A row with
+         * sub-millisecond digits present came through a microsecond store: only
+         * sub-microsecond digits are unknowable, and a whole-microsecond shift is a
+         * real edit that recovery must NOT absorb.
+         */
+        @Test
+        @DisplayName("a microsecond-precision row shifted by whole microseconds is NOT recovered")
+        void microsecondShiftOnMicrosecondRowStaysInvalid() {
+            // µs-aligned signed value, so a whole-µs shift lands exactly on a
+            // candidate the µs tier WOULD try — the only thing standing between this
+            // edit and MATCH_RECOVERED is the precision cap.
+            AuditEntry original = entryAt(Instant.parse("2026-08-20T10:15:30Z").plusNanos(123_456_000L));
+            AuditEntry shifted = original.withTimestamp(original.timestamp().plusNanos(5_000))
+                    .withHmac(signV3(original));
+
+            assertEquals(VerificationOutcome.MISMATCH, AuditHmac.verify(shifted, hmacKey, true),
+                    "the ±µs tier must not run for a row whose sub-ms digits prove a µs-precision store");
+        }
+
         @Test
         @DisplayName("a v3 row whose clock landed on a whole millisecond verifies with no search")
         void exactRowNeedsNoRecovery() {

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
@@ -194,7 +194,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.of("master-key"), "deadletter.jsonl", true, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                true, meterRegistry, natsInstance, signingService, new ObjectMapper());
+                true, 500, meterRegistry, natsInstance, signingService, new ObjectMapper());
         service.init();
 
         var entry = entry("id1", "conv1", "agent1");
@@ -230,7 +230,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "deadletter.jsonl", true, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                true, meterRegistry, natsInstance, signingService, new ObjectMapper());
+                true, 500, meterRegistry, natsInstance, signingService, new ObjectMapper());
         service.init();
 
         var entry = entry("id1", "conv1", "agent1");
@@ -263,7 +263,7 @@ class AuditLedgerServiceBranchTest {
         // No master key → no hmac
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "deadletter.jsonl", true, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                true, meterRegistry, natsInstance, signingService, new ObjectMapper());
+                true, 500, meterRegistry, natsInstance, signingService, new ObjectMapper());
         service.init();
 
         var entry = entry("my-id", "conv1", "agent1");
@@ -313,7 +313,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                true, meterRegistry, natsInstance, null, new ObjectMapper());
+                true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
         // Make flush fail 3 times to trigger dead letter
@@ -350,7 +350,7 @@ class AuditLedgerServiceBranchTest {
         // path)
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "Z:\\nonexistent\\path\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                true, meterRegistry, natsInstance, null, new ObjectMapper());
+                true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
         doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());
@@ -377,7 +377,7 @@ class AuditLedgerServiceBranchTest {
         // Use a nonexistent path to test error handling
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "Z:\\nonexistent\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                true, meterRegistry, natsInstance, null, new ObjectMapper());
+                true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
         doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());
@@ -406,7 +406,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                true, meterRegistry, natsInstance, null, failingMapper);
+                true, 500, meterRegistry, natsInstance, null, failingMapper);
         service.init();
 
         var e = entry("1", "conv1", "agent1");
@@ -455,7 +455,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "Z:\\nonexistent\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                true, meterRegistry, natsInstance, null, new ObjectMapper());
+                true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
         doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
@@ -194,7 +194,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.of("master-key"), "deadletter.jsonl", true, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                meterRegistry, natsInstance, signingService, new ObjectMapper());
+                true, meterRegistry, natsInstance, signingService, new ObjectMapper());
         service.init();
 
         var entry = entry("id1", "conv1", "agent1");
@@ -230,7 +230,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "deadletter.jsonl", true, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                meterRegistry, natsInstance, signingService, new ObjectMapper());
+                true, meterRegistry, natsInstance, signingService, new ObjectMapper());
         service.init();
 
         var entry = entry("id1", "conv1", "agent1");
@@ -263,7 +263,7 @@ class AuditLedgerServiceBranchTest {
         // No master key → no hmac
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "deadletter.jsonl", true, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                meterRegistry, natsInstance, signingService, new ObjectMapper());
+                true, meterRegistry, natsInstance, signingService, new ObjectMapper());
         service.init();
 
         var entry = entry("my-id", "conv1", "agent1");
@@ -313,7 +313,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                meterRegistry, natsInstance, null, new ObjectMapper());
+                true, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
         // Make flush fail 3 times to trigger dead letter
@@ -350,7 +350,7 @@ class AuditLedgerServiceBranchTest {
         // path)
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "Z:\\nonexistent\\path\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                meterRegistry, natsInstance, null, new ObjectMapper());
+                true, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
         doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());
@@ -377,7 +377,7 @@ class AuditLedgerServiceBranchTest {
         // Use a nonexistent path to test error handling
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "Z:\\nonexistent\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                meterRegistry, natsInstance, null, new ObjectMapper());
+                true, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
         doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());
@@ -406,7 +406,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                meterRegistry, natsInstance, null, failingMapper);
+                true, meterRegistry, natsInstance, null, failingMapper);
         service.init();
 
         var e = entry("1", "conv1", "agent1");
@@ -455,7 +455,7 @@ class AuditLedgerServiceBranchTest {
 
         var service = new AuditLedgerService(auditStore, true, 60,
                 Optional.empty(), "Z:\\nonexistent\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
-                meterRegistry, natsInstance, null, new ObjectMapper());
+                true, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
         doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -139,6 +140,36 @@ class AuditLedgerServiceTest {
         assertEquals(0, stored.timestamp().getNano() % 1_000_000, "stamped at the signed (millisecond) precision");
         assertEquals(AuditVerificationStatus.VALID, service.verifyEntry(stored),
                 "what was signed is what is stored, so it must verify as-is");
+    }
+
+    /**
+     * The submit path must floor the timestamp BEFORE signing — deterministically
+     * pinned with a nano-precise input, so this does not depend on the test host's
+     * clock resolution. Without the flooring, PostgreSQL's microsecond rounding can
+     * move a stored timestamp across the millisecond the v4 signature covers, and
+     * roughly one row in two thousand reports tampered for no reason.
+     */
+    @Test
+    @DisplayName("flush — a nano-precise timestamp is floored before signing, and verifies")
+    @SuppressWarnings("unchecked")
+    void nanoPreciseTimestampIsFlooredBeforeSigning() {
+        service = createService(true, "master-key");
+        Instant nanoPrecise = Instant.parse("2026-08-20T10:15:30Z").plusNanos(123_999_600L);
+        service.submit(new AuditEntry("floor-1", "conv1", "agent1", 1, "user1", "production",
+                0, "taskId", "LlmTask", 0, 100L,
+                Map.of("text", "hello"), Map.of("text", "response"),
+                null, null, List.of("action1"), 0.0, nanoPrecise, null, null));
+
+        service.flush();
+
+        var persisted = ArgumentCaptor.forClass(List.class);
+        verify(auditStore).appendBatch(persisted.capture());
+        AuditEntry stored = ((List<AuditEntry>) persisted.getValue()).getFirst();
+
+        assertEquals(0, stored.timestamp().getNano() % 1_000_000,
+                "the stored row must carry the millisecond value the signature covers — nothing left to round");
+        assertEquals(nanoPrecise.truncatedTo(ChronoUnit.MILLIS), stored.timestamp());
+        assertEquals(AuditVerificationStatus.VALID, service.verifyEntry(stored));
     }
 
     // ==================== sequence-table eviction ====================

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceTest.java
@@ -112,6 +112,35 @@ class AuditLedgerServiceTest {
         assertEquals(0, service.getQueueSize());
     }
 
+    /**
+     * A null timestamp must be stamped before signing, not by the store. v4 signs
+     * the empty string for a null timestamp, but PostgresAuditStore substitutes
+     * now() on write — so a null-timestamped entry would read back carrying a
+     * timestamp the signature never covered and report INVALID forever, on that
+     * backend only. Stamping in the service makes the stored row the signed row.
+     */
+    @Test
+    @DisplayName("flush — a null timestamp is stamped before signing, and verifies")
+    @SuppressWarnings("unchecked")
+    void nullTimestampIsStampedBeforeSigning() {
+        service = createService(true, "master-key");
+        service.submit(new AuditEntry("nts-1", "conv1", "agent1", 1, "user1", "production",
+                0, "taskId", "LlmTask", 0, 100L,
+                Map.of("text", "hello"), Map.of("text", "response"),
+                null, null, List.of("action1"), 0.0, null, null, null));
+
+        service.flush();
+
+        var persisted = ArgumentCaptor.forClass(List.class);
+        verify(auditStore).appendBatch(persisted.capture());
+        AuditEntry stored = ((List<AuditEntry>) persisted.getValue()).getFirst();
+
+        assertNotNull(stored.timestamp(), "the store's now()-fallback must never be what stamps a signed entry");
+        assertEquals(0, stored.timestamp().getNano() % 1_000_000, "stamped at the signed (millisecond) precision");
+        assertEquals(AuditVerificationStatus.VALID, service.verifyEntry(stored),
+                "what was signed is what is stored, so it must verify as-is");
+    }
+
     // ==================== sequence-table eviction ====================
 
     /**

--- a/src/test/java/ai/labs/eddi/engine/audit/PostgresAuditHmacRoundTripTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/PostgresAuditHmacRoundTripTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import ai.labs.eddi.modules.output.model.types.TextOutputItem;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Map;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -133,6 +136,42 @@ class PostgresAuditHmacRoundTripTest extends PostgresTestBase {
         assertNotEquals(VerificationOutcome.MISMATCH,
                 AuditHmac.verify(stored, hmacKey, new AuditRecoveryBudget(1)),
                 "the completion search must find the signed timestamp on either side of what was stored");
+    }
+
+    /**
+     * The timestamp was not the only field that failed to round-trip.
+     * <p>
+     * The pipeline hands the ledger LIVE Java objects — a turn's {@code output} is
+     * a list of {@code TextOutputItem} POJOs, not of Maps — and the signature was
+     * computed over those while verification later ran over what JSON gave back.
+     * The two canonicalize completely differently: {@code s:<toString()>} against
+     * {@code m&#123;…&#125;}. Measured here before the fix, one output item signed
+     * as {@code {output=[Hi there!]}} came back as {@code {output=[{text=Hi there!,
+     * type=text, delay=0}]}}.
+     * <p>
+     * This is why fixing the timestamp alone was not enough: the end-to-end IT
+     * reported {@code entriesChecked=5 valid=2} on a plain rule-based turn, the
+     * three failures being every task with rendered output in scope. The cure is
+     * the one the timestamp got — normalise to the stored shape, THEN sign — which
+     * lives in {@code AuditLedgerService}, so this test drives the real submit path
+     * rather than hand-building the entry.
+     */
+    @Test
+    @DisplayName("an entry whose payload holds POJOs verifies after the real round-trip")
+    void pojoPayloadSurvivesTheDatabase() {
+        AuditEntry raw = new AuditEntry(UUID.randomUUID().toString(), "conv-pojo", "agent1", 1,
+                "user1", "test", 0, "t1", "output", 0, 42L,
+                null, Map.of("output", List.of(new TextOutputItem("Hi there!", 0))), null, null,
+                List.of("greet"), 0.0, Instant.now(), null, null, 1L);
+
+        var service = AuditLedgerService.createForTesting(store, true, 3600, "pg-roundtrip-test-key",
+                new SimpleMeterRegistry());
+        service.init();
+        service.submit(raw);
+        service.flush();
+
+        assertTrue(AuditHmac.verifyHmac(readBack("conv-pojo"), hmacKey),
+                "an entry carrying rendered output must verify — that is most of a real turn's entries");
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/audit/PostgresAuditHmacRoundTripTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/PostgresAuditHmacRoundTripTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.audit;
+
+import ai.labs.eddi.datastore.postgres.PostgresAuditStore;
+import ai.labs.eddi.datastore.postgres.PostgresTestBase;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.datastore.serialization.JsonSerialization;
+import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
+import ai.labs.eddi.engine.audit.AuditHmac.VerificationOutcome;
+import ai.labs.eddi.engine.audit.model.AuditEntry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The audit signature must survive the REAL database — not a simulated one.
+ * <p>
+ * The original defect (D7) was a cross-layer mismatch: the JVM signed
+ * nanoseconds, PostgreSQL stored microseconds, and every unit test with a mock
+ * store was structurally blind to it — a live ledger reported
+ * {@code valid=0 invalid=78} while all its tests were green. The unit tests
+ * that now cover the fix <em>simulate</em> storage truncation; this class
+ * closes the loop against a real PostgreSQL container, so whatever the server
+ * and JDBC driver actually do to a timestamp (floor, round to nearest, either
+ * direction) is what the assertions run against. If a future PostgreSQL or
+ * driver upgrade changes that behaviour, this is the test that says so.
+ * <p>
+ * <b>Scope, precisely:</b> this class pins the <em>shipped pipeline</em> (floor
+ * → sign → store → read → verify) and the recovery search against real storage.
+ * It deliberately floors before signing, exactly like the service — so a
+ * canonical-form regression alone would still pass here (flooring makes even v3
+ * round-trip); that regression is pinned by
+ * {@code AuditHmacTimestampPrecisionTest}, which signs raw nanoseconds, and a
+ * service-side flooring removal is pinned by {@code AuditLedgerServiceTest}.
+ * What this class uniquely catches was demonstrated by mutation against the
+ * live container: making the recovery search forward-only fails
+ * {@code v3LegacyRowIsRecoverableFromRealStorage}, because the real
+ * PostgreSQL/JDBC pipeline rounds a 789ns remainder <em>up</em> — the stored
+ * value sits above the signed one, where a forward search can never reach it.
+ */
+@DisplayName("audit HMAC round-trip against real PostgreSQL")
+class PostgresAuditHmacRoundTripTest extends PostgresTestBase {
+
+    private static PostgresAuditStore store;
+    private static DataSource ds;
+    private static byte[] hmacKey;
+
+    @BeforeAll
+    static void init() {
+        var dsInstance = createDataSourceInstance();
+        ds = dsInstance.get();
+        IJsonSerialization json = new JsonSerialization(
+                SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false));
+        store = new PostgresAuditStore(dsInstance, json);
+        hmacKey = AuditHmac.deriveHmacKey("pg-roundtrip-test-key");
+    }
+
+    @BeforeEach
+    void clean() {
+        try {
+            truncateTables(ds, "audit_ledger");
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private static AuditEntry entryAt(String convId, Instant timestamp) {
+        return new AuditEntry(UUID.randomUUID().toString(), convId, "agent1", 1,
+                "user1", "test", 0, "t1", "langchain", 0, 42L,
+                null, null, null, null, List.of("greet"), 0.0,
+                timestamp, null, null, 1L);
+    }
+
+    private static AuditEntry readBack(String convId) {
+        List<AuditEntry> rows = store.getEntries(convId, 0, 10);
+        assertEquals(1, rows.size());
+        return rows.getFirst();
+    }
+
+    @Test
+    @DisplayName("a v4-signed entry verifies after the real timestamptz round-trip")
+    void v4SignedEntrySurvivesTheDatabase() {
+        AuditEntry raw = entryAt("conv-rt-v4", Instant.now());
+        // Exactly what AuditLedgerService does on submit: floor, then sign.
+        AuditEntry floored = AuditHmac.withStorablePrecision(raw);
+        AuditEntry signed = floored.withHmac(AuditHmac.computeHmac(floored, hmacKey));
+
+        store.appendEntry(signed);
+        AuditEntry stored = readBack("conv-rt-v4");
+
+        assertEquals(signed.timestamp(), stored.timestamp(),
+                "a millisecond-floored timestamp must round-trip byte-identically — nothing left for the database to round");
+        assertTrue(AuditHmac.verifyHmac(stored, hmacKey),
+                "the row read back must be the row that was signed");
+    }
+
+    /**
+     * The pre-fix write path, replayed against the real database: sign the raw
+     * nano-precision instant with v3, store it, read back whatever PostgreSQL kept.
+     * Direct verification fails — that IS the defect — and the completion search
+     * must still prove the row, whichever direction the server and driver moved the
+     * timestamp. This test deliberately refuses to assume the direction.
+     */
+    @Test
+    @DisplayName("a legacy v3 row is recoverable from what PostgreSQL actually stored")
+    void v3LegacyRowIsRecoverableFromRealStorage() {
+        AuditEntry raw = entryAt("conv-rt-v3",
+                Instant.now().truncatedTo(ChronoUnit.SECONDS).plusNanos(123_456_789L));
+        String v3Hmac = "v3:" + AuditHmacTestSupport.hmacHex(AuditHmac.buildCanonicalStringV3(raw), hmacKey);
+
+        store.appendEntry(raw.withHmac(v3Hmac));
+        AuditEntry stored = readBack("conv-rt-v3");
+
+        assertNotEquals(raw.timestamp(), stored.timestamp(),
+                "precondition: the database really does not keep nanoseconds");
+        assertEquals(VerificationOutcome.MISMATCH, AuditHmac.verify(stored, hmacKey, false),
+                "precondition: the stored row is not the signed row — the live defect");
+        assertNotEquals(VerificationOutcome.MISMATCH,
+                AuditHmac.verify(stored, hmacKey, new AuditRecoveryBudget(1)),
+                "the completion search must find the signed timestamp on either side of what was stored");
+    }
+
+    @Test
+    @DisplayName("the Ed25519 agent signature round-trips (D7b)")
+    void agentSignatureRoundTrips() {
+        AuditEntry signed = entryAt("conv-rt-sig", Instant.now())
+                .withAgentSignature("ed25519:dGVzdC1zaWduYXR1cmU=");
+
+        store.appendEntry(signed);
+
+        assertEquals("ed25519:dGVzdC1zaWduYXR1cmU=", readBack("conv-rt-sig").agentSignature(),
+                "the column existed nowhere and the row-mapper hard-coded null — signatures were computed and discarded");
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/audit/model/AuditVerificationReportTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/model/AuditVerificationReportTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.audit.model;
+
+import ai.labs.eddi.engine.audit.model.AuditVerificationReport.ChainStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The two health bits have to distinguish "disproven" from "not proven".
+ * <p>
+ * A pre-v4 row that fails its direct check and is then not searched — because
+ * the sweep's recovery budget ran out — establishes nothing either way. Failing
+ * the direct check is the <em>expected</em> outcome for such a row, so counting
+ * it as tampering would let a large enough page raise a compliance alarm purely
+ * by exhausting a budget. That is the same "reported as proven when it is not"
+ * shape this release exists to remove, pointed the other way.
+ */
+@DisplayName("verification report health bits")
+class AuditVerificationReportTest {
+
+    private static AuditVerificationReport report(int valid, int recovered, int recoverySkipped, int invalid, ChainStatus chain) {
+        return new AuditVerificationReport("conversation", "conv-1", true, valid + invalid, valid, recovered, recoverySkipped,
+                invalid, 0, chain, List.of(), List.of(), List.of(), List.of(), Instant.parse("2026-08-20T10:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("an entry whose HMAC was shown not to recompute is tampering")
+    void realMismatchIsTampering() {
+        var swept = report(9, 0, 0, 1, ChainStatus.INTACT);
+
+        assertTrue(swept.tamperingSuspected());
+        assertEquals(1, swept.disproven());
+        assertFalse(swept.intact());
+    }
+
+    @Test
+    @DisplayName("rows left unsearched by the budget are not tampering")
+    void skippedRecoveryIsNotTampering() {
+        var swept = report(0, 0, 500, 500, ChainStatus.INTACT);
+
+        assertFalse(swept.tamperingSuspected(),
+                "nothing was established about these rows — a budget ran out");
+        assertEquals(0, swept.disproven());
+    }
+
+    @Test
+    @DisplayName("but an unfinished sweep is still not a clean bill of health")
+    void skippedRecoveryStillDefeatsIntact() {
+        assertFalse(report(0, 0, 500, 500, ChainStatus.INTACT).intact(),
+                "a sweep that could not finish checking must not report intact");
+    }
+
+    @Test
+    @DisplayName("a real mismatch alongside skipped rows still raises the alarm")
+    void mixedSweepReportsTheRealOne() {
+        var swept = report(10, 2, 4, 5, ChainStatus.INTACT);
+
+        assertTrue(swept.tamperingSuspected(), "one row of the five was actually disproven");
+        assertEquals(1, swept.disproven());
+    }
+
+    @Test
+    @DisplayName("a broken chain is tampering regardless of the recovery counts")
+    void brokenChainStillCounts() {
+        assertTrue(report(10, 0, 3, 3, ChainStatus.BROKEN).tamperingSuspected());
+    }
+
+    @Test
+    @DisplayName("a clean sweep stays clean")
+    void cleanSweep() {
+        var swept = report(10, 0, 0, 0, ChainStatus.INTACT);
+
+        assertTrue(swept.intact());
+        assertFalse(swept.tamperingSuspected());
+        assertEquals(0, swept.disproven());
+    }
+
+    @Test
+    @DisplayName("recovered rows are valid and raise nothing")
+    void recoveredRowsAreClean() {
+        var swept = report(10, 10, 0, 0, ChainStatus.INTACT);
+
+        assertTrue(swept.intact(), "recovery proves integrity as strongly as a direct match");
+        assertFalse(swept.tamperingSuspected());
+    }
+
+    /** Defensive: the counts come from one sweep, but never go negative. */
+    @Test
+    @DisplayName("a skipped count larger than invalid cannot produce a negative")
+    void countsCannotGoNegative() {
+        assertEquals(0, report(0, 0, 7, 3, ChainStatus.INTACT).disproven());
+        assertFalse(report(0, 0, 7, 3, ChainStatus.INTACT).tamperingSuspected());
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/audit/rest/RestAuditStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/rest/RestAuditStoreTest.java
@@ -106,6 +106,56 @@ class RestAuditStoreTest {
     }
 
     /**
+     * A recovered legacy row is intact — it counts as valid, appears in the
+     * dedicated {@code recovered} tally so an operator can see how much of the
+     * ledger predates v4, and is NOT listed as a problem. Miswiring any of the
+     * three turns a healthy legacy ledger into a wall of alarms.
+     */
+    @Test
+    @DisplayName("a VALID_RECOVERED row counts as valid + recovered, and is no problem")
+    void recoveredRowCountsAsValid() {
+        var direct = entryAt("id-1", 0);
+        var recovered = entryAt("id-2", 1);
+        when(auditStore.getEntries("conv-1", 0, 1000)).thenReturn(List.of(direct, recovered));
+        when(auditLedgerService.verifyEntry(eq(direct), any())).thenReturn(AuditVerificationStatus.VALID);
+        when(auditLedgerService.verifyEntry(eq(recovered), any())).thenReturn(AuditVerificationStatus.VALID_RECOVERED);
+
+        var report = restAuditStore.verifyConversation("conv-1", 0, 1000);
+
+        assertEquals(2, report.valid(), "a recovered row is proven intact and belongs in valid");
+        assertEquals(1, report.recovered());
+        assertEquals(0, report.invalid());
+        assertTrue(report.problems().isEmpty(), "a recovered row is not a problem to escalate");
+    }
+
+    /**
+     * The sweep's budget lives on the service; the report's {@code recoverySkipped}
+     * must be read back off that same budget after the loop — wiring a literal 0
+     * here would make a budget-exhausted sweep look more thorough than it was, and
+     * nothing else fails.
+     */
+    @Test
+    @DisplayName("recoverySkipped is read off the sweep's own budget")
+    void recoverySkippedIsWiredFromTheBudget() {
+        var one = entryAt("id-1", 0);
+        var two = entryAt("id-2", 1);
+        when(auditStore.getEntries("conv-1", 0, 1000)).thenReturn(List.of(one, two));
+        // A real, already-exhausted budget: every consume attempt is a skip.
+        when(auditLedgerService.newRecoveryBudget()).thenReturn(new AuditRecoveryBudget(0));
+        when(auditLedgerService.verifyEntry(any(), any())).thenAnswer(invocation -> {
+            invocation.getArgument(1, AuditRecoveryBudget.class).tryConsume();
+            return AuditVerificationStatus.INVALID;
+        });
+
+        var report = restAuditStore.verifyConversation("conv-1", 0, 1000);
+
+        assertEquals(2, report.recoverySkipped(), "the count must come from the budget the sweep actually used");
+        assertEquals(2, report.invalid());
+        assertFalse(report.tamperingSuspected(), "nothing was disproven — a budget ran out");
+        assertFalse(report.intact(), "an unfinished sweep is still not a clean bill of health");
+    }
+
+    /**
      * The point of the endpoint: {@code AuditHmac.verifyHmac} previously had no
      * production caller at all, so a tampered row shipped undetected. A row whose
      * HMAC no longer recomputes must be named in the report.

--- a/src/test/java/ai/labs/eddi/engine/audit/rest/RestAuditStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/rest/RestAuditStoreTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.audit.rest;
 
 import ai.labs.eddi.engine.audit.AuditLedgerService;
+import ai.labs.eddi.engine.audit.AuditRecoveryBudget;
 import ai.labs.eddi.engine.audit.AuditVerificationStatus;
 import ai.labs.eddi.engine.audit.IAuditStore;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -44,7 +46,9 @@ class RestAuditStoreTest {
         auditStore = mock(IAuditStore.class);
         auditLedgerService = mock(AuditLedgerService.class);
         when(auditLedgerService.isSigningEnabled()).thenReturn(true);
-        when(auditLedgerService.verifyEntry(any())).thenReturn(AuditVerificationStatus.VALID);
+        // The sweep asks the service for one budget and passes it to every entry.
+        when(auditLedgerService.newRecoveryBudget()).thenReturn(AuditRecoveryBudget.none());
+        when(auditLedgerService.verifyEntry(any(), any())).thenReturn(AuditVerificationStatus.VALID);
         restAuditStore = new RestAuditStore(auditStore, auditLedgerService);
     }
 
@@ -112,8 +116,8 @@ class RestAuditStoreTest {
         var good = entryAt("id-1", 0);
         var tampered = entryAt("id-2", 1);
         when(auditStore.getEntries("conv-1", 0, 1000)).thenReturn(List.of(good, tampered));
-        when(auditLedgerService.verifyEntry(good)).thenReturn(AuditVerificationStatus.VALID);
-        when(auditLedgerService.verifyEntry(tampered)).thenReturn(AuditVerificationStatus.INVALID);
+        when(auditLedgerService.verifyEntry(eq(good), any())).thenReturn(AuditVerificationStatus.VALID);
+        when(auditLedgerService.verifyEntry(eq(tampered), any())).thenReturn(AuditVerificationStatus.INVALID);
 
         var report = restAuditStore.verifyConversation("conv-1", 0, 1000);
 
@@ -311,7 +315,7 @@ class RestAuditStoreTest {
     @DisplayName("without a signing key the sweep proves nothing")
     void withoutSigningKeyNothingIsProven() {
         when(auditLedgerService.isSigningEnabled()).thenReturn(false);
-        when(auditLedgerService.verifyEntry(any())).thenReturn(AuditVerificationStatus.SIGNING_DISABLED);
+        when(auditLedgerService.verifyEntry(any(), any())).thenReturn(AuditVerificationStatus.SIGNING_DISABLED);
         when(auditStore.getEntries("conv-1", 0, 1000)).thenReturn(List.of(entryAt("id-1", 0)));
 
         var report = restAuditStore.verifyConversation("conv-1", 0, 1000);

--- a/src/test/java/ai/labs/eddi/engine/audit/rest/RestAuditStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/rest/RestAuditStoreTest.java
@@ -106,6 +106,30 @@ class RestAuditStoreTest {
     }
 
     /**
+     * The triage field: a verify sweep reports both a tampered v4 row and an
+     * unrecoverable legacy row as INVALID, and those demand opposite reactions —
+     * one is an alarm, the other is the expected residue of rows signed over live
+     * Java objects that nothing can reconstruct. The problem entry must say which
+     * one the operator is looking at.
+     */
+    @Test
+    @DisplayName("a problem entry names the canonical form its HMAC was written with")
+    void problemEntriesCarryTheHmacVersion() {
+        var legacy = entryAt("id-legacy", 0); // "v3:deadbeef"
+        var current = entryAt("id-current", 1).withHmac("v4:" + "0".repeat(64));
+        when(auditStore.getEntries("conv-1", 0, 1000)).thenReturn(List.of(legacy, current));
+        when(auditLedgerService.verifyEntry(any(), any())).thenReturn(AuditVerificationStatus.INVALID);
+
+        var report = restAuditStore.verifyConversation("conv-1", 0, 1000);
+
+        assertEquals(2, report.problems().size());
+        assertEquals("v3", report.problems().get(0).hmacVersion(),
+                "a pre-v4 INVALID is usually unrecoverable legacy payload, not tampering");
+        assertEquals("v4", report.problems().get(1).hmacVersion(),
+                "a v4 INVALID is the alarm — something touched a row this release wrote");
+    }
+
+    /**
      * A recovered legacy row is intact — it counts as valid, appears in the
      * dedicated {@code recovered} tally so an operator can see how much of the
      * ledger predates v4, and is NOT listed as a problem. Miswiring any of the

--- a/src/test/java/ai/labs/eddi/engine/exception/ClientErrorExceptionMapperTest.java
+++ b/src/test/java/ai/labs/eddi/engine/exception/ClientErrorExceptionMapperTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.exception;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A 4xx has to say why.
+ * <p>
+ * {@code throw new BadRequestException("…")} builds its response from the
+ * status alone, so the message never leaves the JVM. Validation across this
+ * codebase is written as though it does — {@code POST /channelstore/channels}
+ * throws four distinct, carefully worded messages and delivered an empty body
+ * for every one of them. On a live sweep that made channel integrations
+ * impossible to create through the API without reading the Java source to work
+ * out which rule was being violated, and it produced four false findings whose
+ * only cause was a call shape nothing would explain.
+ */
+@DisplayName("4xx messages reach the client")
+class ClientErrorExceptionMapperTest {
+
+    private final ClientErrorExceptionMapper mapper = new ClientErrorExceptionMapper();
+
+    @Test
+    @DisplayName("a BadRequestException's message becomes the response body")
+    void badRequestMessageBecomesTheBody() {
+        Response response = mapper.toResponse(new BadRequestException("Channel integration name is required."));
+
+        assertEquals(400, response.getStatus());
+        assertEquals("Channel integration name is required.", response.getEntity());
+        assertEquals(MediaType.TEXT_PLAIN_TYPE, response.getMediaType());
+    }
+
+    @Test
+    @DisplayName("the status is preserved, whatever the 4xx")
+    void statusIsPreserved() {
+        assertEquals(404, mapper.toResponse(new NotFoundException("No such agent.")).getStatus());
+        assertEquals(403, mapper.toResponse(new ForbiddenException("Not your conversation.")).getStatus());
+    }
+
+    @Test
+    @DisplayName("an exception that already carries an entity is left alone")
+    void existingEntityIsNotOverwritten() {
+        Response existing = Response.status(400).entity("{\"error\":\"structured\"}")
+                .type(MediaType.APPLICATION_JSON).build();
+
+        Response response = mapper.toResponse(new BadRequestException(existing));
+
+        assertEquals("{\"error\":\"structured\"}", response.getEntity());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+    }
+
+    @Test
+    @DisplayName("no message — the response stays as it was, no empty body invented")
+    void noMessageLeavesTheResponseAlone() {
+        Response response = mapper.toResponse(new BadRequestException());
+
+        assertEquals(400, response.getStatus());
+        // JAX-RS supplies a default reason for a message-less exception; whatever it
+        // is, the mapper must not turn it into something misleading.
+        assertTrue(response.getEntity() == null || !response.getEntity().toString().isBlank());
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
@@ -489,6 +489,27 @@ class RestAgentEngineTest {
             assertTrue(capturedInput.getContext().containsKey("lang"));
         }
 
+        /**
+         * {@code language} used to be mandatory ({@code checkNotEmpty}) and 400'd every
+         * caller who followed the endpoint's own description, which never mentioned it.
+         * It is optional now, like on {@code say()} — a rerun without it simply carries
+         * no language context.
+         */
+        @Test
+        @DisplayName("a rerun without a language proceeds, with no language context")
+        void nullLanguageIsOptional() throws Exception {
+            var asyncResponse = mock(AsyncResponse.class);
+
+            restAgentEngine.rerunLastConversationStep("conv-1", null, false, false,
+                    List.of(), asyncResponse);
+
+            var captor = ArgumentCaptor.forClass(InputData.class);
+            verify(conversationService).say(eq("conv-1"), eq(false), eq(false),
+                    eq(List.of()), captor.capture(), eq(true), any());
+            assertTrue(captor.getValue().getContext().isEmpty(),
+                    "absent language means no context entry, exactly as on say()");
+        }
+
         @Test
         @DisplayName("should resume with 503 while draining (rerun shares sayInternal)")
         void rejectedWhileShuttingDown() throws Exception {

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineToolPauseDetailsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineToolPauseDetailsTest.java
@@ -358,37 +358,69 @@ class RestAgentEngineToolPauseDetailsTest {
             assertEquals(List.of("PAUSE_CONVERSATION", "notify_manager"), pauseDetails.get("actions"));
         }
 
+        /**
+         * {@code getConversationSteps()} is CHRONOLOGICAL — index 0 is the oldest step,
+         * which is always the CONVERSATION_START turn.
+         * <p>
+         * {@code convertConversationMemory} counts down from {@code size() - 1}, which
+         * reads like a reversal, but it indexes a {@code ConversationStepStack} whose
+         * own {@code get(i)} already counts back from the newest, so the two inversions
+         * cancel. This test previously asserted the opposite and passed only because
+         * the code under test shared the same wrong premise: it walked forward from
+         * index 0, so a live rule pause reported {@code ["CONVERSATION_START"]} as the
+         * cause every single time, whatever rule had actually fired. Verified against a
+         * real ConversationMemory round-trip, not read off the loop.
+         */
         @Test
         @DisplayName("with multiple steps, actions come from the MOST RECENT step "
-                + "(getConversationSteps() is reverse-chronological — index 0 is newest)")
+                + "(getConversationSteps() is chronological — index 0 is oldest)")
         void rulePauseUsesMostRecentStepAmongMultiple() throws Exception {
             var snapshot = snapshotInState(ConversationState.AWAITING_HUMAN);
             snapshot.setHitlPauseType("RULE");
             snapshot.setHitlPauseReason("needs manager sign-off");
 
-            // Index 0 = most recent step (matches
-            // ConversationMemoryUtilities.convertConversationMemory's reverse
-            // insertion order) — this is the one whose actions must win.
+            // Index 0 = the oldest step: on a real conversation, CONVERSATION_START.
+            var oldestStep = new ConversationMemorySnapshot.ConversationStepSnapshot();
+            var oldestWorkflow = new ConversationMemorySnapshot.WorkflowRunSnapshot();
+            oldestWorkflow.getLifecycleTasks().add(new ConversationMemorySnapshot.ResultSnapshot(
+                    "actions", List.of("CONVERSATION_START"), null, null, "wf-1", true));
+            oldestStep.getWorkflows().add(oldestWorkflow);
+
             var newestStep = new ConversationMemorySnapshot.ConversationStepSnapshot();
             var newestWorkflow = new ConversationMemorySnapshot.WorkflowRunSnapshot();
             newestWorkflow.getLifecycleTasks().add(new ConversationMemorySnapshot.ResultSnapshot(
                     "actions", List.of("PAUSE_CONVERSATION", "notify_manager"), null, null, "wf-2", true));
             newestStep.getWorkflows().add(newestWorkflow);
 
-            var olderStep = new ConversationMemorySnapshot.ConversationStepSnapshot();
-            var olderWorkflow = new ConversationMemorySnapshot.WorkflowRunSnapshot();
-            olderWorkflow.getLifecycleTasks().add(new ConversationMemorySnapshot.ResultSnapshot(
-                    "actions", List.of("some_older_action"), null, null, "wf-1", true));
-            olderStep.getWorkflows().add(olderWorkflow);
-
+            snapshot.getConversationSteps().add(oldestStep);
             snapshot.getConversationSteps().add(newestStep);
-            snapshot.getConversationSteps().add(olderStep);
 
             Response response = restAgentEngine.getApprovalStatus(CONVERSATION_ID, "summary");
 
             var pauseDetails = (Map<String, Object>) summaryOf(response).get("pauseDetails");
             assertEquals(List.of("PAUSE_CONVERSATION", "notify_manager"), pauseDetails.get("actions"),
-                    "must use the newest step's actions, not the oldest");
+                    "reporting step 0 means every rule pause blames CONVERSATION_START");
+        }
+
+        @Test
+        @DisplayName("steps without actions are skipped on the way back")
+        void skipsTrailingStepsWithoutActions() throws Exception {
+            var snapshot = snapshotInState(ConversationState.AWAITING_HUMAN);
+            snapshot.setHitlPauseType("RULE");
+
+            var step = new ConversationMemorySnapshot.ConversationStepSnapshot();
+            var workflow = new ConversationMemorySnapshot.WorkflowRunSnapshot();
+            workflow.getLifecycleTasks().add(new ConversationMemorySnapshot.ResultSnapshot(
+                    "actions", List.of("notify_manager"), null, null, "wf-1", true));
+            step.getWorkflows().add(workflow);
+
+            snapshot.getConversationSteps().add(step);
+            snapshot.getConversationSteps().add(new ConversationMemorySnapshot.ConversationStepSnapshot());
+
+            Response response = restAgentEngine.getApprovalStatus(CONVERSATION_ID, "summary");
+
+            var pauseDetails = (Map<String, Object>) summaryOf(response).get("pauseDetails");
+            assertEquals(List.of("notify_manager"), pauseDetails.get("actions"));
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerTest.java
+++ b/src/test/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManagerTest.java
@@ -1858,6 +1858,40 @@ class LifecycleManagerTest {
             verify(output).execute(memory, OUTPUT_COMPONENT);
         }
 
+        /**
+         * The rerun restart list is {@code [langchain, output, quickReplies]}. On an
+         * LLM agent the langchain task sits BEFORE the output task and is the one that
+         * writes the answer — restarting at output alone is what destroyed the reply
+         * without regenerating it (D11). This pins that a task typed "langchain" wins
+         * the start-index race over "output" when both are present.
+         */
+        @Test
+        @DisplayName("the rerun list restarts at langchain when the workflow has one")
+        void rerunListRestartsAtTheLangchainTask() throws Exception {
+            var langchain = mock(ILifecycleTask.class);
+            when(langchain.getId()).thenReturn(new TaskId("ai.labs.llm"));
+            when(langchain.getType()).thenReturn("langchain");
+
+            // A fresh manager wired as the standard LLM layout: parser, behavior,
+            // langchain, output — the langchain task BEFORE the output task.
+            var llmPipeline = new LifecycleManager(componentCache, workflowId);
+            llmPipeline.addLifecycleTask(parser);
+            llmPipeline.addLifecycleTask(behavior);
+            llmPipeline.addLifecycleTask(langchain);
+            llmPipeline.addLifecycleTask(output);
+            when(componentCache.getComponentMap("ai.labs.llm"))
+                    .thenReturn(new HashMap<>(Map.of("wf1:1:2", BEHAVIOR_COMPONENT)));
+            when(componentCache.getComponentMap("ai.labs.output"))
+                    .thenReturn(new HashMap<>(Map.of("wf1:1:3", OUTPUT_COMPONENT)));
+
+            llmPipeline.executeLifecycle(memory, List.of("langchain", "output", "quickReplies"));
+
+            verify(parser, never()).execute(any(), any());
+            verify(behavior, never()).execute(any(), any());
+            verify(langchain).execute(memory, BEHAVIOR_COMPONENT);
+            verify(output).execute(memory, OUTPUT_COMPONENT);
+        }
+
         @Test
         @DisplayName("HITL resume from an absolute index resolves the component at that index")
         void resumeFromIndexResolvesComponent() throws Exception {

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsBranchCoverageTest.java
@@ -31,6 +31,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 import ai.labs.eddi.configs.rest.StrictConfigurationParser;
+import java.io.IOException;
 
 @DisplayName("McpAdminTools — Branch Coverage")
 class McpAdminToolsBranchCoverageTest {
@@ -913,7 +914,7 @@ class McpAdminToolsBranchCoverageTest {
         try {
             lenient().when(parser.parse(anyString(), any()))
                     .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
-        } catch (java.io.IOException e) {
+        } catch (IOException e) {
             throw new IllegalStateException(e);
         }
         return parser;

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsBranchCoverageTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 
 @DisplayName("McpAdminTools — Branch Coverage")
 class McpAdminToolsBranchCoverageTest {
@@ -56,6 +57,7 @@ class McpAdminToolsBranchCoverageTest {
         openMocks(this);
         // authEnabled=false so tests don't fail on requireRole
         tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization,
+                strictConfigurationParser(),
                 scheduleStore, scheduleFireExecutor, schedulePollerService,
                 identity, false);
     }
@@ -897,5 +899,23 @@ class McpAdminToolsBranchCoverageTest {
             assertNotNull(result);
             assertTrue(result.contains("schedule_deleted") || result.contains("error"));
         }
+    }
+
+    /**
+     * A parser that defers to this test's {@code jsonSerialization} mock, so the
+     * existing {@code when(jsonSerialization.deserialize(...))} stubs keep
+     * describing what these dispatch tests are actually about. Strictness itself is
+     * covered by {@code StrictConfigurationParserTest}; here the only thing that
+     * matters is that each resource type reaches the right store.
+     */
+    private StrictConfigurationParser strictConfigurationParser() {
+        var parser = mock(StrictConfigurationParser.class);
+        try {
+            lenient().when(parser.parse(anyString(), any()))
+                    .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return parser;
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsCrudTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsCrudTest.java
@@ -565,4 +565,29 @@ class McpAdminToolsCrudTest {
         }
         return parser;
     }
+
+    // ==================== D12: strict rejection reaches the MCP caller
+    // ====================
+
+    /**
+     * End-to-end pin for the parity fix: the strict parser's rejection travels as a
+     * 4xx response entity, and {@code errorJson(prefix, cause)} must surface it —
+     * {@code getMessage()} on that exception is only "HTTP 400 Bad Request", which
+     * is what MCP callers used to see instead of the field-level diagnosis.
+     */
+    @Test
+    void createResource_unknownField_reportsTheKnownFieldsMessage() {
+        var strictTools = new McpAdminTools(mock(IRestInterfaceFactory.class), agentAdmin, jsonSerialization,
+                new StrictConfigurationParser(new com.fasterxml.jackson.databind.ObjectMapper()), scheduleStore,
+                scheduleFireExecutor, schedulePollerService,
+                mock(io.quarkus.security.identity.SecurityIdentity.class), false);
+
+        String result = strictTools.createResource("propertysetter",
+                "{\"setProperties\":[{\"name\":\"x\",\"valueString\":\"y\"}]}");
+
+        assertTrue(result.contains("error"));
+        assertTrue(result.contains("setProperties"), "the offending field must be named: " + result);
+        assertTrue(result.contains("setOnActions"), "the legal fields must be listed: " + result);
+        assertFalse(result.contains("HTTP 400"), "the status line is not a diagnosis: " + result);
+    }
 }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsCrudTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsCrudTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 
 /**
  * Unit tests for McpAdminTools Phase 8a.2 — update_resource, create_resource,
@@ -106,7 +107,8 @@ class McpAdminToolsCrudTest {
         schedulePollerService = mock(SchedulePollerService.class);
         var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
-        tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization, scheduleStore, scheduleFireExecutor, schedulePollerService,
+        tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization, strictConfigurationParser(), scheduleStore,
+                scheduleFireExecutor, schedulePollerService,
                 mockIdentity, false);
     }
 
@@ -544,5 +546,23 @@ class McpAdminToolsCrudTest {
         String result = tools.deleteAgentTrigger(null);
         assertTrue(result.contains("error"));
         assertTrue(result.contains("intent is required"));
+    }
+
+    /**
+     * A parser that defers to this test's {@code jsonSerialization} mock, so the
+     * existing {@code when(jsonSerialization.deserialize(...))} stubs keep
+     * describing what these dispatch tests are actually about. Strictness itself is
+     * covered by {@code StrictConfigurationParserTest}; here the only thing that
+     * matters is that each resource type reaches the right store.
+     */
+    private StrictConfigurationParser strictConfigurationParser() {
+        var parser = mock(StrictConfigurationParser.class);
+        try {
+            lenient().when(parser.parse(anyString(), any()))
+                    .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return parser;
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsCrudTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsCrudTest.java
@@ -560,7 +560,7 @@ class McpAdminToolsCrudTest {
         try {
             lenient().when(parser.parse(anyString(), any()))
                     .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
-        } catch (java.io.IOException e) {
+        } catch (IOException e) {
             throw new IllegalStateException(e);
         }
         return parser;

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsExtendedTest.java
@@ -1526,7 +1526,7 @@ class McpAdminToolsExtendedTest {
         try {
             lenient().when(parser.parse(anyString(), any()))
                     .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
-        } catch (java.io.IOException e) {
+        } catch (IOException e) {
             throw new IllegalStateException(e);
         }
         return parser;

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsExtendedTest.java
@@ -50,6 +50,7 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 
 /**
  * Extended tests for McpAdminTools — schedule management, channel integrations,
@@ -122,6 +123,7 @@ class McpAdminToolsExtendedTest {
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
 
         tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization,
+                strictConfigurationParser(),
                 scheduleStore, scheduleFireExecutor, schedulePollerService,
                 mockIdentity, false);
     }
@@ -1510,5 +1512,23 @@ class McpAdminToolsExtendedTest {
         String result = tools.deleteAgentTrigger("support");
 
         assertTrue(result.contains("error"));
+    }
+
+    /**
+     * A parser that defers to this test's {@code jsonSerialization} mock, so the
+     * existing {@code when(jsonSerialization.deserialize(...))} stubs keep
+     * describing what these dispatch tests are actually about. Strictness itself is
+     * covered by {@code StrictConfigurationParserTest}; here the only thing that
+     * matters is that each resource type reaches the right store.
+     */
+    private StrictConfigurationParser strictConfigurationParser() {
+        var parser = mock(StrictConfigurationParser.class);
+        try {
+            lenient().when(parser.parse(anyString(), any()))
+                    .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return parser;
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsSwitchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsSwitchCoverageTest.java
@@ -51,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 
 /**
  * Covers ALL switch cases in readResourceByType, updateResourceByType,
@@ -106,6 +107,7 @@ class McpAdminToolsSwitchCoverageTest {
     void setUp() throws Exception {
         openMocks(this);
         tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization,
+                strictConfigurationParser(),
                 scheduleStore, scheduleFireExecutor, schedulePollerService,
                 identity, false);
 
@@ -1142,5 +1144,23 @@ class McpAdminToolsSwitchCoverageTest {
             assertNotNull(result);
             verify(restAgentStore, never()).updateAgent(anyString(), anyInt(), any());
         }
+    }
+
+    /**
+     * A parser that defers to this test's {@code jsonSerialization} mock, so the
+     * existing {@code when(jsonSerialization.deserialize(...))} stubs keep
+     * describing what these dispatch tests are actually about. Strictness itself is
+     * covered by {@code StrictConfigurationParserTest}; here the only thing that
+     * matters is that each resource type reaches the right store.
+     */
+    private StrictConfigurationParser strictConfigurationParser() {
+        var parser = mock(StrictConfigurationParser.class);
+        try {
+            lenient().when(parser.parse(anyString(), any()))
+                    .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return parser;
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsSwitchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsSwitchCoverageTest.java
@@ -52,6 +52,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 import ai.labs.eddi.configs.rest.StrictConfigurationParser;
+import java.io.IOException;
 
 /**
  * Covers ALL switch cases in readResourceByType, updateResourceByType,
@@ -1158,7 +1159,7 @@ class McpAdminToolsSwitchCoverageTest {
         try {
             lenient().when(parser.parse(anyString(), any()))
                     .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
-        } catch (java.io.IOException e) {
+        } catch (IOException e) {
             throw new IllegalStateException(e);
         }
         return parser;

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsTest.java
@@ -605,7 +605,7 @@ class McpAdminToolsTest {
         try {
             lenient().when(parser.parse(anyString(), any()))
                     .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
-        } catch (java.io.IOException e) {
+        } catch (IOException e) {
             throw new IllegalStateException(e);
         }
         return parser;

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 
 /**
  * Unit tests for McpAdminTools — MCP tools for Agent administration.
@@ -66,7 +67,8 @@ class McpAdminToolsTest {
         lenient().when(jsonSerialization.serialize(any())).thenReturn("{}");
         var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
-        tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization, scheduleStore, scheduleFireExecutor, schedulePollerService,
+        tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization, strictConfigurationParser(), scheduleStore,
+                scheduleFireExecutor, schedulePollerService,
                 mockIdentity, false);
     }
 
@@ -589,5 +591,23 @@ class McpAdminToolsTest {
     void createSchedule_blankName_returnsError() {
         String result = tools.createSchedule(AGENT_ID, null, null, null, null, null, null, null, null, null);
         assertTrue(result.contains("error"));
+    }
+
+    /**
+     * A parser that defers to this test's {@code jsonSerialization} mock, so the
+     * existing {@code when(jsonSerialization.deserialize(...))} stubs keep
+     * describing what these dispatch tests are actually about. Strictness itself is
+     * covered by {@code StrictConfigurationParserTest}; here the only thing that
+     * matters is that each resource type reaches the right store.
+     */
+    private StrictConfigurationParser strictConfigurationParser() {
+        var parser = mock(StrictConfigurationParser.class);
+        try {
+            lenient().when(parser.parse(anyString(), any()))
+                    .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return parser;
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.mcp;
 
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -62,8 +64,8 @@ class McpGroupToolsTest {
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
         // authorization disabled — OwnershipValidator's checks are no-ops, matching the
         // pre-existing tests. Ownership enforcement is covered separately below.
-        tools = new McpGroupTools(groupStore, groupConversationService, jsonSerialization, mockIdentity,
-                new OwnershipValidator(false), workspaceStore, templateService(), false);
+        tools = new McpGroupTools(groupStore, groupConversationService, jsonSerialization, strictConfigurationParser(),
+                mockIdentity, new OwnershipValidator(false), workspaceStore, templateService(), false);
     }
 
     // --- describe_discussion_styles ---
@@ -536,8 +538,8 @@ class McpGroupToolsTest {
         lenient().when(principal.getName()).thenReturn(callerId);
         lenient().when(identity.getPrincipal()).thenReturn(principal);
         lenient().when(identity.hasRole(role)).thenReturn(true);
-        return new McpGroupTools(groupStore, groupConversationService, jsonSerialization, identity,
-                new OwnershipValidator(true), workspaceStore, templateService(), true);
+        return new McpGroupTools(groupStore, groupConversationService, jsonSerialization, strictConfigurationParser(),
+                identity, new OwnershipValidator(true), workspaceStore, templateService(), true);
     }
 
     /**
@@ -551,8 +553,8 @@ class McpGroupToolsTest {
         lenient().when(principal.getName()).thenReturn(callerId);
         lenient().when(identity.getPrincipal()).thenReturn(principal);
         lenient().when(identity.hasRole(anyString())).thenReturn(true);
-        return new McpGroupTools(groupStore, groupConversationService, jsonSerialization, identity,
-                new OwnershipValidator(true), workspaceStore, templateService(), true);
+        return new McpGroupTools(groupStore, groupConversationService, jsonSerialization, strictConfigurationParser(),
+                identity, new OwnershipValidator(true), workspaceStore, templateService(), true);
     }
 
     @Test
@@ -874,5 +876,22 @@ class McpGroupToolsTest {
         when(workspaceStore.find("g1")).thenReturn(null);
         String result = tools.list_team_backlog("g1");
         assertFalse(result.contains("error"), "no workspace is an empty backlog, not an error: " + result);
+    }
+
+    /**
+     * A parser that defers to this test's {@code jsonSerialization} mock, so the
+     * existing {@code when(jsonSerialization.deserialize(...))} stubs keep
+     * describing what these dispatch tests are about. Strictness itself is covered
+     * by {@code StrictConfigurationParserTest}.
+     */
+    private StrictConfigurationParser strictConfigurationParser() {
+        var parser = mock(StrictConfigurationParser.class);
+        try {
+            lenient().when(parser.parse(anyString(), any()))
+                    .thenAnswer(invocation -> jsonSerialization.deserialize(invocation.getArgument(0), invocation.getArgument(1)));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return parser;
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpScheduleToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpScheduleToolsTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 
 /**
  * Unit tests for MCP schedule tools (create, list, read, fire, delete, retry).
@@ -57,7 +58,8 @@ class McpScheduleToolsTest {
         });
         when(pollerService.getInstanceId()).thenReturn("test-instance");
 
-        tools = new McpAdminTools(restInterfaceFactory, mock(IRestAgentAdministration.class), jsonSerialization, scheduleStore, fireExecutor,
+        tools = new McpAdminTools(restInterfaceFactory, mock(IRestAgentAdministration.class), jsonSerialization,
+                mock(StrictConfigurationParser.class), scheduleStore, fireExecutor,
                 pollerService, mock(SecurityIdentity.class), false);
     }
 

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpToolUtilsDescribeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpToolUtilsDescribeTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.mcp;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What an MCP tool tells its caller when something failed.
+ * <p>
+ * Two constraints pull against each other here. A 4xx raised by EDDI's own REST
+ * stores — which these tools call in-process — carries its useful text in the
+ * response entity, and that text has to reach the MCP client or the MCP/REST
+ * parity this release restored is only half done: "Unknown field
+ * &#39;setProperties&#39;" would arrive as "HTTP 400 Bad Request". A 5xx entity
+ * is not written to that contract and can carry endpoint or datastore detail,
+ * so it is never lifted verbatim.
+ */
+@DisplayName("MCP failure descriptions")
+class McpToolUtilsDescribeTest {
+
+    private static Response entity(int status, String body) {
+        return Response.status(status).entity(body).type(MediaType.TEXT_PLAIN_TYPE).build();
+    }
+
+    @Test
+    @DisplayName("a 4xx entity reaches the caller, so MCP and REST say the same thing")
+    void clientErrorEntityIsSurfaced() {
+        var rejected = new BadRequestException(entity(400,
+                "Unknown field 'setProperties' in PropertySetterConfiguration. Known fields: [setOnActions]"));
+
+        assertTrue(McpToolUtils.describe(rejected).contains("setOnActions"));
+    }
+
+    @Test
+    @DisplayName("a 5xx entity is not lifted verbatim")
+    void serverErrorEntityIsNotSurfaced() {
+        var failure = new InternalServerErrorException(entity(500,
+                "com.mongodb.MongoSocketOpenException: internal-db.prod.local:27017"));
+
+        assertFalse(McpToolUtils.describe(failure).contains("internal-db.prod.local"),
+                "a 5xx body is not written for the caller and may name internal infrastructure");
+    }
+
+    @Test
+    @DisplayName("an exception with no message names its class rather than rendering null")
+    void nullMessageNamesTheClass() {
+        assertEquals("IOException", McpToolUtils.describe(new IOException()));
+    }
+
+    @Test
+    @DisplayName("an ordinary message is used as-is")
+    void plainMessageIsUsed() {
+        assertEquals("boom", McpToolUtils.describe(new IllegalStateException("boom")));
+    }
+
+    @Test
+    @DisplayName("no cause at all still produces something readable")
+    void nullCause() {
+        assertEquals("unknown cause", McpToolUtils.describe(null));
+    }
+
+    @Test
+    @DisplayName("errorJson(prefix, cause) keeps the prefix and adds the description")
+    void errorJsonCombinesBoth() {
+        String json = McpToolUtils.errorJson("Failed to create resource", new IllegalStateException("boom"));
+
+        assertTrue(json.contains("Failed to create resource"));
+        assertTrue(json.contains("boom"));
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/memory/ConversationLogGeneratorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/ConversationLogGeneratorTest.java
@@ -519,4 +519,82 @@ class ConversationLogGeneratorTest {
             assertEquals("valid", log.getMessages().get(1).getContent().getFirst().getValue());
         }
     }
+
+    // ─── D3: HITL-gated turns must survive into the log ─────────
+
+    @Nested
+    @DisplayName("heterogeneous output lists (HITL turns)")
+    class HeterogeneousOutput {
+
+        private IConversationMemory memoryWith(ConversationOutput output) {
+            var memory = mock(IConversationMemory.class);
+            when(memory.getConversationOutputs()).thenReturn(new ArrayList<>(List.of(output)));
+            return memory;
+        }
+
+        /**
+         * The stored shape of a HITL-gated turn: two announcements written via
+         * {@code addConversationOutputString(...)} followed by the ordinary output map.
+         * Reading the list's shape from element zero dropped the assistant turn
+         * entirely, so {@code GET /agents/&#123;id&#125;/log} returned
+         * {@code user, assistant, user, user} and the agent's own history lost every
+         * turn a human had approved.
+         */
+        @Test
+        @DisplayName("String, String, Map → assistant turn is present with all three texts")
+        void hitlShapedOutputIsKept() {
+            var output = new ConversationOutput();
+            output.put("input", "create the group");
+            output.put("output", List.of(
+                    "I'll create that group for you.",
+                    "Waiting for your approval.",
+                    Map.of("text", "Group created.")));
+
+            var log = new ConversationLogGenerator(memoryWith(output)).generate();
+
+            assertEquals(2, log.getMessages().size());
+            assertEquals("assistant", log.getMessages().get(1).getRole());
+            assertEquals("I'll create that group for you. Waiting for your approval. Group created.",
+                    log.getMessages().get(1).getContent().getFirst().getValue());
+        }
+
+        @Test
+        @DisplayName("a list of plain Strings still produces an assistant turn")
+        void plainStringListIsKept() {
+            var output = new ConversationOutput();
+            output.put("input", "hi");
+            output.put("output", List.of("Paused for approval."));
+
+            var log = new ConversationLogGenerator(memoryWith(output)).generate();
+
+            assertEquals(2, log.getMessages().size());
+            assertEquals("Paused for approval.", log.getMessages().get(1).getContent().getFirst().getValue());
+        }
+
+        @Test
+        @DisplayName("TextOutputItem entries keep working")
+        void textOutputItemsStillWork() {
+            var output = new ConversationOutput();
+            output.put("input", "hi");
+            output.put("output", List.of(new TextOutputItem("hello", 0)));
+
+            var log = new ConversationLogGenerator(memoryWith(output)).generate();
+
+            assertEquals(2, log.getMessages().size());
+            assertEquals("hello", log.getMessages().get(1).getContent().getFirst().getValue());
+        }
+
+        @Test
+        @DisplayName("an emptied output adds no assistant turn")
+        void emptiedOutputAddsNothing() {
+            var output = new ConversationOutput();
+            output.put("input", "hi");
+            output.put("output", List.of());
+
+            var log = new ConversationLogGenerator(memoryWith(output)).generate();
+
+            assertEquals(1, log.getMessages().size());
+        }
+    }
+
 }

--- a/src/test/java/ai/labs/eddi/engine/memory/RedoCacheOutputRoundTripTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/RedoCacheOutputRoundTripTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.memory;
+
+import ai.labs.eddi.engine.memory.model.ConversationMemorySnapshot;
+import ai.labs.eddi.engine.memory.model.Data;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A redone step must come back carrying the answer it had.
+ * <p>
+ * Undo/redo inside one live memory object always worked — the step holds its
+ * own {@code ConversationOutput}. The loss happened across the store: the
+ * snapshot serialised only {@code workflows/lifecycleTasks}, so a rehydrated
+ * redo entry got a fresh empty output and {@code redoLastStep()} pushed
+ * <em>that</em> over the restored turn. Because every request reloads memory
+ * from the store, this fired on every real redo: the API returned 200, the step
+ * reappeared, and its text was gone — from the transcript and, since
+ * {@code conversationOutputs} feeds {@code ConversationHistoryBuilder}, from
+ * the model's own history too. Asked afterwards what word it had just said, the
+ * agent answered with its greeting.
+ */
+@DisplayName("redo cache survives a store round-trip with its output")
+class RedoCacheOutputRoundTripTest {
+
+    private static ConversationMemory memoryWithUndoneTurn() {
+        var memory = new ConversationMemory("conv-1", "agent-1", 1, "user-1");
+        memory.getCurrentStep().storeData(new Data<>("input", "Say the single word BANANA."));
+        memory.getCurrentStep().getConversationOutput().put("input", "Say the single word BANANA.");
+
+        memory.startNextStep();
+        memory.getCurrentStep().storeData(new Data<>("output", "BANANA."));
+        memory.getCurrentStep().getConversationOutput().put("output", List.of(Map.of("text", "BANANA.")));
+
+        memory.undoLastStep();
+        return memory;
+    }
+
+    @Test
+    @DisplayName("snapshot → memory → redo restores the turn's output, not an empty one")
+    void redoAfterRoundTripKeepsTheAnswer() {
+        var snapshot = ConversationMemoryUtilities.convertConversationMemory(memoryWithUndoneTurn());
+
+        assertEquals(1, snapshot.getRedoCache().size(), "the undone step belongs in the redo cache");
+        assertNotNull(snapshot.getRedoCache().peek().getConversationOutput(),
+                "the redo entry must carry its own output — it is not in conversationOutputs, undo popped it");
+
+        var restored = ConversationMemoryUtilities.convertConversationMemorySnapshot(snapshot);
+        assertTrue(restored.isRedoAvailable());
+
+        restored.redoLastStep();
+
+        var outputs = restored.getConversationOutputs();
+        assertEquals(2, outputs.size());
+        assertEquals(List.of(Map.of("text", "BANANA.")), outputs.get(outputs.size() - 1).get("output"),
+                "redo restored the step but blanked its answer");
+    }
+
+    @Test
+    @DisplayName("ordinary conversation steps carry no output — it lives in conversationOutputs")
+    void ordinaryStepsAreUnchanged() {
+        var memory = new ConversationMemory("conv-2", "agent-1", 1, "user-1");
+        memory.getCurrentStep().storeData(new Data<>("input", "hello"));
+
+        var snapshot = ConversationMemoryUtilities.convertConversationMemory(memory);
+
+        assertEquals(1, snapshot.getConversationSteps().size());
+        assertNull(snapshot.getConversationSteps().getFirst().getConversationOutput(),
+                "duplicating the output onto every step would double the stored document for no gain");
+    }
+
+    @Test
+    @DisplayName("a legacy redo entry with no stored output still loads")
+    void legacyDocumentsLoadUnchanged() {
+        var snapshot = new ConversationMemorySnapshot();
+        snapshot.setConversationId("conv-3");
+        snapshot.setAgentId("agent-1");
+        snapshot.setAgentVersion(1);
+        snapshot.setUserId("user-1");
+        // Written before the field existed: conversationOutput is absent, so null.
+        snapshot.getRedoCache().push(new ConversationMemorySnapshot.ConversationStepSnapshot());
+
+        var restored = ConversationMemoryUtilities.convertConversationMemorySnapshot(snapshot);
+
+        assertTrue(restored.isRedoAvailable());
+        restored.redoLastStep();
+        assertNotNull(restored.getConversationOutputs().getLast());
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/memory/RedoCacheOutputRoundTripTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/RedoCacheOutputRoundTripTest.java
@@ -67,6 +67,39 @@ class RedoCacheOutputRoundTripTest {
                 "redo restored the step but blanked its answer");
     }
 
+    /**
+     * Two undone turns must redo in order, each with its own answer. If the cache's
+     * order flipped anywhere across the round-trip, redo would restore the WRONG
+     * turn's output — silently, since both steps and both outputs exist.
+     */
+    @Test
+    @DisplayName("two undone turns redo in order, each with its own output")
+    void multiEntryRedoPreservesOrderAndOutputs() {
+        var memory = new ConversationMemory("conv-multi", "agent-1", 1, "user-1");
+        memory.getCurrentStep().getConversationOutput().put("input", "start");
+
+        memory.startNextStep();
+        memory.getCurrentStep().getConversationOutput().put("output", List.of(Map.of("text", "FIRST.")));
+        memory.startNextStep();
+        memory.getCurrentStep().getConversationOutput().put("output", List.of(Map.of("text", "SECOND.")));
+
+        memory.undoLastStep();
+        memory.undoLastStep();
+
+        var roundTripped = ConversationMemoryUtilities.convertConversationMemorySnapshot(
+                ConversationMemoryUtilities.convertConversationMemory(memory));
+
+        roundTripped.redoLastStep();
+        assertEquals(List.of(Map.of("text", "FIRST.")),
+                roundTripped.getConversationOutputs().getLast().get("output"),
+                "the first redo must restore the FIRST undone turn's answer");
+
+        roundTripped.redoLastStep();
+        assertEquals(List.of(Map.of("text", "SECOND.")),
+                roundTripped.getConversationOutputs().getLast().get("output"),
+                "the second redo must restore the SECOND turn's answer");
+    }
+
     @Test
     @DisplayName("ordinary conversation steps carry no output — it lives in conversationOutputs")
     void ordinaryStepsAreUnchanged() {

--- a/src/test/java/ai/labs/eddi/engine/runtime/client/agents/AgentStoreClientLibraryMemoryToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/client/agents/AgentStoreClientLibraryMemoryToolsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.runtime.client.agents;
+
+import ai.labs.eddi.engine.runtime.service.IAgentStoreService;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.engine.runtime.IWorkflowFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code enableMemoryTools} is the opt-in; {@code userMemoryConfig} is tuning
+ * on top of it.
+ * <p>
+ * Requiring both made the second a hidden switch. Every field of
+ * {@code UserMemoryConfig} already carries a working default, so an agent that
+ * turned memory on and configured nothing else was asking for the defaults —
+ * but got no memory tool at all, and no explanation, because the skip was
+ * silent.
+ */
+@DisplayName("memory tools attach on enableMemoryTools alone")
+class AgentStoreClientLibraryMemoryToolsTest {
+
+    private IAgentStoreService agentStoreService;
+    private AgentStoreClientLibrary library;
+
+    @BeforeEach
+    void setUp() {
+        agentStoreService = mock(IAgentStoreService.class);
+        library = new AgentStoreClientLibrary(agentStoreService, mock(IWorkflowFactory.class));
+    }
+
+    private AgentConfiguration configuration(boolean enableMemoryTools, AgentConfiguration.UserMemoryConfig memoryConfig) {
+        var config = new AgentConfiguration();
+        config.setWorkflows(List.of());
+        config.setEnableMemoryTools(enableMemoryTools);
+        config.setUserMemoryConfig(memoryConfig);
+        return config;
+    }
+
+    @Test
+    @DisplayName("enabled with no config — falls back to the defaults instead of skipping")
+    void defaultsWhenConfigOmitted() throws Exception {
+        when(agentStoreService.getAgentConfiguration("agent-1", 1)).thenReturn(configuration(true, null));
+
+        var agent = library.getAgent("agent-1", 1);
+
+        assertNotNull(agent.getUserMemoryConfig(),
+                "an agent that enabled memory and tuned nothing must still get the tool");
+        assertEquals("self", agent.getUserMemoryConfig().getDefaultVisibility());
+    }
+
+    @Test
+    @DisplayName("enabled with a config — that config is used")
+    void explicitConfigWins() throws Exception {
+        var memoryConfig = new AgentConfiguration.UserMemoryConfig();
+        memoryConfig.setDefaultVisibility("group");
+        when(agentStoreService.getAgentConfiguration("agent-1", 1)).thenReturn(configuration(true, memoryConfig));
+
+        var agent = library.getAgent("agent-1", 1);
+
+        assertEquals(memoryConfig, agent.getUserMemoryConfig());
+    }
+
+    @Test
+    @DisplayName("not enabled — no config, whatever else is set")
+    void disabledStaysDisabled() throws Exception {
+        when(agentStoreService.getAgentConfiguration("agent-1", 1))
+                .thenReturn(configuration(false, new AgentConfiguration.UserMemoryConfig()));
+
+        var agent = library.getAgent("agent-1", 1);
+
+        assertNull(agent.getUserMemoryConfig(), "enableMemoryTools is the opt-in and it says no");
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationExtendedTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
 import java.util.*;
@@ -208,6 +209,47 @@ class ConversationExtendedTest {
             verify(currentStep).removeData("quickReplies");
             verify(currentStep).resetConversationOutput("output");
             verify(currentStep).resetConversationOutput("quickReplies");
+        }
+
+        /**
+         * A rerun must not clear a result it will not regenerate. The answer lives
+         * under {@code output} but is written by the {@code langchain} task, which runs
+         * before the output task — so restarting at {@code output} wiped the reply and
+         * never re-ran the model. The turn returned 200 with an empty output array,
+         * which is destruction, not a retry.
+         */
+        @Test
+        @DisplayName("rerun restarts the pipeline at the langchain task, not at output")
+        void rerunRestartsAtTheTaskThatProducesTheOutput() throws Exception {
+            when(memory.getConversationState()).thenReturn(ConversationState.READY);
+            when(propertiesHandler.getUserMemoryStore()).thenReturn(null);
+
+            var conv = createConversation();
+            conv.rerun(Map.of());
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<String>> types = ArgumentCaptor.forClass(List.class);
+            verify(lifecycleManager).executeLifecycle(eq(memory), types.capture());
+
+            assertTrue(types.getValue().contains("langchain"),
+                    "without langchain the model never re-runs and the cleared answer is gone for good");
+            assertTrue(types.getValue().contains("output"),
+                    "a rule-based agent has no langchain task and must still restart at output");
+        }
+
+        @Test
+        @DisplayName("rerun does not reset a langchain output key it never wrote")
+        void rerunDoesNotClearLangchainOutput() throws Exception {
+            when(memory.getConversationState()).thenReturn(ConversationState.READY);
+            when(propertiesHandler.getUserMemoryStore()).thenReturn(null);
+
+            var conv = createConversation();
+            conv.rerun(Map.of());
+
+            // resetConversationOutput(key) creates the key as an empty list, so
+            // clearing "langchain" would add a spurious entry to every rerun's output.
+            verify(currentStep, never()).resetConversationOutput("langchain");
+            verify(currentStep, never()).removeData("langchain");
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationUserMemoryConfigTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/ConversationUserMemoryConfigTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.runtime.internal;
+
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.engine.lifecycle.IConversation;
+import ai.labs.eddi.engine.lifecycle.ILifecycleManager;
+import ai.labs.eddi.engine.memory.ConversationMemory;
+import ai.labs.eddi.engine.memory.IConversationMemory.IConversationProperties;
+import ai.labs.eddi.engine.memory.IConversationMemory.IWritableConversationStep;
+import ai.labs.eddi.engine.memory.IPropertiesHandler;
+import ai.labs.eddi.engine.runtime.IExecutableWorkflow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The agent's user-memory configuration has to reach memory on every turn, not
+ * only the first.
+ * <p>
+ * {@code userMemoryConfig} is not part of the persisted conversation snapshot
+ * and every request rebuilds memory from the store, so assigning it in
+ * {@code init()} alone left it null from the second turn onwards. The gate in
+ * {@code ContextualToolsProvider.addUserMemoryToolIfEnabled} reads exactly that
+ * field, so {@code UserMemoryTool} was never assembled on any turn a user could
+ * talk to: an agent with memory fully enabled and verified could not write a
+ * single memory, and said nothing about it. The model, handed no tool,
+ * confabulated success — once emitting raw pseudo-XML tool syntax into
+ * user-visible output.
+ * <p>
+ * A control from the same sweep proves the isolation: on the same agent and the
+ * same turn the calculator built-in ran fine, so tool assembly worked and only
+ * the memory tool was missing.
+ */
+@DisplayName("user memory config reaches every turn")
+class ConversationUserMemoryConfigTest {
+
+    private ConversationMemory memory;
+    private IPropertiesHandler propertiesHandler;
+    private IExecutableWorkflow workflow;
+
+    @BeforeEach
+    void setUp() {
+        memory = mock(ConversationMemory.class);
+        propertiesHandler = mock(IPropertiesHandler.class);
+        workflow = mock(IExecutableWorkflow.class);
+
+        when(memory.getCurrentStep()).thenReturn(mock(IWritableConversationStep.class));
+        when(memory.getConversationProperties()).thenReturn(mock(IConversationProperties.class));
+        when(workflow.getLifecycleManager()).thenReturn(mock(ILifecycleManager.class));
+        when(workflow.getWorkflowId()).thenReturn("wf-test");
+    }
+
+    private Conversation createConversation() {
+        return new Conversation(List.of(workflow), memory, propertiesHandler,
+                mock(IConversation.IConversationOutputRenderer.class));
+    }
+
+    @Test
+    @DisplayName("constructing a turn applies the config — not just init()")
+    void configIsAppliedPerTurn() {
+        var config = new AgentConfiguration.UserMemoryConfig();
+        when(propertiesHandler.getUserMemoryConfig()).thenReturn(config);
+
+        createConversation();
+
+        // Agent#continueConversation builds a Conversation for say, resume and rerun
+        // alike, so the constructor is the one point every turn passes through.
+        verify(memory).setUserMemoryConfig(config);
+    }
+
+    @Test
+    @DisplayName("an agent without memory enabled sets nothing")
+    void noConfigSetsNothing() {
+        when(propertiesHandler.getUserMemoryConfig()).thenReturn(null);
+
+        createConversation();
+
+        verify(memory, never()).setUserMemoryConfig(null);
+    }
+}

--- a/src/test/java/ai/labs/eddi/integration/AuditAndSecurityIT.java
+++ b/src/test/java/ai/labs/eddi/integration/AuditAndSecurityIT.java
@@ -194,8 +194,13 @@ public class AuditAndSecurityIT extends BaseIntegrationIT {
         try {
             ResourceId conversationId = createConversation(agentId.id(), "audit-verify-user");
 
-            // Entries are queued and flushed on an interval — poll until the
-            // CONVERSATION_START turn's entries have landed.
+            // A user TURN, not just conversation creation: the audit collector is
+            // attached in ConversationService.say(), so a conversation that has only
+            // been started produces no entries at all.
+            sendUserInput(agentId.id(), conversationId.id(), "hello", false, false)
+                    .then().statusCode(200);
+
+            // Entries are queued and flushed on an interval — poll until they land.
             int entryCount = 0;
             for (int i = 0; i < 30 && entryCount == 0; i++) {
                 Thread.sleep(500);
@@ -205,17 +210,24 @@ public class AuditAndSecurityIT extends BaseIntegrationIT {
             }
             Assertions.assertTrue(entryCount > 0, "the conversation's turn must produce audit entries");
 
-            given().get(AUDIT_BASE + "verify/" + conversationId.id())
-                    .then().assertThat()
-                    .statusCode(200)
-                    .body("signingEnabled", equalTo(true))
-                    .body("entriesChecked", equalTo(entryCount))
-                    .body("valid", equalTo(entryCount))
-                    .body("invalid", equalTo(0))
-                    .body("unsigned", equalTo(0))
-                    .body("recovered", equalTo(0))
-                    .body("recoverySkipped", equalTo(0))
-                    .body("chainStatus", equalTo("INTACT"));
+            // Assert the INVARIANT (every checked entry is valid), not a count captured
+            // a moment earlier — the flush is asynchronous, so more entries may land
+            // between the poll above and this call. "valid == entriesChecked" is both
+            // the stronger claim and the race-free one.
+            var report = given().get(AUDIT_BASE + "verify/" + conversationId.id())
+                    .then().statusCode(200).extract().jsonPath();
+
+            int checked = report.getInt("entriesChecked");
+            Assertions.assertTrue(checked > 0, "the sweep must actually have checked something");
+            Assertions.assertTrue(report.getBoolean("signingEnabled"), "the vault key is configured in this profile");
+            Assertions.assertEquals(checked, report.getInt("valid"),
+                    "every entry the sweep checked must verify — this is what reported valid=0 invalid=78 in the wild");
+            Assertions.assertEquals(0, report.getInt("invalid"));
+            Assertions.assertEquals(0, report.getInt("unsigned"));
+            Assertions.assertEquals(0, report.getInt("recovered"),
+                    "freshly written entries are v4 and verify directly, with no legacy recovery");
+            Assertions.assertEquals(0, report.getInt("recoverySkipped"));
+            Assertions.assertEquals("INTACT", report.getString("chainStatus"));
         } finally {
             undeployAgentQuietly(agentId.id(), agentId.version());
         }

--- a/src/test/java/ai/labs/eddi/integration/AuditAndSecurityIT.java
+++ b/src/test/java/ai/labs/eddi/integration/AuditAndSecurityIT.java
@@ -172,6 +172,55 @@ public class AuditAndSecurityIT extends BaseIntegrationIT {
                 .statusCode(200);
     }
 
+    // ==================== D7 end-to-end: verify must say VALID for real turns
+    // ====================
+
+    /**
+     * The regression net the run-0820a sweep prescribed as its definition of done.
+     * <p>
+     * Every earlier test in this class reads an EMPTY conversation's trail — which
+     * is exactly why the ledger could ship reporting {@code valid=0 invalid=78} on
+     * every real conversation: writes were exercised, verification never was, and
+     * no test ever drove entries through the full pipeline (sign → queue → flush →
+     * store → read → verify) against a real backend. This one does. It would have
+     * failed on every EDDI version before the v4 canonical form, on either storage
+     * backend, and it fails again if any layer of the timestamp handling regresses.
+     */
+    @Test
+    @Order(12)
+    @DisplayName("a real conversation's audit entries all verify VALID with an INTACT chain")
+    void auditVerify_realConversationIsFullyValid() throws Exception {
+        ResourceId agentId = setupAndDeployMinimalAgent();
+        try {
+            ResourceId conversationId = createConversation(agentId.id(), "audit-verify-user");
+
+            // Entries are queued and flushed on an interval — poll until the
+            // CONVERSATION_START turn's entries have landed.
+            int entryCount = 0;
+            for (int i = 0; i < 30 && entryCount == 0; i++) {
+                Thread.sleep(500);
+                entryCount = given().get(AUDIT_BASE + conversationId.id())
+                        .then().statusCode(200)
+                        .extract().jsonPath().getList("$").size();
+            }
+            Assertions.assertTrue(entryCount > 0, "the conversation's turn must produce audit entries");
+
+            given().get(AUDIT_BASE + "verify/" + conversationId.id())
+                    .then().assertThat()
+                    .statusCode(200)
+                    .body("signingEnabled", equalTo(true))
+                    .body("entriesChecked", equalTo(entryCount))
+                    .body("valid", equalTo(entryCount))
+                    .body("invalid", equalTo(0))
+                    .body("unsigned", equalTo(0))
+                    .body("recovered", equalTo(0))
+                    .body("recoverySkipped", equalTo(0))
+                    .body("chainStatus", equalTo("INTACT"));
+        } finally {
+            undeployAgentQuietly(agentId.id(), agentId.version());
+        }
+    }
+
     // ==================== Helpers ====================
 
     private boolean isVaultAvailable() {

--- a/src/test/java/ai/labs/eddi/integration/LlmAgentEngineIT.java
+++ b/src/test/java/ai/labs/eddi/integration/LlmAgentEngineIT.java
@@ -136,7 +136,7 @@ public class LlmAgentEngineIT extends BaseIntegrationIT {
                     "type": "function",
                     "function": {
                       "name": "rememberFact",
-                      "arguments": "{\"key\":\"favorite_color\",\"value\":\"blue\",\"category\":\"preference\",\"visibility\":\"self\"}"
+                      "arguments": "{\\"key\\":\\"favorite_color\\",\\"value\\":\\"blue\\",\\"category\\":\\"preference\\",\\"visibility\\":\\"self\\"}"
                     }
                   }]
                 },

--- a/src/test/java/ai/labs/eddi/integration/LlmAgentEngineIT.java
+++ b/src/test/java/ai/labs/eddi/integration/LlmAgentEngineIT.java
@@ -350,6 +350,16 @@ public class LlmAgentEngineIT extends BaseIntegrationIT {
             Assertions.assertTrue(sayBody.contains("Noted"),
                     "the final scripted answer must reach the turn's output; say body was: " + sayBody);
 
+            // The second upstream request carries the tool's OWN return message back
+            // to the model — the one place the tool says in its own words whether it
+            // wrote, refused, or errored. rememberFact returns "✅ Remembered: …" on
+            // success and a named refusal on every guardrail path, so this assertion
+            // either passes or puts the exact cause verbatim into the CI log.
+            var upstreamRequests = wireMock.getAllServeEvents();
+            String toolResultRequest = upstreamRequests.get(0).getRequest().getBodyAsString();
+            Assertions.assertTrue(toolResultRequest.contains("Remembered"),
+                    "the tool result sent back upstream was: " + toolResultRequest);
+
             String memories = given().get("/usermemorystore/memories/" + memoryUserId)
                     .then().statusCode(200).extract().asString();
             Assertions.assertTrue(memories.contains("favorite_color"),

--- a/src/test/java/ai/labs/eddi/integration/LlmAgentEngineIT.java
+++ b/src/test/java/ai/labs/eddi/integration/LlmAgentEngineIT.java
@@ -12,6 +12,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.*;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static io.restassured.RestAssured.given;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.hamcrest.Matchers.*;
 
@@ -92,6 +93,69 @@ public class LlmAgentEngineIT extends BaseIntegrationIT {
                 "finish_reason": "stop"
               }],
               "usage": {"prompt_tokens": 80, "completion_tokens": 10, "total_tokens": 90}
+            }
+            """;
+
+    private static final String RERUN_FIRST_RESPONSE = """
+            {
+              "id": "chatcmpl-rerun-1",
+              "object": "chat.completion",
+              "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "ALPHA."},
+                "finish_reason": "stop"
+              }],
+              "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
+            }
+            """;
+
+    private static final String RERUN_SECOND_RESPONSE = """
+            {
+              "id": "chatcmpl-rerun-2",
+              "object": "chat.completion",
+              "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "BRAVO."},
+                "finish_reason": "stop"
+              }],
+              "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
+            }
+            """;
+
+    private static final String MEMORY_TOOL_CALL_RESPONSE = """
+            {
+              "id": "chatcmpl-mem-tool",
+              "object": "chat.completion",
+              "choices": [{
+                "index": 0,
+                "message": {
+                  "role": "assistant",
+                  "content": null,
+                  "tool_calls": [{
+                    "id": "call_mem1",
+                    "type": "function",
+                    "function": {
+                      "name": "rememberFact",
+                      "arguments": "{\"key\":\"favorite_color\",\"value\":\"blue\",\"category\":\"preference\",\"visibility\":\"self\"}"
+                    }
+                  }]
+                },
+                "finish_reason": "tool_calls"
+              }],
+              "usage": {"prompt_tokens": 40, "completion_tokens": 20, "total_tokens": 60}
+            }
+            """;
+
+    private static final String MEMORY_FINAL_RESPONSE = """
+            {
+              "id": "chatcmpl-mem-final",
+              "object": "chat.completion",
+              "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Noted — your favorite color is blue."},
+                "finish_reason": "stop"
+              }],
+              "usage": {"prompt_tokens": 70, "completion_tokens": 10, "total_tokens": 80}
             }
             """;
 
@@ -192,6 +256,207 @@ public class LlmAgentEngineIT extends BaseIntegrationIT {
 
         // Verify WireMock received exactly 2 requests (tool call + final)
         wireMock.verify(2, postRequestedFor(urlPathEqualTo("/v1/chat/completions")));
+    }
+
+    // ==================== Test 3: D11 — rerun re-executes the model
+    // ====================
+
+    /**
+     * The D11 acceptance criterion, end to end with a real (stubbed) model. A rerun
+     * used to restart the pipeline at the output task, so the model never
+     * re-executed: the answer was cleared and never regenerated, and the API
+     * returned 200 for its own destruction. Two DISTINCT scripted responses prove
+     * re-execution — a cached or surviving answer would still read ALPHA.
+     * <p>
+     * The rerun call deliberately sends no {@code ?language=}, pinning live that
+     * the previously undocumented mandatory parameter is now optional.
+     */
+    @Test
+    @Order(3)
+    @DisplayName("rerun re-executes the LLM and replaces the answer")
+    void testRerunReExecutesTheModel() throws Exception {
+        wireMock.resetAll();
+        wireMock.stubFor(post(urlPathEqualTo("/v1/chat/completions"))
+                .inScenario("Rerun")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(okJson(RERUN_FIRST_RESPONSE).withHeader("Content-Type", "application/json"))
+                .willSetStateTo("FirstAnswered"));
+        wireMock.stubFor(post(urlPathEqualTo("/v1/chat/completions"))
+                .inScenario("Rerun")
+                .whenScenarioStateIs("FirstAnswered")
+                .willReturn(okJson(RERUN_SECOND_RESPONSE).withHeader("Content-Type", "application/json")));
+
+        ResourceId conversationId = createConversation(legacyAgentId.id(), TEST_USER_ID);
+        waitForConversationReady(legacyAgentId.id(), conversationId.id());
+
+        String firstBody = sendUserInput(legacyAgentId.id(), conversationId.id(), "ask", false, false)
+                .then().statusCode(200).extract().asString();
+        Assertions.assertTrue(firstBody.contains("ALPHA."),
+                "precondition: the first turn carries the first scripted answer");
+
+        String rerunBody = given()
+                .post("agents/" + conversationId.id() + "/rerun?returnDetailed=false&returnCurrentStepOnly=false")
+                .then().statusCode(200).extract().asString();
+
+        Assertions.assertTrue(rerunBody.contains("BRAVO."),
+                "the model must have re-executed — this is the answer only the second call produces");
+        Assertions.assertFalse(rerunBody.contains("ALPHA."),
+                "the cleared answer must be replaced, not left beside the new one");
+        wireMock.verify(2, postRequestedFor(urlPathEqualTo("/v1/chat/completions")));
+    }
+
+    // ==================== Test 4: D10 — the agent writes a memory
+    // ====================
+
+    /**
+     * The D10 acceptance criterion, end to end with a real (stubbed) model: an
+     * agent with {@code enableMemoryTools: true} — and deliberately NO
+     * {@code userMemoryConfig}, pinning the defaults fallback — receives a scripted
+     * {@code rememberFact} tool call, and the memory must actually land in the
+     * store. Before the fix this failed silently at the third leg of the
+     * conjunction: {@code userMemoryConfig} was assigned only in {@code init()} and
+     * never persisted, so on every say-turn the tool was absent and the live model
+     * confabulated saves it never made.
+     */
+    @Test
+    @Order(4)
+    @DisplayName("an agent with memory enabled writes a memory the store can read back")
+    void testAgentWritesUserMemory() throws Exception {
+        wireMock.resetAll();
+        wireMock.stubFor(post(urlPathEqualTo("/v1/chat/completions"))
+                .inScenario("MemoryWrite")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(okJson(MEMORY_TOOL_CALL_RESPONSE).withHeader("Content-Type", "application/json"))
+                .willSetStateTo("Remembered"));
+        wireMock.stubFor(post(urlPathEqualTo("/v1/chat/completions"))
+                .inScenario("MemoryWrite")
+                .whenScenarioStateIs("Remembered")
+                .willReturn(okJson(MEMORY_FINAL_RESPONSE).withHeader("Content-Type", "application/json")));
+
+        ResourceId memoryAgentId = setupMemoryLlmAgent();
+        String memoryUserId = "memoryWriteUser";
+        try {
+            ResourceId conversationId = createConversation(memoryAgentId.id(), memoryUserId);
+            waitForConversationReady(memoryAgentId.id(), conversationId.id());
+
+            sendUserInput(memoryAgentId.id(), conversationId.id(), "remember", false, false)
+                    .then().statusCode(200);
+
+            given().get("/usermemorystore/memories/" + memoryUserId)
+                    .then().statusCode(200)
+                    .body("size()", greaterThanOrEqualTo(1))
+                    .body("key", hasItem("favorite_color"));
+        } finally {
+            undeployAgentQuietly(memoryAgentId.id(), memoryAgentId.version());
+        }
+    }
+
+    /**
+     * An LLM agent with the memory tool enabled the way an agent designer would:
+     * {@code enableMemoryTools: true} on the AGENT, {@code enableBuiltInTools} on
+     * the task, and no {@code userMemoryConfig} — the defaults must carry it.
+     */
+    private ResourceId setupMemoryLlmAgent() throws Exception {
+        String dictionary = """
+                {
+                  "words": [
+                    {"word": "remember", "expressions": "do_remember(remember)", "frequency": 0}
+                  ],
+                  "phrases": []
+                }
+                """;
+        String rules = """
+                {
+                  "behaviorGroups": [{
+                    "name": "MemoryGroup",
+                    "behaviorRules": [
+                      {
+                        "name": "Welcome",
+                        "actions": ["welcome"],
+                        "conditions": [{
+                          "type": "occurrence",
+                          "configs": {"maxTimesOccurred": "0", "behaviorRuleName": "Welcome"}
+                        }]
+                      },
+                      {
+                        "name": "DoRemember",
+                        "actions": ["call_memory_llm"],
+                        "conditions": [{
+                          "type": "inputmatcher",
+                          "configs": {"expressions": "do_remember(*)", "occurrence": "currentStep"}
+                        }]
+                      }
+                    ]
+                  }]
+                }
+                """;
+        String output = """
+                {
+                  "outputSet": [{
+                    "action": "welcome",
+                    "timesOccurred": 0,
+                    "outputs": [{"valueAlternatives": [{"type": "text", "text": "Welcome to memory test"}]}]
+                  }]
+                }
+                """;
+        String llmConfig = String.format("""
+                {
+                  "tasks": [{
+                    "id": "test-memory",
+                    "type": "openai",
+                    "actions": ["call_memory_llm"],
+                    "parameters": {
+                      "baseUrl": "http://localhost:%d/v1",
+                      "apiKey": "sk-test-fake-key",
+                      "modelName": "gpt-4o-test",
+                      "systemMessage": "You remember things about the user.",
+                      "addToOutput": "true",
+                      "timeout": "30000"
+                    },
+                    "enableBuiltInTools": true,
+                    "builtInToolsWhitelist": ["usermemory"],
+                    "enableHttpCallTools": false,
+                    "enableMcpCallTools": false,
+                    "conversationHistoryLimit": 5,
+                    "maxToolIterations": 3
+                  }]
+                }
+                """, wireMock.port());
+
+        String locationDictionary = createResource(dictionary, "/dictionarystore/dictionaries");
+        String locationRules = createResource(rules, "/rulestore/rulesets");
+        String locationOutput = createResource(output, "/outputstore/outputsets");
+        String locationLlm = createResource(llmConfig, "/llmstore/llms");
+
+        String workflowBody = String.format("""
+                {
+                  "workflowSteps": [
+                    {
+                      "type": "eddi://ai.labs.parser",
+                      "config": {},
+                      "extensions": {
+                        "dictionaries": [
+                          {"type": "eddi://ai.labs.parser.dictionaries.regular", "config": {"uri": "%s"}}
+                        ],
+                        "corrections": []
+                      }
+                    },
+                    {"type": "eddi://ai.labs.rules", "config": {"uri": "%s"}},
+                    {"type": "eddi://ai.labs.llm", "config": {"uri": "%s"}},
+                    {"type": "eddi://ai.labs.output", "config": {"uri": "%s"}},
+                    {"type": "eddi://ai.labs.templating", "config": {}},
+                    {"type": "eddi://ai.labs.property", "config": {}}
+                  ]
+                }
+                """, locationDictionary, locationRules, locationLlm, locationOutput);
+        String locationWorkflow = createResource(workflowBody, "/workflowstore/workflows");
+
+        // enableMemoryTools on the AGENT; no userMemoryConfig — defaults carry it.
+        String agentBody = String.format("""
+                {"packages": ["%s"], "enableMemoryTools": true}""", locationWorkflow);
+        ResourceId agentId = extractResourceId(createResource(agentBody, "/agentstore/agents"));
+        deployAgent(agentId.id(), agentId.version());
+        return agentId;
     }
 
     // ==================== Agent Setup Helpers ====================

--- a/src/test/java/ai/labs/eddi/integration/LlmAgentEngineIT.java
+++ b/src/test/java/ai/labs/eddi/integration/LlmAgentEngineIT.java
@@ -339,13 +339,22 @@ public class LlmAgentEngineIT extends BaseIntegrationIT {
             ResourceId conversationId = createConversation(memoryAgentId.id(), memoryUserId);
             waitForConversationReady(memoryAgentId.id(), conversationId.id());
 
-            sendUserInput(memoryAgentId.id(), conversationId.id(), "remember", false, false)
-                    .then().statusCode(200);
+            String sayBody = sendUserInput(memoryAgentId.id(), conversationId.id(), "remember", false, false)
+                    .then().statusCode(200).extract().asString();
 
-            given().get("/usermemorystore/memories/" + memoryUserId)
-                    .then().statusCode(200)
-                    .body("size()", greaterThanOrEqualTo(1))
-                    .body("key", hasItem("favorite_color"));
+            // Discriminators, most-specific first, each carrying the evidence a CI-only
+            // failure needs: two upstream calls prove the tool-call loop executed the
+            // tool and went back for the final answer; the final scripted text proves
+            // the loop completed into output; only then is the store consulted.
+            wireMock.verify(2, postRequestedFor(urlPathEqualTo("/v1/chat/completions")));
+            Assertions.assertTrue(sayBody.contains("Noted"),
+                    "the final scripted answer must reach the turn's output; say body was: " + sayBody);
+
+            String memories = given().get("/usermemorystore/memories/" + memoryUserId)
+                    .then().statusCode(200).extract().asString();
+            Assertions.assertTrue(memories.contains("favorite_color"),
+                    "the rememberFact write must land in the store for user '" + memoryUserId
+                            + "'; store returned: " + memories);
         } finally {
             undeployAgentQuietly(memoryAgentId.id(), memoryAgentId.version());
         }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProviderMemoryGateTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProviderMemoryGateTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.properties.IUserMemoryStore;
+import ai.labs.eddi.engine.attachments.IAttachmentStore;
+import ai.labs.eddi.engine.memory.IConversationMemory;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.modules.llm.tools.impl.AttachmentTextExtractor;
+import ai.labs.eddi.modules.llm.tools.spi.ToolAssemblyContext;
+import ai.labs.eddi.modules.llm.tools.spi.ToolContribution;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The user-memory tool's enablement rule, pinned at the {@code contribute()}
+ * level.
+ * <p>
+ * The rule is deliberate and two-sided. With {@code enableBuiltInTools: true}
+ * and a memory config present, the tool MUST assemble — this is the conjunction
+ * whose third leg (the config surviving past {@code init()}) silently failed on
+ * every live turn, leaving the model to confabulate saves it never made. With
+ * built-ins off, the tool must NOT assemble even though memory is configured:
+ * user memory is a persistent cross-conversation <em>write</em>, and a
+ * task-level "no built-in capability" statement wins over the agent-level
+ * opt-in. That restrictive half is a security posture, so a regression in
+ * either direction matters.
+ */
+@DisplayName("user-memory tool enablement")
+class ContextualToolsProviderMemoryGateTest {
+
+    private IConversationMemory memory;
+    private LlmConfiguration.Task task;
+    private ContextualToolsProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        memory = mock(IConversationMemory.class);
+        var currentStep = mock(IConversationMemory.IWritableConversationStep.class);
+        lenient().when(memory.getCurrentStep()).thenReturn(currentStep);
+        lenient().when(memory.getUserId()).thenReturn("user-1");
+        lenient().when(memory.getAgentId()).thenReturn("agent-gate-1");
+        lenient().when(memory.getConversationId()).thenReturn("conv-1");
+        lenient().when(memory.getUserMemoryConfig()).thenReturn(new AgentConfiguration.UserMemoryConfig());
+
+        task = mock(LlmConfiguration.Task.class);
+
+        provider = new ContextualToolsProvider(mock(IUserMemoryStore.class), mock(IAttachmentStore.class),
+                mock(AttachmentTextExtractor.class));
+    }
+
+    private ToolContribution contribute() {
+        return provider.contribute(new ToolAssemblyContext(memory, task, null, null, "user-1", "agent-gate-1", null));
+    }
+
+    @Test
+    @DisplayName("built-ins on + memory config present → UserMemoryTool assembles")
+    void memoryToolAssemblesWhenBothSwitchesAgree() {
+        when(task.getEnableBuiltInTools()).thenReturn(true);
+
+        ToolContribution contribution = contribute();
+
+        assertFalse(contribution.specs().isEmpty(),
+                "with every switch on, no tool means the agent will confabulate saves again");
+        assertTrue(contribution.specs().stream().anyMatch(spec -> spec.name().toLowerCase().contains("memor")),
+                "the assembled tools must include the user-memory tool: " + contribution.specs());
+    }
+
+    @Test
+    @DisplayName("built-ins off → no memory tool, despite the memory config")
+    void builtInsOffWinsOverTheMemoryConfig() {
+        when(task.getEnableBuiltInTools()).thenReturn(false);
+
+        assertTrue(contribute().specs().isEmpty(),
+                "a task-level 'no built-ins' must win over the agent-level opt-in for a cross-conversation write");
+    }
+
+    @Test
+    @DisplayName("null enableBuiltInTools means off — null is the default")
+    void nullBuiltInsMeansOff() {
+        when(task.getEnableBuiltInTools()).thenReturn(null);
+
+        assertTrue(contribute().specs().isEmpty());
+    }
+
+    @Test
+    @DisplayName("no memory config → nothing assembles even with built-ins on")
+    void noConfigNoTool() {
+        when(task.getEnableBuiltInTools()).thenReturn(true);
+        when(memory.getUserMemoryConfig()).thenReturn(null);
+
+        assertTrue(contribute().specs().isEmpty(),
+                "the config carries enableMemoryTools' verdict — absent means the agent never opted in");
+    }
+}

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProviderWarnDedupTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/ContextualToolsProviderWarnDedupTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The memory-misconfiguration warning is suppressed per agent, not per turn.
+ * <p>
+ * Two ways the first version got this wrong. The dedup key was skipped entirely
+ * for a null agent id, so the defensive path was the one case that logged on
+ * every turn — the exact flood the cache exists to prevent. And the plain set
+ * behind it grew for the JVM lifetime, which is unbounded on a platform that
+ * creates dynamic and ephemeral agents with fresh ids at runtime; it is a
+ * bounded, expiring cache now, so suppression is deliberately best-effort.
+ * <p>
+ * The cache is static and JVM-wide, so every test here uses ids unique to this
+ * class — asserting on an id another test may have warmed would be flaky by
+ * construction.
+ */
+@DisplayName("memory-misconfiguration warning dedup")
+class ContextualToolsProviderWarnDedupTest {
+
+    @Test
+    @DisplayName("an agent warns once, then is suppressed")
+    void warnsOncePerAgent() {
+        assertTrue(ContextualToolsProvider.shouldWarnAboutMemoryMisconfiguration("warn-dedup-agent-1"),
+                "the first sighting must warn");
+        assertFalse(ContextualToolsProvider.shouldWarnAboutMemoryMisconfiguration("warn-dedup-agent-1"),
+                "the second sighting must be suppressed");
+    }
+
+    @Test
+    @DisplayName("distinct agents each get their own warning")
+    void distinctAgentsWarnIndependently() {
+        assertTrue(ContextualToolsProvider.shouldWarnAboutMemoryMisconfiguration("warn-dedup-agent-2"));
+        assertTrue(ContextualToolsProvider.shouldWarnAboutMemoryMisconfiguration("warn-dedup-agent-3"));
+    }
+
+    /**
+     * A null agent id used to bypass deduplication entirely and log on every turn.
+     * It maps to a stable fallback key instead — which also means all null-id
+     * callers share one suppression slot, the right trade for a defensive path that
+     * a real conversation should never hit.
+     */
+    @Test
+    @DisplayName("a null agent id is deduplicated too, not logged per turn")
+    void nullAgentIdDoesNotFloodTheLog() {
+        // Whether the FIRST call warns depends on whether anything else in this JVM
+        // already consumed the shared fallback slot — so only the invariant is
+        // asserted: a second consecutive sighting must be suppressed.
+        ContextualToolsProvider.shouldWarnAboutMemoryMisconfiguration(null);
+        assertFalse(ContextualToolsProvider.shouldWarnAboutMemoryMisconfiguration(null),
+                "every null-id turn warning again is the flood the cache exists to prevent");
+    }
+}

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/ConversationHistoryBuilderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/ConversationHistoryBuilderTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static ai.labs.eddi.engine.memory.model.ConversationLog.ConversationPart.ContentType.text;
 import static org.junit.jupiter.api.Assertions.*;
@@ -105,6 +106,78 @@ class ConversationHistoryBuilderTest {
             assertFalse(messages.isEmpty());
             assertInstanceOf(SystemMessage.class, messages.getFirst());
             assertEquals("You are helpful", ((SystemMessage) messages.getFirst()).text());
+        }
+
+        /**
+         * A turn whose output was written with
+         * {@code addConversationOutputString("output", …)} holds a plain String — the
+         * shape every HITL-gated turn has. This caller used to pre-filter on
+         * {@code output instanceof List}, silently dropping such turns from the model's
+         * own chat history while the summary and recall tool kept them: the Operator
+         * then reported an approved change "was never created".
+         */
+        @Test
+        @DisplayName("a String-shaped output still reaches the model as an AiMessage")
+        void buildMessages_stringOutputTurnIsNotDropped() {
+            IConversationMemory memory = mock(IConversationMemory.class);
+
+            var output = new ConversationOutput();
+            output.put("input", "create the group");
+            output.put("output", "Waiting for your approval.");
+            when(memory.getConversationOutputs()).thenReturn(List.of(output));
+
+            List<ChatMessage> messages = builder.buildMessages(memory, null, null, -1, true);
+
+            assertEquals(2, messages.size(), "user turn AND assistant turn — the assistant half used to vanish");
+            assertInstanceOf(AiMessage.class, messages.get(1));
+            assertEquals("Waiting for your approval.", ((AiMessage) messages.get(1)).text());
+        }
+
+        /**
+         * The summarized-window path ({@code skipSteps > 0}) has its own render loop —
+         * the one that carried the {@code instanceof List} pre-filter. A rolling
+         * summary is exactly when losing turns hurts most: the summarized prefix is
+         * gone by design, so a dropped recent turn has no other copy anywhere in the
+         * prompt.
+         */
+        @Test
+        @DisplayName("the skipSteps window keeps String-shaped turns too")
+        void buildMessages_skipStepsWindowKeepsStringOutputs() {
+            IConversationMemory memory = mock(IConversationMemory.class);
+
+            var summarized = new ConversationOutput();
+            summarized.put("input", "old turn");
+            summarized.put("output", List.of(Map.of("text", "old answer")));
+
+            var hitlShaped = new ConversationOutput();
+            hitlShaped.put("input", "create the group");
+            hitlShaped.put("output", "Waiting for your approval.");
+
+            when(memory.getConversationOutputs()).thenReturn(List.of(summarized, hitlShaped));
+            when(memory.getAllSteps()).thenReturn(mock(IConversationMemory.IConversationStepStack.class));
+
+            List<ChatMessage> messages = builder.buildMessages(memory, null, null, -1, true, "summary of older turns", 1);
+
+            // system(summary) + user + assistant — the assistant half used to vanish.
+            assertEquals(3, messages.size());
+            assertInstanceOf(AiMessage.class, messages.get(2));
+            assertEquals("Waiting for your approval.", ((AiMessage) messages.get(2)).text());
+        }
+
+        @Test
+        @DisplayName("a mixed String-then-Map output list is joined, not truncated")
+        void buildMessages_mixedOutputListFullyRendered() {
+            IConversationMemory memory = mock(IConversationMemory.class);
+
+            var output = new ConversationOutput();
+            output.put("input", "hi");
+            output.put("output", List.of("Paused for approval.", Map.of("text", "Group created.")));
+            when(memory.getConversationOutputs()).thenReturn(List.of(output));
+
+            List<ChatMessage> messages = builder.buildMessages(memory, null, null, -1, true);
+
+            assertEquals(2, messages.size());
+            assertEquals("Paused for approval. Group created.", ((AiMessage) messages.get(1)).text());
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/ConversationOutputUtilsTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/ConversationOutputUtilsTest.java
@@ -43,18 +43,56 @@ class ConversationOutputUtilsTest {
         assertNull(ConversationOutputUtils.extractOutputText(output));
     }
 
+    /**
+     * A bare String under {@code output} is what
+     * {@code addConversationOutputString("output", …)} stores, so it is real agent
+     * output rather than a malformed value — this previously returned null.
+     */
     @Test
-    void extractOutputText_nonListValue_returnsNull() {
+    void extractOutputText_plainStringValue_isExtracted() {
         var output = new ConversationOutput();
         output.put("output", "not a list");
-        assertNull(ConversationOutputUtils.extractOutputText(output));
+        assertEquals("not a list", ConversationOutputUtils.extractOutputText(output));
+    }
+
+    /**
+     * Was {@code extractOutputText_listOfNonMaps_returnsNull}, which pinned the
+     * defect: a plain String is exactly what
+     * {@code addConversationOutputString(...)} writes, so returning null here
+     * silently erased every HITL-gated turn from the log, the summary, the recall
+     * tool and the agent's own history.
+     */
+    @Test
+    void extractOutputText_listOfPlainStrings_extractsThem() {
+        var output = new ConversationOutput();
+        output.put("output", List.of("just a string"));
+        assertEquals("just a string", ConversationOutputUtils.extractOutputText(output));
     }
 
     @Test
-    void extractOutputText_listOfNonMaps_returnsNull() {
+    void extractOutputText_hitlShapedList_stringsThenMap_extractsAll() {
+        // The literal shape observed on a stored HITL turn: STRING, STRING, OBJECT.
         var output = new ConversationOutput();
-        output.put("output", List.of("just a string"));
-        assertNull(ConversationOutputUtils.extractOutputText(output));
+        output.put("output", List.of(
+                "I'll create that group for you.",
+                "Waiting for your approval.",
+                Map.of("text", "Group created.", "type", "text", "delay", 0)));
+        assertEquals("I'll create that group for you. Waiting for your approval. Group created.",
+                ConversationOutputUtils.extractOutputText(output));
+    }
+
+    @Test
+    void extractOutputText_mapFirstThenString_stillExtractsTheString() {
+        var output = new ConversationOutput();
+        output.put("output", List.of(Map.of("text", "first"), "second"));
+        assertEquals("first second", ConversationOutputUtils.extractOutputText(output));
+    }
+
+    @Test
+    void extractOutputText_blankStringsAreNotOutput() {
+        var output = new ConversationOutput();
+        output.put("output", List.of("   ", "real"));
+        assertEquals("real", ConversationOutputUtils.extractOutputText(output));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/modules/templating/MissingPropertyRenderingTest.java
+++ b/src/test/java/ai/labs/eddi/modules/templating/MissingPropertyRenderingTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.templating;
+
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.Expression;
+import io.quarkus.qute.ResultMapper;
+import io.quarkus.qute.Results;
+import io.quarkus.qute.TemplateNode.Origin;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A template that references a property nobody set must render nothing there —
+ * not the word {@code NOT_FOUND}.
+ * <p>
+ * {@code quarkus.qute.strict-rendering=false} only stops the render from
+ * throwing. The missing value still resolves to Qute's NotFound sentinel, and
+ * the default mapper writes the literal constant {@code NOT_FOUND} into the
+ * output. On a live instance that reached end users verbatim — "Your favourite
+ * programming language is: NOT_FOUND." — and equally reached system prompts and
+ * HTTP call bodies, wherever an optional property was referenced. Dev mode
+ * defaults to throwing instead, so the two profiles did not even agree, and the
+ * documented guard ({@code .orEmpty}) is for iterables and fails on NotFound,
+ * so config authors following the docs had nothing that worked.
+ * <p>
+ * The behaviour is a configuration property rather than code, so this test pins
+ * both halves: that leaving it unset really does produce the literal, and that
+ * {@code application.properties} sets it.
+ */
+@DisplayName("a missing property renders as nothing")
+class MissingPropertyRenderingTest {
+
+    private static final String TEMPLATE = "Your favourite programming language is: {properties.language}.";
+
+    /** Equivalent of Quarkus's package-private {@code PropertyNotFoundNoop}. */
+    private static final ResultMapper RENDER_NOTHING = new ResultMapper() {
+        @Override
+        public boolean appliesTo(Origin origin, Object result) {
+            return Results.isNotFound(result);
+        }
+
+        @Override
+        public String map(Object result, Expression expression) {
+            return "";
+        }
+    };
+
+    private static String render(Engine engine) {
+        return engine.parse(TEMPLATE).render(Map.of("properties", Map.of("other", "value")));
+    }
+
+    @Test
+    @DisplayName("lenient rendering alone still emits the literal NOT_FOUND")
+    void withoutTheStrategyTheLiteralLeaks() {
+        String rendered = render(Engine.builder().addDefaults().strictRendering(false).build());
+
+        assertTrue(rendered.contains("NOT_FOUND"),
+                "precondition: this is exactly what reached end users, and why the config property is required");
+    }
+
+    @Test
+    @DisplayName("with the NOOP strategy the expression renders empty")
+    void withTheStrategyNothingIsRendered() {
+        String rendered = render(Engine.builder().addDefaults().strictRendering(false)
+                .addResultMapper(RENDER_NOTHING).build());
+
+        assertEquals("Your favourite programming language is: .", rendered);
+    }
+
+    @Test
+    @DisplayName("application.properties selects NOOP, in every profile")
+    void configurationSelectsNoop() {
+        Path root = Path.of("").toAbsolutePath();
+        String properties;
+        try {
+            properties = Files.readString(root.resolve("src/main/resources/application.properties"), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        assertTrue(properties.contains("quarkus.qute.property-not-found-strategy=NOOP"),
+                "without this line a missing property renders the literal NOT_FOUND into user-visible output");
+        assertTrue(properties.contains("quarkus.qute.strict-rendering=false"),
+                "NOOP only applies while strict rendering is off");
+        assertTrue(!properties.contains("%prod.quarkus.qute.property-not-found-strategy")
+                && !properties.contains("%dev.quarkus.qute.property-not-found-strategy"),
+                "a per-profile override would reintroduce dev and prod rendering differently");
+    }
+}


### PR DESCRIPTION
Fixes the twelve defects from the run-0820a live sweep of the MCP and REST surfaces, plus the two security/operability notes it raised. Every fix has a regression test that was confirmed to fail when the fix is reverted.

The sweep's own summary is what shaped this PR: **five of the twelve were silent false-success** — the system reported that something worked when it had not, with no error anywhere — and three of those sat on the exact surfaces you would point at to prove the platform is trustworthy: the audit ledger, the approval-gated operator, and persistent memory.

| | What the system said | What actually happened |
|---|---|---|
| **D7** | `signingEnabled=true entriesChecked=78 valid=0 invalid=78`, chain INTACT | Nothing was tampered with — the *check* was broken on both backends |
| **D3** | Operator: "the group was never created" | It was created, and a human had approved it |
| **D10** | Agent: "I've saved that you're allergic to peanuts" | Nothing was written; no memory tool was ever assembled |
| **D12** | MCP: `201 created`, then `newVersion: 2` | Config silently emptied; REST rejects the same body |
| **D2 / D11** | `200 OK` on redo / rerun | The turn's answer is destroyed, not restored |

### D7 — the audit ledger reported every entry as forged

`buildCanonicalStringV3` signed the raw `Instant`, which carries nanoseconds on a Linux container. No backend stores that: `TIMESTAMPTZ` keeps microseconds, a BSON `Date` keeps milliseconds. The entry read back was never the entry that was signed, so verification failed for effectively every row — an operator could not distinguish a forged row from a healthy one, because the control emitted no signal in either direction.

Fixed forward with a **v4 canonical form** (per the class's own frozen-once-written rule): identical to v3 except `ts` is the millisecond epoch value. Existing v3 rows are **recovered, not re-signed** — the stored HMAC still identifies the digits storage dropped, so verification tries each candidate completion (at most 999 for a microsecond-floored row, 999 more for a millisecond-floored one). A match proves integrity exactly as strongly as a direct one; blind re-signing was rejected because resealing without verifying would launder tampering that had already happened. Recovered rows report `VALID_RECOVERED` and are counted in a new `recovered` field on `/auditstore/verify`.

The review pass caught a residual: signing milliseconds is not enough on its own, because `timestamp(6)` **rounds** rather than truncates — about one row in two thousand would still have read back a millisecond late. The timestamp is now floored *before* signing, so the stored row is the signed row.

**D7b:** `audit_ledger` had no `agent_signature` column and the Postgres row-mapper hard-coded `null`, so Ed25519 signatures were computed and silently discarded on that backend while MongoDB kept them. Added via the same `ADD COLUMN IF NOT EXISTS` upgrade as `sequence`.

### D3 — HITL-gated turns vanished from the log and the agent's own history

`extractOutputText` and `ConversationLogGenerator` both decided the shape of the whole output list from `getFirst() instanceof Map`. A HITL turn writes its pre-pause announcements as plain Strings, so its stored list reads `STRING, STRING, OBJECT` — the guard failed and the entire turn was discarded, later Maps included. Both now delegate to `ConversationOutputExtractor`, which already tolerated mixed lists. This fixes `ConversationHistoryBuilder`, `ConversationSummarizer`, `ConversationRecallTool` and the REST log at once.

### D10 — agent-facing persistent memory never attached

`ContextualToolsProvider` gates on `memory.getUserMemoryConfig()`, whose only assignment was `Conversation.init()`. The field is not persisted and every request rebuilds memory from the store, so it was set for the CONVERSATION_START turn and null for every turn a user could actually talk to. Now applied in the `Conversation` constructor, which `say`, `resume` and `rerun` all pass through.

`userMemoryConfig` also now defaults instead of disabling the tool when omitted, and the remaining `enableBuiltInTools` conjunction — kept deliberately, since a task-level "no built-ins" should win over an agent-level opt-in for a cross-conversation *write* — now logs a WARN naming the missing switch rather than skipping in silence.

### D12 — MCP writes bypassed the validation REST enforces

The strictness lived in a JAX-RS `ReaderInterceptor`, which only fires on a real inbound HTTP body; MCP calls the same stores in-process. Extracted to `StrictConfigurationParser`, used by both surfaces, so there is one implementation and one message.

## The rest

- **D1** — ruleset, apicall and dictionary listings could never return anything: each queried a legacy type name against a v6 URI namespace, matching nothing, silently. Fixed *structurally* — the type is derived from each store's own `resourceURI`, and `DescriptorTypeConsistencyTest` sweeps the sources so the class of bug cannot recur.
- **D2** — the redo cache never serialised a step's `ConversationOutput`, so redo pushed an empty output over the answer it was restoring.
- **D11** — a rerun cleared results it would not regenerate: it discarded `output` then restarted at the *output* task, while on an LLM agent the answer is written by the earlier `langchain` task. The cleared set and the restart set are now separate and stated to agree. The undocumented mandatory `?language=` on `/rerun` is now optional.
- **D8** — `throw new BadRequestException("...")` yields a 400 with an empty body; `POST /channelstore/channels` alone threw four well-written messages and delivered none of them. `ClientErrorExceptionMapper` copies a 4xx message into the entity (4xx only, never over an existing entity).
- **D4 / D5** — descriptor `PATCH` was a full replace that wiped `name` and returned 204; it now merges. A body that is not the `PatchInstruction` wrapper is a 400 naming the expected shape rather than an NPE-driven 500.
- **D6** — `strict-rendering=false` only stops the *throw*; the literal `NOT_FOUND` still reached system prompts, HTTP call bodies and user-visible replies. Added `quarkus.qute.property-not-found-strategy=NOOP` and corrected AGENTS.md 5.4, which claimed the empty-string behaviour already held.
- **D9** — the delete descriptions now say member conversations are **ended**, which is what the code does. Truly deleting them is a behaviour change on data that GDPR erasure is meant to destroy; **left as an open maintainer decision** rather than taken unilaterally.
- **Minors** — 404 instead of an unlogged 500 for a missing export archive; `pauseDetails.actions` reports the paused turn rather than step 0 (the lookup walked forward believing the step list was reverse-chronological — it is chronological, verified against a real memory round-trip, and an existing test had encoded the same wrong premise and passed because the code shared it); MCP errors no longer render `"...: null"`; A2A cards use the descriptor's name; `create_group` lists all eight styles; the cadence cron dialect is documented.
- **O1 / O2** — a cost ceiling states its pricing prerequisite at save time (EDDI ships no price table by design, so unpriced members make the ceiling inert); plaintext channel credentials warn toward the vault, which `ChannelTargetRouter` already resolves at send time.

## Review pass

A critical pass over these fixes found four more, all fixed in `6d4bed0`: the audit rounding hazard above; `ConversationHistoryBuilder` still pre-filtering on `instanceof List` and so defeating the D3 fix for its most important caller; two channel call sites still missing D12's parity; and an over-claim in the rerun comment about side effects.

## Verification

- `./mvnw compile` and `./mvnw package -DskipTests` green — the latter exercises CDI augmentation for the new beans and provider.
- Full `./mvnw test` sits at the local environmental baseline. The only failures are the known loopback/selector cluster that cannot bind sockets in this sandbox; none are in touched code. CI is the gate for those.
- Repo-wide guards green: `ImportStyleTest`, `DocumentationLinksTest`, `StrictBoundaryShippedConfigsTest`, `RuleSetStoreShippedRulesetsTest`.
- Every regression test mutation-checked: reverting the fix fails the test.

## Not covered

The sweep's own 3b applies here too: it ran with OIDC disabled, so nothing in this PR says anything about whether the role model is correct. `AuditHmac`'s v3 recovery is exercised by unit tests but has not been run against a real legacy ledger — worth piloting on a few rows before trusting a bulk verify.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Missing template properties now render as empty strings consistently.
  - Missing export archives return a clear 404 response.
  - Conversation reruns regenerate responses without repeating side effects.
  - Conversation history, redo operations, and user memory settings are preserved more reliably.
  - Audit verification supports timestamp precision differences and legacy entries.
  - Audit records now retain agent signatures.
  - Descriptor updates support partial changes and targeted deletion.
  - Agent cards display configured names when available.

- **Security & Validation**
  - Unknown configuration fields are rejected with clearer 400 errors.
  - API and MCP errors no longer expose internal exception details.
  - Plaintext channel credentials trigger security warnings.

- **Documentation**
  - Clarified conversation deletion behavior and cron schedule syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->