### PR TITLE
chore(ci): persist project metrics to a `metrics` branch

### DIFF
--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -25,7 +25,10 @@ jobs:
   track:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # write: the daily run commits the metrics history to the `metrics` branch.
+      # `main` cannot be used — it requires a PR + review and enforces admins,
+      # so a CI push there is impossible without weakening branch protection.
+      contents: write
     steps:
       # ── Restore cached metrics ──────────────────────────────
       # Uses run_id-based key rotation to avoid needing actions:write for cache delete.
@@ -532,3 +535,129 @@ jobs:
         with:
           path: metrics.json
           key: project-metrics-${{ github.run_id }}
+
+      # ── Persist history to the `metrics` branch ──────────────
+      # Why this exists: the Actions cache above holds only a rolling snapshot,
+      # and job logs expire after 90 days — so the series was unrecoverable
+      # past that horizon. This writes one row per UTC day to an orphan branch
+      # that no workflow builds from (`main` is not an option: it requires a PR
+      # plus review and enforces admins, and every push there would also fire
+      # scorecard.yml).
+      #
+      # It also re-snapshots the stargazer roster. GitHub publishes no unstar
+      # event to any API, so diffing consecutive rosters is the only way to
+      # learn *who* unstarred and how long they had held it.
+      #
+      # Deliberately NOT gated on the 07:00 'daily' schedule: GitHub drops
+      # scheduled runs under load (observed: ~48 min median spacing against a
+      # 15 min cron, and one 9.6 h gap), and a dropped 07:00 run would lose
+      # that day permanently — the values cannot be backfilled. Instead the
+      # first run of each UTC day writes the row; every later run that day
+      # sees it and exits. That also makes a failed push self-healing, since
+      # the next run simply retries.
+      - name: Persist metrics history
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: metrics
+          PULLS: ${{ steps.docker.outputs.pulls }}
+          STARS: ${{ steps.github.outputs.stars }}
+          FORKS: ${{ steps.github.outputs.forks }}
+          VIEWS: ${{ steps.traffic.outputs.views }}
+          UNIQUES: ${{ steps.traffic.outputs.uniques }}
+          CLONES: ${{ steps.traffic.outputs.clones }}
+        run: |
+          set -euo pipefail
+
+          # Never commit a half-empty row: without pulls and stars the entry
+          # is worse than absent, because a gap is visible and a blank is not.
+          if [ -z "${PULLS:-}" ] || [ -z "${STARS:-}" ]; then
+            echo "::warning::Incomplete metrics (pulls='${PULLS:-}' stars='${STARS:-}') — skipping persist"
+            exit 0
+          fi
+
+          rm -rf hist && mkdir hist && cd hist
+          git init -q
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # Reuse the branch if it exists; otherwise start it empty (orphan).
+          # --depth=1 keeps the fetch O(1) as the series grows; the remote
+          # still retains full history because the pushed commit's ancestors
+          # are already there.
+          if git fetch -q --depth=1 origin "$BRANCH" 2>/dev/null; then
+            git checkout -q -B "$BRANCH" FETCH_HEAD
+          else
+            echo "Branch '$BRANCH' not found — creating it"
+            git checkout -q -b "$BRANCH"
+          fi
+
+          mkdir -p data
+          HEADER="date,docker_pulls,stars,forks,views_14d,uniques_14d,clones_14d"
+          [ -f data/metrics.csv ] || echo "$HEADER" > data/metrics.csv
+
+          TODAY=$(date -u +%F)
+          if grep -q "^${TODAY}," data/metrics.csv; then
+            echo "Row for ${TODAY} already present — nothing to do"
+            exit 0
+          fi
+
+          echo "${TODAY},${PULLS},${STARS},${FORKS},${VIEWS},${UNIQUES},${CLONES}" >> data/metrics.csv
+          echo "Appended row for ${TODAY}"
+
+          # Roster sorted by login so a diff shows membership changes only,
+          # never reordering. Git history then *is* the churn record:
+          #   git log -p metrics -- data/stargazers.csv
+          #
+          # Kept non-fatal on purpose: the count row above is already written,
+          # and losing it to a stargazer API hiccup would trade the reliable
+          # data for the optional data.
+          if gh api -H "Accept: application/vnd.github.star+json" \
+                    --paginate "repos/${GITHUB_REPOSITORY}/stargazers?per_page=100" \
+                    --jq '.[] | [.user.login, .starred_at] | @csv' \
+               | sort -f > data/stargazers.new; then
+            # Guard against a truncated page set silently reading as a mass
+            # unstar. Allow drift (stars move between the two API calls) but
+            # reject a roster that is nowhere near the count we just fetched.
+            ROSTER_N=$(wc -l < data/stargazers.new)
+            if [ "$ROSTER_N" -gt 0 ] && [ "$ROSTER_N" -ge $(( STARS * 9 / 10 )) ]; then
+              { echo "login,starred_at"; cat data/stargazers.new; } > data/stargazers.csv
+              echo "Roster snapshot: ${ROSTER_N} entries"
+            else
+              echo "::warning::Roster looks truncated (${ROSTER_N} rows vs ${STARS} stars) — keeping previous"
+            fi
+          else
+            echo "::warning::Stargazer API call failed — keeping previous roster"
+          fi
+          rm -f data/stargazers.new
+
+          # Orient anyone who lands on the branch; it is machine-written and
+          # has no source tree, which is otherwise confusing.
+          if [ ! -f README.md ]; then
+            cat > README.md <<'MD'
+          # EDDI project metrics history
+
+          Machine-generated by the `Project Metrics Tracker` workflow. Do not
+          edit by hand and do not merge into `main` — this is an orphan branch
+          with no source tree.
+
+          - `data/metrics.csv` — one row per UTC day: Docker pulls, stars,
+            forks, and GitHub's rolling 14-day views/clones.
+          - `data/stargazers.csv` — the stargazer roster, sorted by login.
+            GitHub publishes no unstar event, so the commit history of this
+            file is the only record of who unstarred and when:
+
+                git log -p metrics -- data/stargazers.csv
+          MD
+          fi
+
+          git add data README.md
+          if git diff --quiet --cached; then
+            echo "Nothing changed"
+          else
+            git commit -q -m "chore(metrics): ${TODAY} — ${PULLS} pulls, ${STARS} stars"
+            git push -q origin "$BRANCH"
+            echo "Pushed to '$BRANCH'"
+          fi

--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -569,12 +569,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Never commit a half-empty row: without pulls and stars the entry
-          # is worse than absent, because a gap is visible and a blank is not.
-          if [ -z "${PULLS:-}" ] || [ -z "${STARS:-}" ]; then
-            echo "::warning::Incomplete metrics (pulls='${PULLS:-}' stars='${STARS:-}') — skipping persist"
-            exit 0
-          fi
+          # Never commit a malformed row: a gap is visible, a bad value is not.
+          # Must test for digits, not just non-emptiness — the upstream steps
+          # read these with `jq '.pull_count'` etc., and jq prints the literal
+          # `null` when a field is missing from an otherwise-200 response.
+          # `null` is non-empty, so an emptiness check would let it through and
+          # the roster arithmetic below would then abort on it.
+          for name in PULLS STARS FORKS VIEWS UNIQUES CLONES; do
+            value="${!name:-}"
+            case "$value" in
+              ''|*[!0-9]*)
+                echo "::warning::Metric ${name} is not a number ('${value}') — skipping persist"
+                exit 0
+                ;;
+            esac
+          done
 
           rm -rf hist && mkdir hist && cd hist
           git init -q
@@ -597,6 +606,15 @@ jobs:
           mkdir -p data
           HEADER="date,docker_pulls,stars,forks,views_14d,uniques_14d,clones_14d"
           [ -f data/metrics.csv ] || echo "$HEADER" > data/metrics.csv
+
+          # `>>` writes at the current end of file, so a missing trailing
+          # newline would splice today's row onto the previous one and corrupt
+          # both. Only reachable after a hand edit or a truncated push, but
+          # this branch is the only durable copy — cheap to prevent, costly to
+          # repair.
+          if [ -s data/metrics.csv ] && [ -n "$(tail -c1 data/metrics.csv)" ]; then
+            echo >> data/metrics.csv
+          fi
 
           TODAY=$(date -u +%F)
           if grep -q "^${TODAY}," data/metrics.csv; then
@@ -650,6 +668,27 @@ jobs:
             file is the only record of who unstarred and when:
 
                 git log -p metrics -- data/stargazers.csv
+
+          ## Data retention
+
+          `data/stargazers.csv` contains GitHub logins and star timestamps.
+          Both are public — the same values the stargazers API returns to any
+          caller — but the commit history of this file is not: it reconstructs
+          *departures*, which GitHub deliberately does not publish. Treat it as
+          a per-person record, not as incidental public data.
+
+          - **Purpose:** understanding project health — whether lost stars are
+            brief visitors or long-term followers.
+          - **Retention:** kept for the life of the branch. Snapshots are not
+            pruned, because the history *is* the dataset.
+          - **Removal:** to erase an individual, rewrite the branch (it has no
+            dependants and nothing builds from it):
+            `git filter-repo --path data/stargazers.csv --invert-paths` on a
+            clone of `metrics`, then force-push that branch only. To stop
+            collection entirely, delete the roster block from the
+            `Persist metrics history` step in
+            `.github/workflows/docker-pull-notify.yml`; `data/metrics.csv` is
+            aggregate-only and unaffected.
           MD
           fi
 

--- a/.github/workflows/docker-pull-notify.yml
+++ b/.github/workflows/docker-pull-notify.yml
@@ -681,14 +681,30 @@ jobs:
             brief visitors or long-term followers.
           - **Retention:** kept for the life of the branch. Snapshots are not
             pruned, because the history *is* the dataset.
-          - **Removal:** to erase an individual, rewrite the branch (it has no
-            dependants and nothing builds from it):
-            `git filter-repo --path data/stargazers.csv --invert-paths` on a
-            clone of `metrics`, then force-push that branch only. To stop
-            collection entirely, delete the roster block from the
-            `Persist metrics history` step in
-            `.github/workflows/docker-pull-notify.yml`; `data/metrics.csv` is
-            aggregate-only and unaffected.
+          - **Removal:** to erase one person from the whole history while
+            keeping the file and everyone else's rows, run a row-level
+            rewrite on a fresh clone. Nothing builds from this branch, so
+            force-pushing it is safe — but force-push `metrics` only.
+
+                git clone --single-branch -b metrics <repo-url> erase
+                cd erase
+                git filter-repo --force --refs metrics --blob-callback '
+                lines = blob.data.split(b"\n")
+                if lines and lines[0].startswith(b"login,starred_at"):
+                    blob.data = b"\n".join(
+                        l for l in lines if not l.startswith(b"\"THE_LOGIN\","))
+                '
+                git push --force origin metrics
+
+            `data/metrics.csv` is aggregate-only and is not touched by the
+            callback above. To stop collection entirely, delete the roster
+            block from the `Persist metrics history` step in
+            `.github/workflows/docker-pull-notify.yml`.
+
+            As with any history rewrite, the pre-rewrite commits survive in
+            existing clones and stay reachable on GitHub until it garbage
+            collects them — ask GitHub Support to expire them if the removal
+            has to be complete.
           MD
           fi
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,9 +21,11 @@ traffic, pushes them to GA4 and Umami, and posts digests to Slack. Everything it
 current totals plus digest baselines. The workflow uploads no artifact. So the only historical record
 was the incidental one — every run echoes its numbers into the job log — and job logs expire.
 
-Confirmed the horizon empirically rather than trusting the documented default: runs from 2026-05-22
-back return `HTTP 410 Gone`, 2026-05-23 forward return `200`. Exactly 90 days. Recovered what was
-still reachable (2,295 of 2,400 retained runs, 2026-05-22 → 08-20) before it ages out.
+Confirmed the horizon empirically rather than trusting the documented default. The boundary fell
+*mid-day* on 2026-05-22: runs up to 22:56 UTC that day return `HTTP 410 Gone`, every run after it
+returns `200` — exactly 90 days, rolling, to the hour. Recovered what was still reachable (2,295 of
+2,400 retained runs, 2026-05-22 22:56 → 08-20) before it ages out. The per-day series derived from it
+starts 2026-05-23, since 05-22 survives only as a partial day.
 
 ### What changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,75 @@
 
 
 
+## chore(ci): persist the project metrics series instead of letting it expire (2026-08-21)
+
+**Repo:** EDDI (`chore/persist-repo-metrics-history`)
+
+Started from "can we still fetch the repo analytics the CI posts to Slack?". The answer was *only for
+90 days*, and only by scraping job logs — which is worth writing down, because the workflow looks like
+it stores its data and does not.
+
+`docker-pull-notify.yml` ("Project Metrics Tracker") collects Docker pulls, stars, forks and GitHub
+traffic, pushes them to GA4 and Umami, and posts digests to Slack. Everything it keeps locally is a
+**rolling snapshot**: `metrics.json` in the Actions cache is overwritten on every run and holds only
+current totals plus digest baselines. The workflow uploads no artifact. So the only historical record
+was the incidental one — every run echoes its numbers into the job log — and job logs expire.
+
+Confirmed the horizon empirically rather than trusting the documented default: runs from 2026-05-22
+back return `HTTP 410 Gone`, 2026-05-23 forward return `200`. Exactly 90 days. Recovered what was
+still reachable (2,295 of 2,400 retained runs, 2026-05-22 → 08-20) before it ages out.
+
+### What changed
+
+One step appended to the `track` job, plus `contents: read` → `write` on that job.
+
+It writes one row per UTC day to an orphan `metrics` branch. `main` was considered and is not usable:
+it requires a PR plus one approving review, requires the `CodeQL Analysis` and `Build & Test` checks,
+and sets `enforce_admins: true` — a CI push there is impossible without weakening branch protection,
+which would also cost OpenSSF Scorecard points. A push to `main` would additionally fire
+`scorecard.yml` on every commit. The orphan branch triggers nothing, and `GITHUB_TOKEN` pushes do not
+start workflows anyway.
+
+### Design decisions
+
+**Not gated on the 07:00 `daily` schedule.** GitHub drops scheduled runs under load — measured ~48 min
+median spacing against a 15 min cron, with one 9.6 h gap. A dropped 07:00 run would lose that day
+permanently, since the values cannot be reconstructed after the fact. Instead the first run of each UTC
+day writes the row and every later run that day sees it and exits, which also makes a failed push
+self-healing: the next run retries.
+
+**The stargazer roster is snapshotted too.** This is the part that is not just convenience. GitHub
+publishes no unstar event through any API — the stargazers endpoint returns only current stars, the
+repo events endpoint is capped at 300 events (~1 day here, and saturated by PR traffic), and GH
+Archive's `WatchEvent` coverage for this period is broken (verified against three known stars with
+exact timestamps; none appear, and hourly global counts of 16–217 are far below a complete firehose).
+So diffing consecutive rosters is the *only* way to ever learn who unstarred. Sorted by login so the
+diff shows membership changes rather than reordering.
+
+**Failure modes preferred to fail open.** The roster fetch is non-fatal and the count row is written
+first — losing a reliable row to an optional API call would be the wrong trade. A truncated page set
+is rejected by comparing the roster size against the star count just fetched, so a partial response
+cannot read as a mass unstar. A row with empty pulls or stars is skipped entirely: a visible gap is
+better than a blank that looks like data.
+
+### What this enables
+
+`git log -p metrics -- data/stargazers.csv` will give, for every future unstar: who, when they starred,
+and exactly how long they held it. None of that is recoverable today.
+
+For reference, the 90 days that *were* recoverable showed 11 unstars — not the 9 a naive reading of the
+count gives, because two were masked by same-day arrivals. At most 4 were drive-bys; at least 7 had
+held the star longer than the observation window. Caveat for whoever reads this later: a deleted or
+spam-purged account is indistinguishable from a deliberate unstar, and 59.5% of the star base is older
+than three years.
+
+### Not done
+
+The recovered 2026-05-22 → 08-20 series is **not** seeded into the branch — the series starts from the
+first workflow run after merge. Seeding it is a separate call.
+
+---
+
 ## 🛑 fix(ci): the Red Hat certify workflow would have overwritten the signed release (2026-08-20)
 
 **Repo:** EDDI (`fix/preflight-version-1-20-0`)


### PR DESCRIPTION
## Problem

The **Project Metrics Tracker** (`docker-pull-notify.yml`) collects Docker pulls, stars, forks and GitHub traffic on every run, ships them to GA4/Umami, and posts Slack digests — but it **keeps nothing durable**:

- `metrics.json` lives in the Actions cache and is **overwritten every run** — current totals plus digest baselines, no series
- the workflow uploads **no artifact**
- the only historical record is incidental: each run echoes its numbers into the job log

Job logs expire. Verified against the API rather than assuming the documented default: runs from **2026-05-22 back return `HTTP 410 Gone`**, 2026-05-23 forward return `200`. Exactly 90 days, rolling. Anything older is gone.

This surfaced when we tried to answer "can we still read the analytics the CI posted to Slack?" — recoverable, but only by scraping 2,295 job logs, and only for 90 days.

## Change

One step appended to the `track` job, plus `contents: read` → `write` on that job.

Writes **one row per UTC day** to an orphan `metrics` branch, and snapshots the **stargazer roster** alongside it.

### Why not `main`

`main` requires a PR plus one approving review, requires the `CodeQL Analysis` and `Build & Test` checks, and sets `enforce_admins: true` — a CI push there is **impossible** without weakening branch protection, which would also cost OpenSSF Scorecard points. A push to `main` would additionally fire `scorecard.yml` on every commit (~365/yr). The orphan branch triggers no workflow, and `GITHUB_TOKEN` pushes don't start workflows anyway.

### Why not gated on the 07:00 `daily` cron

GitHub drops scheduled runs under load — measured **~48 min median spacing against a 15 min cron**, with one **9.6 h gap**. A dropped 07:00 run would lose that day permanently, since the values can't be backfilled. Instead the first run of each UTC day writes the row and later runs exit early. That also makes a failed push self-healing — the next run retries.

### Why the roster snapshot

This is the part that isn't just convenience. **GitHub publishes no unstar event through any API:**

| Route | Status |
|---|---|
| Stargazers API | current stars only — an unstar leaves no trace |
| Repo events API | capped at 300 events (~1 day here), saturated by PR traffic |
| GH Archive | `WatchEvent` coverage broken for this period — verified three known stars with exact timestamps, none present; hourly global counts of 16–217 vs. thousands expected |

Diffing consecutive rosters is the **only** way to ever learn who unstarred. Sorted by login so the diff shows membership changes, not reordering.

```
git log -p metrics -- data/stargazers.csv
```

…gives, for every future unstar: **who**, **when they starred**, and **exactly how long they held it**.

## Failure handling — fails open

- Count row is written **before** the roster call, which is non-fatal — losing reliable data to an optional API call would be the wrong trade
- Truncated page sets rejected by comparing roster size against the star count just fetched, so a partial response can't read as a mass unstar
- A row missing pulls or stars is skipped entirely — a visible gap beats a blank that looks like data
- Whole step is `continue-on-error` — it can never break the Slack digests

## Testing

Ran the step against a local bare repo with stubbed `gh`/`date` across seven scenarios:

| Scenario | Result |
|---|---|
| Fresh branch | ✅ creates orphan branch + README |
| Re-run same day | ✅ exits early, no duplicate row |
| Next day | ✅ appends |
| `gh` API fails | ✅ **row still committed**, roster preserved |
| Roster truncated | ✅ row committed, truncated roster rejected |
| Real unstar | ✅ roster diff names the user + original `starred_at` |
| Empty `PULLS` | ✅ skipped with warning |

Then confirmed the committed history contains **exactly one** roster departure — neither the API failure nor the truncation produced a false unstar signal.

Also verified history survives `--depth=1` fetches (the failure mode that would silently defeat the point — pushing from a shallow clone truncating the remote; it doesn't, and the fetch stays O(1) as the series grows).

`DocumentationLinksTest` passes.

## Not included

The recovered 2026-05-22 → 08-20 series is **not** seeded — the branch starts from the first run after merge. Happy to seed it as a follow-up if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily project metrics tracking with duplicate-day protection and data validation.
  * Added periodic stargazer roster snapshots with safeguards against incomplete or invalid data.
  * Published metrics and stargazer data on a dedicated branch with rolling 90-day retention.
  * Added recovery handling for missing data and noncritical collection or publishing failures.

* **Documentation**
  * Documented metrics persistence, retention limits, recovery behavior, and historical data availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->