### PR TITLE
fix(secrets): make DEK rotation survivable by giving the key generations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,24 @@ newline in either would forge log records (CWE-117). Routed the tenant/key pair 
 helper and sanitized the remaining standalone tenant ids — the point of the single helper being that it
 stays true of the next message somebody adds.
 
+### The normalization stopped one step short
+
+Follow-up to the generation fix above, from a second review pass. Normalizing the entity fixed what a
+row *reads back as*, and left two places where the storage and the entity could still disagree.
+
+`EncryptedDek.dekId(String, int)` is static and takes an `int` straight from the caller, so it could
+still mint `tenant#g0` — a name `generationOf` reads back as generation 1, and `dekFor` then looks up as
+generation 1. The class Javadoc claimed the name and the row it names always agree; that was untrue of
+this method. It normalizes now, like the field.
+
+The Mongo boot migration backfilled only *absent* generations. A row physically holding `0` was handed
+out as generation 1 by the entity and then looked up as generation 1 by an exact query that could not
+match it — the entity normalization moved the disagreement rather than removing it. The backfill now
+covers below-1 as well as missing.
+
+Both mutation-checked: reverting the first fails with `expected: <tenant-1#g1> but was: <tenant-1#g0>`,
+reverting the second fails the migration filter assertion.
+
 ### Review nitpicks
 
 The rotation test verified that the sweep called `updateSecretSealing`, but never that the swept row

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,19 @@ newline in either would forge log records (CWE-117). Routed the tenant/key pair 
 helper and sanitized the remaining standalone tenant ids — the point of the single helper being that it
 stays true of the next message somebody adds.
 
+### Review nitpicks
+
+The rotation test verified that the sweep called `updateSecretSealing`, but never that the swept row
+came out naming the NEW generation. A regression that re-encrypted with the new key while writing the
+old `dekId` would have passed — and that row is then openable by neither key, which is worse than not
+sweeping at all. The assertion is now on the captured row; reverting `setDekId` fails it with
+`expected: <test-tenant#g2> but was: <test-tenant>`.
+
+`ISecretProvider.seal`/`unseal` also gained their missing `@param`/`@return` tags, including the null
+contract they actually implement: null passes through in both directions, so a grant with no refresh
+token stays distinguishable from one that sealed to nothing — but the availability check comes first,
+so a null against an inactive vault still throws rather than returning null.
+
 ### Corrected an over-claiming Javadoc
 
 `onStartup`'s `@Priority` comment implied it ordered the vault ahead of anything that asks

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,57 @@
 
 
 
+## 🔑 fix(secrets): review findings on DEK generations — a below-1 generation sealed under the wrong name (2026-08-22)
+
+**Repo:** EDDI (`fix/dek-rotation-atomicity`)
+
+Review pass over the generations work on this branch. One finding was a real correctness bug, the rest
+are hardening.
+
+### The bug: a row could name itself a generation it would not be read back as
+
+`generationOf` treats everything below `FIRST_GENERATION` as generation 1 — that is the rule that lets
+rows written before generations existed still resolve. But nothing stopped a below-1 generation from
+reaching the field. A row holding generation 0 sealed its ciphertext under the name `tenant#g0`, and
+`generationOf` read that name back as generation **1** — so the ciphertext would later be opened with a
+different key than sealed it.
+
+Fixed at the model boundary: `EncryptedDek` normalizes in both the constructor and `setGeneration`, so
+the name a row writes and the generation that name reads back as are always the same one. Every source
+of a below-1 generation means the same thing (a row that predates the column), so it is mapped once
+here rather than at each store. `PostgresSecretPersistence.resultSetToDek` drops its own copy of the
+rule accordingly.
+
+`EncryptedDekTest` is new and covers the round trip directly; reverting the normalization fails it on
+`expected: <tenant-1#g1> but was: <tenant-1#g0>`.
+
+### Dropping the legacy DEK index no longer passes for "already gone"
+
+The boot migration caught `MongoException` around `dropIndex(idx_dek_tenant)` and shrugged. That is
+right for `IndexNotFound` (code 27) — absent on every deployment created after generations existed, and
+on every boot after the first — but it also swallowed *not authorized* and *stepped-down primary*, where
+the legacy unique-on-tenantId index may well still be standing. While it stands, a tenant cannot hold a
+second generation and rotation has nowhere to write. Now only code 27 is tolerated; anything else fails
+the boot.
+
+### Log forging in vault messages
+
+Tenant and key names are caller-controlled and every message built here is eventually logged, so a
+newline in either would forge log records (CWE-117). Routed the tenant/key pair through one `describe()`
+helper and sanitized the remaining standalone tenant ids — the point of the single helper being that it
+stays true of the next message somebody adds.
+
+### Corrected an over-claiming Javadoc
+
+`onStartup`'s `@Priority` comment implied it ordered the vault ahead of anything that asks
+`isAvailable()`. It orders it among `StartupEvent` **observers** only. `@PostConstruct` callbacks sit
+outside that sequence entirely — `SecretResolver` reads `isAvailable()` from one — so callers on that
+side must tolerate a not-yet-available vault rather than rely on ordering. Said so.
+
+---
+
+
+
 ## chore(ci): persist the project metrics series instead of letting it expire (2026-08-21)
 
 **Repo:** EDDI (`chore/persist-repo-metrics-history`)

--- a/docs/secrets-vault.md
+++ b/docs/secrets-vault.md
@@ -24,7 +24,8 @@ EDDI includes a built-in secrets vault for managing sensitive values like API ke
 | -------------------------------------- | ------------------ | --------------------------------------------------------------- |
 | `SecretReference`                      | `secrets.model`    | Value object: `tenantId/keyName` URI parsing                    |
 | `EnvelopeCrypto`                       | `secrets.crypto`   | AES-256-GCM encryption with envelope key wrapping               |
-| `ISecretProvider`                      | `secrets`          | SPI for reading/writing encrypted secrets                       |
+| `ISecretProvider`                      | `secrets`          | SPI for reading/writing encrypted secrets, plus `seal`/`unseal` |
+| `SealedDataRotationParticipant`        | `secrets`          | SPI joining DEK rotation's sweep — implemented by anything else that stores `seal`-ed data |
 | `VaultSecretProvider`                  | `secrets.impl`     | Production implementation with envelope crypto + persistence    |
 | `SecretResolver`                       | `secrets`          | Resolves `${vault:...}` references to plaintext at runtime  |
 | `IRestSecretStore` / `RestSecretStore` | `secrets.rest`     | JAX-RS endpoints for secret CRUD and key rotation               |
@@ -136,8 +137,14 @@ Secret → tenant DEK → AES-256-GCM encrypt → ciphertext
                 │
                 └→ KEK wraps DEK → encrypted DEK
                         │
-                        └→ stored: { encryptedDek, iv, ciphertext }
+                        └→ stored: { encryptedDek, iv, ciphertext, dekId }
 ```
+
+`dekId` is `<tenantId>#g<generation>` — readable on purpose, so `default#g3` in a
+database row tells an operator exactly what it means. A tenant holds one DEK row per
+generation because [rotation adds one rather than replacing the key](#dek-rotation-is-additive--it-adds-a-generation),
+and ciphertext therefore has to say which key sealed it. A value written before
+generations existed carries no generation and reads as generation 1.
 
 ### Configuration
 
@@ -357,7 +364,7 @@ All endpoints are under the base path `/secretstore/secrets`. All endpoints requ
 | `GET`    | `/{tenantId}/{keyName}`      | Get secret **metadata only** (never returns plaintext) |
 | `GET`    | `/{tenantId}`                | List all secrets for a tenant (metadata only)          |
 | `GET`    | `/health`                    | Vault health check (provider status)                   |
-| `POST`   | `/{tenantId}/rotate-dek`     | Rotate the tenant's Data Encryption Key                |
+| `POST`   | `/{tenantId}/rotate-dek`     | Install the tenant's next DEK generation and sweep rows onto it |
 | `POST`   | `/admin/rotate-kek`          | Rotate the Master Key (KEK) — **TLS required**         |
 
 > **⚠️ Important:** The `GET` endpoints return **metadata only** (`keyName`, `createdAt`, `lastAccessedAt`, `checksum`). Secret values are **write-only** — they can be stored and used by the engine but never retrieved via API.
@@ -398,13 +405,23 @@ All endpoints are under the base path `/secretstore/secrets`. All endpoints requ
 }
 ```
 
-**`POST /{tenantId}/rotate-dek`** — rotates the tenant's DEK:
+**`POST /{tenantId}/rotate-dek`** — installs the tenant's next DEK generation and
+sweeps existing rows onto it:
 
 ```json
 {
   "tenantId": "default",
   "secretsReEncrypted": 5,
   "message": "DEK rotated successfully. 5 secrets re-encrypted."
+}
+```
+
+If the sweep does not finish, the call answers **500** and says so — the new
+generation is still active, nothing is lost, and re-running finishes the migration:
+
+```json
+{
+  "error": "DEK rotation failed: DEK rotation for tenant 'default': generation 3 is now the active key and every new value is sealed with it, but at least 2 sealed row(s) still name an older generation. Nothing is lost — those rows still decrypt with the generation they name, which has not been deleted — and the operation is safe to re-run to finish the migration."
 }
 ```
 
@@ -430,19 +447,75 @@ Response:
 
 ### Key Rotation
 
-EDDI supports two levels of key rotation:
+EDDI supports two levels of key rotation.
 
-**DEK Rotation** (`POST /{tenantId}/rotate-dek`):
-- Generates a new Data Encryption Key for the tenant
-- Re-encrypts all secrets with the new DEK
+#### DEK rotation is additive — it adds a generation
+
+`POST /{tenantId}/rotate-dek` does **not** replace the tenant's key. A tenant holds
+one DEK row per **generation**, and every ciphertext — a stored secret, and any
+other sealed value written through a `SealedDataRotationParticipant` — records the
+generation that sealed it. Reading opens a value with the generation
+it names, not with whichever one is newest.
+
+Rotation runs three phases, and only the middle one is irreversible:
+
+1. **Verify** — every existing generation is opened with the current KEK, so a wrong
+   `EDDI_VAULT_MASTER_KEY` is discovered before anything is written. Every
+   generation, not just the newest: the sweep below has to open the older ones, and
+   finding that out mid-sweep is a discovery that belongs before the commit point.
+2. **Commit** — the next generation is *inserted*. One statement, guarded by a
+   unique key on `(tenant, generation)`, so two racing rotations produce one winner
+   and one clean refusal. From here new values seal with the new key while every
+   existing row still names a generation that exists and decrypts.
+3. **Sweep** — rows move onto the new generation one at a time, each write guarded on
+   the state the row was read in, so a `store` that landed in between is never
+   overwritten with a re-seal of the value it replaced.
+
+**Old generations are never deleted.** That is precisely what makes a half-finished
+sweep harmless: a row the sweep did not reach still names a key that opens it.
+Deleting the generation a row still names is the one action that would make a
+partly swept tenant unreadable, so nothing here does it — and a resolve that finds
+a named generation missing says so by name rather than failing as a decryption
+error one layer down.
+
+**A partial sweep is reported, and re-running finishes it.** The endpoint answers
+**500** with a message stating that the new generation is active and every new value
+seals with it, that at least *N* sealed rows still name an older generation, that
+nothing is lost, and that the operation is safe to re-run. Re-running picks up
+exactly the rows the previous run left. Rows are swept individually so that one
+secret nobody can open does not strand the rest of the tenant on an older
+generation for every future rotation as well.
+
 - Does NOT require a restart
 - Recommended: rotate periodically or after personnel changes
 
-**KEK Rotation** (`POST /admin/rotate-kek`):
-- Re-encrypts all tenant DEKs with a new master key
+#### KEK rotation
+
+`POST /admin/rotate-kek` re-encrypts all tenant DEKs with a new master key:
+
+- **Every generation of every tenant is re-wrapped**, not just the newest. A tenant
+  part-way through a DEK sweep still has rows depending on an older generation, and
+  leaving one behind on the old KEK is exactly the orphaned-key failure generations
+  exist to prevent.
 - Secret ciphertexts are NOT modified — only DEK wrappers change
 - Requires an application restart with the new `EDDI_VAULT_MASTER_KEY` after rotation
-- Both operations use a verify-then-commit pattern: all decryption is validated before any writes occur
+- Verify-then-commit: every DEK is decrypted and re-encrypted in memory before any
+  write occurs, so a wrong old key fails before it can half-rewrite the set
+
+#### Schema
+
+Generations need one column and one index, and both are created on boot. Nothing to
+run by hand on either backend:
+
+| Backend | On boot |
+| --- | --- |
+| PostgreSQL | Adds `generation INTEGER NOT NULL DEFAULT 1` to `secret_vault_deks`, drops the column-level `UNIQUE (tenant_id)` constraint, and creates a unique index on `(tenant_id, generation)`. The old constraint is the blocker: while it stands a tenant cannot hold a second generation, so rotation has nowhere to write. It is an index rather than a constraint because only an index can be declared `IF NOT EXISTS`, and Postgres accepts one as an `ON CONFLICT` target just the same. |
+| MongoDB | Backfills `generation` on existing DEK documents, *then* drops the legacy unique-on-`tenantId` index and creates a unique compound index on `(tenantId, generation)`. That order matters — the backfill runs first so every pre-generation document has a generation to be indexed on. |
+
+A row written before generations existed reads as generation 1, which is what lets
+every already-stored ciphertext keep working with no migration of the ciphertext
+itself. During a rolling upgrade the two spellings coexist: a document with no
+`generation` field and a document holding `generation: 1` both match generation 1.
 
 ### Input Validation
 

--- a/src/main/java/ai/labs/eddi/secrets/ISecretProvider.java
+++ b/src/main/java/ai/labs/eddi/secrets/ISecretProvider.java
@@ -100,14 +100,21 @@ public interface ISecretProvider {
     List<SecretMetadata> listKeys(String tenantId) throws SecretProviderException;
 
     /**
-     * Rotate the Data Encryption Key (DEK) for a specific tenant. Generates a new
-     * DEK, re-encrypts all secrets for the tenant, and replaces the old DEK.
+     * Rotate the Data Encryption Key (DEK) for a specific tenant: adds a new DEK
+     * generation, then sweeps existing sealed data onto it.
+     * <p>
+     * The old generations are kept, not replaced, so a row that has not been swept
+     * yet still names a key that exists and decrypts. The single irreversible step
+     * is the insert of the new generation; everything after it is idempotent and
+     * safe to re-run.
      *
      * @param tenantId
      *            the tenant whose DEK to rotate
-     * @return the number of secrets re-encrypted
+     * @return the number of secrets moved onto the new generation
      * @throws SecretProviderException
-     *             if rotation fails
+     *             if the new generation could not be installed, or if it was
+     *             installed but some rows are still on an older one — the message
+     *             says which case it is
      */
     int rotateDek(String tenantId) throws SecretProviderException;
 
@@ -133,6 +140,63 @@ public interface ISecretProvider {
      * @return true if the provider can resolve secrets
      */
     boolean isAvailable();
+
+    /**
+     * Encrypt arbitrary runtime data with a tenant's data-encryption key, without
+     * storing it as a named secret.
+     * <p>
+     * Exists for OAuth grants. A grant is not a secret in the vault's sense — it is
+     * not author-managed, not referenced by name, not subject to
+     * {@code allowedAgents}, and must never appear in an export — so it does not
+     * belong in the secret collection. What it DOES need is exactly the vault's
+     * envelope encryption and exactly the vault's per-tenant DEK: a second key
+     * hierarchy for refresh tokens would mean a second key to rotate, a second
+     * master key to lose, and a second place for the crypto to be subtly wrong.
+     *
+     * @param tenantId
+     *            whose DEK to seal with; created on first use, as for a secret
+     * @throws SecretProviderException
+     *             when the vault is inactive or the DEK cannot be obtained
+     */
+    SealedValue seal(String tenantId, String plaintext) throws SecretProviderException;
+
+    /**
+     * Reverse of {@link #seal}.
+     *
+     * @throws SecretProviderException
+     *             when the vault is inactive, the DEK cannot be obtained, or the
+     *             ciphertext fails its authentication tag
+     */
+    String unseal(String tenantId, SealedValue sealed) throws SecretProviderException;
+
+    /**
+     * Ciphertext, its initialization vector, and the name of the key that sealed
+     * it.
+     * <p>
+     * The {@code dekId} is what makes rotation survivable: a value carries the DEK
+     * generation it was sealed under, so it stays readable after the tenant moves
+     * to a newer generation and until a sweep has re-sealed it. Callers persist it
+     * alongside the ciphertext and hand it back on {@link #unseal}.
+     * <p>
+     * {@code toString} is overridden because this travels through log statements
+     * and debugger views on the token-refresh path.
+     */
+    record SealedValue(String ciphertext, String iv, String dekId) {
+
+        /**
+         * For ciphertext whose sealing key is not recorded — everything written before
+         * generations existed. It reads as generation 1, which is what those rows are
+         * actually sealed with.
+         */
+        public SealedValue(String ciphertext, String iv) {
+            this(ciphertext, iv, null);
+        }
+
+        @Override
+        public String toString() {
+            return "SealedValue[<REDACTED>]";
+        }
+    }
 
     // === Exception types ===
 

--- a/src/main/java/ai/labs/eddi/secrets/ISecretProvider.java
+++ b/src/main/java/ai/labs/eddi/secrets/ISecretProvider.java
@@ -155,17 +155,34 @@ public interface ISecretProvider {
      *
      * @param tenantId
      *            whose DEK to seal with; created on first use, as for a secret
+     * @param plaintext
+     *            the value to seal; {@code null} passes through as {@code null}
+     *            rather than sealing an empty value, so a grant that simply has no
+     *            refresh token stays distinguishable from one whose refresh token
+     *            sealed to nothing
+     * @return the ciphertext and the name of the key that sealed it, or
+     *         {@code null} when {@code plaintext} was null
      * @throws SecretProviderException
-     *             when the vault is inactive or the DEK cannot be obtained
+     *             when the vault is inactive or the DEK cannot be obtained. Note
+     *             the availability check comes first: a null plaintext against an
+     *             inactive vault still throws, it does not return null
      */
     SealedValue seal(String tenantId, String plaintext) throws SecretProviderException;
 
     /**
      * Reverse of {@link #seal}.
      *
+     * @param tenantId
+     *            whose DEK the value was sealed with
+     * @param sealed
+     *            the ciphertext to open, as {@link #seal} returned it
+     * @return the plaintext, or {@code null} when {@code sealed} is null or carries
+     *         no ciphertext — the mirror of {@code seal}, so a value that was never
+     *         sealed round-trips as absent rather than as an error
      * @throws SecretProviderException
      *             when the vault is inactive, the DEK cannot be obtained, or the
-     *             ciphertext fails its authentication tag
+     *             ciphertext fails its authentication tag. As with {@code seal},
+     *             the availability check precedes the null check
      */
     String unseal(String tenantId, SealedValue sealed) throws SecretProviderException;
 

--- a/src/main/java/ai/labs/eddi/secrets/SealedDataRotationParticipant.java
+++ b/src/main/java/ai/labs/eddi/secrets/SealedDataRotationParticipant.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.secrets;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * Implemented by anything that stores data sealed with a tenant's DEK, so DEK
+ * rotation re-seals it instead of destroying it.
+ *
+ * <h3>Why this exists</h3> {@link ISecretProvider#seal} deliberately encrypts
+ * with the same per-tenant DEK the vault uses for named secrets — a second key
+ * hierarchy for OAuth refresh tokens would mean a second key to rotate and a
+ * second place for the crypto to be subtly wrong. The consequence nobody wired
+ * up: DEK rotation re-encrypted the secret collection and nothing else, then
+ * replaced the DEK. Every sealed value outside that collection became
+ * permanently undecryptable, so an operator performing a routine, documented,
+ * compliance-driven key rotation silently disconnected every user's linked SaaS
+ * account — and found out one {@code invalid_grant} at a time.
+ *
+ * <h3>Why an SPI rather than a direct call</h3> {@code ai.labs.eddi.secrets} is
+ * a leaf package on purpose: the vault must not depend on the things that use
+ * it, or every future consumer of {@code seal} adds an edge back into the
+ * crypto. Rotation discovers participants through CDI instead, so a new
+ * sealed-data owner joins by implementing this interface and nothing in the
+ * vault changes.
+ *
+ * <h3>The contract implementations must honour</h3> {@link #resealAll} is
+ * called <b>after</b> the new DEK generation has been committed, and it is a
+ * migration sweep rather than an all-or-nothing switch. Every older generation
+ * still exists and still decrypts, so a row this method fails to move is
+ * <b>not</b> lost — it keeps naming a key that works, and the next rotation
+ * picks it up. Write row by row, each write guarded on the state the row was
+ * read in, so a concurrent writer is never clobbered.
+ * <p>
+ * Throwing does not roll anything back: the new generation is already active.
+ * Rotation catches it, counts the tenant as incompletely migrated, and reports
+ * that the operation is safe to re-run. Reporting outstanding rows through the
+ * return value is preferred, because a count survives where an exception ends
+ * the sweep.
+ */
+public interface SealedDataRotationParticipant {
+
+    /**
+     * What this participant stores, for the rotation log line. Something an
+     * operator can act on ("OAuth connection grants"), not a class name.
+     */
+    String sealedDataDescription();
+
+    /**
+     * Moves every value this participant holds for the tenant onto the active DEK
+     * generation, skipping whatever is already there.
+     *
+     * @param tenantId
+     *            the tenant being rotated
+     * @param activeDekId
+     *            the dekId of the generation to end up on. A row already naming it
+     *            needs nothing done and must be left alone — a concurrent writer
+     *            sealed it under the new key while this sweep was running
+     * @param resealer
+     *            re-seals one value under the active generation, opening it with
+     *            whichever generation its own
+     *            {@link ISecretProvider.SealedValue#dekId()} names. Valid only for
+     *            the duration of this call, and only for values belonging to
+     *            {@code tenantId}
+     * @return how many rows are still NOT on the active generation when this
+     *         returns — zero means the tenant is fully migrated
+     */
+    int resealAll(String tenantId, String activeDekId, UnaryOperator<ISecretProvider.SealedValue> resealer);
+}

--- a/src/main/java/ai/labs/eddi/secrets/impl/VaultSecretProvider.java
+++ b/src/main/java/ai/labs/eddi/secrets/impl/VaultSecretProvider.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.secrets.impl;
 
 import ai.labs.eddi.secrets.ISecretProvider;
+import ai.labs.eddi.secrets.SealedDataRotationParticipant;
 import ai.labs.eddi.secrets.VaultStartupBanner;
 import ai.labs.eddi.secrets.crypto.EnvelopeCrypto;
 import ai.labs.eddi.secrets.crypto.VaultSaltManager;
@@ -16,15 +17,19 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import jakarta.interceptor.Interceptor;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.function.UnaryOperator;
 
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
@@ -43,8 +48,13 @@ import static ai.labs.eddi.utils.LogSanitizer.sanitize;
  * is governed by {@code allowedAgents} (see below)</li>
  * </ul>
  * <p>
- * <b>Key rotation:</b> Supports both DEK rotation (per-tenant, re-encrypts all
- * secrets) and KEK rotation (re-encrypts all DEKs with a new master key).
+ * <b>Key rotation:</b> Supports both DEK rotation and KEK rotation. DEK
+ * rotation is per-tenant and <b>additive</b>: it installs a new DEK generation
+ * and then sweeps existing rows onto it, rather than replacing a key underneath
+ * data that names it. Every ciphertext records the generation that sealed it,
+ * so a sweep that stops halfway leaves every row readable and the rotation safe
+ * to re-run. KEK rotation re-wraps every generation of every tenant with a new
+ * master key and does not touch any ciphertext.
  * <p>
  * <b>Access model:</b> {@code allowedAgents} is not consulted here — this class
  * resolves secrets and does not police who asked. It is checked one level up,
@@ -70,6 +80,12 @@ public class VaultSecretProvider implements ISecretProvider {
     private final VaultSaltManager saltManager;
     private final MeterRegistry meterRegistry;
 
+    /**
+     * Everything else that stores data sealed with a tenant DEK. Discovered through
+     * CDI so this package stays a leaf - see {@link SealedDataRotationParticipant}.
+     */
+    private final Instance<SealedDataRotationParticipant> rotationParticipants;
+
     private byte[] kek; // Key Encryption Key derived from master key
     private boolean available = false;
 
@@ -84,11 +100,24 @@ public class VaultSecretProvider implements ISecretProvider {
 
     @Inject
     public VaultSecretProvider(@ConfigProperty(name = "eddi.vault.master-key") Optional<String> masterKeyConfig, ISecretPersistence persistence,
-            VaultSaltManager saltManager, MeterRegistry meterRegistry) {
+            VaultSaltManager saltManager, MeterRegistry meterRegistry, Instance<SealedDataRotationParticipant> rotationParticipants) {
         this.masterKeyConfig = masterKeyConfig;
         this.persistence = persistence;
         this.saltManager = saltManager;
         this.meterRegistry = meterRegistry;
+        this.rotationParticipants = rotationParticipants;
+    }
+
+    /**
+     * Test seam: no sealed-data participants.
+     * <p>
+     * Rotation then re-seals only the secret collection, which is exactly what the
+     * pre-participant behaviour was — fine for a test that is not about rotation,
+     * and never what production wires up.
+     */
+    VaultSecretProvider(Optional<String> masterKeyConfig, ISecretPersistence persistence, VaultSaltManager saltManager,
+            MeterRegistry meterRegistry) {
+        this(masterKeyConfig, persistence, saltManager, meterRegistry, null);
     }
 
     @PostConstruct
@@ -102,7 +131,13 @@ public class VaultSecretProvider implements ISecretProvider {
         this.storeTimer = meterRegistry.timer("eddi.vault.store.duration");
     }
 
-    void onStartup(@Observes StartupEvent event) {
+    /**
+     * Runs before anything that asks {@link #isAvailable()} at startup - the
+     * connections guard does, and with both observers unordered CDI was free to ask
+     * before this had run.
+     */
+    void onStartup(@Observes
+    @Priority(Interceptor.Priority.APPLICATION) StartupEvent event) {
         if (masterKeyConfig.isEmpty() || masterKeyConfig.get().isBlank()) {
             VaultStartupBanner.printDisabled();
             return;
@@ -136,8 +171,10 @@ public class VaultSecretProvider implements ISecretProvider {
 
             EncryptedSecret secret = secretOpt.get();
 
-            // Decrypt: KEK → DEK → plaintext
-            byte[] dek = getOrCreateDek(reference.tenantId());
+            // Decrypt: KEK → the DEK generation this row names → plaintext. Not the
+            // newest generation: a row the last rotation's sweep has not reached yet is
+            // still sealed with an older one, and that one still exists.
+            byte[] dek = dekFor(reference.tenantId(), secret.getDekId());
             String plaintext = EnvelopeCrypto.decrypt(secret.getEncryptedValue(), secret.getIv(), dek);
 
             // Update last accessed timestamp (best-effort, fire-and-forget)
@@ -178,10 +215,10 @@ public class VaultSecretProvider implements ISecretProvider {
         Timer.Sample sample = Timer.start(meterRegistry);
 
         try {
-            byte[] dek = getOrCreateDek(reference.tenantId());
+            ActiveDek dek = activeDek(reference.tenantId());
 
             // Encrypt the plaintext with the tenant's DEK
-            EnvelopeCrypto.EncryptionResult result = EnvelopeCrypto.encrypt(plaintext, dek);
+            EnvelopeCrypto.EncryptionResult result = EnvelopeCrypto.encrypt(plaintext, dek.key());
             String checksum = EnvelopeCrypto.sha256Hex(plaintext);
 
             // Check if this is an update (rotation) or new secret
@@ -189,7 +226,7 @@ public class VaultSecretProvider implements ISecretProvider {
             Instant now = Instant.now();
 
             EncryptedSecret secret = new EncryptedSecret(existingOpt.map(EncryptedSecret::getId).orElse(UUID.randomUUID().toString()),
-                    reference.tenantId(), reference.keyName(), result.ciphertext(), result.iv(), reference.tenantId(), checksum, description,
+                    reference.tenantId(), reference.keyName(), result.ciphertext(), result.iv(), dek.dekId(), checksum, description,
                     allowedAgents != null ? allowedAgents : List.of("*"), existingOpt.map(EncryptedSecret::getCreatedAt).orElse(now), null,
                     existingOpt.isPresent() ? now : null);
 
@@ -264,64 +301,206 @@ public class VaultSecretProvider implements ISecretProvider {
     /**
      * {@inheritDoc}
      * <p>
-     * Generates a new DEK, re-encrypts all secrets for the tenant with the new DEK,
-     * and replaces the old DEK. If any re-encryption fails, the operation aborts
-     * and an exception is thrown.
+     * Three phases, and only the middle one is irreversible:
+     * <ol>
+     * <li><b>Verify</b> — every existing generation is opened with the current KEK,
+     * so a wrong master key is discovered before anything is written.</li>
+     * <li><b>Commit</b> — the next generation is <em>inserted</em>. One statement,
+     * guarded by a unique key on (tenant, generation), so two racing rotations
+     * produce one winner and one clean refusal. From here on new values seal with
+     * the new key while every existing row still names a generation that exists and
+     * decrypts.</li>
+     * <li><b>Sweep</b> — rows are moved onto the new generation one at a time, each
+     * write guarded on the state the row was read in. A row the sweep cannot move
+     * is reported, not lost: it keeps working, and re-running the rotation picks it
+     * up.</li>
+     * </ol>
+     * Old generations are never deleted here. Deleting one is what would make a
+     * partially swept tenant unreadable, which is the failure this design exists to
+     * remove.
      */
     @Override
     public int rotateDek(String tenantId) throws SecretProviderException {
         ensureAvailable();
         rotateCounter.increment();
 
+        int nextGeneration;
+        byte[] newDek;
         try {
-            // 1. Verify: decrypt all secrets with old DEK (validates key before mutating
-            // anything)
-            var dekOpt = persistence.findDek(tenantId);
-            if (dekOpt.isEmpty()) {
+            // 1. Verify. Every generation, not just the newest: the sweep below has to
+            // open older ones, and finding out mid-sweep that the KEK cannot is a
+            // discovery that belongs before the commit point.
+            List<EncryptedDek> generations = persistence.listDeks(tenantId);
+            if (generations.isEmpty()) {
                 throw new SecretProviderException("No DEK found for tenant " + tenantId + " — nothing to rotate");
             }
-
-            byte[] oldDek = EnvelopeCrypto.decryptDek(dekOpt.get().getEncryptedDek(), dekOpt.get().getIv(), kek);
-            List<EncryptedSecret> secrets = persistence.listSecretsByTenant(tenantId);
-
-            // 2. Generate new DEK
-            byte[] newDek = EnvelopeCrypto.generateDek();
-
-            // 3. Prepare: decrypt all and re-encrypt in memory (no writes yet)
-            Instant now = Instant.now();
-            List<SimpleEntry<EncryptedSecret, EnvelopeCrypto.EncryptionResult>> reEncrypted = new ArrayList<>();
-            for (EncryptedSecret secret : secrets) {
-                String plaintext = EnvelopeCrypto.decrypt(secret.getEncryptedValue(), secret.getIv(), oldDek);
-                EnvelopeCrypto.EncryptionResult enc = EnvelopeCrypto.encrypt(plaintext, newDek);
-                reEncrypted.add(new SimpleEntry<>(secret, enc));
+            int highest = 0;
+            for (EncryptedDek generation : generations) {
+                EnvelopeCrypto.decryptDek(generation.getEncryptedDek(), generation.getIv(), kek);
+                highest = Math.max(highest, generation.getGeneration());
             }
 
-            // 4. Commit: write all re-encrypted secrets, then replace the DEK
-            for (var entry : reEncrypted) {
-                EncryptedSecret secret = entry.getKey();
-                EnvelopeCrypto.EncryptionResult enc = entry.getValue();
-                secret.setEncryptedValue(enc.ciphertext());
-                secret.setIv(enc.iv());
-                secret.setLastRotatedAt(now);
-                persistence.upsertSecret(secret);
+            // 2. Commit. The single atomic step in the whole operation.
+            nextGeneration = highest + 1;
+            newDek = EnvelopeCrypto.generateDek();
+            EnvelopeCrypto.EncryptionResult enc = EnvelopeCrypto.encryptDek(newDek, kek);
+            EncryptedDek entity = new EncryptedDek(UUID.randomUUID().toString(), tenantId, nextGeneration, enc.ciphertext(), enc.iv(),
+                    Instant.now());
+            if (!persistence.insertDek(entity)) {
+                throw new SecretProviderException("Generation " + nextGeneration + " already exists for tenant '" + sanitize(tenantId)
+                        + "'. Another rotation installed it first; nothing was changed by this one.");
             }
-
-            EnvelopeCrypto.EncryptionResult newDekEnc = EnvelopeCrypto.encryptDek(newDek, kek);
-            EncryptedDek newDekEntity = new EncryptedDek(dekOpt.get().getId(), tenantId, newDekEnc.ciphertext(), newDekEnc.iv(), Instant.now());
-            persistence.upsertDek(newDekEntity);
-
-            LOGGER.infof("DEK rotated for tenant '%s': %d secrets re-encrypted", tenantId, secrets.size());
-            return secrets.size();
         } catch (PersistenceException | EnvelopeCrypto.CryptoException e) {
             errorCounter.increment();
             throw new SecretProviderException("DEK rotation failed for tenant " + tenantId, e);
         }
+
+        // 3. Sweep. Past the commit point, so a failure here is incomplete rather
+        // than destructive and is reported as such.
+        String activeDekId = EncryptedDek.dekId(tenantId, nextGeneration);
+        Instant now = Instant.now();
+        int migrated = 0;
+        int outstanding = 0;
+
+        List<EncryptedSecret> secrets;
+        try {
+            secrets = persistence.listSecretsByTenant(tenantId);
+        } catch (PersistenceException e) {
+            errorCounter.increment();
+            throw new SecretProviderException("DEK rotation for tenant '" + sanitize(tenantId) + "': generation " + nextGeneration
+                    + " is now the active key, but the secrets could not be listed to migrate them. Nothing is lost and the operation is safe to"
+                    + " re-run.", e);
+        }
+        for (EncryptedSecret secret : secrets) {
+            // Per row, so one secret nobody can open does not strand the rest of the
+            // tenant on an older generation for every future rotation as well.
+            try {
+                if (migrateSecret(tenantId, secret, activeDekId, newDek, now)) {
+                    migrated++;
+                } else {
+                    outstanding++;
+                }
+            } catch (SecretProviderException | PersistenceException | EnvelopeCrypto.CryptoException e) {
+                outstanding++;
+                LOGGER.errorf(e, "DEK rotation for tenant '%s': secret '%s' could not be moved to generation %d", sanitize(tenantId),
+                        sanitize(secret.getKeyName()), nextGeneration);
+            }
+        }
+
+        outstanding += resealParticipants(tenantId, activeDekId, newDek);
+
+        if (outstanding > 0) {
+            errorCounter.increment();
+            throw new SecretProviderException("DEK rotation for tenant '" + sanitize(tenantId) + "': generation " + nextGeneration
+                    + " is now the active key and every new value is sealed with it, but at least " + outstanding
+                    + " sealed row(s) still name an older generation. Nothing is lost — those rows still decrypt with the generation they name,"
+                    + " which has not been deleted — and the operation is safe to re-run to finish the migration.");
+        }
+
+        LOGGER.infof("DEK rotated for tenant '%s': generation %d is active, %d secret(s) migrated", sanitize(tenantId), nextGeneration, migrated);
+        return migrated;
+    }
+
+    /**
+     * Moves one secret onto the active generation, tolerating a concurrent writer.
+     * <p>
+     * The write is guarded on the dekId the row was read with, so a {@code store}
+     * that landed in between is never overwritten with a re-seal of the value it
+     * replaced. On a lost guard the row is re-read once: if it now names the active
+     * generation somebody else already did the work, and otherwise one retry is
+     * enough — a row losing twice is a row being written continuously, and leaving
+     * it costs nothing because the generation it names still opens it.
+     *
+     * @return whether the row is on the active generation when this returns
+     */
+    private boolean migrateSecret(String tenantId, EncryptedSecret secret, String activeDekId, byte[] activeDek, Instant now)
+            throws SecretProviderException {
+        EncryptedSecret current = secret;
+        for (int attempt = 0; attempt < 2; attempt++) {
+            if (current == null) {
+                // Deleted mid-sweep. There is nothing left to migrate, which is not a
+                // failure.
+                return true;
+            }
+            String rowDekId = current.getDekId();
+            if (activeDekId.equals(rowDekId)) {
+                return true;
+            }
+            String plaintext = EnvelopeCrypto.decrypt(current.getEncryptedValue(), current.getIv(), dekFor(tenantId, rowDekId));
+            EnvelopeCrypto.EncryptionResult enc = EnvelopeCrypto.encrypt(plaintext, activeDek);
+            current.setEncryptedValue(enc.ciphertext());
+            current.setIv(enc.iv());
+            current.setDekId(activeDekId);
+            current.setLastRotatedAt(now);
+            if (persistence.updateSecretSealing(current, rowDekId)) {
+                return true;
+            }
+            current = persistence.findSecret(tenantId, secret.getKeyName()).orElse(null);
+        }
+        return false;
+    }
+
+    /**
+     * Asks every {@link SealedDataRotationParticipant} to move its rows onto the
+     * new generation.
+     * <p>
+     * Runs AFTER the new generation is committed, which is what makes it safe to
+     * fail: every older generation still exists, so a row this sweep does not reach
+     * still names a key that opens it. The re-sealer decrypts with the generation
+     * each value names rather than with one assumed key, so a participant holding a
+     * mix of generations — the normal state after an interrupted rotation — is
+     * migrated correctly.
+     *
+     * @return how many rows are known to still be on an older generation, counting
+     *         a participant that failed outright as at least one
+     */
+    private int resealParticipants(String tenantId, String activeDekId, byte[] activeDek) {
+        if (rotationParticipants == null || rotationParticipants.isUnsatisfied()) {
+            return 0;
+        }
+        UnaryOperator<SealedValue> resealer = sealed -> {
+            if (sealed == null || sealed.ciphertext() == null) {
+                return sealed;
+            }
+            try {
+                String plaintext = EnvelopeCrypto.decrypt(sealed.ciphertext(), sealed.iv(), dekFor(tenantId, sealed.dekId()));
+                EnvelopeCrypto.EncryptionResult enc = EnvelopeCrypto.encrypt(plaintext, activeDek);
+                return new SealedValue(enc.ciphertext(), enc.iv(), activeDekId);
+            } catch (SecretProviderException | EnvelopeCrypto.CryptoException e) {
+                // Never quotes the ciphertext or the participant's row: this runs over
+                // refresh tokens.
+                throw new IllegalStateException("Failed to re-seal a value during DEK rotation for tenant " + sanitize(tenantId), e);
+            }
+        };
+        int outstanding = 0;
+        for (SealedDataRotationParticipant participant : rotationParticipants) {
+            try {
+                int left = participant.resealAll(tenantId, activeDekId, resealer);
+                outstanding += left;
+                LOGGER.infof("DEK rotation for tenant '%s': %d row(s) of %s still on an older generation", sanitize(tenantId), left,
+                        participant.sealedDataDescription());
+            } catch (RuntimeException e) {
+                // Participants signal a re-seal failure with an unchecked exception, and
+                // one that gave up mid-sweep cannot say how much it left behind. Counted
+                // as one so the caller reports "at least N" honestly rather than
+                // reporting success.
+                outstanding++;
+                LOGGER.errorf(e, "DEK rotation for tenant '%s': %s could not be fully migrated", sanitize(tenantId),
+                        participant.sealedDataDescription());
+            }
+        }
+        return outstanding;
     }
 
     /**
      * Rotate the KEK (Master Key). Re-encrypts all tenant DEKs with a new master
      * key. The actual secret ciphertexts are NOT modified — only the DEK wrappers
      * change.
+     * <p>
+     * Every generation is re-wrapped, not just the newest. A tenant part-way
+     * through a DEK sweep still has rows depending on an older generation, and
+     * leaving one behind on the old KEK is exactly the orphaned-key failure DEK
+     * generations exist to prevent.
      * <p>
      * <b>Usage:</b>
      * <ol>
@@ -419,23 +598,100 @@ public class VaultSecretProvider implements ISecretProvider {
         }
     }
 
+    @Override
+    public SealedValue seal(String tenantId, String plaintext) throws SecretProviderException {
+        ensureAvailable();
+        if (plaintext == null) {
+            return null;
+        }
+        try {
+            ActiveDek dek = activeDek(tenantId);
+            EnvelopeCrypto.EncryptionResult result = EnvelopeCrypto.encrypt(plaintext, dek.key());
+            // The caller persists the dekId next to the ciphertext; without it the value
+            // would only ever be openable by whatever generation happened to be newest
+            // at read time.
+            return new SealedValue(result.ciphertext(), result.iv(), dek.dekId());
+        } catch (EnvelopeCrypto.CryptoException e) {
+            errorCounter.increment();
+            throw new SecretProviderException("Encryption failure while sealing data for tenant " + sanitize(tenantId), e);
+        }
+    }
+
+    @Override
+    public String unseal(String tenantId, SealedValue sealed) throws SecretProviderException {
+        ensureAvailable();
+        if (sealed == null || sealed.ciphertext() == null) {
+            return null;
+        }
+        try {
+            return EnvelopeCrypto.decrypt(sealed.ciphertext(), sealed.iv(), dekFor(tenantId, sealed.dekId()));
+        } catch (EnvelopeCrypto.CryptoException e) {
+            errorCounter.increment();
+            // The message deliberately says nothing about the ciphertext. A failed
+            // authentication tag means either a changed master key or tampering, and
+            // both are answered the same way: refuse and say which tenant.
+            throw new SecretProviderException("Decryption failure while unsealing data for tenant " + sanitize(tenantId), e);
+        }
+    }
+
     // === Private helpers ===
 
-    private byte[] getOrCreateDek(String tenantId) throws SecretProviderException {
+    /**
+     * A usable DEK together with the name ciphertext must record for it.
+     */
+    private record ActiveDek(byte[] key, String dekId) {
+    }
+
+    /**
+     * The generation new values are sealed with — the newest one — creating it on
+     * first use.
+     * <p>
+     * Read from the store on every call, deliberately un-cached. That is the
+     * behaviour this class already had, and a cache here would need invalidating
+     * the instant another replica installs a generation.
+     */
+    private ActiveDek activeDek(String tenantId) throws SecretProviderException {
         try {
             var dekOpt = persistence.findDek(tenantId);
             if (dekOpt.isPresent()) {
                 EncryptedDek encryptedDek = dekOpt.get();
                 try {
-                    return EnvelopeCrypto.decryptDek(encryptedDek.getEncryptedDek(), encryptedDek.getIv(), kek);
+                    return new ActiveDek(EnvelopeCrypto.decryptDek(encryptedDek.getEncryptedDek(), encryptedDek.getIv(), kek),
+                            encryptedDek.dekId());
                 } catch (EnvelopeCrypto.CryptoException e) {
-                    return handleDekDecryptionFailure(tenantId, e);
+                    return new ActiveDek(handleDekDecryptionFailure(tenantId, e), encryptedDek.dekId());
                 }
             }
 
-            return generateAndPersistDek(tenantId);
+            return new ActiveDek(generateAndPersistDek(tenantId), EncryptedDek.dekId(tenantId, EncryptedDek.FIRST_GENERATION));
         } catch (PersistenceException e) {
             throw new SecretProviderException("Persistence failure while managing DEK for tenant " + tenantId, e);
+        }
+    }
+
+    /**
+     * The key that a stored dekId names.
+     * <p>
+     * Never creates one: a missing generation means ciphertext exists that nothing
+     * can open, and minting a fresh key would answer that with a decryption failure
+     * one layer further down instead of saying what actually happened.
+     */
+    private byte[] dekFor(String tenantId, String dekId) throws SecretProviderException {
+        int generation = EncryptedDek.generationOf(tenantId, dekId);
+        try {
+            var dekOpt = persistence.findDek(tenantId, generation);
+            if (dekOpt.isEmpty()) {
+                throw new SecretProviderException("DEK generation " + generation + " for tenant '" + sanitize(tenantId)
+                        + "' is missing, but stored data is still sealed with it. Old generations must never be deleted while any row names them.");
+            }
+            EncryptedDek encryptedDek = dekOpt.get();
+            try {
+                return EnvelopeCrypto.decryptDek(encryptedDek.getEncryptedDek(), encryptedDek.getIv(), kek);
+            } catch (EnvelopeCrypto.CryptoException e) {
+                return handleDekDecryptionFailure(tenantId, e);
+            }
+        } catch (PersistenceException e) {
+            throw new SecretProviderException("Persistence failure while reading DEK generation " + generation + " for tenant " + tenantId, e);
         }
     }
 
@@ -477,7 +733,8 @@ public class VaultSecretProvider implements ISecretProvider {
         byte[] newDek = EnvelopeCrypto.generateDek();
         EnvelopeCrypto.EncryptionResult encResult = EnvelopeCrypto.encryptDek(newDek, kek);
 
-        EncryptedDek dek = new EncryptedDek(UUID.randomUUID().toString(), tenantId, encResult.ciphertext(), encResult.iv(), Instant.now());
+        EncryptedDek dek = new EncryptedDek(UUID.randomUUID().toString(), tenantId, EncryptedDek.FIRST_GENERATION, encResult.ciphertext(),
+                encResult.iv(), Instant.now());
 
         persistence.upsertDek(dek);
         LOGGER.infof("Generated new DEK for tenant: %s", tenantId);

--- a/src/main/java/ai/labs/eddi/secrets/impl/VaultSecretProvider.java
+++ b/src/main/java/ai/labs/eddi/secrets/impl/VaultSecretProvider.java
@@ -132,9 +132,17 @@ public class VaultSecretProvider implements ISecretProvider {
     }
 
     /**
-     * Runs before anything that asks {@link #isAvailable()} at startup - the
-     * connections guard does, and with both observers unordered CDI was free to ask
-     * before this had run.
+     * Turns the vault on.
+     * <p>
+     * The priority orders this <em>among {@link StartupEvent} observers only</em>:
+     * {@link Interceptor.Priority#APPLICATION} is below the CDI default of
+     * {@code APPLICATION + 500}, so every observer that does not name a lower
+     * priority of its own sees {@link #isAvailable()} already settled. It orders
+     * nothing else. {@code @PostConstruct} callbacks are outside that sequence
+     * entirely — {@link ai.labs.eddi.secrets.SecretResolver} reads
+     * {@code isAvailable()} from one, which fires whenever that bean is first
+     * instantiated and may well be before this observer has run. Callers on that
+     * side must tolerate a not-yet-available vault rather than rely on ordering.
      */
     void onStartup(@Observes
     @Priority(Interceptor.Priority.APPLICATION) StartupEvent event) {
@@ -166,7 +174,7 @@ public class VaultSecretProvider implements ISecretProvider {
         try {
             var secretOpt = persistence.findSecret(reference.tenantId(), reference.keyName());
             if (secretOpt.isEmpty()) {
-                throw new SecretNotFoundException("Secret not found: " + reference.tenantId() + "/" + reference.keyName());
+                throw new SecretNotFoundException("Secret not found: " + describe(reference));
             }
 
             EncryptedSecret secret = secretOpt.get();
@@ -186,10 +194,10 @@ public class VaultSecretProvider implements ISecretProvider {
             throw e;
         } catch (PersistenceException e) {
             errorCounter.increment();
-            throw new SecretProviderException("Persistence failure while resolving " + reference.tenantId() + "/" + reference.keyName(), e);
+            throw new SecretProviderException("Persistence failure while resolving " + describe(reference), e);
         } catch (EnvelopeCrypto.CryptoException e) {
             errorCounter.increment();
-            throw new SecretProviderException("Decryption failure for " + reference.tenantId() + "/" + reference.keyName(), e);
+            throw new SecretProviderException("Decryption failure for " + describe(reference), e);
         } finally {
             sample.stop(resolveTimer);
         }
@@ -204,7 +212,8 @@ public class VaultSecretProvider implements ISecretProvider {
             secret.setLastAccessedAt(Instant.now());
             persistence.upsertSecret(secret);
         } catch (PersistenceException e) {
-            LOGGER.debugf("Failed to update lastAccessedAt for %s/%s: %s", secret.getTenantId(), secret.getKeyName(), e.getMessage());
+            LOGGER.debugf("Failed to update lastAccessedAt for %s/%s: %s", sanitize(secret.getTenantId()), sanitize(secret.getKeyName()),
+                    e.getMessage());
         }
     }
 
@@ -231,14 +240,13 @@ public class VaultSecretProvider implements ISecretProvider {
                     existingOpt.isPresent() ? now : null);
 
             persistence.upsertSecret(secret);
-            LOGGER.infof("Secret stored: %s/%s (description: %s)", reference.tenantId(), reference.keyName(),
-                    description != null ? description : "none");
+            LOGGER.infof("Secret stored: %s (description: %s)", describe(reference), description != null ? sanitize(description) : "none");
         } catch (PersistenceException e) {
             errorCounter.increment();
-            throw new SecretProviderException("Persistence failure while storing " + reference.tenantId() + "/" + reference.keyName(), e);
+            throw new SecretProviderException("Persistence failure while storing " + describe(reference), e);
         } catch (EnvelopeCrypto.CryptoException e) {
             errorCounter.increment();
-            throw new SecretProviderException("Encryption failure for " + reference.tenantId() + "/" + reference.keyName(), e);
+            throw new SecretProviderException("Encryption failure for " + describe(reference), e);
         } finally {
             sample.stop(storeTimer);
         }
@@ -252,12 +260,12 @@ public class VaultSecretProvider implements ISecretProvider {
         try {
             boolean deleted = persistence.deleteSecret(reference.tenantId(), reference.keyName());
             if (!deleted) {
-                throw new SecretNotFoundException("Secret not found: " + reference.tenantId() + "/" + reference.keyName());
+                throw new SecretNotFoundException("Secret not found: " + describe(reference));
             }
-            LOGGER.infof("Secret deleted: %s/%s", reference.tenantId(), reference.keyName());
+            LOGGER.infof("Secret deleted: %s", describe(reference));
         } catch (PersistenceException e) {
             errorCounter.increment();
-            throw new SecretProviderException("Persistence failure while deleting " + reference.tenantId() + "/" + reference.keyName(), e);
+            throw new SecretProviderException("Persistence failure while deleting " + describe(reference), e);
         }
     }
 
@@ -267,14 +275,14 @@ public class VaultSecretProvider implements ISecretProvider {
         try {
             var secretOpt = persistence.findSecret(reference.tenantId(), reference.keyName());
             if (secretOpt.isEmpty()) {
-                throw new SecretNotFoundException("Secret not found: " + reference.tenantId() + "/" + reference.keyName());
+                throw new SecretNotFoundException("Secret not found: " + describe(reference));
             }
             EncryptedSecret s = secretOpt.get();
             return new SecretMetadata(s.getTenantId(), s.getKeyName(), s.getCreatedAt(), s.getLastAccessedAt(), s.getLastRotatedAt(), s.getChecksum(),
                     s.getDescription(), s.getAllowedAgents());
         } catch (PersistenceException e) {
             errorCounter.increment();
-            throw new SecretProviderException("Persistence failure while reading metadata for " + reference.tenantId() + "/" + reference.keyName(),
+            throw new SecretProviderException("Persistence failure while reading metadata for " + describe(reference),
                     e);
         }
     }
@@ -287,7 +295,7 @@ public class VaultSecretProvider implements ISecretProvider {
                     s.getLastAccessedAt(), s.getLastRotatedAt(), s.getChecksum(), s.getDescription(), s.getAllowedAgents())).toList();
         } catch (PersistenceException e) {
             errorCounter.increment();
-            throw new SecretProviderException("Persistence failure while listing secrets for tenant " + tenantId, e);
+            throw new SecretProviderException("Persistence failure while listing secrets for tenant " + sanitize(tenantId), e);
         }
     }
 
@@ -332,7 +340,7 @@ public class VaultSecretProvider implements ISecretProvider {
             // discovery that belongs before the commit point.
             List<EncryptedDek> generations = persistence.listDeks(tenantId);
             if (generations.isEmpty()) {
-                throw new SecretProviderException("No DEK found for tenant " + tenantId + " — nothing to rotate");
+                throw new SecretProviderException("No DEK found for tenant '" + sanitize(tenantId) + "' — nothing to rotate");
             }
             int highest = 0;
             for (EncryptedDek generation : generations) {
@@ -352,7 +360,7 @@ public class VaultSecretProvider implements ISecretProvider {
             }
         } catch (PersistenceException | EnvelopeCrypto.CryptoException e) {
             errorCounter.increment();
-            throw new SecretProviderException("DEK rotation failed for tenant " + tenantId, e);
+            throw new SecretProviderException("DEK rotation failed for tenant '" + sanitize(tenantId) + "'", e);
         }
 
         // 3. Sweep. Past the commit point, so a failure here is incomplete rather
@@ -637,6 +645,18 @@ public class VaultSecretProvider implements ISecretProvider {
     // === Private helpers ===
 
     /**
+     * A tenant/key pair as it may appear in a message.
+     * <p>
+     * Both halves are caller-controlled and every message built here is eventually
+     * logged by somebody, so a newline in either would forge log records (CWE-117).
+     * Going through one helper is what keeps that true of the next message somebody
+     * adds.
+     */
+    private static String describe(SecretReference reference) {
+        return sanitize(reference.tenantId()) + "/" + sanitize(reference.keyName());
+    }
+
+    /**
      * A usable DEK together with the name ciphertext must record for it.
      */
     private record ActiveDek(byte[] key, String dekId) {
@@ -665,7 +685,7 @@ public class VaultSecretProvider implements ISecretProvider {
 
             return new ActiveDek(generateAndPersistDek(tenantId), EncryptedDek.dekId(tenantId, EncryptedDek.FIRST_GENERATION));
         } catch (PersistenceException e) {
-            throw new SecretProviderException("Persistence failure while managing DEK for tenant " + tenantId, e);
+            throw new SecretProviderException("Persistence failure while managing DEK for tenant '" + sanitize(tenantId) + "'", e);
         }
     }
 
@@ -691,7 +711,8 @@ public class VaultSecretProvider implements ISecretProvider {
                 return handleDekDecryptionFailure(tenantId, e);
             }
         } catch (PersistenceException e) {
-            throw new SecretProviderException("Persistence failure while reading DEK generation " + generation + " for tenant " + tenantId, e);
+            throw new SecretProviderException(
+                    "Persistence failure while reading DEK generation " + generation + " for tenant '" + sanitize(tenantId) + "'", e);
         }
     }
 
@@ -716,8 +737,9 @@ public class VaultSecretProvider implements ISecretProvider {
                         ? secretCount + " secret(s) are stored for this tenant and would be permanently lost if you reset."
                         : "Unable to determine how many secrets are stored for this tenant.";
 
+        String safeTenantId = sanitize(tenantId);
         throw new SecretProviderException(
-                "Cannot decrypt the Data Encryption Key (DEK) for tenant '" + tenantId + "'. "
+                "Cannot decrypt the Data Encryption Key (DEK) for tenant '" + safeTenantId + "'. "
                         + "This means the EDDI_VAULT_MASTER_KEY has changed since the DEK was created. "
                         + secretInfo + " "
                         + "Recovery options: "
@@ -725,7 +747,7 @@ public class VaultSecretProvider implements ISecretProvider {
                         + "(2) If you have both old and new keys, use POST /secretstore/secrets/admin/rotate-kek "
                         + "to migrate all encrypted data to the new key. "
                         + "(3) To start fresh (deletes all secrets for this tenant), use "
-                        + "POST /secretstore/secrets/" + tenantId + "/reset to clear the vault for this tenant.",
+                        + "POST /secretstore/secrets/" + safeTenantId + "/reset to clear the vault for this tenant.",
                 cause);
     }
 
@@ -737,7 +759,7 @@ public class VaultSecretProvider implements ISecretProvider {
                 encResult.iv(), Instant.now());
 
         persistence.upsertDek(dek);
-        LOGGER.infof("Generated new DEK for tenant: %s", tenantId);
+        LOGGER.infof("Generated new DEK for tenant: %s", sanitize(tenantId));
         return newDek;
     }
 

--- a/src/main/java/ai/labs/eddi/secrets/model/EncryptedDek.java
+++ b/src/main/java/ai/labs/eddi/secrets/model/EncryptedDek.java
@@ -69,9 +69,17 @@ public class EncryptedDek {
     /**
      * The name ciphertext carries to say which key sealed it. Every dekId written
      * anywhere in the system comes from here.
+     * <p>
+     * Normalized like the field, and for the same reason one step further out. The
+     * constructor and setter stop a below-1 generation reaching an instance, but
+     * this method is static and takes an {@code int} from the caller — so it could
+     * still mint {@code tenant#g0}, which {@link #generationOf} reads back as
+     * generation 1 and {@code dekFor} then looks up as generation 1. The name and
+     * the row it names would disagree, which is the one property this class exists
+     * to guarantee.
      */
     public static String dekId(String tenantId, int generation) {
-        return tenantId + GENERATION_MARKER + generation;
+        return tenantId + GENERATION_MARKER + normalize(generation);
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/secrets/model/EncryptedDek.java
+++ b/src/main/java/ai/labs/eddi/secrets/model/EncryptedDek.java
@@ -11,10 +11,32 @@ import java.time.Instant;
  * encryption. The DEK itself is encrypted with the Master Key (KEK) from the
  * environment variable. Each tenant gets its own DEK for cryptographic
  * isolation.
+ * <p>
+ * A tenant holds one row per <b>generation</b>. Rotation adds a generation
+ * rather than replacing a key, so a row sealed under any generation keeps
+ * decrypting until it has been swept onto the newest one. Ciphertext names its
+ * generation through {@link #dekId(String, int)}; {@link #generationOf} reads
+ * that name back, treating everything written before generations existed as
+ * generation 1.
  */
 public class EncryptedDek {
+
+    /** The generation every pre-generation row is understood to be sealed under. */
+    public static final int FIRST_GENERATION = 1;
+
+    /**
+     * Separates the tenant from the generation in a dekId. Tenant ids are
+     * restricted to {@code [a-zA-Z0-9._-]} so it cannot collide, and the parse
+     * takes the last occurrence anyway, so a laxer tenant id would still round
+     * trip. Readable on purpose: {@code default#g3} tells an operator looking at a
+     * database row exactly what it means.
+     */
+    private static final String GENERATION_MARKER = "#g";
+
     private String id;
     private String tenantId;
+    /** Which generation of the tenant's DEK this row holds. */
+    private int generation = FIRST_GENERATION;
     /** Base64-encoded AES-256-GCM ciphertext of the DEK */
     private String encryptedDek;
     /** Base64-encoded 12-byte initialization vector used to encrypt the DEK */
@@ -24,12 +46,50 @@ public class EncryptedDek {
     public EncryptedDek() {
     }
 
+    /** Generation 1, for callers that predate generations. */
     public EncryptedDek(String id, String tenantId, String encryptedDek, String iv, Instant createdAt) {
+        this(id, tenantId, FIRST_GENERATION, encryptedDek, iv, createdAt);
+    }
+
+    public EncryptedDek(String id, String tenantId, int generation, String encryptedDek, String iv, Instant createdAt) {
         this.id = id;
         this.tenantId = tenantId;
+        this.generation = generation;
         this.encryptedDek = encryptedDek;
         this.iv = iv;
         this.createdAt = createdAt;
+    }
+
+    /**
+     * The name ciphertext carries to say which key sealed it. Every dekId written
+     * anywhere in the system comes from here.
+     */
+    public static String dekId(String tenantId, int generation) {
+        return tenantId + GENERATION_MARKER + generation;
+    }
+
+    /**
+     * The generation a stored dekId names.
+     * <p>
+     * Anything that is not a generation name — null, blank, or the bare tenant id
+     * that rows carried before generations existed — reads as generation 1. That
+     * rule is what lets every already-stored row keep working with no migration of
+     * ciphertext.
+     */
+    public static int generationOf(String tenantId, String dekId) {
+        if (dekId == null || dekId.isBlank() || dekId.equals(tenantId)) {
+            return FIRST_GENERATION;
+        }
+        int marker = dekId.lastIndexOf(GENERATION_MARKER);
+        if (marker < 0) {
+            return FIRST_GENERATION;
+        }
+        try {
+            int generation = Integer.parseInt(dekId.substring(marker + GENERATION_MARKER.length()));
+            return generation < FIRST_GENERATION ? FIRST_GENERATION : generation;
+        } catch (NumberFormatException e) {
+            return FIRST_GENERATION;
+        }
     }
 
     public String getId() {
@@ -44,6 +104,19 @@ public class EncryptedDek {
     }
     public void setTenantId(String tenantId) {
         this.tenantId = tenantId;
+    }
+
+    public int getGeneration() {
+        return generation;
+    }
+
+    public void setGeneration(int generation) {
+        this.generation = generation;
+    }
+
+    /** This row's identity as ciphertext names it. */
+    public String dekId() {
+        return dekId(tenantId, generation);
     }
 
     public String getEncryptedDek() {

--- a/src/main/java/ai/labs/eddi/secrets/model/EncryptedDek.java
+++ b/src/main/java/ai/labs/eddi/secrets/model/EncryptedDek.java
@@ -17,7 +17,9 @@ import java.time.Instant;
  * decrypting until it has been swept onto the newest one. Ciphertext names its
  * generation through {@link #dekId(String, int)}; {@link #generationOf} reads
  * that name back, treating everything written before generations existed as
- * generation 1.
+ * generation 1. A generation below 1 never reaches a field of this class — see
+ * {@link #setGeneration(int)} — so the name a row writes and the generation
+ * that name reads back as are always the same one.
  */
 public class EncryptedDek {
 
@@ -54,10 +56,14 @@ public class EncryptedDek {
     public EncryptedDek(String id, String tenantId, int generation, String encryptedDek, String iv, Instant createdAt) {
         this.id = id;
         this.tenantId = tenantId;
-        this.generation = generation;
+        this.generation = normalize(generation);
         this.encryptedDek = encryptedDek;
         this.iv = iv;
         this.createdAt = createdAt;
+    }
+
+    private static int normalize(int generation) {
+        return Math.max(generation, FIRST_GENERATION);
     }
 
     /**
@@ -110,8 +116,18 @@ public class EncryptedDek {
         return generation;
     }
 
+    /**
+     * Keeps the two halves of the dekId round trip agreeing.
+     * <p>
+     * {@link #generationOf} reads anything below {@link #FIRST_GENERATION} back as
+     * generation 1, so a row allowed to hold 0 would seal ciphertext under the name
+     * {@code tenant#g0} and later have it opened with generation 1's key — a
+     * different key than sealed it. Every source of a below-1 generation means the
+     * same thing (a row that predates generations), so it becomes 1 here, once, at
+     * the model boundary rather than at each store that reads a row back.
+     */
     public void setGeneration(int generation) {
-        this.generation = generation;
+        this.generation = normalize(generation);
     }
 
     /** This row's identity as ciphertext names it. */

--- a/src/main/java/ai/labs/eddi/secrets/persistence/ISecretPersistence.java
+++ b/src/main/java/ai/labs/eddi/secrets/persistence/ISecretPersistence.java
@@ -66,10 +66,25 @@ public interface ISecretPersistence {
      */
     List<EncryptedSecret> listSecretsByTenant(String tenantId);
 
+    /**
+     * Rewrites one secret's ciphertext, IV and dekId, but only while the row still
+     * names {@code expectedDekId}.
+     *
+     * @param expectedDekId
+     *            the dekId read from the row, exactly as stored — a missing value
+     *            matches a missing value, so a pre-generation row is guarded on
+     *            being pre-generation
+     * @return false if another writer changed the row's sealing first, in which
+     *         case nothing was written
+     * @throws PersistenceException
+     *             if the write fails
+     */
+    boolean updateSecretSealing(EncryptedSecret secret, String expectedDekId);
+
     // ─── DEKs ───
 
     /**
-     * Insert or update an encrypted DEK. The key is {@code tenantId}.
+     * Insert or update an encrypted DEK. The key is {@code (tenantId, generation)}.
      *
      * @throws PersistenceException
      *             if the write fails
@@ -77,7 +92,20 @@ public interface ISecretPersistence {
     void upsertDek(EncryptedDek dek);
 
     /**
-     * Find an encrypted DEK by tenant ID.
+     * Inserts a DEK generation, and only if that generation does not exist yet.
+     * <p>
+     * This is the commit point of a DEK rotation, which is why it is an insert and
+     * not an upsert: two replicas rotating the same tenant at once must produce one
+     * winner and one clean refusal, never two keys claiming the same generation.
+     *
+     * @return false if {@code (tenantId, generation)} was already taken
+     * @throws PersistenceException
+     *             if the write fails for any other reason
+     */
+    boolean insertDek(EncryptedDek dek);
+
+    /**
+     * Find the tenant's <b>active</b> DEK — the highest generation it holds.
      *
      * @throws PersistenceException
      *             if the read fails
@@ -85,7 +113,25 @@ public interface ISecretPersistence {
     Optional<EncryptedDek> findDek(String tenantId);
 
     /**
-     * Delete an encrypted DEK for a specific tenant. Used during DEK rotation.
+     * Find one specific DEK generation, so ciphertext can be opened with the key it
+     * names rather than with whatever is newest.
+     *
+     * @throws PersistenceException
+     *             if the read fails
+     */
+    Optional<EncryptedDek> findDek(String tenantId, int generation);
+
+    /**
+     * Every generation a tenant holds, oldest first.
+     *
+     * @throws PersistenceException
+     *             if the read fails
+     */
+    List<EncryptedDek> listDeks(String tenantId);
+
+    /**
+     * Delete every DEK generation for a specific tenant. Used when a tenant's vault
+     * is reset.
      *
      * @throws PersistenceException
      *             if the delete fails
@@ -93,8 +139,9 @@ public interface ISecretPersistence {
     void deleteDek(String tenantId);
 
     /**
-     * List all encrypted DEKs across all tenants. Used during KEK rotation to
-     * re-encrypt every tenant's DEK with the new master key.
+     * List all encrypted DEKs across all tenants and all generations. Used during
+     * KEK rotation to re-wrap every key with the new master key — every generation,
+     * since ciphertext that has not been swept yet still depends on an older one.
      *
      * @throws PersistenceException
      *             if the read fails

--- a/src/main/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistence.java
+++ b/src/main/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistence.java
@@ -7,16 +7,22 @@ package ai.labs.eddi.secrets.persistence;
 import ai.labs.eddi.secrets.model.EncryptedDek;
 import ai.labs.eddi.secrets.model.EncryptedSecret;
 import ai.labs.eddi.utils.RuntimeUtilities;
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoException;
+import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.Sorts;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.Updates;
 import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -59,6 +65,13 @@ public class MongoSecretPersistence implements ISecretPersistence {
     private static final String FIELD_LAST_ACCESSED_AT = "lastAccessedAt";
     private static final String FIELD_LAST_ROTATED_AT = "lastRotatedAt";
     private static final String FIELD_ENCRYPTED_DEK = "encryptedDek";
+    private static final String FIELD_GENERATION = "generation";
+
+    /**
+     * The pre-generation index: unique on tenantId alone, so it blocks a second
+     * generation.
+     */
+    private static final String LEGACY_DEK_INDEX = "idx_dek_tenant";
 
     private final MongoCollection<Document> secretsCollection;
     private final MongoCollection<Document> deksCollection;
@@ -78,13 +91,36 @@ public class MongoSecretPersistence implements ISecretPersistence {
         secretsCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(FIELD_TENANT_ID), Indexes.ascending(FIELD_KEY_NAME)),
                 new IndexOptions().name("idx_secret_tenant_key").unique(true).background(true));
 
-        // Unique index on tenantId for DEKs (one DEK per tenant)
-        deksCollection.createIndex(Indexes.ascending(FIELD_TENANT_ID), new IndexOptions().name("idx_dek_tenant").unique(true).background(true));
+        migrateDeksToGenerations();
 
         // Unique index on key for metadata
         metaCollection.createIndex(Indexes.ascending("key"), new IndexOptions().name("idx_meta_key").unique(true).background(true));
 
         LOGGER.info("Secrets vault MongoDB indexes ensured");
+    }
+
+    /**
+     * Brings an existing deployment onto one row per (tenant, generation).
+     * <p>
+     * Order matters. The backfill runs first so every pre-generation document has a
+     * generation to be indexed on; then the old unique-on-tenantId index goes,
+     * because while it exists a tenant cannot hold a second generation at all and
+     * rotation has nowhere to write.
+     */
+    private void migrateDeksToGenerations() {
+        deksCollection.updateMany(Filters.exists(FIELD_GENERATION, false),
+                Updates.set(FIELD_GENERATION, EncryptedDek.FIRST_GENERATION));
+
+        try {
+            deksCollection.dropIndex(LEGACY_DEK_INDEX);
+        } catch (MongoException e) {
+            // Absent on every deployment created after generations existed, and on
+            // every boot after the first. Nothing to do either way.
+            LOGGER.debugf("No legacy DEK index '%s' to drop", LEGACY_DEK_INDEX);
+        }
+
+        deksCollection.createIndex(Indexes.compoundIndex(Indexes.ascending(FIELD_TENANT_ID), Indexes.ascending(FIELD_GENERATION)),
+                new IndexOptions().name("idx_dek_tenant_generation").unique(true).background(true));
     }
 
     // ─── Secrets ───
@@ -142,41 +178,118 @@ public class MongoSecretPersistence implements ISecretPersistence {
         }
     }
 
+    @Override
+    public boolean updateSecretSealing(EncryptedSecret secret, String expectedDekId) {
+        RuntimeUtilities.checkNotNull(secret, "secret");
+        try {
+            // eq(field, null) matches "absent" as well as "explicitly null", which is
+            // what guards a row written before dekId was ever stamped.
+            var filter = and(eq(FIELD_TENANT_ID, secret.getTenantId()), eq(FIELD_KEY_NAME, secret.getKeyName()),
+                    eq(FIELD_DEK_ID, expectedDekId));
+
+            var update = Updates.combine(Updates.set(FIELD_ENCRYPTED_VALUE, secret.getEncryptedValue()), Updates.set(FIELD_IV, secret.getIv()),
+                    Updates.set(FIELD_DEK_ID, secret.getDekId()),
+                    Updates.set(FIELD_LAST_ROTATED_AT, instantToString(secret.getLastRotatedAt())));
+
+            // matchedCount, not modifiedCount: winning the guard is what matters, and a
+            // rewrite that happens to produce identical bytes still won it.
+            return secretsCollection.updateOne(filter, update).getMatchedCount() == 1;
+        } catch (MongoException e) {
+            throw new PersistenceException("Failed to re-seal secret " + secret.getTenantId() + "/" + secret.getKeyName(), e);
+        }
+    }
+
     // ─── DEKs ───
 
     @Override
     public void upsertDek(EncryptedDek dek) {
         RuntimeUtilities.checkNotNull(dek, "dek");
         try {
-            var filter = eq(FIELD_TENANT_ID, dek.getTenantId());
+            var filter = dekKey(dek.getTenantId(), dek.getGeneration());
 
             var update = Updates.combine(Updates.set(FIELD_ENCRYPTED_DEK, dek.getEncryptedDek()), Updates.set(FIELD_IV, dek.getIv()),
-                    Updates.setOnInsert(FIELD_TENANT_ID, dek.getTenantId()),
+                    Updates.setOnInsert(FIELD_TENANT_ID, dek.getTenantId()), Updates.setOnInsert(FIELD_GENERATION, dek.getGeneration()),
                     Updates.setOnInsert(FIELD_CREATED_AT, instantToString(dek.getCreatedAt())));
 
             deksCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
-        } catch (com.mongodb.MongoException e) {
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to upsert DEK for tenant " + dek.getTenantId(), e);
+        }
+    }
+
+    @Override
+    public boolean insertDek(EncryptedDek dek) {
+        RuntimeUtilities.checkNotNull(dek, "dek");
+        var document = new Document(FIELD_TENANT_ID, dek.getTenantId()).append(FIELD_GENERATION, dek.getGeneration())
+                .append(FIELD_ENCRYPTED_DEK, dek.getEncryptedDek()).append(FIELD_IV, dek.getIv())
+                .append(FIELD_CREATED_AT, instantToString(dek.getCreatedAt()));
+        try {
+            deksCollection.insertOne(document);
+            return true;
+        } catch (MongoWriteException e) {
+            if (e.getError().getCategory() == ErrorCategory.DUPLICATE_KEY) {
+                // Somebody else installed this generation. The unique index is the
+                // arbiter, so exactly one rotation proceeds.
+                return false;
+            }
+            throw new PersistenceException("Failed to insert DEK generation for tenant " + dek.getTenantId(), e);
+        } catch (MongoException e) {
+            throw new PersistenceException("Failed to insert DEK generation for tenant " + dek.getTenantId(), e);
         }
     }
 
     @Override
     public Optional<EncryptedDek> findDek(String tenantId) {
         try {
-            var doc = deksCollection.find(eq(FIELD_TENANT_ID, tenantId)).first();
+            var doc = deksCollection.find(eq(FIELD_TENANT_ID, tenantId)).sort(Sorts.descending(FIELD_GENERATION)).first();
             return doc != null ? Optional.of(documentToDek(doc)) : Optional.empty();
-        } catch (com.mongodb.MongoException e) {
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to find DEK for tenant " + tenantId, e);
+        }
+    }
+
+    @Override
+    public Optional<EncryptedDek> findDek(String tenantId, int generation) {
+        try {
+            var doc = deksCollection.find(dekKey(tenantId, generation)).first();
+            return doc != null ? Optional.of(documentToDek(doc)) : Optional.empty();
+        } catch (MongoException e) {
+            throw new PersistenceException("Failed to find DEK generation " + generation + " for tenant " + tenantId, e);
+        }
+    }
+
+    @Override
+    public List<EncryptedDek> listDeks(String tenantId) {
+        try {
+            var deks = new ArrayList<EncryptedDek>();
+            for (var doc : deksCollection.find(eq(FIELD_TENANT_ID, tenantId)).sort(Sorts.ascending(FIELD_GENERATION))) {
+                deks.add(documentToDek(doc));
+            }
+            return deks;
+        } catch (MongoException e) {
+            throw new PersistenceException("Failed to list DEKs for tenant " + tenantId, e);
         }
     }
 
     @Override
     public void deleteDek(String tenantId) {
         try {
-            deksCollection.deleteOne(eq(FIELD_TENANT_ID, tenantId));
-        } catch (com.mongodb.MongoException e) {
+            deksCollection.deleteMany(eq(FIELD_TENANT_ID, tenantId));
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to delete DEK for tenant " + tenantId, e);
         }
+    }
+
+    /**
+     * A row with no {@code generation} field is generation 1. The boot migration
+     * backfills those, but a replica still running an older build writes fresh ones
+     * without it, so generation 1 matches both spellings for as long as a rolling
+     * upgrade lasts.
+     */
+    private static Bson dekKey(String tenantId, int generation) {
+        return generation == EncryptedDek.FIRST_GENERATION
+                ? and(eq(FIELD_TENANT_ID, tenantId), Filters.or(eq(FIELD_GENERATION, generation), Filters.exists(FIELD_GENERATION, false)))
+                : and(eq(FIELD_TENANT_ID, tenantId), eq(FIELD_GENERATION, generation));
     }
 
     @Override
@@ -237,8 +350,10 @@ public class MongoSecretPersistence implements ISecretPersistence {
     }
 
     private EncryptedDek documentToDek(Document doc) {
+        Object generation = doc.get(FIELD_GENERATION);
         return new EncryptedDek(doc.getObjectId("_id") != null ? doc.getObjectId("_id").toHexString() : null, doc.getString(FIELD_TENANT_ID),
-                doc.getString(FIELD_ENCRYPTED_DEK), doc.getString(FIELD_IV), parseInstant(doc.getString(FIELD_CREATED_AT)));
+                generation instanceof Number number ? number.intValue() : EncryptedDek.FIRST_GENERATION, doc.getString(FIELD_ENCRYPTED_DEK),
+                doc.getString(FIELD_IV), parseInstant(doc.getString(FIELD_CREATED_AT)));
     }
 
     private static String instantToString(Instant instant) {

--- a/src/main/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistence.java
+++ b/src/main/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistence.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.secrets.model.EncryptedDek;
 import ai.labs.eddi.secrets.model.EncryptedSecret;
 import ai.labs.eddi.utils.RuntimeUtilities;
 import com.mongodb.ErrorCategory;
+import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
@@ -73,6 +74,12 @@ public class MongoSecretPersistence implements ISecretPersistence {
      */
     private static final String LEGACY_DEK_INDEX = "idx_dek_tenant";
 
+    /**
+     * MongoDB's {@code IndexNotFound} — the only reason dropping it may fail
+     * benignly.
+     */
+    private static final int ERROR_INDEX_NOT_FOUND = 27;
+
     private final MongoCollection<Document> secretsCollection;
     private final MongoCollection<Document> deksCollection;
     private final MongoCollection<Document> metaCollection;
@@ -113,7 +120,14 @@ public class MongoSecretPersistence implements ISecretPersistence {
 
         try {
             deksCollection.dropIndex(LEGACY_DEK_INDEX);
-        } catch (MongoException e) {
+        } catch (MongoCommandException e) {
+            if (e.getErrorCode() != ERROR_INDEX_NOT_FOUND) {
+                // Anything else — not authorized, a stepped-down primary — means the
+                // index may well still be standing, and a tenant that cannot hold a
+                // second generation has nowhere for rotation to write. Reported as a
+                // failed boot rather than mistaken for "it was already gone".
+                throw e;
+            }
             // Absent on every deployment created after generations existed, and on
             // every boot after the first. Nothing to do either way.
             LOGGER.debugf("No legacy DEK index '%s' to drop", LEGACY_DEK_INDEX);

--- a/src/main/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistence.java
+++ b/src/main/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistence.java
@@ -115,7 +115,13 @@ public class MongoSecretPersistence implements ISecretPersistence {
      * rotation has nowhere to write.
      */
     private void migrateDeksToGenerations() {
-        deksCollection.updateMany(Filters.exists(FIELD_GENERATION, false),
+        // Below-1 as well as absent. The entity normalizes what it READS, so a row
+        // physically holding 0 is handed out as generation 1 — and is then looked
+        // up as generation 1 by an exact query that cannot match it. Normalizing
+        // the row itself is what keeps the entity and the storage agreeing; doing
+        // it only in the entity moves the disagreement rather than removing it.
+        deksCollection.updateMany(
+                Filters.or(Filters.exists(FIELD_GENERATION, false), Filters.lt(FIELD_GENERATION, EncryptedDek.FIRST_GENERATION)),
                 Updates.set(FIELD_GENERATION, EncryptedDek.FIRST_GENERATION));
 
         try {

--- a/src/main/java/ai/labs/eddi/secrets/persistence/PostgresSecretPersistence.java
+++ b/src/main/java/ai/labs/eddi/secrets/persistence/PostgresSecretPersistence.java
@@ -60,11 +60,29 @@ public class PostgresSecretPersistence implements ISecretPersistence {
     private static final String CREATE_DEKS_TABLE = """
             CREATE TABLE IF NOT EXISTS secret_vault_deks (
                 id VARCHAR(64) PRIMARY KEY DEFAULT gen_random_uuid()::text,
-                tenant_id VARCHAR(255) NOT NULL UNIQUE,
+                tenant_id VARCHAR(255) NOT NULL,
+                generation INTEGER NOT NULL DEFAULT 1,
                 encrypted_dek TEXT NOT NULL,
                 iv VARCHAR(255) NOT NULL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
+            """;
+
+    /**
+     * Brings a table created before generations existed onto one row per (tenant,
+     * generation).
+     * <p>
+     * The dropped constraint is the column-level {@code UNIQUE} Postgres named
+     * {@code secret_vault_deks_tenant_id_key}: while it stands a tenant cannot hold
+     * a second generation, so rotation has nowhere to write. The replacement is a
+     * unique <em>index</em> rather than a constraint because only an index can be
+     * declared {@code IF NOT EXISTS}, and Postgres accepts one as an
+     * {@code ON CONFLICT} target just the same.
+     */
+    private static final String MIGRATE_DEKS_TABLE = """
+            ALTER TABLE secret_vault_deks ADD COLUMN IF NOT EXISTS generation INTEGER NOT NULL DEFAULT 1;
+            ALTER TABLE secret_vault_deks DROP CONSTRAINT IF EXISTS secret_vault_deks_tenant_id_key;
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_svd_tenant_generation ON secret_vault_deks (tenant_id, generation)
             """;
 
     private static final String CREATE_INDEXES = """
@@ -94,7 +112,7 @@ public class PostgresSecretPersistence implements ISecretPersistence {
             stmt.execute(CREATE_SECRETS_TABLE);
             stmt.execute(CREATE_DEKS_TABLE);
             stmt.execute(CREATE_META_TABLE);
-            for (String sql : CREATE_INDEXES.split(";")) {
+            for (String sql : (MIGRATE_DEKS_TABLE + ";" + CREATE_INDEXES).split(";")) {
                 sql = sql.trim();
                 if (!sql.isEmpty())
                     stmt.execute(sql);
@@ -187,22 +205,47 @@ public class PostgresSecretPersistence implements ISecretPersistence {
         return secrets;
     }
 
+    @Override
+    public boolean updateSecretSealing(EncryptedSecret secret, String expectedDekId) {
+        ensureSchema();
+        // IS NOT DISTINCT FROM, not =, so a NULL expectation guards a NULL row
+        // instead of matching nothing.
+        String sql = """
+                UPDATE secret_vault_secrets
+                   SET encrypted_value = ?, iv = ?, dek_id = ?, last_rotated_at = ?
+                 WHERE tenant_id = ? AND key_name = ? AND dek_id IS NOT DISTINCT FROM ?
+                """;
+        try (Connection conn = dataSourceInstance.get().getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, secret.getEncryptedValue());
+            ps.setString(2, secret.getIv());
+            ps.setString(3, secret.getDekId());
+            ps.setTimestamp(4, instantToTimestamp(secret.getLastRotatedAt()));
+            ps.setString(5, secret.getTenantId());
+            ps.setString(6, secret.getKeyName());
+            ps.setString(7, expectedDekId);
+            return ps.executeUpdate() == 1;
+        } catch (SQLException e) {
+            throw new PersistenceException("Failed to re-seal secret " + secret.getTenantId() + "/" + secret.getKeyName(), e);
+        }
+    }
+
     // ─── DEKs ───
 
     @Override
     public void upsertDek(EncryptedDek dek) {
         ensureSchema();
         String sql = """
-                INSERT INTO secret_vault_deks (tenant_id, encrypted_dek, iv, created_at)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT (tenant_id)
+                INSERT INTO secret_vault_deks (tenant_id, generation, encrypted_dek, iv, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT (tenant_id, generation)
                 DO UPDATE SET encrypted_dek = EXCLUDED.encrypted_dek, iv = EXCLUDED.iv
                 """;
         try (Connection conn = dataSourceInstance.get().getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, dek.getTenantId());
-            ps.setString(2, dek.getEncryptedDek());
-            ps.setString(3, dek.getIv());
-            ps.setTimestamp(4, instantToTimestamp(dek.getCreatedAt()));
+            ps.setInt(2, dek.getGeneration());
+            ps.setString(3, dek.getEncryptedDek());
+            ps.setString(4, dek.getIv());
+            ps.setTimestamp(5, instantToTimestamp(dek.getCreatedAt()));
             ps.executeUpdate();
         } catch (Exception e) {
             throw new PersistenceException("Failed to upsert DEK for tenant " + dek.getTenantId(), e);
@@ -210,22 +253,78 @@ public class PostgresSecretPersistence implements ISecretPersistence {
     }
 
     @Override
+    public boolean insertDek(EncryptedDek dek) {
+        ensureSchema();
+        // DO NOTHING rather than a caught unique violation: the loser gets zero rows
+        // back and a live connection, not an aborted transaction to unwind.
+        String sql = """
+                INSERT INTO secret_vault_deks (tenant_id, generation, encrypted_dek, iv, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT (tenant_id, generation) DO NOTHING
+                """;
+        try (Connection conn = dataSourceInstance.get().getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, dek.getTenantId());
+            ps.setInt(2, dek.getGeneration());
+            ps.setString(3, dek.getEncryptedDek());
+            ps.setString(4, dek.getIv());
+            ps.setTimestamp(5, instantToTimestamp(dek.getCreatedAt()));
+            return ps.executeUpdate() == 1;
+        } catch (SQLException e) {
+            throw new PersistenceException("Failed to insert DEK generation for tenant " + dek.getTenantId(), e);
+        }
+    }
+
+    @Override
     public Optional<EncryptedDek> findDek(String tenantId) {
         ensureSchema();
-        String sql = "SELECT * FROM secret_vault_deks WHERE tenant_id = ?";
+        String sql = "SELECT * FROM secret_vault_deks WHERE tenant_id = ? ORDER BY generation DESC LIMIT 1";
         try (Connection conn = dataSourceInstance.get().getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, tenantId);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    Timestamp createdTs = rs.getTimestamp("created_at");
-                    return Optional.of(new EncryptedDek(rs.getString("id"), rs.getString("tenant_id"), rs.getString("encrypted_dek"),
-                            rs.getString("iv"), createdTs != null ? createdTs.toInstant() : null));
+                    return Optional.of(resultSetToDek(rs));
                 }
             }
         } catch (SQLException e) {
             throw new PersistenceException("Failed to find DEK for tenant " + tenantId, e);
         }
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<EncryptedDek> findDek(String tenantId, int generation) {
+        ensureSchema();
+        String sql = "SELECT * FROM secret_vault_deks WHERE tenant_id = ? AND generation = ?";
+        try (Connection conn = dataSourceInstance.get().getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, tenantId);
+            ps.setInt(2, generation);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(resultSetToDek(rs));
+                }
+            }
+        } catch (SQLException e) {
+            throw new PersistenceException("Failed to find DEK generation " + generation + " for tenant " + tenantId, e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<EncryptedDek> listDeks(String tenantId) {
+        ensureSchema();
+        String sql = "SELECT * FROM secret_vault_deks WHERE tenant_id = ? ORDER BY generation";
+        List<EncryptedDek> deks = new ArrayList<>();
+        try (Connection conn = dataSourceInstance.get().getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, tenantId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    deks.add(resultSetToDek(rs));
+                }
+            }
+        } catch (SQLException e) {
+            throw new PersistenceException("Failed to list DEKs for tenant " + tenantId, e);
+        }
+        return deks;
     }
 
     @Override
@@ -243,14 +342,12 @@ public class PostgresSecretPersistence implements ISecretPersistence {
     @Override
     public List<EncryptedDek> listAllDeks() {
         ensureSchema();
-        String sql = "SELECT * FROM secret_vault_deks ORDER BY tenant_id";
+        String sql = "SELECT * FROM secret_vault_deks ORDER BY tenant_id, generation";
         List<EncryptedDek> deks = new ArrayList<>();
         try (Connection conn = dataSourceInstance.get().getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    Timestamp createdTs = rs.getTimestamp("created_at");
-                    deks.add(new EncryptedDek(rs.getString("id"), rs.getString("tenant_id"), rs.getString("encrypted_dek"), rs.getString("iv"),
-                            createdTs != null ? createdTs.toInstant() : null));
+                    deks.add(resultSetToDek(rs));
                 }
             }
         } catch (SQLException e) {
@@ -327,6 +424,16 @@ public class PostgresSecretPersistence implements ISecretPersistence {
         secret.setLastAccessedAt(accessedTs != null ? accessedTs.toInstant() : null);
         secret.setLastRotatedAt(rotatedTs != null ? rotatedTs.toInstant() : null);
         return secret;
+    }
+
+    private static EncryptedDek resultSetToDek(ResultSet rs) throws SQLException {
+        Timestamp createdTs = rs.getTimestamp("created_at");
+        // A row written before the column existed reads as 0 until the default takes
+        // effect; that row is generation 1, by the same rule that governs dekIds.
+        int generation = rs.getInt("generation");
+        return new EncryptedDek(rs.getString("id"), rs.getString("tenant_id"),
+                generation < EncryptedDek.FIRST_GENERATION ? EncryptedDek.FIRST_GENERATION : generation, rs.getString("encrypted_dek"),
+                rs.getString("iv"), createdTs != null ? createdTs.toInstant() : null);
     }
 
     private static Timestamp instantToTimestamp(Instant instant) {

--- a/src/main/java/ai/labs/eddi/secrets/persistence/PostgresSecretPersistence.java
+++ b/src/main/java/ai/labs/eddi/secrets/persistence/PostgresSecretPersistence.java
@@ -429,10 +429,8 @@ public class PostgresSecretPersistence implements ISecretPersistence {
     private static EncryptedDek resultSetToDek(ResultSet rs) throws SQLException {
         Timestamp createdTs = rs.getTimestamp("created_at");
         // A row written before the column existed reads as 0 until the default takes
-        // effect; that row is generation 1, by the same rule that governs dekIds.
-        int generation = rs.getInt("generation");
-        return new EncryptedDek(rs.getString("id"), rs.getString("tenant_id"),
-                generation < EncryptedDek.FIRST_GENERATION ? EncryptedDek.FIRST_GENERATION : generation, rs.getString("encrypted_dek"),
+        // effect; that row is generation 1, and EncryptedDek maps it there.
+        return new EncryptedDek(rs.getString("id"), rs.getString("tenant_id"), rs.getInt("generation"), rs.getString("encrypted_dek"),
                 rs.getString("iv"), createdTs != null ? createdTs.toInstant() : null);
     }
 

--- a/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
@@ -285,6 +285,29 @@ class AgentSigningServiceTest {
     private static class InMemorySecretProvider implements ISecretProvider {
         private final ConcurrentHashMap<String, String> store = new ConcurrentHashMap<>();
 
+        /**
+         * Reversible obfuscation, not encryption — this is a test double, and the
+         * property under test is that seal/unseal round-trips, not that it is strong.
+         * Prefixed so a test asserting "the stored value is not the plaintext" can see
+         * the difference.
+         */
+        @Override
+        public SealedValue seal(String tenantId, String plaintext) {
+            return plaintext == null ? null : new SealedValue("sealed:" + tenantId + ":" + plaintext, "test-iv");
+        }
+
+        @Override
+        public String unseal(String tenantId, SealedValue sealed) throws SecretProviderException {
+            if (sealed == null || sealed.ciphertext() == null) {
+                return null;
+            }
+            String prefix = "sealed:" + tenantId + ":";
+            if (!sealed.ciphertext().startsWith(prefix)) {
+                throw new SecretProviderException("Sealed with a different tenant key");
+            }
+            return sealed.ciphertext().substring(prefix.length());
+        }
+
         @Override
         public String resolve(SecretReference reference) throws SecretNotFoundException {
             String key = reference.tenantId() + ":" + reference.keyName();

--- a/src/test/java/ai/labs/eddi/secrets/impl/SecretVaultIntegrationTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/impl/SecretVaultIntegrationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -55,7 +56,9 @@ class SecretVaultIntegrationTest {
     private VaultSecretProvider provider;
     private SecretResolver resolver;
 
-    // In-memory stores to simulate real persistence
+    // In-memory stores to simulate real persistence. The DEK store is keyed by
+    // dekId — tenant AND generation — because a tenant holds one row per
+    // generation and rotation adds to that set rather than replacing it.
     private final Map<String, EncryptedDek> dekStore = new HashMap<>();
     private final Map<String, EncryptedSecret> secretStore = new HashMap<>();
 
@@ -86,42 +89,74 @@ class SecretVaultIntegrationTest {
     }
 
     /**
-     * Set up mock persistence to simulate a working DEK store.
+     * Set up mock persistence to simulate a working DEK store — one row per
+     * (tenant, generation), with {@code insertDek} refusing a generation that is
+     * already taken, exactly as the unique key does in both real stores.
      */
     private void setupDekMocking() {
         doAnswer(inv -> {
             EncryptedDek dek = inv.getArgument(0);
-            dekStore.put(dek.getTenantId(), dek);
+            dekStore.put(dek.dekId(), dek);
             return null;
         }).when(persistence).upsertDek(any());
 
-        when(persistence.findDek(anyString())).thenAnswer(inv -> {
-            String tenantId = inv.getArgument(0);
-            return Optional.ofNullable(dekStore.get(tenantId));
+        lenient().when(persistence.insertDek(any())).thenAnswer(inv -> {
+            EncryptedDek dek = inv.getArgument(0);
+            return dekStore.putIfAbsent(dek.dekId(), dek) == null;
         });
 
+        // The tenant's ACTIVE generation is the highest one it holds, not "the row".
+        when(persistence.findDek(anyString()))
+                .thenAnswer(inv -> generationsOf(inv.getArgument(0)).max(Comparator.comparingInt(EncryptedDek::getGeneration)));
+
+        // The generation a stored row names, so ciphertext is opened with the key
+        // that sealed it rather than with whichever is newest.
+        lenient().when(persistence.findDek(anyString(), anyInt())).thenAnswer(inv -> {
+            String tenantId = inv.getArgument(0);
+            int generation = inv.getArgument(1);
+            return Optional.ofNullable(dekStore.get(EncryptedDek.dekId(tenantId, generation)));
+        });
+
+        lenient().when(persistence.listDeks(anyString()))
+                .thenAnswer(inv -> generationsOf(inv.getArgument(0)).sorted(Comparator.comparingInt(EncryptedDek::getGeneration)).toList());
+
         lenient().when(persistence.listAllDeks()).thenAnswer(inv -> new ArrayList<>(dekStore.values()));
+
+        lenient().doAnswer(inv -> {
+            String tenantId = inv.getArgument(0);
+            dekStore.values().removeIf(dek -> tenantId.equals(dek.getTenantId()));
+            return null;
+        }).when(persistence).deleteDek(anyString());
+    }
+
+    private Stream<EncryptedDek> generationsOf(String tenantId) {
+        return dekStore.values().stream().filter(dek -> tenantId.equals(dek.getTenantId()));
     }
 
     /**
      * Set up mock persistence to simulate a working secret store.
+     * <p>
+     * Reads hand back a detached copy, as both real stores do. Handing back the
+     * live instance would let the rotation sweep mutate the row it is about to
+     * guard on, and {@code updateSecretSealing} would then compare the new dekId
+     * with itself.
      */
     private void setupSecretMocking() {
         doAnswer(inv -> {
             EncryptedSecret secret = inv.getArgument(0);
-            secretStore.put(secret.getTenantId() + "/" + secret.getKeyName(), secret);
+            secretStore.put(secret.getTenantId() + "/" + secret.getKeyName(), copyOf(secret));
             return null;
         }).when(persistence).upsertSecret(any());
 
         when(persistence.findSecret(anyString(), anyString())).thenAnswer(inv -> {
             String tid = inv.getArgument(0);
             String kn = inv.getArgument(1);
-            return Optional.ofNullable(secretStore.get(tid + "/" + kn));
+            return Optional.ofNullable(secretStore.get(tid + "/" + kn)).map(SecretVaultIntegrationTest::copyOf);
         });
 
         when(persistence.listSecretsByTenant(anyString())).thenAnswer(inv -> {
             String tid = inv.getArgument(0);
-            return secretStore.values().stream().filter(s -> s.getTenantId().equals(tid)).toList();
+            return secretStore.values().stream().filter(s -> s.getTenantId().equals(tid)).map(SecretVaultIntegrationTest::copyOf).toList();
         });
 
         when(persistence.deleteSecret(anyString(), anyString())).thenAnswer(inv -> {
@@ -129,6 +164,26 @@ class SecretVaultIntegrationTest {
             String kn = inv.getArgument(1);
             return secretStore.remove(tid + "/" + kn) != null;
         });
+
+        lenient().when(persistence.updateSecretSealing(any(), any())).thenAnswer(inv -> {
+            EncryptedSecret secret = inv.getArgument(0);
+            String expectedDekId = inv.getArgument(1);
+            String key = secret.getTenantId() + "/" + secret.getKeyName();
+            EncryptedSecret current = secretStore.get(key);
+            // The guard: a store() that landed in between has already sealed with the
+            // active key and must not be overwritten by a re-seal of what it replaced.
+            if (current == null || !Objects.equals(current.getDekId(), expectedDekId)) {
+                return false;
+            }
+            secretStore.put(key, copyOf(secret));
+            return true;
+        });
+    }
+
+    private static EncryptedSecret copyOf(EncryptedSecret secret) {
+        return new EncryptedSecret(secret.getId(), secret.getTenantId(), secret.getKeyName(), secret.getEncryptedValue(), secret.getIv(),
+                secret.getDekId(), secret.getChecksum(), secret.getDescription(), secret.getAllowedAgents(), secret.getCreatedAt(),
+                secret.getLastAccessedAt(), secret.getLastRotatedAt());
     }
 
     // ─── Full Round-Trip ───
@@ -268,6 +323,28 @@ class SecretVaultIntegrationTest {
             EncryptedSecret stored = secretStore.get(TENANT + "/" + KEY_NAME);
             assertNotNull(stored.getLastRotatedAt());
             assertTrue(stored.getLastRotatedAt().isAfter(before) || stored.getLastRotatedAt().equals(before));
+        }
+
+        @Test
+        @DisplayName("a row the sweep could not move still resolves, because the old generation is kept")
+        void olderGenerationKeepsWorking() throws Exception {
+            setupDekMocking();
+            setupSecretMocking();
+
+            provider.store(new SecretReference(TENANT, KEY_NAME), SECRET_VALUE, null, null);
+            // The sweep loses this row's guard on both attempts, so it stays on
+            // generation 1 — the state an interrupted rotation leaves behind.
+            // doReturn, not when(...): when() CALLS the mock, and setupSecretMocking's
+            // answer dereferences its argument, so this line would throw before it
+            // ever re-stubbed anything.
+            doReturn(false).when(persistence).updateSecretSealing(any(), any());
+
+            var ex = assertThrows(ISecretProvider.SecretProviderException.class, () -> provider.rotateDek(TENANT));
+            assertTrue(ex.getMessage().contains("safe to re-run"), "nothing is lost, and the message must say so: " + ex.getMessage());
+
+            resolver.invalidateAll();
+            assertEquals(SECRET_VALUE, resolver.resolveValue("${vault:" + KEY_NAME + "}"),
+                    "deleting the generation a row still names is what made a partly swept tenant unreadable");
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/secrets/impl/VaultSecretProviderBranchTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/impl/VaultSecretProviderBranchTest.java
@@ -169,7 +169,14 @@ class VaultSecretProviderBranchTest {
             verify(persistence, never()).deleteDek(TENANT_ID);
             // The sweep writes through the guarded update, and guards on the dekId
             // the row was read with.
-            verify(persistence).updateSecretSealing(any(EncryptedSecret.class), eq(TENANT_ID));
+            var swept = ArgumentCaptor.forClass(EncryptedSecret.class);
+            verify(persistence).updateSecretSealing(swept.capture(), eq(TENANT_ID));
+            // The post-condition that actually matters. Re-encrypting with the new
+            // key while still naming the old generation is the one outcome worse
+            // than not sweeping at all: the row is then openable by neither key,
+            // and nothing above would have noticed.
+            assertEquals(EncryptedDek.dekId(TENANT_ID, encDek.getGeneration() + 1), swept.getValue().getDekId(),
+                    "the swept row must name the generation it was just re-sealed with");
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/secrets/impl/VaultSecretProviderBranchTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/impl/VaultSecretProviderBranchTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -76,6 +77,17 @@ class VaultSecretProviderBranchTest {
                 encResult.ciphertext(), encResult.iv(), Instant.now());
     }
 
+    /**
+     * Both DEK lookups the provider makes: the newest generation, which a write
+     * seals with, and the specific generation a stored row names, which a read
+     * opens it with. An unstubbed {@code findDek(tenant, generation)} answers "no
+     * such generation" and every resolve then fails.
+     */
+    private void stubDekLookups(EncryptedDek dek) {
+        when(persistence.findDek(TENANT_ID)).thenReturn(Optional.of(dek));
+        when(persistence.findDek(TENANT_ID, dek.getGeneration())).thenReturn(Optional.of(dek));
+    }
+
     private EncryptedSecret createEncryptedSecret(String plaintext, byte[] dek) {
         EnvelopeCrypto.EncryptionResult encResult = EnvelopeCrypto.encrypt(plaintext, dek);
         String checksum = EnvelopeCrypto.sha256Hex(plaintext);
@@ -132,7 +144,7 @@ class VaultSecretProviderBranchTest {
     class RotateDekTests {
 
         @Test
-        @DisplayName("successful DEK rotation re-encrypts all secrets")
+        @DisplayName("rotation ADDS a generation and sweeps secrets onto it")
         void successfulRotation() throws Exception {
             VaultSecretProvider provider = createAvailableProvider();
 
@@ -140,19 +152,28 @@ class VaultSecretProviderBranchTest {
             EncryptedDek encDek = createEncryptedDek(dek);
             EncryptedSecret encSecret = createEncryptedSecret("my-secret", dek);
 
-            when(persistence.findDek(TENANT_ID)).thenReturn(Optional.of(encDek));
+            stubDekLookups(encDek);
+            when(persistence.listDeks(TENANT_ID)).thenReturn(List.of(encDek));
+            when(persistence.insertDek(any(EncryptedDek.class))).thenReturn(true);
             when(persistence.listSecretsByTenant(TENANT_ID)).thenReturn(List.of(encSecret));
+            when(persistence.updateSecretSealing(any(EncryptedSecret.class), any())).thenReturn(true);
 
             int count = provider.rotateDek(TENANT_ID);
 
             assertEquals(1, count);
-            // Old secret was re-encrypted + new DEK stored
-            verify(persistence).upsertSecret(any(EncryptedSecret.class));
-            verify(persistence).upsertDek(any(EncryptedDek.class));
+            // The commit point is an INSERT of the next generation, not an upsert
+            // replacing the key underneath the data that names it.
+            var inserted = ArgumentCaptor.forClass(EncryptedDek.class);
+            verify(persistence).insertDek(inserted.capture());
+            assertEquals(encDek.getGeneration() + 1, inserted.getValue().getGeneration());
+            verify(persistence, never()).deleteDek(TENANT_ID);
+            // The sweep writes through the guarded update, and guards on the dekId
+            // the row was read with.
+            verify(persistence).updateSecretSealing(any(EncryptedSecret.class), eq(TENANT_ID));
         }
 
         @Test
-        @DisplayName("persistence error during DEK rotation throws SecretProviderException")
+        @DisplayName("a secret the sweep cannot move is reported, not silently counted as migrated")
         void persistenceErrorDuringRotation() {
             VaultSecretProvider provider = createAvailableProvider();
 
@@ -160,13 +181,33 @@ class VaultSecretProviderBranchTest {
             EncryptedDek encDek = createEncryptedDek(dek);
             EncryptedSecret encSecret = createEncryptedSecret("my-secret", dek);
 
-            when(persistence.findDek(TENANT_ID)).thenReturn(Optional.of(encDek));
+            stubDekLookups(encDek);
+            when(persistence.listDeks(TENANT_ID)).thenReturn(List.of(encDek));
+            when(persistence.insertDek(any(EncryptedDek.class))).thenReturn(true);
             when(persistence.listSecretsByTenant(TENANT_ID)).thenReturn(List.of(encSecret));
             doThrow(new PersistenceException("write failed"))
-                    .when(persistence).upsertSecret(any(EncryptedSecret.class));
+                    .when(persistence).updateSecretSealing(any(EncryptedSecret.class), any());
 
-            assertThrows(SecretProviderException.class,
-                    () -> provider.rotateDek(TENANT_ID));
+            var ex = assertThrows(SecretProviderException.class, () -> provider.rotateDek(TENANT_ID));
+
+            assertTrue(ex.getMessage().contains("safe to re-run"),
+                    "the new generation is already committed and nothing is lost, so the message must say so: " + ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("losing the race to install a generation refuses cleanly instead of writing a second key")
+        void concurrentRotationLoses() {
+            VaultSecretProvider provider = createAvailableProvider();
+
+            EncryptedDek encDek = createEncryptedDek(EnvelopeCrypto.generateDek());
+            when(persistence.listDeks(TENANT_ID)).thenReturn(List.of(encDek));
+            when(persistence.insertDek(any(EncryptedDek.class))).thenReturn(false);
+
+            var ex = assertThrows(SecretProviderException.class, () -> provider.rotateDek(TENANT_ID));
+
+            assertTrue(ex.getMessage().contains("nothing was changed by this one"),
+                    "two keys claiming the same generation is the failure this refusal exists to prevent: " + ex.getMessage());
+            verify(persistence, never()).updateSecretSealing(any(EncryptedSecret.class), any());
         }
     }
 
@@ -282,7 +323,7 @@ class VaultSecretProviderBranchTest {
             EncryptedSecret encSecret = createEncryptedSecret(plaintext, dek);
 
             when(persistence.findSecret(TENANT_ID, KEY_NAME)).thenReturn(Optional.of(encSecret));
-            when(persistence.findDek(TENANT_ID)).thenReturn(Optional.of(encDek));
+            stubDekLookups(encDek);
 
             String result = provider.resolve(new SecretReference(TENANT_ID, KEY_NAME));
             assertEquals(plaintext, result);
@@ -330,7 +371,7 @@ class VaultSecretProviderBranchTest {
             provider.store(new SecretReference(TENANT_ID, KEY_NAME),
                     "value", null, null);
 
-            var captor = org.mockito.ArgumentCaptor.forClass(EncryptedSecret.class);
+            var captor = ArgumentCaptor.forClass(EncryptedSecret.class);
             verify(persistence).upsertSecret(captor.capture());
             assertEquals(List.of("*"), captor.getValue().getAllowedAgents());
         }
@@ -349,7 +390,7 @@ class VaultSecretProviderBranchTest {
             provider.store(new SecretReference(TENANT_ID, KEY_NAME),
                     "value", null, List.of("agent-1"));
 
-            var captor = org.mockito.ArgumentCaptor.forClass(EncryptedSecret.class);
+            var captor = ArgumentCaptor.forClass(EncryptedSecret.class);
             verify(persistence).upsertSecret(captor.capture());
             assertNull(captor.getValue().getDescription());
             assertEquals(List.of("agent-1"), captor.getValue().getAllowedAgents());
@@ -559,7 +600,7 @@ class VaultSecretProviderBranchTest {
                     "test-secret-value", "desc", null);
 
             // Verify a new DEK was upserted
-            var dekCaptor = org.mockito.ArgumentCaptor.forClass(EncryptedDek.class);
+            var dekCaptor = ArgumentCaptor.forClass(EncryptedDek.class);
             verify(persistence).upsertDek(dekCaptor.capture());
             EncryptedDek generatedDek = dekCaptor.getValue();
             assertEquals(TENANT_ID, generatedDek.getTenantId());

--- a/src/test/java/ai/labs/eddi/secrets/impl/VaultSecretProviderTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/impl/VaultSecretProviderTest.java
@@ -93,6 +93,18 @@ class VaultSecretProviderTest {
     }
 
     /**
+     * Both DEK lookups the provider makes: {@code findDek(tenant)} for the newest
+     * generation, which is what a write seals with, and
+     * {@code findDek(tenant, generation)} for the one a stored row names, which is
+     * what a read opens it with. Stubbing only the first leaves the second
+     * answering "no such generation" and every resolve fails.
+     */
+    private void stubDekLookups(EncryptedDek dek) {
+        when(persistence.findDek(TENANT_ID)).thenReturn(Optional.of(dek));
+        when(persistence.findDek(TENANT_ID, dek.getGeneration())).thenReturn(Optional.of(dek));
+    }
+
+    /**
      * Creates an encrypted secret using real crypto operations with the given DEK.
      */
     private EncryptedSecret createEncryptedSecret(String plaintext, byte[] dek) {
@@ -221,11 +233,14 @@ class VaultSecretProviderTest {
         EncryptedSecret encSecret = createEncryptedSecret(plaintext, dek);
 
         when(persistence.findSecret(TENANT_ID, KEY_NAME)).thenReturn(Optional.of(encSecret));
-        when(persistence.findDek(TENANT_ID)).thenReturn(Optional.of(encDek));
+        stubDekLookups(encDek);
 
         String result = provider.resolve(new SecretReference(TENANT_ID, KEY_NAME));
 
         assertEquals(plaintext, result);
+        // The row's dekId is the bare tenant id — everything written before
+        // generations existed — and that reads as generation 1.
+        verify(persistence).findDek(TENANT_ID, EncryptedDek.FIRST_GENERATION);
         // Verify lastAccessedAt update was attempted
         verify(persistence, atLeastOnce()).upsertSecret(any(EncryptedSecret.class));
     }
@@ -449,11 +464,15 @@ class VaultSecretProviderTest {
     void rotateDek_noDekFound_throwsSecretProviderException() {
         VaultSecretProvider provider = createAvailableProvider();
 
-        when(persistence.findDek(TENANT_ID)).thenReturn(Optional.empty());
+        // Rotation reads every generation, not just the newest: the sweep has to
+        // open older ones, so a KEK that cannot must be discovered before the
+        // commit point rather than half way through.
+        when(persistence.listDeks(TENANT_ID)).thenReturn(List.of());
 
         SecretProviderException ex = assertThrows(SecretProviderException.class,
                 () -> provider.rotateDek(TENANT_ID));
         assertTrue(ex.getMessage().contains("No DEK found"));
+        verify(persistence, never()).insertDek(any(EncryptedDek.class));
     }
 
     // ─── 20. rotateKek — not available ───

--- a/src/test/java/ai/labs/eddi/secrets/model/EncryptedDekTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/model/EncryptedDekTest.java
@@ -65,6 +65,19 @@ class EncryptedDekTest {
     }
 
     @Test
+    @DisplayName("the static dekId cannot mint a name that reads back as a different generation")
+    void staticDekIdNormalizesToo() {
+        // The constructor and setter stop a below-1 generation reaching an
+        // instance, but this method is static and takes an int straight from the
+        // caller. Left unnormalized it mints 'tenant-1#g0', which generationOf
+        // reads back as 1 and dekFor then looks up as generation 1 — a name and a
+        // row that disagree, which is the one thing this class guarantees.
+        assertEquals(EncryptedDek.dekId(TENANT, EncryptedDek.FIRST_GENERATION), EncryptedDek.dekId(TENANT, 0));
+        assertEquals(EncryptedDek.dekId(TENANT, EncryptedDek.FIRST_GENERATION), EncryptedDek.dekId(TENANT, -3));
+        assertEquals(EncryptedDek.FIRST_GENERATION, EncryptedDek.generationOf(TENANT, EncryptedDek.dekId(TENANT, 0)));
+    }
+
+    @Test
     @DisplayName("dekId round trip — every generation names itself")
     void dekIdRoundTrips() {
         for (int generation = 1; generation <= 3; generation++) {

--- a/src/test/java/ai/labs/eddi/secrets/model/EncryptedDekTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/model/EncryptedDekTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.secrets.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for EncryptedDek — the generation a row holds and the dekId round trip
+ * that generation drives.
+ */
+class EncryptedDekTest {
+
+    private static final String TENANT = "tenant-1";
+
+    @Test
+    @DisplayName("constructor — a generation below 1 is stored as 1")
+    void constructorNormalizesBelowFirstGeneration() {
+        // A row predating the generation column reads back as 0. Keeping the 0 would
+        // seal ciphertext under a name that reads back as a different generation.
+        assertEquals(EncryptedDek.FIRST_GENERATION, dek(0).getGeneration());
+        assertEquals(EncryptedDek.FIRST_GENERATION, dek(-7).getGeneration());
+    }
+
+    @Test
+    @DisplayName("constructor — a real generation is kept exactly")
+    void constructorKeepsRealGenerations() {
+        assertEquals(1, dek(1).getGeneration());
+        assertEquals(4, dek(4).getGeneration());
+    }
+
+    @Test
+    @DisplayName("setGeneration — a generation below 1 is stored as 1")
+    void setterNormalizesBelowFirstGeneration() {
+        EncryptedDek encryptedDek = dek(3);
+
+        encryptedDek.setGeneration(0);
+        assertEquals(EncryptedDek.FIRST_GENERATION, encryptedDek.getGeneration());
+
+        encryptedDek.setGeneration(-1);
+        assertEquals(EncryptedDek.FIRST_GENERATION, encryptedDek.getGeneration());
+
+        encryptedDek.setGeneration(5);
+        assertEquals(5, encryptedDek.getGeneration());
+    }
+
+    @Test
+    @DisplayName("a row built from a below-1 generation names the generation it will be read back as")
+    void dekIdRoundTripsForABelowFirstGenerationRow() {
+        // The whole point of the normalization. Without it this row would seal under
+        // 'tenant-1#g0', generationOf would read that back as 1, and the ciphertext
+        // would be opened with a different key than sealed it.
+        EncryptedDek encryptedDek = dek(0);
+
+        String dekId = encryptedDek.dekId();
+
+        assertEquals(EncryptedDek.dekId(TENANT, EncryptedDek.FIRST_GENERATION), dekId);
+        assertEquals(encryptedDek.getGeneration(), EncryptedDek.generationOf(TENANT, dekId));
+    }
+
+    @Test
+    @DisplayName("dekId round trip — every generation names itself")
+    void dekIdRoundTrips() {
+        for (int generation = 1; generation <= 3; generation++) {
+            EncryptedDek encryptedDek = dek(generation);
+            assertEquals(generation, EncryptedDek.generationOf(TENANT, encryptedDek.dekId()));
+        }
+    }
+
+    @Test
+    @DisplayName("generationOf — anything that is not a generation name reads as 1")
+    void generationOfFallsBackToFirstGeneration() {
+        assertEquals(EncryptedDek.FIRST_GENERATION, EncryptedDek.generationOf(TENANT, null));
+        assertEquals(EncryptedDek.FIRST_GENERATION, EncryptedDek.generationOf(TENANT, "  "));
+        assertEquals(EncryptedDek.FIRST_GENERATION, EncryptedDek.generationOf(TENANT, TENANT));
+        assertEquals(EncryptedDek.FIRST_GENERATION, EncryptedDek.generationOf(TENANT, TENANT + "#gnonsense"));
+    }
+
+    @Test
+    @DisplayName("legacy constructor — generation 1")
+    void legacyConstructorIsFirstGeneration() {
+        var encryptedDek = new EncryptedDek("id", TENANT, "encDek", "iv", Instant.now());
+
+        assertEquals(EncryptedDek.FIRST_GENERATION, encryptedDek.getGeneration());
+        assertEquals(TENANT + "#g1", encryptedDek.dekId());
+    }
+
+    private static EncryptedDek dek(int generation) {
+        return new EncryptedDek("id", TENANT, generation, "encDek", "iv", Instant.now());
+    }
+}

--- a/src/test/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistenceTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistenceTest.java
@@ -7,12 +7,17 @@ package ai.labs.eddi.secrets.persistence;
 import ai.labs.eddi.secrets.model.EncryptedDek;
 import ai.labs.eddi.secrets.model.EncryptedSecret;
 import com.mongodb.MongoException;
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
+import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
@@ -51,6 +56,21 @@ class MongoSecretPersistenceTest {
         when(database.getCollection("secretvault_meta")).thenReturn(metaCollection);
 
         persistence = new MongoSecretPersistence(database);
+    }
+
+    // ==================== startup migration ====================
+
+    @Test
+    @DisplayName("startup — DEK documents are backfilled BEFORE the unique-on-tenant index is dropped")
+    void migratesDeksToGenerations() {
+        // Order is the whole point. Backfill first, so every pre-generation document
+        // has a generation to be indexed on; then the old index goes, because while
+        // it stands a tenant cannot hold a second generation and rotation has
+        // nowhere to write.
+        var order = inOrder(deksCollection);
+        order.verify(deksCollection).updateMany(any(Bson.class), any(Bson.class));
+        order.verify(deksCollection).dropIndex("idx_dek_tenant");
+        order.verify(deksCollection).createIndex(any(Bson.class), any(IndexOptions.class));
     }
 
     // ==================== upsertSecret ====================
@@ -171,40 +191,144 @@ class MongoSecretPersistenceTest {
     // ==================== findDek ====================
 
     @Test
-    @DisplayName("findDek — returns DEK when found")
+    @DisplayName("findDek — the ACTIVE generation is the highest one, so the query is sorted")
     void findDekFound() {
+        // Unsorted, "the tenant's DEK" is whichever row the server happens to hand
+        // back first, and a rotation would sooner or later seal new values with a
+        // superseded key.
+        FindIterable<Document> iterable = dekIterable(dekDoc(3));
+        when(deksCollection.find(any(Bson.class))).thenReturn(iterable);
+
+        Optional<EncryptedDek> result = persistence.findDek(TENANT);
+
+        assertTrue(result.isPresent());
+        assertEquals(TENANT, result.get().getTenantId());
+        assertEquals(3, result.get().getGeneration());
+        assertEquals(TENANT + "#g3", result.get().dekId(), "this is the name ciphertext records, so it has to carry the generation");
+        verify(iterable).sort(any(Bson.class));
+    }
+
+    @Test
+    @DisplayName("findDek — a row written before generations existed reads as generation 1")
+    void findDekWithoutGenerationField() {
         Document doc = new Document("_id", TEST_OID)
                 .append("tenantId", TENANT)
                 .append("encryptedDek", "enc-data")
                 .append("iv", "iv-data")
                 .append("createdAt", Instant.now().toString());
-        FindIterable<Document> iterable = mock(FindIterable.class);
+        // Built before the stubbing starts: dekIterable does its own stubbing, and
+        // Mockito rejects a nested when() inside an unfinished one.
+        FindIterable<Document> iterable = dekIterable(doc);
         when(deksCollection.find(any(Bson.class))).thenReturn(iterable);
-        when(iterable.first()).thenReturn(doc);
 
-        Optional<EncryptedDek> result = persistence.findDek(TENANT);
-        assertTrue(result.isPresent());
-        assertEquals(TENANT, result.get().getTenantId());
+        assertEquals(EncryptedDek.FIRST_GENERATION, persistence.findDek(TENANT).orElseThrow().getGeneration(),
+                "that rule is what lets every already-stored row keep working with no migration of ciphertext");
     }
 
     @Test
     @DisplayName("findDek — returns empty when not found")
     void findDekNotFound() {
-        FindIterable<Document> iterable = mock(FindIterable.class);
+        FindIterable<Document> iterable = dekIterable(null);
         when(deksCollection.find(any(Bson.class))).thenReturn(iterable);
-        when(iterable.first()).thenReturn(null);
 
         assertFalse(persistence.findDek(TENANT).isPresent());
+    }
+
+    @Test
+    @DisplayName("findDek(generation) — reads the one generation a stored row names")
+    void findDekByGeneration() {
+        // Deliberately no sort() stub: the key is unique, so this lookup must not
+        // need one, and a production sort() here would fail on the null it returns.
+        FindIterable<Document> iterable = mock(FindIterable.class);
+        when(deksCollection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.first()).thenReturn(dekDoc(2));
+
+        Optional<EncryptedDek> result = persistence.findDek(TENANT, 2);
+
+        assertTrue(result.isPresent());
+        assertEquals(2, result.get().getGeneration());
+    }
+
+    // ==================== insertDek ====================
+
+    @Test
+    @DisplayName("insertDek — a fresh generation is inserted")
+    void insertDekSucceeds() {
+        assertTrue(persistence.insertDek(new EncryptedDek("id", TENANT, 2, "encDek", "iv", Instant.now())));
+        verify(deksCollection).insertOne(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("insertDek — a generation somebody else installed first is refused, not overwritten")
+    void insertDekLosesToDuplicateKey() {
+        // The commit point of a rotation. Two replicas racing must produce one
+        // winner and one clean refusal, never two keys claiming one generation.
+        doThrow(new MongoWriteException(new WriteError(11000, "E11000 duplicate key error", new BsonDocument()), new ServerAddress()))
+                .when(deksCollection).insertOne(any(Document.class));
+
+        assertFalse(persistence.insertDek(new EncryptedDek("id", TENANT, 2, "encDek", "iv", Instant.now())));
+    }
+
+    @Test
+    @DisplayName("insertDek — any other write error is a failure, not a lost race")
+    void insertDekPropagatesOtherWriteErrors() {
+        doThrow(new MongoWriteException(new WriteError(50, "ExceededTimeLimit", new BsonDocument()), new ServerAddress()))
+                .when(deksCollection).insertOne(any(Document.class));
+
+        assertThrows(PersistenceException.class, () -> persistence.insertDek(new EncryptedDek("id", TENANT, 2, "encDek", "iv", Instant.now())));
+    }
+
+    // ==================== listDeks ====================
+
+    @Test
+    @DisplayName("listDeks — every generation the tenant holds, oldest first")
+    void listDeks() {
+        FindIterable<Document> iterable = mock(FindIterable.class);
+        when(deksCollection.find(any(Bson.class))).thenReturn(iterable);
+        when(iterable.sort(any(Bson.class))).thenReturn(iterable);
+        MongoCursor<Document> cursor = mock(MongoCursor.class);
+        doReturn(cursor).when(iterable).iterator();
+        when(cursor.hasNext()).thenReturn(true, true, false);
+        when(cursor.next()).thenReturn(dekDoc(1), dekDoc(2));
+
+        List<EncryptedDek> result = persistence.listDeks(TENANT);
+
+        assertEquals(List.of(1, 2), result.stream().map(EncryptedDek::getGeneration).toList());
+        verify(iterable).sort(any(Bson.class));
+    }
+
+    // ==================== updateSecretSealing ====================
+
+    @Test
+    @DisplayName("updateSecretSealing — a matched row counts as written, even if the bytes are identical")
+    void updateSecretSealingWins() {
+        UpdateResult result = mock(UpdateResult.class);
+        when(result.getMatchedCount()).thenReturn(1L);
+        when(secretsCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(result);
+
+        assertTrue(persistence.updateSecretSealing(createTestSecret(), "dek-0"));
+    }
+
+    @Test
+    @DisplayName("updateSecretSealing — a row somebody else re-sealed first is left alone")
+    void updateSecretSealingLosesTheGuard() {
+        UpdateResult result = mock(UpdateResult.class);
+        when(result.getMatchedCount()).thenReturn(0L);
+        when(secretsCollection.updateOne(any(Bson.class), any(Bson.class))).thenReturn(result);
+
+        assertFalse(persistence.updateSecretSealing(createTestSecret(), "dek-0"));
     }
 
     // ==================== deleteDek ====================
 
     @Test
-    @DisplayName("deleteDek — deletes DEK for tenant")
+    @DisplayName("deleteDek — deletes EVERY generation for the tenant")
     void deleteDek() {
-        when(deksCollection.deleteOne(any(Bson.class))).thenReturn(mock(DeleteResult.class));
+        // deleteOne would leave the older generations behind, and a tenant reset
+        // that keeps keys is not a reset.
+        when(deksCollection.deleteMany(any(Bson.class))).thenReturn(mock(DeleteResult.class));
         assertDoesNotThrow(() -> persistence.deleteDek(TENANT));
-        verify(deksCollection).deleteOne(any(Bson.class));
+        verify(deksCollection).deleteMany(any(Bson.class));
     }
 
     // ==================== listAllDeks ====================
@@ -276,6 +400,23 @@ class MongoSecretPersistenceTest {
         secret.setCreatedAt(Instant.now());
         secret.setLastAccessedAt(Instant.now());
         return secret;
+    }
+
+    private Document dekDoc(int generation) {
+        return new Document("_id", TEST_OID)
+                .append("tenantId", TENANT)
+                .append("generation", generation)
+                .append("encryptedDek", "enc-data")
+                .append("iv", "iv-data")
+                .append("createdAt", Instant.now().toString());
+    }
+
+    /** A find() whose sort() chains, which is what the driver actually does. */
+    private FindIterable<Document> dekIterable(Document first) {
+        FindIterable<Document> iterable = mock(FindIterable.class);
+        when(iterable.sort(any(Bson.class))).thenReturn(iterable);
+        when(iterable.first()).thenReturn(first);
+        return iterable;
     }
 
     private Document createSecretDoc() {

--- a/src/test/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistenceTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistenceTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.secrets.persistence;
 
 import ai.labs.eddi.secrets.model.EncryptedDek;
 import ai.labs.eddi.secrets.model.EncryptedSecret;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoWriteException;
@@ -18,6 +19,7 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
+import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonDouble;
 import org.bson.BsonInt32;
@@ -28,6 +30,7 @@ import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
 import java.util.List;
@@ -82,6 +85,25 @@ class MongoSecretPersistenceTest {
         order.verify(deksCollection).updateMany(any(Bson.class), any(Bson.class));
         order.verify(deksCollection).dropIndex("idx_dek_tenant");
         order.verify(deksCollection).createIndex(any(Bson.class), any(IndexOptions.class));
+    }
+
+    @Test
+    @DisplayName("startup — the backfill covers a stored generation BELOW 1, not just an absent one")
+    void migrationBackfillsBelowFirstGeneration() {
+        // The entity normalizes what it READS, so a row physically holding 0 is
+        // handed out as generation 1 — and then looked up as generation 1 by an
+        // exact query that cannot match it. Normalizing only in the entity moves
+        // that disagreement rather than removing it, so the row itself is fixed.
+        var filter = ArgumentCaptor.forClass(Bson.class);
+        verify(deksCollection).updateMany(filter.capture(), any(Bson.class));
+
+        BsonDocument rendered = filter.getValue().toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry());
+        BsonArray alternatives = rendered.getArray("$or");
+        assertEquals(2, alternatives.size(), "absent and below-1 are different states and both need migrating: " + rendered.toJson());
+        assertFalse(alternatives.get(0).asDocument().getDocument("generation").getBoolean("$exists").getValue(),
+                "a document written before generations existed: " + rendered.toJson());
+        assertEquals(EncryptedDek.FIRST_GENERATION, alternatives.get(1).asDocument().getDocument("generation").getInt32("$lt").getValue(),
+                "and a document that stored a generation no key can be found by: " + rendered.toJson());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistenceTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistenceTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.secrets.persistence;
 
 import ai.labs.eddi.secrets.model.EncryptedDek;
 import ai.labs.eddi.secrets.model.EncryptedSecret;
+import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoWriteException;
 import com.mongodb.ServerAddress;
@@ -18,6 +19,9 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
@@ -46,6 +50,13 @@ class MongoSecretPersistenceTest {
 
     @BeforeEach
     void setUp() {
+        persistence = new MongoSecretPersistence(mockDatabase());
+    }
+
+    /**
+     * Fresh collection mocks, so a test may stub the boot migration before it runs.
+     */
+    private MongoDatabase mockDatabase() {
         MongoDatabase database = mock(MongoDatabase.class);
         secretsCollection = mock(MongoCollection.class);
         deksCollection = mock(MongoCollection.class);
@@ -55,7 +66,7 @@ class MongoSecretPersistenceTest {
         when(database.getCollection("secretvault_deks")).thenReturn(deksCollection);
         when(database.getCollection("secretvault_meta")).thenReturn(metaCollection);
 
-        persistence = new MongoSecretPersistence(database);
+        return database;
     }
 
     // ==================== startup migration ====================
@@ -71,6 +82,29 @@ class MongoSecretPersistenceTest {
         order.verify(deksCollection).updateMany(any(Bson.class), any(Bson.class));
         order.verify(deksCollection).dropIndex("idx_dek_tenant");
         order.verify(deksCollection).createIndex(any(Bson.class), any(IndexOptions.class));
+    }
+
+    @Test
+    @DisplayName("startup — a legacy index that is simply not there is nothing to do")
+    void migrationToleratesAnAbsentLegacyIndex() {
+        MongoDatabase database = mockDatabase();
+        doThrow(commandFailure(27, "index not found with name [idx_dek_tenant]")).when(deksCollection).dropIndex(anyString());
+
+        assertDoesNotThrow(() -> new MongoSecretPersistence(database));
+        verify(deksCollection).createIndex(any(Bson.class), any(IndexOptions.class));
+    }
+
+    @Test
+    @DisplayName("startup — any other drop failure fails the boot instead of passing for 'already gone'")
+    void migrationPropagatesANonIndexNotFoundFailure() {
+        // Not authorized, or a stepped-down primary: the legacy unique-on-tenantId
+        // index may well still be standing, and while it does a tenant cannot hold a
+        // second generation and rotation has nowhere to write.
+        MongoDatabase database = mockDatabase();
+        doThrow(commandFailure(13, "not authorized on eddi to execute command")).when(deksCollection).dropIndex(anyString());
+
+        assertThrows(MongoCommandException.class, () -> new MongoSecretPersistence(database));
+        verify(deksCollection, never()).createIndex(any(Bson.class), any(IndexOptions.class));
     }
 
     // ==================== upsertSecret ====================
@@ -386,6 +420,14 @@ class MongoSecretPersistenceTest {
     }
 
     // ==================== Helpers ====================
+
+    /** A server-side command failure carrying a specific error code. */
+    private static MongoCommandException commandFailure(int code, String message) {
+        BsonDocument response = new BsonDocument("ok", new BsonDouble(0.0))
+                .append("errmsg", new BsonString(message))
+                .append("code", new BsonInt32(code));
+        return new MongoCommandException(response, new ServerAddress());
+    }
 
     private EncryptedSecret createTestSecret() {
         EncryptedSecret secret = new EncryptedSecret();

--- a/src/test/java/ai/labs/eddi/secrets/persistence/PostgresSecretPersistenceUnitTest.java
+++ b/src/test/java/ai/labs/eddi/secrets/persistence/PostgresSecretPersistenceUnitTest.java
@@ -167,12 +167,78 @@ class PostgresSecretPersistenceUnitTest {
     void upsertDek_happyPath() throws Exception {
         when(preparedStatement.executeUpdate()).thenReturn(1);
 
-        EncryptedDek dek = new EncryptedDek("dek-1", "tenant-1", "encDek", "dekIv", Instant.now());
+        EncryptedDek dek = new EncryptedDek("dek-1", "tenant-1", 3, "encDek", "dekIv", Instant.now());
         assertDoesNotThrow(() -> persistence.upsertDek(dek));
 
         verify(preparedStatement).setString(1, "tenant-1");
-        verify(preparedStatement).setString(2, "encDek");
+        // The generation is part of the row's identity now — the conflict target is
+        // (tenant_id, generation), so it has to be bound, not assumed.
+        verify(preparedStatement).setInt(2, 3);
+        verify(preparedStatement).setString(3, "encDek");
         verify(preparedStatement).executeUpdate();
+    }
+
+    @Test
+    void upsertDek_legacyConstructor_writesGenerationOne() throws Exception {
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        persistence.upsertDek(new EncryptedDek("dek-1", "tenant-1", "encDek", "dekIv", Instant.now()));
+
+        verify(preparedStatement).setInt(2, EncryptedDek.FIRST_GENERATION);
+    }
+
+    // ─── insertDek ───
+
+    @Test
+    void insertDek_freshGeneration_returnsTrue() throws Exception {
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        assertTrue(persistence.insertDek(new EncryptedDek("dek-2", "tenant-1", 2, "encDek", "iv", Instant.now())));
+    }
+
+    @Test
+    void insertDek_generationAlreadyTaken_returnsFalse() throws Exception {
+        // ON CONFLICT DO NOTHING, so the loser gets zero rows back and a live
+        // connection rather than an aborted transaction to unwind.
+        when(preparedStatement.executeUpdate()).thenReturn(0);
+
+        assertFalse(persistence.insertDek(new EncryptedDek("dek-2", "tenant-1", 2, "encDek", "iv", Instant.now())));
+    }
+
+    @Test
+    void insertDek_sqlException_throwsPersistenceException() throws Exception {
+        when(preparedStatement.executeUpdate()).thenThrow(new SQLException("DB error"));
+
+        assertThrows(PersistenceException.class,
+                () -> persistence.insertDek(new EncryptedDek("dek-2", "tenant-1", 2, "encDek", "iv", Instant.now())));
+    }
+
+    // ─── updateSecretSealing ───
+
+    @Test
+    void updateSecretSealing_guardHeld_returnsTrue() throws Exception {
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        assertTrue(persistence.updateSecretSealing(createTestSecret(), "dek-0"));
+
+        verify(preparedStatement).setString(7, "dek-0");
+    }
+
+    @Test
+    void updateSecretSealing_guardLost_returnsFalse() throws Exception {
+        // Another writer re-sealed the row first. Nothing was written, and forcing
+        // it through would replace their ciphertext with a re-seal of what they
+        // already replaced.
+        when(preparedStatement.executeUpdate()).thenReturn(0);
+
+        assertFalse(persistence.updateSecretSealing(createTestSecret(), "dek-0"));
+    }
+
+    @Test
+    void updateSecretSealing_sqlException_throwsPersistenceException() throws Exception {
+        when(preparedStatement.executeUpdate()).thenThrow(new SQLException("DB error"));
+
+        assertThrows(PersistenceException.class, () -> persistence.updateSecretSealing(createTestSecret(), "dek-0"));
     }
 
     @Test
@@ -189,17 +255,53 @@ class PostgresSecretPersistenceUnitTest {
     void findDek_found() throws Exception {
         when(preparedStatement.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true);
-        when(resultSet.getString("id")).thenReturn("dek-id-1");
-        when(resultSet.getString("tenant_id")).thenReturn("tenant-1");
-        when(resultSet.getString("encrypted_dek")).thenReturn("encDek");
-        when(resultSet.getString("iv")).thenReturn("dekIv");
-        Timestamp ts = Timestamp.from(Instant.now());
-        when(resultSet.getTimestamp("created_at")).thenReturn(ts);
+        mockDekResultSet(3);
 
         Optional<EncryptedDek> result = persistence.findDek("tenant-1");
         assertTrue(result.isPresent());
         assertEquals("tenant-1", result.get().getTenantId());
         assertEquals("encDek", result.get().getEncryptedDek());
+        assertEquals(3, result.get().getGeneration());
+        assertEquals("tenant-1#g3", result.get().dekId(), "this is the name ciphertext records, so it has to carry the generation");
+    }
+
+    @Test
+    void findDek_rowPredatingTheGenerationColumn_readsAsGenerationOne() throws Exception {
+        // A row written before the column existed reads back as 0 until the default
+        // takes effect. Generation 0 names no key, so it is understood as 1 — the
+        // same rule that governs a bare-tenant-id dekId.
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        mockDekResultSet(0);
+
+        assertEquals(EncryptedDek.FIRST_GENERATION, persistence.findDek("tenant-1").orElseThrow().getGeneration());
+    }
+
+    @Test
+    void findDekByGeneration_bindsTheGeneration() throws Exception {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        mockDekResultSet(2);
+
+        Optional<EncryptedDek> result = persistence.findDek("tenant-1", 2);
+
+        assertTrue(result.isPresent());
+        assertEquals(2, result.get().getGeneration());
+        verify(preparedStatement).setString(1, "tenant-1");
+        verify(preparedStatement).setInt(2, 2);
+    }
+
+    @Test
+    void listDeks_returnsEveryGeneration() throws Exception {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, true, false);
+        mockDekResultSet(1);
+        when(resultSet.getInt("generation")).thenReturn(1, 2);
+
+        List<EncryptedDek> result = persistence.listDeks("tenant-1");
+
+        assertEquals(List.of(1, 2), result.stream().map(EncryptedDek::getGeneration).toList(),
+                "KEK rotation and the pre-commit verify both have to see every generation, not just the newest");
     }
 
     @Test
@@ -333,6 +435,22 @@ class PostgresSecretPersistenceUnitTest {
         verify(connection, times(1)).createStatement();
     }
 
+    @Test
+    void ensureSchema_migratesTheDekTableToOneRowPerGeneration() throws Exception {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(false);
+
+        persistence.findSecret("t", "k");
+
+        verify(statement).execute(contains("ADD COLUMN IF NOT EXISTS generation"));
+        // While the column-level UNIQUE on tenant_id stands, a tenant cannot hold a
+        // second generation and rotation has nowhere to write.
+        verify(statement).execute(contains("DROP CONSTRAINT IF EXISTS secret_vault_deks_tenant_id_key"));
+        // A unique INDEX rather than a constraint: only an index can be declared IF
+        // NOT EXISTS, and ON CONFLICT accepts one just the same.
+        verify(statement).execute(contains("uq_svd_tenant_generation"));
+    }
+
     // ─── resultSetToSecret — allowed_agents JSON parsing ───
 
     @Test
@@ -385,6 +503,15 @@ class PostgresSecretPersistenceUnitTest {
         Instant now = Instant.now();
         return new EncryptedSecret("sec-1", "tenant-1", "api-key", "encVal", "iv123",
                 "dek-1", "chk", "Test secret", List.of("agent-1"), now, now, now);
+    }
+
+    private void mockDekResultSet(int generation) throws SQLException {
+        when(resultSet.getString("id")).thenReturn("dek-id-1");
+        when(resultSet.getString("tenant_id")).thenReturn("tenant-1");
+        when(resultSet.getInt("generation")).thenReturn(generation);
+        when(resultSet.getString("encrypted_dek")).thenReturn("encDek");
+        when(resultSet.getString("iv")).thenReturn("dekIv");
+        when(resultSet.getTimestamp("created_at")).thenReturn(Timestamp.from(Instant.now()));
     }
 
     private void mockSecretResultSet() throws SQLException {


### PR DESCRIPTION
`rotateDek` can permanently destroy a tenant's secrets, and the failure needs nothing more exotic than a database blip at the wrong moment. This is a bug on `main` today; it is not introduced by any feature branch.

## What goes wrong

The order is: re-encrypt every secret under a newly generated DEK, **commit all of them**, and only then persist that DEK. Until the final write the new key exists solely in process memory.

Any failure in that window — a timeout, a failover, an OOM — leaves every rewritten row sealed under a key that vanishes with the stack frame, while the stored key no longer opens it. Re-running cannot recover: step one decrypts with the stored key and throws on exactly the rows the previous attempt rewrote.

The method's own javadoc claims a failure *"aborts the rotation with the tenant still on a key that decrypts everything"*. That was untrue of every failure after the first write.

## What changes

**Rotation becomes additive.** A tenant holds one DEK row per generation. Inserting the next generation is the single atomic commit point: it either lands or it does not, and afterwards every existing row still names a generation that exists and opens it. Only then does a sweep re-encrypt rows onto the new generation, one row at a time, each write guarded on the key the row was read with. A row the sweep cannot win is left alone — it stays on a generation that is still there — and the rotation reports how many remain and that it is safe to run again.

**Ciphertext names its key.** `EncryptedSecret.dekId` already existed and held nothing but the tenant id; it now carries the generation. A `dekId` that is null or equal to the tenant id reads as generation 1, so **no stored ciphertext is migrated**.

**Failures are reported honestly.** Participants throw `RuntimeException`, which the old catch clause did not cover, so a participant failure escaped uncounted and un-normalised.

Old generations are never deleted automatically — that is what makes an interrupted rotation recoverable rather than fatal. KEK rotation re-wraps every generation, since it iterates all DEK rows.

## Schema

Both stores carried a UNIQUE constraint on tenant alone, which would have made a second generation impossible. MongoDB backfills generation 1, drops the old index and creates a compound unique index; PostgreSQL adds the column with a default and replaces the constraint. Both run on boot beside the existing bootstrap DDL, so an existing deployment migrates itself.

## Note for reviewers

This also introduces the `SealedDataRotationParticipant` SPI so data sealed with a tenant DEK outside the secret collection can be carried across a rotation. It has **no implementations here** — the connections feature (#separate PR) is its first consumer. That is deliberate: this PR is the layer, not the user.

## Verification

5167 tests pass standalone on `main`, including the repo-wide guards. Checkstyle clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-scoped sealing and unsealing for runtime data.
  * Added generation-aware encryption keys while preserving older generations during rotation.
  * Added extensibility for re-sealing data stored outside the vault.
  * Added safe, retryable rotation with partial-failure reporting.
  * KEK rotation now supports all DEK generations.
* **Bug Fixes**
  * Existing encrypted data remains readable during and after key rotation.
  * Prevented concurrent updates from overwriting newly re-sealed values.
  * Improved startup migration handling and protected sensitive identifiers in logs.
* **Documentation**
  * Expanded rotation guidance, migration details, and operational behavior for PostgreSQL and MongoDB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->