### PR TITLE
fix(api,docs): correct the quickstart, and the API behaviours it exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,18 @@ docker compose -f docker-compose.yml -f docker-compose.auth.yml up
 # With Prometheus + Grafana monitoring
 docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up
 
+# With a local LLM — Ollama on the same Docker network, reachable as
+# http://ollama:11434 (no host.docker.internal needed)
+docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d
+
 # Full stack (all overlays)
 docker compose -f docker-compose.yml -f docker-compose.auth.yml \
   -f docker-compose.monitoring.yml -f docker-compose.nats.yml up
 ```
 
-Available compose overlays: `docker-compose.auth.yml` (Keycloak), `docker-compose.monitoring.yml` (Prometheus+Grafana), `docker-compose.nats.yml` (NATS JetStream), `docker-compose.postgres.yml` / `docker-compose.postgres-only.yml`, `docker-compose.local.yml` (build from source).
+Available compose overlays: `docker-compose.auth.yml` (Keycloak), `docker-compose.monitoring.yml` (Prometheus+Grafana), `docker-compose.nats.yml` (NATS JetStream), `docker-compose.ollama.yml` (local LLM), `docker-compose.chroma.yml` (vector store), `docker-compose.postgres.yml` / `docker-compose.postgres-only.yml`, `docker-compose.local.yml` (build from source).
+
+The Ollama overlay pulls `llama3.2:3b` on first start and keeps models in a named volume; override with `OLLAMA_PULL_MODEL=qwen3:4b`, or set it empty to skip the pull. It also sets `EDDI_OLLAMA_DEFAULT_BASE_URL`, so the agent wizard and the setup API pre-fill a base URL that resolves from inside the container — the one thing that trips up every first local-LLM agent, because `localhost` there is the container, not the host.
 
 ```bash
 docker pull labsai/eddi    # Pull latest from Docker Hub

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up
 # http://ollama:11434 (no host.docker.internal needed)
 docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d
 
-# Full stack (all overlays)
+# Auth + monitoring + NATS together (overlays stack in any combination)
 docker compose -f docker-compose.yml -f docker-compose.auth.yml \
   -f docker-compose.monitoring.yml -f docker-compose.nats.yml up
 ```

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -1,0 +1,76 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Ollama overlay — a local LLM on the same Docker network as EDDI.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d
+#
+# Why an overlay rather than "just run Ollama on the host": inside the eddi
+# container, `localhost` is the container. An Ollama on the host is reachable
+# only as http://host.docker.internal:11434, which needs the extra_hosts entry
+# the base compose file already carries and still breaks on hosts where the
+# gateway alias is unavailable. With this overlay the base URL is simply
+#
+#     http://ollama:11434
+#
+# — plain container-to-container DNS, identical on Linux, macOS and Windows.
+# That is also the value EDDI hands new agents by default here, via
+# eddi.ollama.default-base-url (EDDI_OLLAMA_DEFAULT_BASE_URL), so the Manager's
+# agent wizard and the setup API pre-fill something that actually resolves.
+#
+# The port is still published on the host, so `ollama run …` and curl against
+# http://localhost:11434 keep working from your shell.
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+  eddi:
+    environment:
+      # Consumed by AgentSetupService as the default baseUrl for ollama tasks.
+      - "EDDI_OLLAMA_DEFAULT_BASE_URL=${EDDI_OLLAMA_DEFAULT_BASE_URL:-http://ollama:11434}"
+    depends_on:
+      ollama:
+        condition: service_healthy
+
+  ollama:
+    image: ollama/ollama:0.13.0
+    restart: always
+    ports:
+      # Host-visible so the `ollama` CLI and curl still reach it directly.
+      - "${OLLAMA_PORT:-11434}:11434"
+    volumes:
+      # Named volume, so pulled models survive `docker compose down`. Model
+      # weights are measured in gigabytes — re-pulling them on every restart is
+      # the difference between a 5-second and a 5-minute start.
+      - ollama-models:/root/.ollama
+    healthcheck:
+      # `ollama list` rather than an HTTP probe: the image ships no curl, and
+      # this is the same check that proves the API is answering.
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  # One-shot: pulls a model so the stack is usable on first start instead of
+  # answering "model not found" to the first message. Override the model with
+  #   OLLAMA_PULL_MODEL=qwen3:4b docker compose -f … up -d
+  # or set it empty to skip the pull entirely.
+  ollama-pull:
+    image: ollama/ollama:0.13.0
+    restart: "no"
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      - "OLLAMA_HOST=http://ollama:11434"
+      - "OLLAMA_PULL_MODEL=${OLLAMA_PULL_MODEL:-llama3.2:3b}"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        if [ -n "$${OLLAMA_PULL_MODEL}" ]; then
+          echo "Pulling $${OLLAMA_PULL_MODEL} …";
+          ollama pull "$${OLLAMA_PULL_MODEL}";
+        else
+          echo "OLLAMA_PULL_MODEL is empty — skipping the model pull.";
+        fi
+
+volumes:
+  ollama-models:

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -28,6 +28,12 @@ services:
     depends_on:
       ollama:
         condition: service_healthy
+      # `ollama list` answers as soon as the server is up, which is well before a
+      # first-run model pull has finished — so without this EDDI accepts a
+      # conversation and the first message fails with "model not found".
+      # An empty OLLAMA_PULL_MODEL still satisfies it: the job echoes and exits 0.
+      ollama-pull:
+        condition: service_completed_successfully
 
   ollama:
     image: ollama/ollama:0.13.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -270,7 +270,7 @@ A workflow is a **container of functionality** with a list of steps:
     {
       "type": "eddi://ai.labs.behavior",
       "extensions": {
-        "uri": "eddi://ai.labs.behavior/behaviorstore/behaviorsets/{behaviorId}?version={version}"
+        "uri": "eddi://ai.labs.rules/rulestore/rulesets/{behaviorId}?version={version}"
       },
       "config": {
         "appendActions": true
@@ -279,7 +279,7 @@ A workflow is a **container of functionality** with a list of steps:
     {
       "type": "eddi://ai.labs.httpcalls",
       "extensions": {
-        "uri": "eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/{httpCallsId}?version={version}"
+        "uri": "eddi://ai.labs.apicalls/apicallstore/apicalls/{httpCallsId}?version={version}"
       }
     }
   ]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,17 +268,15 @@ A workflow is a **container of functionality** with a list of steps:
 {
   "workflowSteps": [
     {
-      "type": "eddi://ai.labs.behavior",
-      "extensions": {
-        "uri": "eddi://ai.labs.rules/rulestore/rulesets/{behaviorId}?version={version}"
-      },
+      "type": "eddi://ai.labs.rules",
       "config": {
+        "uri": "eddi://ai.labs.rules/rulestore/rulesets/{behaviorId}?version={version}",
         "appendActions": true
       }
     },
     {
-      "type": "eddi://ai.labs.httpcalls",
-      "extensions": {
+      "type": "eddi://ai.labs.apicalls",
+      "config": {
         "uri": "eddi://ai.labs.apicalls/apicallstore/apicalls/{httpCallsId}?version={version}"
       }
     }

--- a/docs/behavior-rules.md
+++ b/docs/behavior-rules.md
@@ -366,13 +366,13 @@ The **`{id}`** is a path parameters that indicate which behavior rule you want t
 
 | HTTP Method | API Endpoint                                      | Request Body          | Response              |
 | ----------- | ------------------------------------------------- | --------------------- | --------------------- |
-| **DELETE**  | `/behaviorstore/behaviorsets/{id}`                | N/A                   | N/A                   |
-| **GET**     | `/behaviorstore/behaviorsets/{id}`                | N/A                   | **BehaviorSet model** |
-| **PUT**     | `/behaviorstore/behaviorsets/{id}`                | **BehaviorSet model** | N/A                   |
-| **GET**     | `/behaviorstore/behaviorsets/descriptors`         | N/A                   | **BehaviorSet model** |
-| **POST**    | `/behaviorstore/behaviorsets`                     | **BehaviorSet model** | N/A                   |
-| **GET**     | `/behaviorstore/behaviorsets/{id}/currentversion` | N/A                   | **BehaviorSet model** |
-| **POST**    | `/behaviorstore/behaviorsets/{id}/currentversion` | **BehaviorSet model** | N/A                   |
+| **DELETE**  | `/rulestore/rulesets/{id}`                | N/A                   | N/A                   |
+| **GET**     | `/rulestore/rulesets/{id}`                | N/A                   | **BehaviorSet model** |
+| **PUT**     | `/rulestore/rulesets/{id}`                | **BehaviorSet model** | N/A                   |
+| **GET**     | `/rulestore/rulesets/descriptors`         | N/A                   | **BehaviorSet model** |
+| **POST**    | `/rulestore/rulesets`                     | **BehaviorSet model** | N/A                   |
+| **GET**     | `/rulestore/rulesets/{id}/currentversion` | N/A                   | **BehaviorSet model** |
+| **POST**    | `/rulestore/rulesets/{id}/currentversion` | **BehaviorSet model** | N/A                   |
 
 ### Example
 
@@ -380,7 +380,7 @@ We will demonstrate here the creation of a `BehaviorSet`
 
 _Request URL_
 
-`POST http://localhost:7070/behaviorstore/behaviorsets`
+`POST http://localhost:7070/rulestore/rulesets`
 
 _Request Body_
 
@@ -485,5 +485,5 @@ _Response Code_
 The `Location` response header contains the URI of the newly created resource:
 
 ```
-Location: eddi://ai.labs.behavior/behaviorstore/behaviorsets/{id}?version=1
+Location: eddi://ai.labs.rules/rulestore/rulesets/{id}?version=1
 ```

--- a/docs/behavior-rules.md
+++ b/docs/behavior-rules.md
@@ -369,7 +369,7 @@ The **`{id}`** is a path parameters that indicate which behavior rule you want t
 | **DELETE**  | `/rulestore/rulesets/{id}`                | N/A                   | N/A                   |
 | **GET**     | `/rulestore/rulesets/{id}`                | N/A                   | **BehaviorSet model** |
 | **PUT**     | `/rulestore/rulesets/{id}`                | **BehaviorSet model** | N/A                   |
-| **GET**     | `/rulestore/rulesets/descriptors`         | N/A                   | **BehaviorSet model** |
+| **GET**     | `/rulestore/rulesets/descriptors`         | N/A                   | **DocumentDescriptor[]** |
 | **POST**    | `/rulestore/rulesets`                     | **BehaviorSet model** | N/A                   |
 | **GET**     | `/rulestore/rulesets/{id}/currentversion` | N/A                   | **BehaviorSet model** |
 | **POST**    | `/rulestore/rulesets/{id}/currentversion` | **BehaviorSet model** | N/A                   |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,185 @@
 
 
 
+## 🩹 fix(api,docs): everything a new user hit walking the developer quickstart (2026-08-25)
+
+**Repo:** EDDI (`fix/quickstart-truth-and-api-honesty`)
+
+Karol worked through
+[`docs/developer-quickstart.md`](developer-quickstart.md) against `labsai/eddi:6.3.0`
+and reported what happened. Seven steps produced four failures, and every one of them was
+ours — the documentation in most cases, the API in the rest. Each item below was
+**reproduced against a real 6.3.0 container** before being fixed, and the fix verified
+against the same stack where it could be.
+
+### The documentation was wrong, and the compatibility layer hid it
+
+The v5→v6 rename gave every store a new path, and `LegacyPathRewriteFilter` keeps the
+old ones answering. That is right for clients and was poison for the docs: a reader
+following `POST /packagestore/packages` got a `201`, so nothing said the page was years
+stale — right up until the *payload* shape had drifted too, at which point the same page
+produced a `400` with an empty body and no way to tell which half was wrong.
+
+`developer-quickstart.md`'s API walkthrough is rewritten end to end against the running
+server: `/dictionarystore/dictionaries`, `/rulestore/rulesets`, `/workflowstore/workflows`
+with `workflowSteps`, agents with `workflows`, `valueAlternatives` as typed output items
+rather than bare strings, and the two-call start/say sequence (the start endpoint takes a
+*context map*, never a message). It now also documents the `descriptors` listings —
+without which there is no way to find what you just created — and the descriptor `PATCH`
+that stops everything being called "Unnamed Agent".
+
+The legacy spellings are swept out of eleven other pages, and
+`DocumentedRestPathsTest` fails the build on any that come back. Writing the test found
+three more the sweep had missed, in `AGENTS.md` and `planning/manager-ui-handoff.md`.
+
+Also corrected in the same page: prerequisites (`./mvnw`, not a separate Maven; MongoDB 7),
+`docker compose up -d` rather than `docker-compose up`, `/manage` for the dashboard, an
+`examples/` folder that has never existed, and a Troubleshooting section that pointed at
+three endpoints which do not exist. The `sendConversation` LLM parameter in the old
+example is read by nothing.
+
+### `DELETE /conversationstore/conversations/{id}` did nothing
+
+`deletePermanently` defaults to `false`, and that branch was a comment claiming a
+`DocumentDescriptorInterceptor` would mark the descriptor deleted "regardless of whether
+it has been permanently deleted or not". No such interceptor exists anywhere in the code
+base. So the endpoint answered `204`, the row stayed `"deleted": false`, and it stayed
+listed. The Manager's dialog describes exactly the behaviour that was missing and then
+reports "Conversation deleted" — a success toast beside a conversation that is still
+there. Now implemented: the descriptor is retired, the snapshot and attachments are
+deliberately kept, which is the whole distinction from the permanent path.
+
+### Deploying an agent that does not exist returned `202 Accepted`
+
+`POST /administration/{env}/deploy/{agentId}` has always advertised a 404 and never
+produced one. Without `waitForCompletion`, any id at all was accepted; the deployment
+then failed on the runtime executor, where no status code can reach the caller, so the
+only signal was a log line. A CI pipeline, the Manager and the setup API all read 202 as
+success and move on to start a conversation that can never exist. The agent store is now
+consulted on the request thread. A store *outage* still deploys — it is not evidence the
+agent is missing. An id the datastore cannot even parse is a 404 too: the MongoDB driver
+rejects it with "state should be: hexString has 24 characters" before any lookup, which
+both blames the wrong thing and names the datastore behind the API.
+
+### Reading a conversation that is not there was a `500`
+
+Not something Karol reported, but the same defect on a different resource — and the
+Troubleshooting section rewritten above now sends people to two of the affected
+endpoints, precisely when something has already gone wrong. Five conversation reads
+answered a deleted or mistyped id with `500 Internal Server Error` and an error id,
+while every one of them documents a 404:
+
+- `loadConversationMemorySnapshot` returns `null` rather than throwing, and the read
+  paths dereferenced it — an NPE on `getEnvironment()`.
+- `GET /conversationstore/conversations/{id}` returned that `null` straight out, which
+  JAX-RS renders as `204 No Content` — indistinguishable from a conversation that
+  exists and is empty.
+- `GET /agents/{id}/status` threw `ConversationNotFoundException`, which nothing
+  mapped, so it reached Quarkus's default handler as an unhandled runtime exception.
+  It never even got that far: `cacheConversationState` put the `null` into Caffeine
+  first, which rejects null values, so the NPE came from inside the cache one line
+  before the check that would have said "no such conversation".
+
+All five now answer `404` naming the conversation id.
+`ConversationNotFoundExceptionMapper` is new; the rest is a `requireSnapshot` guard
+and a null check in the right order.
+
+Deliberately **not** extended to `POST /agents/{id}` and `/stream`: those are the
+async paths, whose exception plumbing is a different problem, and no documentation
+sends anyone there with a dead id. They are no worse than before — the same 500, from
+a named exception instead of an NPE — and the streaming one already reports the
+failure as an SSE error event, which is the right contract once a stream has opened.
+
+### A malformed configuration body was a `400` with no body
+
+Strictness only covered unknown *field names*. A value of the wrong *shape* — the
+quickstart's own `"valueAlternatives": ["Hello!"]` where the model wants
+`[{"type":"text","text":"Hello!"}]` — fell through to RESTEasy, which answers `400` with
+`content-length: 0`. No field, no expectation, no indication the body was even the
+problem. `StrictConfigurationParser` now explains those too:
+
+```
+Cannot read OutputConfigurationSet at outputSet[0].outputs[0].valueAlternatives[0]:
+expected a JSON object here, found a string. The value's shape is wrong — check this
+field against the resource's JSON Schema at GET /<store>/<resource>/jsonSchema.
+```
+
+Both messages render the failing position as a JSON path instead of Jackson's
+`ai.labs.eddi.configs…["outputSet"]->java.util.ArrayList[0]->…`, which named classes
+the caller cannot see and published the internal package layout to every client. What
+was *found* is resolved by re-reading the body at that position rather than off the
+parser — `readValue` closes the parser before the exception propagates, so its current
+token is always null by then.
+
+### Behavior rules read back under a different key than they are written with
+
+`RuleGroupConfiguration`'s accessors are `getRules`/`setRules`, so Jackson serialised the
+list as `rules` — while the shipped reference config, the ZIP fixtures, the documentation
+and the Manager's rules editor all say `behaviorRules`. The alias made writes work either
+way, so this only ever bit on **reads**: post `behaviorRules`, get `rules` back, and the
+Manager renders every group as "No rules in this group" no matter what it contains. Its
+own MSW mocks return `behaviorRules`, so its suite agreed with the fiction rather than the
+server. Now `behaviorRules` out, both names in — every stored document keeps loading.
+
+### Ollama: an overlay, and the switch that decides whether it looks alive
+
+`docker-compose.ollama.yml` puts Ollama on the same Docker network, so the base URL is
+`http://ollama:11434` — plain container DNS, identical on every host — and sets
+`EDDI_OLLAMA_DEFAULT_BASE_URL` so the agent wizard and setup API pre-fill something that
+resolves. Inside the `eddi` container `localhost` is the container, and that is the single
+most common way a first local-LLM agent fails. Verified end to end: model pulled, agent
+deployed, real turn answered.
+
+The builder also gained Ollama's `think` and `returnThinking`. A reasoning model
+(gemma3n, deepseek-r1, qwen3) left on its default thinks before answering, and the
+reasoning arrives in a separate `thinking` field that is not part of the streamed
+content — so a streaming window shows nothing for many seconds and then everything at
+once, which reads as a hang. `think` is deliberately tri-state: `applyBoolean` leaves an
+absent or unparseable value alone rather than letting `Boolean.parseBoolean` turn a typo
+into "reasoning off".
+
+### Already fixed, for the record
+
+Karol could not see dictionaries or behavior rules in the Manager, and their
+`descriptors` listings returned `[]` while the resources read back fine individually.
+That is `60188c2bd` — three stores queried a descriptor type that did not match the
+namespace they write to — which landed *after* 6.3.0 and ships in the next release.
+Reproduced on 6.3.0, confirmed absent on `main`.
+
+### Not reproduced
+
+The `307` seen while streaming against `gemma4:e4b`. Nothing in EDDI emits a 307,
+`langchain4j` normalises the trailing slash before appending `api/chat`, and the Manager's
+streaming client follows redirects. It needs the actual request/response pair — most
+likely from the Ollama side — before anything can be claimed about it. The overlay above
+removes the whole class of host-networking problems it may belong to.
+
+### Files
+
+`docs/developer-quickstart.md` (rewritten walkthrough), eleven other `docs/*.md`
+(legacy-path sweep), `docs/langchain.md` (Ollama parameters + container networking),
+`README.md`, `docker-compose.ollama.yml` (new),
+`RestConversationStore`, `RestAgentAdministration`, `ConversationService`,
+`ConversationStepRunner`, `ConversationNotFoundExceptionMapper` (new),
+`StrictConfigurationParser`, `RuleGroupConfiguration`, `OllamaLanguageModelBuilder`,
+`ModelParameterValues`, `DocumentedRestPathsTest` (new),
+`RuleGroupConfigurationJsonTest` (new), and the existing tests for each behaviour
+above.
+
+### Verified, not assumed
+
+Every item was reproduced against `labsai/eddi:6.3.0` in Docker before being fixed, and
+each fix was then verified against an image built from this branch — including running
+the rewritten quickstart end to end, verbatim, against a clean database.
+`labsai/eddi:latest` (built 2026-08-20) was checked too, which is how the descriptor
+listing bug below was confirmed still live in CI.
+
+> **Local test note.** `LanguageModelBuildersTest` cannot run in this environment — every
+> builder in it, touched or not, fails with "Unable to establish loopback connection"
+> because the JDK HTTP client cannot open a selector here. CI is the gate for that class.
+
+---
+
 ## 🧪 test(connections): cover the four stores nothing was testing, and close two defects that surfaced doing it (2026-08-22)
 
 **Repo:** EDDI (`feat/saas-connectors`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -90,11 +90,19 @@ All five now answer `404` naming the conversation id.
 `ConversationNotFoundExceptionMapper` is new; the rest is a `requireSnapshot` guard
 and a null check in the right order.
 
-Deliberately **not** extended to `POST /agents/{id}` and `/stream`: those are the
-async paths, whose exception plumbing is a different problem, and no documentation
-sends anyone there with a dead id. They are no worse than before — the same 500, from
-a named exception instead of an NPE — and the streaming one already reports the
-failure as an SSE error event, which is the right contract once a stream has opened.
+`POST /agents/{id}` and `/rerun` were the same bug once more, and the file already
+said so twice: `sayInternal` carries two comments explaining that "say() is resumed
+through an AsyncResponse, so the exception never reaches [the mapper]" — one for the
+quota denial that used to surface as 500, one for backpressure. This was the third
+instance. Now caught explicitly, `404` with the message.
+
+The streaming twin reports it as a typed `conversation_not_found` **error event**
+rather than a status, which is deliberate: `buildKnownConditionOrOpaqueErrorEvent`
+exists precisely to map the conditions `sayStreaming` rejects synchronously onto
+machine-readable codes — `awaiting_approval`, `conversation_ended`,
+`agent_not_ready` — and its javadoc already listed the twin's 404 among them.
+Deviating for this one condition would have created a new inconsistency rather than
+removing one.
 
 ### A malformed configuration body was a `400` with no body
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -112,7 +112,7 @@ quickstart's own `"valueAlternatives": ["Hello!"]` where the model wants
 `content-length: 0`. No field, no expectation, no indication the body was even the
 problem. `StrictConfigurationParser` now explains those too:
 
-```
+```text
 Cannot read OutputConfigurationSet at outputSet[0].outputs[0].valueAlternatives[0]:
 expected a JSON object here, found a string. The value's shape is wrong — check this
 field against the resource's JSON Schema at GET /<store>/<resource>/jsonSchema.
@@ -179,6 +179,22 @@ removes the whole class of host-networking problems it may belong to.
 `ModelParameterValues`, `DocumentedRestPathsTest` (new),
 `RuleGroupConfigurationJsonTest` (new), and the existing tests for each behaviour
 above.
+
+### Also corrected under review
+
+Five more pages still carried the pre-v6 workflow payload — `packageExtensions`
+with `extensions.uri` — which the v6 store-path sweep had left alone because it
+rewrote paths, not shapes. Strict parsing rejects `packageExtensions` outright, so
+those were instructions that could not work: `putting-it-all-together.md`,
+`httpcalls.md`, both `creating-your-first-agent` pages and `architecture.md`.
+`DocumentedRestPathsTest` now fails the build on that key too.
+
+`open-webui-integration.md` declared a workflow step of type
+`eddi://ai.labs.langchain`, which no module registers — the LLM module registers
+`ai.labs.llm` only, so that workflow would not load.
+
+And the quickstart still described rule sets reading back as `rules`, which is the
+behaviour *this entry changes*. Corrected to say `behaviorRules` is canonical.
 
 ### Verified, not assumed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,12 +11,11 @@
 
 **Repo:** EDDI (`fix/quickstart-truth-and-api-honesty`)
 
-Karol worked through
-[`docs/developer-quickstart.md`](developer-quickstart.md) against `labsai/eddi:6.3.0`
-and reported what happened. Seven steps produced four failures, and every one of them was
-ours — the documentation in most cases, the API in the rest. Each item below was
-**reproduced against a real 6.3.0 container** before being fixed, and the fix verified
-against the same stack where it could be.
+Following [`docs/developer-quickstart.md`](developer-quickstart.md) against
+`labsai/eddi:6.3.0` produces four failures in seven steps. All of them are ours — the
+documentation in most cases, the API in the rest. Each item below was **reproduced
+against a real 6.3.0 container** before being fixed, and the fix verified against the
+same stack where it could be.
 
 ### The documentation was wrong, and the compatibility layer hid it
 
@@ -69,8 +68,8 @@ both blames the wrong thing and names the datastore behind the API.
 
 ### Reading a conversation that is not there was a `500`
 
-Not something Karol reported, but the same defect on a different resource — and the
-Troubleshooting section rewritten above now sends people to two of the affected
+Not surfaced by the walkthrough, but the same defect on a different resource — and
+the Troubleshooting section rewritten above now sends people to two of the affected
 endpoints, precisely when something has already gone wrong. Five conversation reads
 answered a deleted or mistyped id with `500 Internal Server Error` and an error id,
 while every one of them documents a 404:
@@ -154,8 +153,8 @@ into "reasoning off".
 
 ### Already fixed, for the record
 
-Karol could not see dictionaries or behavior rules in the Manager, and their
-`descriptors` listings returned `[]` while the resources read back fine individually.
+Dictionaries and behavior rules do not appear in the Manager, and their
+`descriptors` listings return `[]` while the resources read back fine individually.
 That is `60188c2bd` — three stores queried a descriptor type that did not match the
 namespace they write to — which landed *after* 6.3.0 and ships in the next release.
 Reproduced on 6.3.0, confirmed absent on `main`.

--- a/docs/creating-your-first-agent/README.md
+++ b/docs/creating-your-first-agent/README.md
@@ -52,13 +52,13 @@ A agent can consists of the following elements:
 
 ### Example of a resource reference
 
-`eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/ID?version=VERSION`
+`eddi://ai.labs.dictionary/dictionarystore/dictionaries/ID?version=VERSION`
 
 `eddi://` URI resources starting with this protocol are to be related with in EDDI&#x20;
 
 `ai.labs.regulardictionary` Type of resource
 
-`/regulardictionarystore/regulardictionaries` API path
+`/dictionarystore/dictionaries` API path
 
 &#x20;`ID` ID of the resources
 

--- a/docs/creating-your-first-agent/README.md
+++ b/docs/creating-your-first-agent/README.md
@@ -56,7 +56,7 @@ A agent can consists of the following elements:
 
 `eddi://` URI resources starting with this protocol are to be related with in EDDI&#x20;
 
-`ai.labs.regulardictionary` Type of resource
+`ai.labs.dictionary` Type of resource
 
 `/dictionarystore/dictionaries` API path
 

--- a/docs/creating-your-first-agent/creating-your-first-agent-1.md
+++ b/docs/creating-your-first-agent/creating-your-first-agent-1.md
@@ -107,7 +107,7 @@ curl -X POST --header 'Content-Type: application/json' --header 'Accept: applica
 
 > See also Behavior Rules
 
-Next, create a `behaviorRule` resource to configure the decision making a. Make a **`POST`** to **`/rulestore/rulesets`** with a JSON in the body like this:
+Next, create a `behaviorRule` resource to configure the agent's decision making. Make a **`POST`** to **`/rulestore/rulesets`** with a JSON in the body like this:
 
 ```javascript
 {
@@ -350,7 +350,7 @@ Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **
 
 ```javascript
 {
-  "packageExtensions": [
+  "workflowSteps": [
     {
       "type": "eddi://ai.labs.parser",
       "extensions": {
@@ -472,7 +472,7 @@ Now you can use the new feature of defining properties in the package definition
 
 ```javascript
 {
-  "packageExtensions": [
+  "workflowSteps": [
    ...
     {
       "type": "eddi://ai.labs.property",

--- a/docs/creating-your-first-agent/creating-your-first-agent-1.md
+++ b/docs/creating-your-first-agent/creating-your-first-agent-1.md
@@ -10,7 +10,7 @@ Follow these steps to create the configuration files you will need:
 
 > See also [Semantic Parser](../semantic-parser.md)
 
-Create regular dictionaries in order to store custom words and phrases. A dictionary is there to map user input to expressions, which are later used in `Behavior Rules`. A **`POST`** to **`/regulardictionarystore/regulardictionaries`** with a JSON in the body like this:
+Create regular dictionaries in order to store custom words and phrases. A dictionary is there to map user input to expressions, which are later used in `Behavior Rules`. A **`POST`** to **`/dictionarystore/dictionaries`** with a JSON in the body like this:
 
 ```javascript
 {
@@ -86,7 +86,7 @@ curl -X POST --header 'Content-Type: application/json' --header 'Accept: applica
 "expressions" : "how_are_you" \
 } \
 ] \
-}' 'http://localhost:7070/regulardictionarystore/regulardictionaries'
+}' 'http://localhost:7070/dictionarystore/dictionaries'
 ```
 
 ### Dictionary parameters
@@ -107,7 +107,7 @@ curl -X POST --header 'Content-Type: application/json' --header 'Accept: applica
 
 > See also Behavior Rules
 
-Next, create a `behaviorRule` resource to configure the decision making a. Make a **`POST`** to **`/behaviorstore/behaviorsets`** with a JSON in the body like this:
+Next, create a `behaviorRule` resource to configure the decision making a. Make a **`POST`** to **`/rulestore/rulesets`** with a JSON in the body like this:
 
 ```javascript
 {
@@ -211,11 +211,11 @@ Next, create a `behaviorRule` resource to configure the decision making a. Make 
 
 You should again get a return code of **`201`** with a **`URI`** in the **`location` header** referencing the newly created `Behavior Rules`:
 
-`eddi://ai.labs.behavior/behaviorstore/behaviorsets/`**`<UNIQUE_BEHAVIOR_ID>`**`?version=`**`<BEHAVIOR_VERSION>`**
+`eddi://ai.labs.rules/rulestore/rulesets/`**`<UNIQUE_BEHAVIOR_ID>`**`?version=`**`<BEHAVIOR_VERSION>`**
 
 Example:
 
-`eddi://ai.labs.behavior/behaviorstore/behaviorsets/5a26d8fd17312628b46119fb?version=1`
+`eddi://ai.labs.rules/rulestore/rulesets/5a26d8fd17312628b46119fb?version=1`
 
 ### 3. Creating Output
 
@@ -346,7 +346,7 @@ Example :
 
 ### 4. Creating the Workflow
 
-Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **`POST`** to **`/packagestore/packages`** with a JSON in the body like this:
+Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **`POST`** to **`/workflowstore/workflows`** with a JSON in the body like this:
 
 ```javascript
 {
@@ -376,7 +376,7 @@ Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **
           {
             "type": "eddi://ai.labs.parser.dictionaries.regular",
             "config": {
-              "uri": "eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/<UNIQUE_DICTIONARY_ID>?version=<DICTIONARY_VERSION>"
+              "uri": "eddi://ai.labs.dictionary/dictionarystore/dictionaries/<UNIQUE_DICTIONARY_ID>?version=<DICTIONARY_VERSION>"
             }
           }
         ],
@@ -404,7 +404,7 @@ Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **
     {
       "type": "eddi://ai.labs.behavior",
       "config": {
-        "uri": "eddi://ai.labs.behavior/behaviorstore/behaviorsets/<UNIQUE_BEHAVIOR_ID>?version=<BEHAVIOR_VERSION>"
+        "uri": "eddi://ai.labs.rules/rulestore/rulesets/<UNIQUE_BEHAVIOR_ID>?version=<BEHAVIOR_VERSION>"
       }
     },
     {
@@ -431,7 +431,7 @@ Extension Types
 | Extension               | Config                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | eddi://ai.labs.parser   | <p><code>Dictionaries</code> and/or corrections </p><p>Object "<code>extensions</code>" can contain "<code>dictionaries</code>" (<code>Array</code> of <code>Dictionary</code>) and/or "<code>corrections</code>" (<code>Array</code> of <code>Correction</code>) </p><p>Object "<code>Dictionary</code>" has params "<code>type</code>" and "<code>config</code>" (optional) </p><p><code>Dictionary.type</code> can reference <code>Regular-Dictionaries</code> "<code>eddi://ai.labs.parser.dictionaries.regular</code>" (needs param "<code>config.uri</code>") or be one of the <strong>EDDI</strong> out of the box types: </p><p>—>"<code>eddi://ai.labs.parser.dictionaries.integer</code>" </p><p>—>"<code>eddi://ai.labs.parser.dictionaries.decimal</code>" </p><p>—>"<code>eddi://ai.labs.parser.dictionaries.punctuation</code>" </p><p>—>"<code>eddi://ai.labs.parser.dictionaries.email</code>" </p><p>—>"<code>eddi://ai.labs.parser.dictionaries.time</code>" </p><p>—>"<code>eddi://ai.labs.parser.dictionaries.ordinalNumber</code>"</p><p>Object "<code>Correction</code>" has params "<code>type</code>" and "<code>config</code>" (optional)</p><p><code>Correction.type</code> can reference one of the EDDI out of the box types: </p><p>—>"<code>eddi://ai.labs.parser.corrections.stemming</code>": Object "<code>config</code>" has params "<code>language</code>" (<code>String</code> e.g. "english") and "<code>lookupIfKnown</code>" (<code>Boolean</code>) </p><p>—>"<code>eddi://ai.labs.parser.corrections.levenshtein</code>": Object "<code>config</code>" has param "<code>distance</code>" (Integer, e.g. 2) </p><p>—>"<code>eddi://ai.labs.parser.corrections.mergedTerms</code>"</p> |
-| eddi://ai.labs.behavior | Object `Config` contains param `uri` with Link to a behavior set, e.g. `eddi://ai.labs.behavior/behaviorstore/behaviorsets/5a26d8fd17312628b46119fb?version=1`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| eddi://ai.labs.behavior | Object `Config` contains param `uri` with Link to a behavior set, e.g. `eddi://ai.labs.rules/rulestore/rulesets/5a26d8fd17312628b46119fb?version=1`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | eddi://ai.labs.output   | Object Config contains param `uri` with Link to output set, e.g. `eddi://ai.labs.output/outputstore/outputsets/5a26d97417312628b46119fc?version=1`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
 > New
@@ -516,11 +516,11 @@ Now you can use the new feature of defining properties in the package definition
 
 You should again get a return code of `201` with an `URI` in the location header referencing the newly created package format
 
-`eddi://ai.labs.package/packagestore/packages/<UNIQUE_WORKFLOW_ID>?version=<WORKFLOW_VERSION>`
+`eddi://ai.labs.workflow/workflowstore/workflows/<UNIQUE_WORKFLOW_ID>?version=<WORKFLOW_VERSION>`
 
 Example
 
-`eddi://ai.labs.package/packagestore/packages/5a2ae60f17312624f8b8a445?version=1`
+`eddi://ai.labs.workflow/workflowstore/workflows/5a2ae60f17312624f8b8a445?version=1`
 
 > See also the API documentation at [http://localhost:7070/q/swagger-ui](http://localhost:7070/q/swagger-ui)
 
@@ -531,7 +531,7 @@ Make a **`POST`** to **`/agentstore/agents`** with a JSON like this:
 ```javascript
 {
 "packages": [
-"eddi://ai.labs.package/packagestore/packages/<UNIQUE_WORKFLOW_ID>?version=<WORKFLOW_VERSION>"
+"eddi://ai.labs.workflow/workflowstore/workflows/<UNIQUE_WORKFLOW_ID>?version=<WORKFLOW_VERSION>"
 ],
 "channels": []
 }

--- a/docs/creating-your-first-agent/creating-your-first-agent.md
+++ b/docs/creating-your-first-agent/creating-your-first-agent.md
@@ -43,7 +43,7 @@ Example :
 
 ### 4. Creating the Workflow
 
-Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **`POST`** to **`/packagestore/packages`** with a JSON in the body like this:
+Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **`POST`** to **`/workflowstore/workflows`** with a JSON in the body like this:
 
 ```javascript
 {
@@ -75,11 +75,11 @@ Extension Types in this examples
 
 >
 
-`eddi://ai.labs.package/packagestore/packages/<UNIQUE_WORKFLOW_ID>?version=<WORKFLOW_VERSION>`
+`eddi://ai.labs.workflow/workflowstore/workflows/<UNIQUE_WORKFLOW_ID>?version=<WORKFLOW_VERSION>`
 
 Example
 
-`eddi://ai.labs.package/packagestore/packages/5a2ae60f17312624f8b8a445?version=1`
+`eddi://ai.labs.workflow/workflowstore/workflows/5a2ae60f17312624f8b8a445?version=1`
 
 > See also the API documentation at [http://localhost:7070/q/swagger-ui](http://localhost:7070/q/swagger-ui)
 
@@ -90,7 +90,7 @@ Make a **`POST`** to **`/agentstore/agents`** with a JSON like this:
 ```javascript
 {
      "packages": [
-          "eddi://ai.labs.package/packagestore/packages/<UNIQUE_WORKFLOW_ID>?version=<WORKFLOW_VERSION>"
+          "eddi://ai.labs.workflow/workflowstore/workflows/<UNIQUE_WORKFLOW_ID>?version=<WORKFLOW_VERSION>"
      ]
 }
 ```

--- a/docs/creating-your-first-agent/creating-your-first-agent.md
+++ b/docs/creating-your-first-agent/creating-your-first-agent.md
@@ -47,7 +47,7 @@ Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **
 
 ```javascript
 {
-  "packageExtensions": [
+  "workflowSteps": [
     {
       "type": "eddi://ai.labs.output",
       "config": {

--- a/docs/deployment-management-of-agents.md
+++ b/docs/deployment-management-of-agents.md
@@ -267,7 +267,7 @@ This will:
 Workflows can also be individually cascade-deleted:
 
 ```
-DELETE /packagestore/packages/{id}?version={version}&cascade=true&permanent=true
+DELETE /workflowstore/workflows/{id}?version={version}&cascade=true&permanent=true
 → 200 OK (package + all extension resources deleted)
 ```
 
@@ -312,13 +312,13 @@ Returns a report listing all unreferenced resources across all stores (workflows
   "deletedCount": 0,
   "orphans": [
     {
-      "resourceUri": "eddi://ai.labs.package/packagestore/packages/abc123?version=1",
+      "resourceUri": "eddi://ai.labs.workflow/workflowstore/workflows/abc123?version=1",
       "type": "ai.labs.package",
       "name": "Unused Workflow",
       "deleted": false
     },
     {
-      "resourceUri": "eddi://ai.labs.behavior/behaviorstore/behaviorsets/def456?version=1",
+      "resourceUri": "eddi://ai.labs.rules/rulestore/rulesets/def456?version=1",
       "type": "ai.labs.behavior",
       "name": "Old Behavior Set",
       "deleted": true

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -30,22 +30,29 @@ Each task transforms the **Conversation Memory** (a state object containing ever
 Agents aren't code—they're **JSON configurations**:
 
 ```
-Agent (list of packages)
-  └─ Workflow (list of extensions)
-      ├─ Behavior Rules (.behavior.json)
-      ├─ HTTP Calls (.httpcalls.json)
-      ├─ LangChain (.langchain.json)
-      └─ Output Templates (.output.json)
+Agent (list of workflows)
+  └─ Workflow (ordered list of pipeline steps)
+      ├─ Parser          — input → expressions
+      ├─ Behavior Rules  — expressions → actions
+      ├─ API Calls / MCP — actions → outbound calls
+      ├─ LLM             — actions → model turn
+      ├─ Output          — actions → user-visible messages
+      └─ Templating      — resolves {…} in the output
 ```
+
+Each step points at a stored configuration document by `eddi://` URI, so the
+same rule set or output set can be reused across workflows and agents.
 
 ## Quick Setup
 
 ### Prerequisites
 
-- Java 25
-- Maven 3.8.4
-- MongoDB 6.0+
-- Docker (optional, recommended)
+- **Java 25** (the version in `pom.xml` is authoritative)
+- **Maven** — not needed separately; the repo ships the `./mvnw` wrapper
+  (`.\mvnw.cmd` on Windows)
+- **MongoDB 7** (or PostgreSQL — see [Architecture](architecture.md))
+- **Docker** — optional for running from source, required for the quick start
+  below
 
 ### Run with Docker (Easiest)
 
@@ -54,11 +61,18 @@ Agent (list of packages)
 git clone https://github.com/labsai/EDDI.git
 cd EDDI
 
-# Start EDDI + MongoDB
-docker-compose up
+# Start EDDI + MongoDB (pin a version, or omit to get :latest)
+EDDI_VERSION=6.3.0 docker compose up -d
 
 # Access dashboard
-open http://localhost:7070
+open http://localhost:7070/manage
+```
+
+Optional overlays stack on top of the base file — for example, a local LLM on
+the same Docker network:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d
 ```
 
 ### Run from Source
@@ -106,38 +120,80 @@ See [LangChain Documentation](langchain.md#tool-configuration-server-side) for d
 
 ## Your First Agent (via API)
 
-### 1. Create a Dictionary
+The walkthrough below is a complete, copy-pasteable session against a stock
+`docker compose up -d` instance on `http://localhost:7070`. Every request and
+every response shape here is the one the running server actually produces.
 
-Dictionaries define what users can say:
+Three things to know before you start, because they surprise everybody once:
+
+1. **A successful create returns `201` with an empty body.** The id is in the
+   `Location` (and `X-Resource-URI`) header, as an `eddi://` URI — not an HTTP
+   URL you can fetch. Take the last path segment as the id:
+   `eddi://ai.labs.dictionary/dictionarystore/dictionaries/68a1…?version=1`
+   → id `68a1…`, version `1`.
+2. **Every store has a `descriptors` listing** — `GET /<store>/<resource>/descriptors`.
+   That is how you find what you created. There is also a cross-type listing,
+   `GET /descriptorstore/descriptors?type=<type>`, which is handy when you want
+   everything of one kind at once.
+3. **Unknown fields are rejected, not ignored.** A `400` naming the offending
+   key means the payload used an older field name — the message lists the legal
+   ones. This is deliberate: a silently dropped key looks like a successful save
+   and changes nothing.
+
+`jq` is used below only to pretty-print; it is not required.
 
 ```bash
-curl -X POST http://localhost:7070/regulardictionarystore/regulardictionaries \
+EDDI=http://localhost:7070
+```
+
+### 1. Create a Dictionary
+
+Dictionaries map what users type to **expressions**, which behavior rules then
+match on:
+
+```bash
+curl -i -X POST $EDDI/dictionarystore/dictionaries \
   -H "Content-Type: application/json" \
   -d '{
     "words": [
-      {
-        "word": "hello",
-        "expressions": "greeting(hello)",
-        "frequency": 0
-      },
-      {
-        "word": "hi",
-        "expressions": "greeting(hi)",
-        "frequency": 0
-      }
+      { "word": "hello", "expressions": "greeting(hello)", "frequency": 0 },
+      { "word": "hi",    "expressions": "greeting(hi)",    "frequency": 0 }
     ],
     "phrases": []
   }'
 ```
 
-**Response**: Dictionary ID (e.g., `eddi://ai.labs.parser.dictionaries.regular/regulardictionarystore/regulardictionaries/abc123?version=1`)
+**Response**: `201 Created`, with
+
+```
+Location: eddi://ai.labs.dictionary/dictionarystore/dictionaries/<DICTIONARY_ID>?version=1
+```
+
+Keep `<DICTIONARY_ID>`. To list every dictionary, or read one back:
+
+```bash
+curl -s "$EDDI/dictionarystore/dictionaries/descriptors?limit=100" | jq
+curl -s "$EDDI/dictionarystore/dictionaries/<DICTIONARY_ID>?version=1" | jq
+```
+
+> **Naming a resource.** A resource created over the API has an empty name, so
+> the Manager UI lists it as "Unnamed …". Names live on the *descriptor*, not on
+> the configuration document — set one with a `PATCH`, and the same call works
+> for every resource type in this guide:
+>
+> ```bash
+> curl -X PATCH "$EDDI/descriptorstore/descriptors/<ANY_RESOURCE_ID>?version=1" \
+>   -H "Content-Type: application/json" \
+>   -d '{ "operation": "SET",
+>         "document": { "name": "Greeting dictionary", "description": "hello / hi" } }'
+> ```
 
 ### 2. Create Behavior Rules
 
-Rules define what the agent does:
+Rules decide which **actions** a turn emits:
 
 ```bash
-curl -X POST http://localhost:7070/behaviorstore/behaviorsets \
+curl -i -X POST $EDDI/rulestore/rulesets \
   -H "Content-Type: application/json" \
   -d '{
     "behaviorGroups": [
@@ -163,12 +219,22 @@ curl -X POST http://localhost:7070/behaviorstore/behaviorsets \
   }'
 ```
 
-**Response**: Behavior set ID
+**Response**: `201`, `Location: eddi://ai.labs.rules/rulestore/rulesets/<RULESET_ID>?version=1`
+
+```bash
+curl -s "$EDDI/rulestore/rulesets/descriptors?limit=100" | jq
+```
+
+> Reading a rule set back shows `rules` where you posted `behaviorRules` — the
+> model accepts both names on write and serialises the canonical one on read.
 
 ### 3. Create Output Templates
 
+Output maps an action to what the user sees. **`valueAlternatives` is a list of
+typed output items, not a list of strings** — a bare string is rejected:
+
 ```bash
-curl -X POST http://localhost:7070/outputstore/outputsets \
+curl -i -X POST $EDDI/outputstore/outputsets \
   -H "Content-Type: application/json" \
   -d '{
     "outputSet": [
@@ -178,7 +244,7 @@ curl -X POST http://localhost:7070/outputstore/outputsets \
         "outputs": [
           {
             "valueAlternatives": [
-              "Hello! How can I help you today?"
+              { "type": "text", "text": "Hello! How can I help you today?" }
             ]
           }
         ]
@@ -187,107 +253,231 @@ curl -X POST http://localhost:7070/outputstore/outputsets \
   }'
 ```
 
-**Response**: Output set ID
+**Response**: `201`, `Location: eddi://ai.labs.output/outputstore/outputsets/<OUTPUT_ID>?version=1`
+
+Besides `text`, an output item may be `image`, `quickReply`, `inputField`,
+`applicationLink`, `button`, `agentFace` or `other`. See
+[Output Configuration](output-configuration.md).
 
 ### 4. Create a Workflow
 
-Workflows bundle extensions together:
+A workflow is the ordered list of pipeline steps — the **`workflowSteps`** array.
+Each step names a lifecycle task by `eddi://` URI; a step that needs a
+configuration document points at it through `config.uri`, and the parser takes
+its dictionaries through `extensions` instead:
 
 ```bash
-curl -X POST http://localhost:7070/packagestore/packages \
+curl -i -X POST $EDDI/workflowstore/workflows \
   -H "Content-Type: application/json" \
   -d '{
-    "packageExtensions": [
+    "workflowSteps": [
       {
-        "type": "eddi://ai.labs.parser.dictionaries.regular",
+        "type": "eddi://ai.labs.parser",
+        "config": {},
         "extensions": {
-          "uri": "eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/abc123?version=1"
+          "dictionaries": [
+            {
+              "type": "eddi://ai.labs.parser.dictionaries.regular",
+              "config": {
+                "uri": "eddi://ai.labs.dictionary/dictionarystore/dictionaries/<DICTIONARY_ID>?version=1"
+              }
+            }
+          ],
+          "corrections": []
         }
       },
       {
-        "type": "eddi://ai.labs.behavior",
-        "extensions": {
-          "uri": "eddi://ai.labs.behavior/behaviorstore/behaviorsets/def456?version=1"
-        },
+        "type": "eddi://ai.labs.rules",
         "config": {
-          "appendActions": true
+          "uri": "eddi://ai.labs.rules/rulestore/rulesets/<RULESET_ID>?version=1"
         }
       },
       {
         "type": "eddi://ai.labs.output",
-        "extensions": {
-          "uri": "eddi://ai.labs.output/outputstore/outputsets/ghi789?version=1"
+        "config": {
+          "uri": "eddi://ai.labs.output/outputstore/outputsets/<OUTPUT_ID>?version=1"
         }
-      }
+      },
+      { "type": "eddi://ai.labs.templating", "config": {} }
     ]
   }'
 ```
 
-**Response**: Workflow ID
+**Response**: `201`, `Location: eddi://ai.labs.workflow/workflowstore/workflows/<WORKFLOW_ID>?version=1`
+
+Step order is execution order. The available step types:
+
+| Step `type`                | Purpose                        | Configuration            |
+| -------------------------- | ------------------------------ | ------------------------ |
+| `eddi://ai.labs.parser`    | Input → expressions            | dictionaries/corrections via `extensions` |
+| `eddi://ai.labs.rules`     | Behavior rules → actions       | `config.uri` → rule set  |
+| `eddi://ai.labs.property`  | Slot-filling / properties      | `config.uri` → property setter |
+| `eddi://ai.labs.apicalls`  | Outbound HTTP calls            | `config.uri` → API calls |
+| `eddi://ai.labs.mcpcalls`  | MCP tool calls                 | `config.uri` → MCP calls |
+| `eddi://ai.labs.llm`       | LLM interaction                | `config.uri` → LLM config |
+| `eddi://ai.labs.output`    | Actions → user-visible output  | `config.uri` → output set |
+| `eddi://ai.labs.templating`| Resolves `{…}` in the output   | none                     |
+
+> **Add `eddi://ai.labs.templating` last** whenever an output or system prompt
+> contains `{properties.x}`-style placeholders. Without it the expressions are
+> never resolved. It is harmless when there is nothing to resolve, so the
+> examples keep it.
+>
+> `eddi://ai.labs.behavior` and `eddi://ai.labs.httpcalls` are accepted as
+> aliases of `ai.labs.rules` and `ai.labs.apicalls`; new configurations should
+> use the names in the table.
 
 ### 5. Create an Agent
 
+An agent is a list of workflows — the field is **`workflows`**:
+
 ```bash
-curl -X POST http://localhost:7070/agentstore/agents \
+curl -i -X POST $EDDI/agentstore/agents \
   -H "Content-Type: application/json" \
   -d '{
-    "packages": [
-      "eddi://ai.labs.package/packagestore/packages/xyz123?version=1"
+    "workflows": [
+      "eddi://ai.labs.workflow/workflowstore/workflows/<WORKFLOW_ID>?version=1"
     ]
   }'
 ```
 
-**Response**: Agent ID (e.g., `agent-abc-123`)
+**Response**: `201`, `Location: eddi://ai.labs.agent/agentstore/agents/<AGENT_ID>?version=1`
+
+Give it a name, or the Manager will list it as "Unnamed Agent":
+
+```bash
+curl -X PATCH "$EDDI/descriptorstore/descriptors/<AGENT_ID>?version=1" \
+  -H "Content-Type: application/json" \
+  -d '{ "operation": "SET",
+        "document": { "name": "Greeter", "description": "Says hello" } }'
+```
+
+> `packages` is still accepted as an alias for `workflows`, so a payload using
+> the old name is stored rather than rejected. It is deprecated — write
+> `workflows`.
 
 ### 6. Deploy the Agent
 
+An agent must be deployed to an environment before it can hold a conversation.
+Pass `waitForCompletion=true` and the call returns the *final* status instead of
+a bare `202 Accepted`:
+
 ```bash
-curl -X POST "http://localhost:7070/administration/production/deploy/agent-abc-123?version=1"
+curl -s -X POST \
+  "$EDDI/administration/production/deploy/<AGENT_ID>?version=1&waitForCompletion=true" | jq
+```
+
+```json
+{
+  "status": "READY",
+  "agentId": "<AGENT_ID>",
+  "version": 1,
+  "environment": "production"
+}
+```
+
+Any status other than `READY` — typically `ERROR` — means the agent's workflow
+references something that does not resolve. Check the server log, then
+re-deploy. The status can be re-read at any time:
+
+```bash
+curl -s "$EDDI/administration/production/deploymentstatus/<AGENT_ID>?version=1" | jq
 ```
 
 ### 7. Chat with Your Agent
 
+Starting a conversation and sending a message are **two separate calls**. The
+start call takes no message body; it creates the conversation and returns its id
+in the `Location` header:
+
 ```bash
-# Start conversation
-curl -X POST http://localhost:7070/agents/agent-abc-123/start \
-  -H "Content-Type: application/json" \
-  -d '{"input": "hello"}'
-
-# Response includes conversationId
-# {
-#   "conversationId": "conv-123",
-#   "conversationState": "READY",
-#   "conversationOutputs": [
-#     {"output": ["Hello! How can I help you today?"]}
-#   ]
-# }
-
-# Continue conversation
-curl -X POST http://localhost:7070/agents/conv-123 \
-  -H "Content-Type: application/json" \
-  -d '{"input": "hi"}'
+curl -i -X POST \
+  "$EDDI/agents/<AGENT_ID>/start?environment=production&userId=test-user"
 ```
 
-## Adding an LLM (OpenAI Example)
+```
+HTTP/1.1 201 Created
+Location: eddi://ai.labs.conversation/conversationstore/conversations/<CONVERSATION_ID>
+```
 
-### 1. Create LangChain Configuration
+Then talk to the **conversation**, not the agent. Plain text is the simplest
+form:
 
 ```bash
-curl -X POST http://localhost:7070/langchainstore/langchains \
+curl -s -X POST "$EDDI/agents/<CONVERSATION_ID>" \
+  -H "Content-Type: text/plain" \
+  --data 'hello' | jq
+```
+
+```json
+{
+  "conversationId": "<CONVERSATION_ID>",
+  "agentId": "<AGENT_ID>",
+  "agentVersion": 1,
+  "userId": "test-user",
+  "environment": "production",
+  "conversationState": "READY",
+  "conversationOutputs": [
+    {
+      "actions": ["welcome_action"],
+      "output": [
+        { "type": "text", "text": "Hello! How can I help you today?", "delay": 0 }
+      ]
+    }
+  ],
+  "conversationProperties": {},
+  "conversationSteps": [ /* … */ ]
+}
+```
+
+The same endpoint accepts JSON when you want to pass context alongside the
+message:
+
+```bash
+curl -s -X POST "$EDDI/agents/<CONVERSATION_ID>" \
+  -H "Content-Type: application/json" \
+  -d '{ "input": "hello",
+        "context": { "language": { "type": "string", "value": "en" } } }' | jq
+```
+
+To start a conversation *with* an initial context, POST that same context map —
+and only a context map — to the start endpoint:
+
+```bash
+curl -i -X POST "$EDDI/agents/<AGENT_ID>/start?environment=production&userId=test-user" \
+  -H "Content-Type: application/json" \
+  -d '{ "userName": { "type": "string", "value": "Karol" } }'
+```
+
+## Adding an LLM (Ollama Example)
+
+Ollama is used here because it needs no API key. Everything below is identical
+for the other providers except `type` and the credential — see
+[LLM Integration](langchain.md) for the full list.
+
+If EDDI runs in Docker and Ollama runs on your host, `localhost` inside the
+container is the container. Either use `http://host.docker.internal:11434`, or
+run Ollama as a compose service with
+`docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d`, which
+puts it on the same network as `http://ollama:11434`.
+
+### 1. Create the LLM Configuration
+
+```bash
+curl -i -X POST $EDDI/llmstore/llms \
   -H "Content-Type: application/json" \
   -d '{
     "tasks": [
       {
+        "id": "assistant",
+        "type": "ollama",
+        "description": "Local Ollama chat",
         "actions": ["send_to_ai"],
-        "id": "openai_chat",
-        "type": "openai",
-        "description": "OpenAI ChatGPT integration",
         "parameters": {
-          "apiKey": "your-openai-api-key",
-          "modelName": "gpt-4o",
+          "baseUrl": "http://host.docker.internal:11434",
+          "model": "llama3.2:3b",
           "temperature": "0.7",
-          "systemMessage": "You are a helpful assistant",
-          "sendConversation": "true",
+          "systemMessage": "You are a helpful assistant.",
           "addToOutput": "true"
         }
       }
@@ -295,20 +485,49 @@ curl -X POST http://localhost:7070/langchainstore/langchains \
   }'
 ```
 
-### 2. Add LangChain to Workflow
+**Response**: `201`, `Location: eddi://ai.labs.llm/llmstore/llms/<LLM_ID>?version=1`
 
-Add this extension to your package:
+> `parameters` is a free-form map, but a key no provider reads is logged as a
+> warning at build time rather than applied. `systemMessage` and `addToOutput`
+> are read by the pipeline; `model`, `baseUrl`, `temperature`, `maxTokens`,
+> `topP` and `topK` are read by the Ollama builder.
+
+For a hosted provider, put the credential in the vault rather than in the
+configuration document:
+
+```json
+"parameters": { "apiKey": "${vault:openai-key}", "modelName": "gpt-4o" }
+```
+
+### 2. Add the LLM Step to the Workflow
+
+Insert an `eddi://ai.labs.llm` step into `workflowSteps`, **before**
+`eddi://ai.labs.output`:
 
 ```json
 {
   "type": "eddi://ai.labs.llm",
-  "extensions": {
-    "uri": "eddi://ai.labs.llm/langchainstore/langchains/langchain-id?version=1"
+  "config": {
+    "uri": "eddi://ai.labs.llm/llmstore/llms/<LLM_ID>?version=1"
   }
 }
 ```
 
-### 3. Create Behavior Rule to Trigger LLM
+Update the workflow in place (this creates version 2):
+
+```bash
+curl -i -X PUT "$EDDI/workflowstore/workflows/<WORKFLOW_ID>?version=1" \
+  -H "Content-Type: application/json" \
+  -d '{ "workflowSteps": [ /* … the full list, with the llm step added … */ ] }'
+```
+
+Then point the agent at the new workflow version and deploy again — a deployed
+agent version is immutable, so a config change always means a re-deploy.
+
+### 3. Trigger the LLM from a Behavior Rule
+
+The LLM task runs when an action it listens for is emitted. Add a rule whose
+`actions` contains `send_to_ai`:
 
 ```json
 {
@@ -316,17 +535,15 @@ Add this extension to your package:
   "conditions": [
     {
       "type": "inputmatcher",
-      "configs": {
-        "expressions": "question(*)",
-        "occurrence": "currentStep"
-      }
+      "configs": { "expressions": "unknown(*)", "occurrence": "currentStep" }
     }
   ],
   "actions": ["send_to_ai"]
 }
 ```
 
-Now when users ask questions, the LLM is automatically called!
+Now anything the dictionary does not recognise is handed to the model, while
+`greeting(*)` still takes the cheap rule-based path.
 
 ## Understanding the Flow
 
@@ -334,9 +551,9 @@ Let's trace what happens when a user says "hello":
 
 ### 1. API Request
 
-```json
-POST /agents/agent-abc-123/start
-{"input": "hello"}
+```
+POST /agents/{agentId}/start?environment=production   → 201, conversation id in Location
+POST /agents/{conversationId}   (text/plain)  "hello" → the turn below
 ```
 
 ### 2. RestAgentEngine
@@ -494,19 +711,27 @@ The LLM receives the API response in memory and can format it naturally.
 
 Use context passed from your app:
 
+The start endpoint's JSON body **is** the context map — there is no `input`
+field on it, because starting a conversation and sending a message are separate
+calls:
+
 ```bash
-curl -X POST http://localhost:7070/agents/agent-abc-123/start \
+# 1. Start with initial context
+curl -i -X POST "http://localhost:7070/agents/<AGENT_ID>/start?environment=production" \
   -H "Content-Type: application/json" \
   -d '{
-    "input": "What is my name?",
-    "context": {
-      "userName": {"type": "string", "value": "John"},
-      "userId": {"type": "string", "value": "user-123"}
-    }
+    "userName": { "type": "string", "value": "John" },
+    "userId":   { "type": "string", "value": "user-123" }
   }'
+
+# 2. Send the message (context may also be supplied per turn)
+curl -s -X POST "http://localhost:7070/agents/<CONVERSATION_ID>" \
+  -H "Content-Type: application/json" \
+  -d '{ "input": "What is my name?" }'
 ```
 
-Access in output template:
+Access in an output template — and remember the `eddi://ai.labs.templating`
+step, or the placeholder is never resolved:
 
 ```
 Hello {context.userName}!
@@ -519,25 +744,28 @@ Hello {context.userName}!
 - **[Architecture Overview](architecture.md)** - Deep dive into design
 - **[Behavior Rules](behavior-rules.md)** - Master decision logic
 - **[HTTP Calls](httpcalls.md)** - Integrate external APIs
-- **[LangChain Integration](langchain.md)** - Configure LLMs
+- **[LLM Integration](langchain.md)** - Configure LLMs (12 providers)
+- **[Output Configuration](output-configuration.md)** - Message and quick-reply types
 - **[Human-in-the-Loop](hitl.md)** - Gate an agent's writes on human approval
 
 ### Use the Dashboard
 
-Visit `http://localhost:7070` to:
+Visit `http://localhost:7070/manage` to:
 
 - Create agents visually
 - Test conversations interactively
 - Browse configurations
 - Monitor deployments
 
-### Explore Examples
+### Explore a Worked Configuration
 
-Check the `examples/` folder for:
-
-- Weather agent (API integration)
-- Support agent (multi-turn conversations)
-- E-commerce agent (context management)
+`docs/agent-configs/rule-based-reference/` is a complete, working rule-based
+agent — a conversational wizard that provisions another agent over EDDI's own
+REST API. It is the canonical reference for behavior-rule patterns, property
+setters capturing free text, HTTP call templates and quick replies. Two unit
+tests sweep it, so the config documents it supplies keep parsing and saving —
+note that descriptors and unmapped filenames are counted as skipped rather than
+checked, so a green sweep is not a claim about every file in the directory.
 
 ### Build Your Own Task
 
@@ -567,29 +795,61 @@ Register it in CDI and it becomes available as an extension!
 
 ## Troubleshooting
 
+### A request failed and I have no idea why
+
+- `400` with a message naming a field — the payload used a key the model does
+  not declare, or put the wrong kind of value in one that it does. The message
+  names the JSON path and the legal fields.
+- `404` on deploy — the agent id or version does not exist.
+- `201` but nothing appears in the Manager — the resource was created with an
+  empty name. Set one via `PATCH /descriptorstore/descriptors/{id}?version=1`.
+
 ### Agent doesn't respond
 
-1. Check deployment status: `GET /administration/deploy/{agentId}`
-2. Check conversation state: `GET /conversationstore/conversations/{conversationId}`
-3. Check logs for errors
+1. Deployment status:
+   `GET /administration/production/deploymentstatus/{agentId}?version=1`
+   — anything other than `READY` means the workflow did not load.
+2. Conversation state: `GET /agents/{conversationId}/status`
+3. Full memory snapshot (what each pipeline step actually produced):
+   `GET /agents/{conversationId}?returnDetailed=true`
+4. Server log: `docker compose logs -f eddi`, or `GET /administration/logs`
 
 ### Rules not matching
 
-- Verify dictionary expressions match your input
-- Check rule conditions are correct
-- Use `occurrence: "anyStep"` to match across conversation
+- Confirm the parser produced the expression you are matching on — the
+  `expressions:parsed` entry of the detailed snapshot above shows exactly what
+  it emitted, and `behavior_rules:success` / `behavior_rules:fail` show which
+  rules matched.
+- The dictionary has to be wired into the **parser step's** `extensions`, not
+  referenced as a step of its own.
+- `actionmatcher` with a comma-separated list means AND (a contiguous sublist),
+  not OR. Use a `connector` with `"operator": "OR"` for alternatives.
+- `occurrence: "anyStep"` matches anywhere in the conversation.
 
 ### LLM not being called
 
-- Ensure behavior rule triggers the LLM action
-- Check LangChain configuration is in the package
-- Verify API key is correct
+- The behavior rule has to emit the action the LLM task lists in its `actions`.
+- The `eddi://ai.labs.llm` step has to be in the **workflow the deployed agent
+  version points at** — adding it to a newer workflow version does nothing until
+  the agent is re-pointed and re-deployed.
+- Check the credential resolves. A `${vault:...}` reference needs
+  `EDDI_VAULT_MASTER_KEY` set, or the vault is disabled.
+
+### Ollama-backed agent times out or answers nothing
+
+- From inside the `eddi` container, `localhost` is the container. Use
+  `http://host.docker.internal:11434`, or the `docker-compose.ollama.yml`
+  overlay and `http://ollama:11434`.
+- Reasoning models (gemma3n, deepseek-r1, qwen3 …) think before answering, and
+  the reasoning is not part of the streamed content — the window stays silent
+  for as long as that takes. Set `"think": "false"` in the task's `parameters`
+  to turn it off, or `"returnThinking": "true"` to surface it.
 
 ### Memory not persisting
 
-- Ensure MongoDB is running
-- Check connection string in config
-- Use correct scope (`conversation` not `step`)
+- Ensure MongoDB is running and the connection string is right.
+- `scope: "step"` is cleared at the end of the turn, `conversation` lives for
+  the session, `longTerm` survives across conversations.
 
 ## Getting Help
 

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -449,7 +449,7 @@ and only a context map — to the start endpoint:
 ```bash
 curl -i -X POST "$EDDI/agents/<AGENT_ID>/start?environment=production&userId=test-user" \
   -H "Content-Type: application/json" \
-  -d '{ "userName": { "type": "string", "value": "Karol" } }'
+  -d '{ "userName": { "type": "string", "value": "Ada" } }'
 ```
 
 ## Adding an LLM (Ollama Example)

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -165,7 +165,7 @@ curl -i -X POST $EDDI/dictionarystore/dictionaries \
 
 **Response**: `201 Created`, with
 
-```
+```text
 Location: eddi://ai.labs.dictionary/dictionarystore/dictionaries/<DICTIONARY_ID>?version=1
 ```
 
@@ -225,8 +225,11 @@ curl -i -X POST $EDDI/rulestore/rulesets \
 curl -s "$EDDI/rulestore/rulesets/descriptors?limit=100" | jq
 ```
 
-> Reading a rule set back shows `rules` where you posted `behaviorRules` — the
-> model accepts both names on write and serialises the canonical one on read.
+> `behaviorRules` is the canonical name: it is what a read returns, and what the
+> shipped reference config and the ZIP fixtures use. `rules` is still accepted on
+> write for older clients. Before 6.4.0 a read answered `rules` regardless of what
+> you posted, which is why a rule set created over the API showed up empty in the
+> Manager.
 
 ### 3. Create Output Templates
 
@@ -395,7 +398,7 @@ curl -i -X POST \
   "$EDDI/agents/<AGENT_ID>/start?environment=production&userId=test-user"
 ```
 
-```
+```text
 HTTP/1.1 201 Created
 Location: eddi://ai.labs.conversation/conversationstore/conversations/<CONVERSATION_ID>
 ```
@@ -551,7 +554,7 @@ Let's trace what happens when a user says "hello":
 
 ### 1. API Request
 
-```
+```text
 POST /agents/{agentId}/start?environment=production   → 201, conversation id in Location
 POST /agents/{conversationId}   (text/plain)  "hello" → the turn below
 ```
@@ -733,7 +736,7 @@ curl -s -X POST "http://localhost:7070/agents/<CONVERSATION_ID>" \
 Access in an output template — and remember the `eddi://ai.labs.templating`
 step, or the placeholder is never resolved:
 
-```
+```text
 Hello {context.userName}!
 ```
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -42,7 +42,7 @@ All EDDI's resources start with `eddi://`, which is used to distinguish EDDI-spe
 Example URI:
 
 ```
-eddi://ai.labs.behavior/behaviorstore/behaviorsets/673abc123?version=1
+eddi://ai.labs.rules/rulestore/rulesets/673abc123?version=1
 ```
 
 ## Extension Discovery

--- a/docs/httpcalls.md
+++ b/docs/httpcalls.md
@@ -223,13 +223,13 @@ You can use _**`${memory.current.httpCalls.<responseObjectName>}`**_ to access y
 
 | HTTP Method | API Endpoint                                    | Request Body    | Response                              |
 | ----------- | ----------------------------------------------- | --------------- | ------------------------------------- |
-| POST        | `/httpcallsstore/httpcalls`                     | http-call-model | N/A                                   |
-| GET         | `/httpcallsstore/httpcalls/descriptors`         | N/A             | list of references to http-call-model |
-| DELETE      | `/httpcallsstore/httpcalls/{id}`                | N/A             | N/A                                   |
-| GET         | `/httpcallsstore/httpcalls/{id}`                | N/A             | http-call-model                       |
-| PUT         | `/httpcallsstore/httpcalls/{id}`                | http-call-model | N/A                                   |
-| GET         | `/httpcallsstore/httpcalls/{id}/currentversion` | N/A             | http-call-model                       |
-| POST        | `/httpcallsstore/httpcalls/{id}/currentversion` | http-call-model | N/A                                   |
+| POST        | `/apicallstore/apicalls`                     | http-call-model | N/A                                   |
+| GET         | `/apicallstore/apicalls/descriptors`         | N/A             | list of references to http-call-model |
+| DELETE      | `/apicallstore/apicalls/{id}`                | N/A             | N/A                                   |
+| GET         | `/apicallstore/apicalls/{id}`                | N/A             | http-call-model                       |
+| PUT         | `/apicallstore/apicalls/{id}`                | http-call-model | N/A                                   |
+| GET         | `/apicallstore/apicalls/{id}/currentversion` | N/A             | http-call-model                       |
+| POST        | `/apicallstore/apicalls/{id}/currentversion` | http-call-model | N/A                                   |
 
 ### httpCall Sample
 
@@ -327,7 +327,7 @@ For the sake of simplicity we will use a free weather API to fetch weather of ci
 
 _Request URL_
 
-`POST` `http://localhost:7070/regulardictionarystore/regulardictionaries`
+`POST` `http://localhost:7070/dictionarystore/dictionaries`
 
 _Request Body_
 
@@ -361,7 +361,7 @@ _Response Code_
 
 `201`
 
-> The `Location` header contains the resource URI, e.g. `eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/<id>?version=1`
+> The `Location` header contains the resource URI, e.g. `eddi://ai.labs.dictionary/dictionarystore/dictionaries/<id>?version=1`
 
 ### 2 - Create the behaviorSet
 
@@ -369,7 +369,7 @@ _Response Code_
 
 _Request URL_
 
-`POST` `http://localhost:7070/behaviorstore/behaviorsets`
+`POST` `http://localhost:7070/rulestore/rulesets`
 
 _Response Body_
 
@@ -422,7 +422,7 @@ _Request Body_
 }
 ```
 
-> The `Location` header contains the resource URI, e.g. `eddi://ai.labs.behavior/behaviorstore/behaviorsets/<id>?version=1`
+> The `Location` header contains the resource URI, e.g. `eddi://ai.labs.rules/rulestore/rulesets/<id>?version=1`
 
 ### 3 - Create the **httpCall**
 
@@ -430,7 +430,7 @@ Note that we can pass user input to the http call using _**`{memory.current.inpu
 
 _Request URL_
 
-`POST` `http://localhost:7070/httpcallsstore/httpcalls`
+`POST` `http://localhost:7070/apicallstore/apicalls`
 
 _Request Body_
 
@@ -470,7 +470,7 @@ _Response Code_
 
 `201`
 
-> The `Location` header contains the resource URI, e.g. `eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/<id>?version=1`
+> The `Location` header contains the resource URI, e.g. `eddi://ai.labs.apicalls/apicallstore/apicalls/<id>?version=1`
 
 ### 4 - Create the outputSet
 
@@ -540,7 +540,7 @@ _Response Code_
 
 _Request URL_
 
-`POST` `http://localhost:7070/packagestore/packages`
+`POST` `http://localhost:7070/workflowstore/workflows`
 
 _Request Body_
 
@@ -572,7 +572,7 @@ _Request Body_
           {
             "type": "eddi://ai.labs.parser.dictionaries.regular",
             "config": {
-              "uri": "eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/{{dictionary_id}}?version=1"
+              "uri": "eddi://ai.labs.dictionary/dictionarystore/dictionaries/{{dictionary_id}}?version=1"
             }
           }
         ],
@@ -600,13 +600,13 @@ _Request Body_
     {
       "type": "eddi://ai.labs.behavior",
       "config": {
-        "uri": "eddi://ai.labs.behavior/behaviorstore/behaviorsets/{{behaviourset_id}}?version=1"
+        "uri": "eddi://ai.labs.rules/rulestore/rulesets/{{behaviourset_id}}?version=1"
       }
     },
     {
       "type": "eddi://ai.labs.httpcalls",
       "config": {
-        "uri": "eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/{{httpcall_id}}?version=1"
+        "uri": "eddi://ai.labs.apicalls/apicallstore/apicalls/{{httpcall_id}}?version=1"
       }
     },
     {
@@ -632,7 +632,7 @@ Response Code
 
 `201`
 
-> The `Location` header contains the resource URI, e.g. `eddi://ai.labs.package/packagestore/packages/<id>?version=1`
+> The `Location` header contains the resource URI, e.g. `eddi://ai.labs.workflow/workflowstore/workflows/<id>?version=1`
 
 ### 6 - Creating the agent
 
@@ -645,7 +645,7 @@ _Request Body_
 ```javascript
 {
   "packages": [
-    "eddi://ai.labs.package/packagestore/packages/{{package_id}}?version=1"
+    "eddi://ai.labs.workflow/workflowstore/workflows/{{package_id}}?version=1"
   ],
   "channels": []
 }

--- a/docs/httpcalls.md
+++ b/docs/httpcalls.md
@@ -546,7 +546,7 @@ _Request Body_
 
 ```javascript
 {
-  "packageExtensions": [
+  "workflowSteps": [
     {
       "type": "eddi://ai.labs.parser",
       "extensions": {
@@ -644,7 +644,7 @@ _Request Body_
 
 ```javascript
 {
-  "packages": [
+  "workflows": [
     "eddi://ai.labs.workflow/workflowstore/workflows/{{package_id}}?version=1"
   ],
   "channels": []

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -312,8 +312,8 @@ Both stored shapes therefore keep working: a config that sets only `streamingTim
 | ---------------- | ------------------------------------------------------------------------------------------- |
 | `baseUrl`        | Ollama's address. Default `http://localhost:11434`, overridable deployment-wide with `EDDI_OLLAMA_DEFAULT_BASE_URL`. |
 | `model`          | Model tag as `ollama list` reports it, e.g. `llama3.2:3b`.                                   |
-| `think`          | `"true"` / `"false"`. Unset leaves the model's own default.                                   |
-| `returnThinking` | `"true"` surfaces a reasoning model's thoughts instead of discarding them. Off by default.   |
+| `think`          | `"true"` / `"false"`. Unset leaves it to Ollama and the model — see below.                    |
+| `returnThinking` | `"true"` surfaces the separate `thinking` field instead of discarding it. Off by default.     |
 | `temperature`, `maxTokens`, `topP`, `topK` | Standard sampling controls. `maxTokens` maps to Ollama's `num_predict`. |
 
 > **Reaching Ollama from a container.** Inside the `eddi` container `localhost`
@@ -324,11 +324,19 @@ Both stored shapes therefore keep working: a config that sets only `streamingTim
 > that base URL for new agents.
 
 > **Reasoning models look like a hang.** gemma3n, deepseek-r1, qwen3 and friends
-> think before they answer, and the reasoning arrives in a separate `thinking`
-> field that is not part of the streamed content — so a streaming chat window
-> shows nothing at all for as long as the model reasons, then the whole answer at
-> once. `"think": "false"` turns reasoning off; `"returnThinking": "true"` shows
-> it. Give such a model a generous `timeout` either way.
+> think before they answer, and where that reasoning goes depends on the model:
+>
+> - Reported in a separate `thinking` field — not part of the streamed content, so
+>   a streaming chat window shows nothing at all for as long as the model reasons,
+>   then the whole answer at once. `"returnThinking": "true"` surfaces it instead
+>   of discarding it.
+> - Prepended to the content itself as `<think>…</think>` — the tags stream into
+>   the reply, where the user sees them. `returnThinking` does not affect this
+>   case; there is no `thinking` field to parse.
+>
+> `"think": "false"` turns reasoning off entirely and is the quickest way to a
+> model that answers immediately. Give such a model a generous `timeout` either
+> way.
 
 #### Hugging Face
 

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -294,8 +294,10 @@ Both stored shapes therefore keep working: a config that sets only `streamingTim
       "type": "ollama",
       "description": "Ollama local model chat",
       "parameters": {
-        "model": "llama3",
-        "timeout": "15000",
+        "baseUrl": "http://ollama:11434",
+        "model": "llama3.2:3b",
+        "timeout": "120000",
+        "think": "false",
         "systemMessage": "You are a helpful assistant",
         "addToOutput": "true"
       }
@@ -303,6 +305,30 @@ Both stored shapes therefore keep working: a config that sets only `streamingTim
   ]
 }
 ```
+
+**Ollama-specific parameters**
+
+| Parameter        | Effect                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| `baseUrl`        | Ollama's address. Default `http://localhost:11434`, overridable deployment-wide with `EDDI_OLLAMA_DEFAULT_BASE_URL`. |
+| `model`          | Model tag as `ollama list` reports it, e.g. `llama3.2:3b`.                                   |
+| `think`          | `"true"` / `"false"`. Unset leaves the model's own default.                                   |
+| `returnThinking` | `"true"` surfaces a reasoning model's thoughts instead of discarding them. Off by default.   |
+| `temperature`, `maxTokens`, `topP`, `topK` | Standard sampling controls. `maxTokens` maps to Ollama's `num_predict`. |
+
+> **Reaching Ollama from a container.** Inside the `eddi` container `localhost`
+> is the container. Use `http://host.docker.internal:11434` for an Ollama on the
+> host, or bring up the overlay —
+> `docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d` —
+> which puts Ollama on the same network as `http://ollama:11434` and pre-fills
+> that base URL for new agents.
+
+> **Reasoning models look like a hang.** gemma3n, deepseek-r1, qwen3 and friends
+> think before they answer, and the reasoning arrives in a separate `thinking`
+> field that is not part of the streamed content — so a streaming chat window
+> shows nothing at all for as long as the model reasons, then the whole answer at
+> once. `"think": "false"` turns reasoning off; `"returnThinking": "true"` shows
+> it. Give such a model a generous `timeout` either way.
 
 #### Hugging Face
 
@@ -937,31 +963,31 @@ The Langchain task configurations can be managed via REST API endpoints.
 ### Endpoints Overview
 
 1. **Read JSON Schema**
-   - **Endpoint:** `GET /langchainstore/langchains/jsonSchema`
+   - **Endpoint:** `GET /llmstore/llms/jsonSchema`
    - **Description:** Retrieves the JSON schema for validating Langchain configurations
 
 2. **List Langchain Descriptors**
-   - **Endpoint:** `GET /langchainstore/langchains/descriptors`
+   - **Endpoint:** `GET /llmstore/llms/descriptors`
    - **Description:** Returns a list of all Langchain configurations with optional filters
 
 3. **Read Langchain Configuration**
-   - **Endpoint:** `GET /langchainstore/langchains/{id}`
+   - **Endpoint:** `GET /llmstore/llms/{id}`
    - **Description:** Fetches a specific Langchain configuration by its ID
 
 4. **Update Langchain Configuration**
-   - **Endpoint:** `PUT /langchainstore/langchains/{id}`
+   - **Endpoint:** `PUT /llmstore/llms/{id}`
    - **Description:** Updates an existing Langchain configuration
 
 5. **Create Langchain Configuration**
-   - **Endpoint:** `POST /langchainstore/langchains`
+   - **Endpoint:** `POST /llmstore/llms`
    - **Description:** Creates a new Langchain configuration
 
 6. **Duplicate Langchain Configuration**
-   - **Endpoint:** `POST /langchainstore/langchains/{id}`
+   - **Endpoint:** `POST /llmstore/llms/{id}`
    - **Description:** Duplicates an existing Langchain configuration
 
 7. **Delete Langchain Configuration**
-   - **Endpoint:** `DELETE /langchainstore/langchains/{id}`
+   - **Endpoint:** `DELETE /llmstore/llms/{id}`
    - **Description:** Deletes a specific Langchain configuration
 
 ---

--- a/docs/open-webui-integration.md
+++ b/docs/open-webui-integration.md
@@ -651,7 +651,7 @@ Set `logSizeLimit: "0"` if you want each turn to carry no conversation history a
   "workflowSteps": [
     { "type": "eddi://ai.labs.parser",    "extensions": { "dictionaries": [], "corrections": [] }, "config": {} },
     { "type": "eddi://ai.labs.behavior",  "extensions": {}, "config": { "uri": "eddi://ai.labs.rules/rulestore/rulesets/…0002?version=1" } },
-    { "type": "eddi://ai.labs.langchain", "extensions": {}, "config": { "uri": "eddi://ai.labs.llm/llmstore/llms/…0003?version=1" } }
+    { "type": "eddi://ai.labs.llm",       "extensions": {}, "config": { "uri": "eddi://ai.labs.llm/llmstore/llms/…0003?version=1" } }
   ]
 }
 ```

--- a/docs/output-templating.md
+++ b/docs/output-templating.md
@@ -154,7 +154,7 @@ EDDI provides custom namespace extensions for use in templates (output, httpcall
 **`extractId` and `extractVersion`** work with both MongoDB ObjectIds (24-char hex) and PostgreSQL UUIDs (36-char with dashes):
 
 ```
-// Input: "http://localhost:7070/behaviorstore/behaviorsets/6740832a2b0f614abcaee7ab?version=1"
+// Input: "http://localhost:7070/rulestore/rulesets/6740832a2b0f614abcaee7ab?version=1"
 {uuidUtils:extractId(properties.location)}     → "6740832a2b0f614abcaee7ab"
 {uuidUtils:extractVersion(properties.location)} → "1"
 ```

--- a/docs/putting-it-all-together.md
+++ b/docs/putting-it-all-together.md
@@ -45,7 +45,7 @@ We'll need:
 **Purpose**: Teach the agent hotel-related language
 
 ```bash
-curl -X POST http://localhost:7070/regulardictionarystore/regulardictionaries \
+curl -X POST http://localhost:7070/dictionarystore/dictionaries \
   -H "Content-Type: application/json" \
   -d '{
     "language": "en",
@@ -89,7 +89,7 @@ curl -X POST http://localhost:7070/regulardictionarystore/regulardictionaries \
   }'
 ```
 
-**Returns**: `eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/DICT_ID?version=1`
+**Returns**: `eddi://ai.labs.dictionary/dictionarystore/dictionaries/DICT_ID?version=1`
 
 **How it connects**: Parser will use this dictionary to convert "I want to book a hotel" → `["intent(book)", "entity(hotel)"]`
 
@@ -98,7 +98,7 @@ curl -X POST http://localhost:7070/regulardictionarystore/regulardictionaries \
 **Purpose**: Define conversation logic and when to trigger actions
 
 ```bash
-curl -X POST http://localhost:7070/behaviorstore/behaviorsets \
+curl -X POST http://localhost:7070/rulestore/rulesets \
   -H "Content-Type: application/json" \
   -d '{
     "behaviorGroups": [
@@ -169,7 +169,7 @@ curl -X POST http://localhost:7070/behaviorstore/behaviorsets \
   }'
 ```
 
-**Returns**: `eddi://ai.labs.behavior/behaviorstore/behaviorsets/BEHAVIOR_ID?version=1`
+**Returns**: `eddi://ai.labs.rules/rulestore/rulesets/BEHAVIOR_ID?version=1`
 
 **How it connects**:
 
@@ -209,7 +209,7 @@ curl -X POST http://localhost:7070/propertysetterstore/propertysetters \
 **Purpose**: Integrate with hotel booking API
 
 ```bash
-curl -X POST http://localhost:7070/httpcallsstore/httpcalls \
+curl -X POST http://localhost:7070/apicallstore/apicalls \
   -H "Content-Type: application/json" \
   -d '{
     "targetServerUrl": "https://api.hotels.example.com",
@@ -267,7 +267,7 @@ curl -X POST http://localhost:7070/httpcallsstore/httpcalls \
   }'
 ```
 
-**Returns**: `eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/HTTP_ID?version=1`
+**Returns**: `eddi://ai.labs.apicalls/apicallstore/apicalls/HTTP_ID?version=1`
 
 **How it connects**:
 
@@ -339,20 +339,20 @@ curl -X POST http://localhost:7070/outputstore/outputsets \
 **Purpose**: Bundle all components together
 
 ```bash
-curl -X POST http://localhost:7070/packagestore/packages \
+curl -X POST http://localhost:7070/workflowstore/workflows \
   -H "Content-Type: application/json" \
   -d '{
     "packageExtensions": [
       {
         "type": "eddi://ai.labs.parser.dictionaries.regular",
         "extensions": {
-          "uri": "eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/DICT_ID?version=1"
+          "uri": "eddi://ai.labs.dictionary/dictionarystore/dictionaries/DICT_ID?version=1"
         }
       },
       {
         "type": "eddi://ai.labs.behavior",
         "extensions": {
-          "uri": "eddi://ai.labs.behavior/behaviorstore/behaviorsets/BEHAVIOR_ID?version=1"
+          "uri": "eddi://ai.labs.rules/rulestore/rulesets/BEHAVIOR_ID?version=1"
         },
         "config": {
           "appendActions": true
@@ -367,7 +367,7 @@ curl -X POST http://localhost:7070/packagestore/packages \
       {
         "type": "eddi://ai.labs.httpcalls",
         "extensions": {
-          "uri": "eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/HTTP_ID?version=1"
+          "uri": "eddi://ai.labs.apicalls/apicallstore/apicalls/HTTP_ID?version=1"
         }
       },
       {
@@ -383,7 +383,7 @@ curl -X POST http://localhost:7070/packagestore/packages \
   }'
 ```
 
-**Returns**: `eddi://ai.labs.package/packagestore/packages/WORKFLOW_ID?version=1`
+**Returns**: `eddi://ai.labs.workflow/workflowstore/workflows/WORKFLOW_ID?version=1`
 
 **How it connects**: Workflow defines the order of lifecycle tasks and loads all configurations
 
@@ -396,7 +396,7 @@ curl -X POST http://localhost:7070/agentstore/agents \
   -H "Content-Type: application/json" \
   -d '{
     "packages": [
-      "eddi://ai.labs.package/packagestore/packages/WORKFLOW_ID?version=1"
+      "eddi://ai.labs.workflow/workflowstore/workflows/WORKFLOW_ID?version=1"
     ]
   }'
 ```

--- a/docs/putting-it-all-together.md
+++ b/docs/putting-it-all-together.md
@@ -342,42 +342,50 @@ curl -X POST http://localhost:7070/outputstore/outputsets \
 curl -X POST http://localhost:7070/workflowstore/workflows \
   -H "Content-Type: application/json" \
   -d '{
-    "packageExtensions": [
+    "workflowSteps": [
       {
-        "type": "eddi://ai.labs.parser.dictionaries.regular",
+        "type": "eddi://ai.labs.parser",
+        "config": {},
         "extensions": {
-          "uri": "eddi://ai.labs.dictionary/dictionarystore/dictionaries/DICT_ID?version=1"
+          "dictionaries": [
+            {
+              "type": "eddi://ai.labs.parser.dictionaries.regular",
+              "config": {
+                "uri": "eddi://ai.labs.dictionary/dictionarystore/dictionaries/DICT_ID?version=1"
+              }
+            }
+          ],
+          "corrections": []
         }
       },
       {
-        "type": "eddi://ai.labs.behavior",
-        "extensions": {
-          "uri": "eddi://ai.labs.rules/rulestore/rulesets/BEHAVIOR_ID?version=1"
-        },
+        "type": "eddi://ai.labs.rules",
         "config": {
+          "uri": "eddi://ai.labs.rules/rulestore/rulesets/BEHAVIOR_ID?version=1",
           "appendActions": true
         }
       },
       {
         "type": "eddi://ai.labs.property",
-        "extensions": {
+        "config": {
           "uri": "eddi://ai.labs.property/propertysetterstore/propertysetters/PROPERTY_ID?version=1"
         }
       },
       {
-        "type": "eddi://ai.labs.httpcalls",
-        "extensions": {
+        "type": "eddi://ai.labs.apicalls",
+        "config": {
           "uri": "eddi://ai.labs.apicalls/apicallstore/apicalls/HTTP_ID?version=1"
         }
       },
       {
         "type": "eddi://ai.labs.output",
-        "extensions": {
+        "config": {
           "uri": "eddi://ai.labs.output/outputstore/outputsets/OUTPUT_ID?version=1"
         }
       },
       {
-        "type": "eddi://ai.labs.templating"
+        "type": "eddi://ai.labs.templating",
+        "config": {}
       }
     ]
   }'

--- a/planning/manager-ui-handoff.md
+++ b/planning/manager-ui-handoff.md
@@ -12,9 +12,9 @@ Changes are organized by **where they live** in the JSON config. The Manager edi
 
 | Config Type | REST Endpoint | Manager Page |
 |-------------|---------------|--------------|
-| **LLM Task** (`langchain.json`) | `GET/PUT /langchainstore/langchains/{id}?version=N` | Workflow Extension → LLM Task editor |
+| **LLM Task** (`langchain.json`) | `GET/PUT /llmstore/llms/{id}?version=N` | Workflow Extension → LLM Task editor |
 | **Agent** (`AgentConfiguration`) | `GET/PUT /agentstore/agents/{id}?version=N` | Agent editor |
-| **Behavior Rules** (`behavior.json`) | `GET/PUT /behaviorstore/behaviorsets/{id}?version=N` | Behavior Rule editor |
+| **Behavior Rules** (`behavior.json`) | `GET/PUT /rulestore/rulesets/{id}?version=N` | Behavior Rule editor |
 
 ---
 

--- a/src/main/java/ai/labs/eddi/configs/rest/StrictConfigurationParser.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/StrictConfigurationParser.java
@@ -5,7 +5,11 @@
 package ai.labs.eddi.configs.rest;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -14,7 +18,10 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -64,35 +71,41 @@ public class StrictConfigurationParser {
      *            the configuration model to read it into
      * @return the parsed configuration
      * @throws BadRequestException
-     *             if the body names a field the model does not declare; the message
-     *             names the field and lists the legal ones
+     *             if the body names a field the model does not declare (the message
+     *             names the field and lists the legal ones), or puts a value of the
+     *             wrong shape in a field that exists
      * @throws IOException
-     *             for every other parse failure, so callers keep whatever error
-     *             they already produced for malformed JSON
+     *             for syntactically malformed JSON, so callers keep whatever error
+     *             they already produced for it
      */
     public <T> T parse(String json, Class<T> type) throws IOException {
         try {
             return strictMapper.readValue(json, type);
         } catch (UnrecognizedPropertyException e) {
             throw badRequest(describe(e, type));
+        } catch (MismatchedInputException e) {
+            throw badRequest(describeMismatch(e, type, json));
         }
     }
 
     /**
-     * Checks a body for unknown fields without taking its parse result. Used where
-     * the caller already has a deserialised object and only wants the rejection.
+     * Checks a body without taking its parse result. Used where the caller already
+     * has a deserialised object and only wants the rejection.
      *
      * @throws BadRequestException
-     *             if the body names an undeclared field
+     *             if the body names an undeclared field, or puts a value of the
+     *             wrong shape in a declared one
      */
     public void rejectUnknownFields(byte[] body, Class<?> type) {
         try {
             strictMapper.readValue(body, type);
         } catch (UnrecognizedPropertyException e) {
             throw badRequest(describe(e, type));
+        } catch (MismatchedInputException e) {
+            throw badRequest(describeMismatch(e, type, body));
         } catch (IOException e) {
-            // Malformed JSON, wrong value type, etc. — not this class's business.
-            // Proceeding lets the regular reader produce the response it always has.
+            // Syntactically malformed JSON — not this class's business. Proceeding
+            // lets the regular reader produce the response it always has.
         }
     }
 
@@ -101,12 +114,224 @@ public class StrictConfigurationParser {
                 .entity(message).type(MediaType.TEXT_PLAIN_TYPE).build());
     }
 
+    /**
+     * Explains a value whose <em>shape</em> is wrong, as opposed to a field whose
+     * name is.
+     * <p>
+     * Jackson's own message is unusable as an API response — it names Java classes
+     * and generic signatures — but the response it replaces was worse: RESTEasy
+     * answers a databind failure with a bare {@code 400} and
+     * {@code content-length: 0}. A user following the quickstart posted
+     * {@code "valueAlternatives": ["Hello!"]} where the model wants
+     * {@code [{"type":"text","text":"Hello!"}]} and got no hint at all — not which
+     * field, not what was expected, not even that the body was the problem. So this
+     * says which JSON path failed and which kind of value belongs there, and leaves
+     * the Java type names out.
+     */
+    private String describeMismatch(MismatchedInputException e, Class<?> type, Object rawBody) {
+        var message = new StringBuilder("Cannot read ").append(type.getSimpleName());
+
+        String path = jsonPath(e);
+        if (!path.isEmpty()) {
+            message.append(" at ").append(path);
+        }
+
+        if (e instanceof InvalidTypeIdException typeId) {
+            // A polymorphic value whose discriminator is missing or unknown —
+            // {"type":"txt"} on an output item, say. "expected a JSON object here,
+            // found an object" would be true and useless; the legal ids are the
+            // only thing that helps.
+            message.append(": ").append(describeTypeId(typeId, rawBody));
+        } else {
+            message.append(": ").append(expected(e.getTargetType())).append(found(e, rawBody));
+        }
+
+        return message.append(" Check this field against the resource's JSON Schema at "
+                + "GET /<store>/<resource>/jsonSchema.").toString();
+    }
+
+    /**
+     * The legal values of a polymorphic model's {@code type} discriminator.
+     * <p>
+     * Read off the Jackson type resolver rather than hard-coded, so a new
+     * {@code @JsonSubTypes} entry cannot leave this list stale.
+     */
+    private String describeTypeId(InvalidTypeIdException e, Object rawBody) {
+        var known = new TreeSet<String>();
+        try {
+            var resolver = strictMapper.getSubtypeResolver();
+            var config = strictMapper.getDeserializationConfig();
+            for (var subtype : resolver.collectAndResolveSubtypesByTypeId(config,
+                    config.introspectClassAnnotations(e.getBaseType()).getClassInfo())) {
+                if (subtype.getName() != null) {
+                    known.add(subtype.getName());
+                }
+            }
+        } catch (RuntimeException ignored) {
+            // Decoration only — fall through to the id-less sentence below.
+        }
+
+        String id = e.getTypeId();
+        var message = new StringBuilder();
+        if (id == null || id.isBlank()) {
+            // Usually a bare scalar where a typed object belongs, so name what was
+            // there — "this object needs a 'type'" is simply untrue of a string.
+            message.append("expected an object with a 'type' field").append(found(e, rawBody));
+        } else {
+            message.append("'").append(id).append("' is not a known 'type'.");
+        }
+        if (!known.isEmpty()) {
+            message.append(" Known types: ").append(known).append(".");
+        }
+        return message.toString();
+    }
+
+    /**
+     * The failing position as a JSON path — {@code outputSet[0].outputs[0]} — built
+     * from Jackson's reference chain.
+     * <p>
+     * Not {@code getPathReference()}, which renders the same chain as
+     * {@code ai.labs.eddi.configs.output.model.OutputConfigurationSet["outputSet"]
+     * ->java.util.ArrayList[0]->…}. That is a debugging aid for whoever wrote the
+     * Java, and this string goes to whoever wrote the JSON: it names classes they
+     * cannot see, in a syntax that does not match the document they are holding,
+     * and it publishes the internal package layout to every API client.
+     */
+    private static String jsonPath(JsonMappingException e) {
+        return jsonPath(e, e.getPath().size());
+    }
+
+    /**
+     * @param depth
+     *            how many leading references to render — the full chain for a
+     *            wrong-shaped value, one short of it for an unknown field, whose
+     *            last reference IS the unknown field.
+     */
+    private static String jsonPath(JsonMappingException e, int depth) {
+        var path = new StringBuilder();
+        for (JsonMappingException.Reference reference : e.getPath().subList(0, Math.max(0, depth))) {
+            if (reference.getFieldName() != null) {
+                if (!path.isEmpty()) {
+                    path.append('.');
+                }
+                path.append(reference.getFieldName());
+            } else if (reference.getIndex() >= 0) {
+                path.append('[').append(reference.getIndex()).append(']');
+            }
+        }
+        return path.toString();
+    }
+
+    private static String expected(Class<?> target) {
+        if (target == null) {
+            // Jackson reports no target type for a polymorphic property whose value is
+            // a scalar — which is exactly the OutputItem case, the most likely one to
+            // reach here. "An object" is right for every polymorphic model in configs.
+            return "expected a JSON object here";
+        }
+        if (Collection.class.isAssignableFrom(target) || target.isArray()) {
+            return "expected a JSON array here";
+        }
+        if (Map.class.isAssignableFrom(target)) {
+            return "expected a JSON object here";
+        }
+        if (target.isEnum()) {
+            return "expected one of " + Arrays.stream(target.getEnumConstants()).map(String::valueOf).sorted()
+                    .collect(Collectors.joining(", ", "[", "]"));
+        }
+        if (target == String.class) {
+            return "expected a string here";
+        }
+        if (target == Boolean.class || target == boolean.class) {
+            return "expected true or false here";
+        }
+        if (target == Integer.class || target == int.class || target == Long.class || target == long.class
+                || target == Short.class || target == short.class) {
+            return "expected a whole number here";
+        }
+        if (Number.class.isAssignableFrom(target) || target.isPrimitive()) {
+            // "expected a int here" was the alternative. The Java type name adds
+            // nothing a JSON author can act on, and reads as a bug in the message.
+            return "expected a number here";
+        }
+        // Everything else is a nested configuration object.
+        return "expected a JSON object here";
+    }
+
+    /**
+     * What was there instead, resolved by re-reading the body at the failing
+     * position.
+     * <p>
+     * Naming only the expectation leaves the reader to work out which of several
+     * candidate values on the line was wrong; naming what was found identifies it
+     * immediately, and does so without Jackson's own message, which spells the
+     * answer as "Cannot construct instance of `ai.labs.eddi...OutputItem` (although
+     * at least one Creator exists)".
+     * <p>
+     * Not read off {@code e.getProcessor()}: {@code readValue} closes the parser in
+     * a finally block before the exception propagates, so its current token is
+     * always {@code null} by the time this is asked. The body is still in hand and
+     * is known to be syntactically valid JSON — a syntax error would have been an
+     * {@link IOException} rather than a {@link MismatchedInputException} — so a
+     * second, tree-shaped read of it is cheap and cannot introduce a new failure
+     * mode. Anything unexpected simply omits the clause.
+     */
+    private String found(MismatchedInputException e, Object rawBody) {
+        try {
+            JsonNode root = rawBody instanceof byte[] bytes
+                    ? strictMapper.readTree(bytes)
+                    : strictMapper.readTree(String.valueOf(rawBody));
+            JsonNode node = root.at(jsonPointer(e));
+
+            if (node.isMissingNode()) {
+                return ".";
+            }
+            if (node.isTextual()) {
+                return ", found a string.";
+            }
+            if (node.isNumber()) {
+                return ", found a number.";
+            }
+            if (node.isBoolean()) {
+                return ", found a boolean.";
+            }
+            if (node.isNull()) {
+                return ", found null.";
+            }
+            if (node.isArray()) {
+                return ", found an array.";
+            }
+            if (node.isObject()) {
+                return ", found an object.";
+            }
+            return ".";
+        } catch (IOException | RuntimeException ignored) {
+            return ".";
+        }
+    }
+
+    /** The failing position as a JSON Pointer, for looking the value back up. */
+    private static String jsonPointer(JsonMappingException e) {
+        var pointer = new StringBuilder();
+        for (JsonMappingException.Reference reference : e.getPath()) {
+            if (reference.getFieldName() != null) {
+                pointer.append('/').append(reference.getFieldName().replace("~", "~0").replace("/", "~1"));
+            } else if (reference.getIndex() >= 0) {
+                pointer.append('/').append(reference.getIndex());
+            }
+        }
+        return pointer.toString();
+    }
+
     private static String describe(UnrecognizedPropertyException e, Class<?> type) {
         var message = new StringBuilder("Unknown field '").append(e.getPropertyName()).append("' in ").append(type.getSimpleName());
 
-        String path = e.getPathReference();
-        if (path != null && !path.isBlank()) {
-            message.append(" at ").append(path);
+        // The CONTAINER of the offending field, not the field itself: the message
+        // has already named it, so "Unknown field 'x' … at x" says it twice, which
+        // is what a root-level typo produced.
+        String path = jsonPath(e, e.getPath().size() - 1);
+        if (!path.isEmpty()) {
+            message.append(" in ").append(path);
         }
 
         Collection<Object> known = e.getKnownPropertyIds();

--- a/src/main/java/ai/labs/eddi/configs/rest/StrictConfigurationParser.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/StrictConfigurationParser.java
@@ -125,8 +125,9 @@ public class StrictConfigurationParser {
      * {@code "valueAlternatives": ["Hello!"]} where the model wants
      * {@code [{"type":"text","text":"Hello!"}]} and got no hint at all — not which
      * field, not what was expected, not even that the body was the problem. So this
-     * says which JSON path failed and which kind of value belongs there, and leaves
-     * the Java type names out.
+     * names the JSON path that failed, what belongs there, and what was found
+     * instead — and for a polymorphic value, the legal {@code type} ids. No Java
+     * type names either way.
      */
     private String describeMismatch(MismatchedInputException e, Class<?> type, Object rawBody) {
         var message = new StringBuilder("Cannot read ").append(type.getSimpleName());
@@ -168,7 +169,8 @@ public class StrictConfigurationParser {
                 }
             }
         } catch (RuntimeException ignored) {
-            // Decoration only — fall through to the id-less sentence below.
+            // Decoration only — the message below simply omits the "Known types"
+            // clause rather than failing to explain the rejection at all.
         }
 
         String id = e.getTypeId();

--- a/src/main/java/ai/labs/eddi/configs/rules/model/RuleGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/rules/model/RuleGroupConfiguration.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.rules.model;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -37,11 +38,34 @@ public class RuleGroupConfiguration {
         this.executionStrategy = executionStrategy;
     }
 
+    /**
+     * The group's rules, on the wire as {@code behaviorRules}.
+     *
+     * <p>
+     * The accessor pair is named {@code getRules}/{@code setRules}, so without the
+     * explicit {@link JsonProperty} Jackson serialised this list as {@code rules}
+     * while every author-facing artefact writes {@code behaviorRules} — the shipped
+     * reference configuration, the ZIP import fixtures, the documentation and the
+     * Manager's rules editor alike. The alias made writes work either way, so the
+     * mismatch only ever showed up on <em>reads</em>: a rule set posted as
+     * {@code behaviorRules} came back as {@code rules}, and the Manager, which
+     * types the field as {@code behaviorRules}, rendered every group as "No rules
+     * in this group" no matter what it contained.
+     * </p>
+     *
+     * <p>
+     * {@code rules} stays accepted as an alias, so stored documents written before
+     * this — every rule set in every existing deployment — keep loading unchanged,
+     * as do the API clients that learned the old spelling.
+     * </p>
+     */
+    @JsonProperty("behaviorRules")
     public List<RuleConfiguration> getRules() {
         return behaviorRules;
     }
 
-    @JsonAlias("behaviorRules")
+    @JsonProperty("behaviorRules")
+    @JsonAlias("rules")
     public void setRules(List<RuleConfiguration> behaviorRules) {
         this.behaviorRules = behaviorRules;
     }

--- a/src/main/java/ai/labs/eddi/engine/exception/ConversationNotFoundExceptionMapper.java
+++ b/src/main/java/ai/labs/eddi/engine/exception/ConversationNotFoundExceptionMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.exception;
+
+import ai.labs.eddi.engine.api.IConversationService.ConversationNotFoundException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Answers "there is no such conversation" with 404.
+ *
+ * <p>
+ * {@link ConversationNotFoundException} has been thrown since the conversation
+ * endpoints were written, and nothing mapped it — so it reached Quarkus's
+ * default handler as an unhandled {@link RuntimeException} and every
+ * conversation endpoint answered a deleted or mistyped id with
+ * {@code 500 Internal Server Error} and an error id, while its own
+ * {@code @APIResponse(responseCode = "404")} promised otherwise. A caller could
+ * not tell "you asked for something that is not here" from "the server is
+ * broken", which are the two things a status code exists to separate.
+ * </p>
+ */
+@Provider
+public class ConversationNotFoundExceptionMapper implements ExceptionMapper<ConversationNotFoundException> {
+    @Override
+    public Response toResponse(ConversationNotFoundException exception) {
+        return Response.status(Response.Status.NOT_FOUND).type(MediaType.TEXT_PLAIN).entity(exception.getLocalizedMessage()).build();
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
@@ -522,7 +522,7 @@ public class ConversationService implements IConversationService {
     public ConversationLogResult readConversationLog(String conversationId, String outputType, Integer logSize)
             throws ResourceStoreException, ResourceNotFoundException {
 
-        var memorySnapshot = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
+        var memorySnapshot = requireSnapshot(conversationId);
         var conversationLog = new ConversationLogGenerator(memorySnapshot).generate(logSize != null ? logSize : -1);
         outputType = outputType.toLowerCase();
 
@@ -955,7 +955,7 @@ public class ConversationService implements IConversationService {
         checkNotNull(conversationId, "conversationId");
 
         try {
-            var snapshot = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
+            var snapshot = requireSnapshot(conversationId);
             var loggingContext = contextLogger.createLoggingContext(snapshot.getEnvironment(), snapshot.getAgentId(), conversationId,
                     snapshot.getUserId());
             contextLogger.setLoggingContext(loggingContext);
@@ -964,6 +964,36 @@ public class ConversationService implements IConversationService {
         } finally {
             recordMetrics(timerConversationLoad, counterConversationLoad, startTime);
         }
+    }
+
+    /**
+     * The snapshot, or a 404 — never a {@code null} for the caller to dereference.
+     *
+     * <p>
+     * {@code loadConversationMemorySnapshot} answers {@code null} for a
+     * conversation that is not there, and the read paths went straight on to call
+     * {@code getEnvironment()} on it. So a deleted or mistyped conversation id
+     * produced a {@link NullPointerException}, which reached the client as
+     * {@code 500 Internal Server Error} plus an error id — from endpoints whose own
+     * {@code @APIResponse} promised a 404, and which the troubleshooting
+     * documentation tells people to call precisely when something has already gone
+     * wrong.
+     * </p>
+     *
+     * <p>
+     * Throws {@link ConversationNotFoundException} rather than the checked
+     * {@code ResourceNotFoundException} that {@code RestConversationStore}'s twin
+     * uses: this is the exception {@link #getConversationState} already raises for
+     * the same condition, and it needs no signature change on {@code say} /
+     * {@code sayStreaming}. Both map to 404.
+     * </p>
+     */
+    private ConversationMemorySnapshot requireSnapshot(String conversationId) throws ResourceStoreException, ResourceNotFoundException {
+        var snapshot = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
+        if (snapshot == null) {
+            throw new ConversationNotFoundException(String.format("No conversation found! (conversationId=%s)", sanitize(conversationId)));
+        }
+        return snapshot;
     }
 
     @Override
@@ -991,7 +1021,7 @@ public class ConversationService implements IConversationService {
             throws Exception {
 
         requireConversationAccess(conversationId);
-        var snapshot = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
+        var snapshot = requireSnapshot(conversationId);
         say(snapshot.getEnvironment(), snapshot.getAgentId(), conversationId, returnDetailed, returnCurrentStepOnly, returningFields, inputData,
                 rerunOnly, responseHandler);
     }
@@ -1002,7 +1032,7 @@ public class ConversationService implements IConversationService {
             throws Exception {
 
         requireConversationAccess(conversationId);
-        var snapshot = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
+        var snapshot = requireSnapshot(conversationId);
         sayStreaming(snapshot.getEnvironment(), snapshot.getAgentId(), conversationId, returnDetailed, returnCurrentStepOnly, returningFields,
                 inputData, streamingHandler);
     }

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
@@ -501,7 +501,7 @@ public class ConversationService implements IConversationService {
         contextLogger.setLoggingContext(loggingContext);
 
         try {
-            var conversationMemorySnapshot = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
+            var conversationMemorySnapshot = requireSnapshot(conversationId);
             loggingContext.put(USER_ID, conversationMemorySnapshot.getUserId());
             contextLogger.setLoggingContext(loggingContext);
 

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationStepRunner.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationStepRunner.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 import static ai.labs.eddi.engine.memory.ConversationMemoryUtilities.convertConversationMemory;
 import static ai.labs.eddi.engine.memory.ConversationMemoryUtilities.convertConversationMemorySnapshot;
 
@@ -490,10 +491,21 @@ class ConversationStepRunner {
         return conversationMemoryStore.storeConversationMemorySnapshotIfState(memorySnapshot, expectedState);
     }
 
+    /**
+     * @param conversationId
+     *            sanitized into the message, because this message does not stay
+     *            server-side: {@code RestAgentEngineStreaming} echoes a
+     *            {@code ConversationNotFoundException}'s text into an SSE
+     *            {@code error} event, and the id is a caller-supplied path
+     *            parameter. {@code sanitize} strips ISO control characters and the
+     *            Unicode line separators, so neither the event's JSON nor a log
+     *            line can be broken by the value. The twin construction site,
+     *            {@code ConversationService#requireSnapshot}, already did this.
+     */
     static void checkConversationMemoryNotNull(IConversationMemory conversationMemory, String conversationId) {
         if (conversationMemory == null) {
             String message = "No conversation found with conversationId: %s";
-            message = String.format(message, conversationId);
+            message = String.format(message, sanitize(conversationId));
             throw new ConversationNotFoundException(message);
         }
     }

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationStepRunner.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationStepRunner.java
@@ -457,6 +457,16 @@ class ConversationStepRunner {
     }
 
     void cacheConversationState(String conversationId, ConversationState conversationState) {
+        if (conversationState == null) {
+            // Caffeine rejects a null value with a bare NullPointerException, and
+            // ConversationService.getConversationState caches BEFORE its own "no such
+            // conversation" check — so a conversation that does not exist produced a
+            // 500 from inside the cache instead of reaching the line that throws
+            // ConversationNotFoundException. There is also nothing to cache: "not
+            // found" is not a state, and caching it would keep it being served for the
+            // TTL even after the conversation appeared.
+            return;
+        }
         conversationStateCache.put(conversationId, conversationState);
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
@@ -173,7 +173,8 @@ public class RestAgentAdministration implements IRestAgentAdministration {
         } catch (IResourceStore.ResourceStoreException e) {
             // A store outage is not "agent missing" — let the deploy proceed and fail
             // (or succeed) on its own terms rather than reporting a false 404.
-            log.warnf("Could not verify that Agent %s v%s exists before deploying: %s", agentId, version, e.getMessage());
+            log.warnf("Could not verify that Agent %s v%s exists before deploying: %s",
+                    LogSanitizer.sanitize(agentId), version, e.getMessage());
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
@@ -24,6 +25,7 @@ import ai.labs.eddi.engine.runtime.model.DeploymentEvent;
 import ai.labs.eddi.engine.runtime.service.ServiceException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
+import ai.labs.eddi.utils.LogSanitizer;
 import ai.labs.eddi.utils.RuntimeUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -46,6 +48,7 @@ import static ai.labs.eddi.engine.model.Deployment.Status.*;
 @ApplicationScoped
 public class RestAgentAdministration implements IRestAgentAdministration {
     private final IAgentFactory agentFactory;
+    private final IAgentStore agentStore;
     private final IDeploymentStore deploymentStore;
     private final IConversationMemoryStore conversationMemoryStore;
     private final IRestConversationStore restConversationStore;
@@ -58,12 +61,13 @@ public class RestAgentAdministration implements IRestAgentAdministration {
     private static final Logger log = Logger.getLogger(RestAgentAdministration.class);
 
     @Inject
-    public RestAgentAdministration(IRuntime runtime, IAgentFactory agentFactory, IDeploymentStore deploymentStore,
+    public RestAgentAdministration(IRuntime runtime, IAgentFactory agentFactory, IAgentStore agentStore, IDeploymentStore deploymentStore,
             IConversationMemoryStore conversationMemoryStore, IRestConversationStore restConversationStore,
             IDocumentDescriptorStore documentDescriptorStore, IDeploymentListener deploymentListener, IScheduleStore scheduleStore,
             TenantQuotaService tenantQuotaService) {
         this.runtime = runtime;
         this.agentFactory = agentFactory;
+        this.agentStore = agentStore;
         this.tenantQuotaService = tenantQuotaService;
         this.deploymentStore = deploymentStore;
         this.conversationMemoryStore = conversationMemoryStore;
@@ -80,6 +84,11 @@ public class RestAgentAdministration implements IRestAgentAdministration {
         RuntimeUtilities.checkNotNull(agentId, "agentId");
         RuntimeUtilities.checkNotNull(version, "version");
         RuntimeUtilities.checkNotNull(autoDeploy, "autoDeploy");
+
+        // MUST sit before the try below, for the same reason as the quota gate: the
+        // catch(Exception) there rethrows as InternalServerErrorException, which
+        // would turn this 404 into a 500.
+        requireAgentExists(agentId, version);
 
         // MUST sit before the try below: the catch(Exception) there rethrows as
         // InternalServerErrorException, which would turn the mapper's 429 into a 500.
@@ -126,6 +135,45 @@ public class RestAgentAdministration implements IRestAgentAdministration {
         } catch (Exception e) {
             log.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getLocalizedMessage(), e);
+        }
+    }
+
+    /**
+     * Rejects a deploy of an agent that does not exist, with the 404 the endpoint
+     * has always advertised.
+     * <p>
+     * Without this the asynchronous path answers {@code 202 Accepted} for any id at
+     * all — a typo'd or already-deleted agent included. The deployment then fails
+     * on the runtime executor, where no status code can reach the caller, so the
+     * only signal is a line in the server log. Everything about the response says
+     * the deploy was taken: a CI pipeline, the Manager and the setup API alike read
+     * 202 as success and move on to start a conversation that can never exist.
+     * <p>
+     * Checked against the agent store rather than the deployment status, because
+     * {@code checkDeploymentStatus} answers {@code NOT_FOUND} for a perfectly valid
+     * agent that simply has not been deployed yet — which is the normal case here.
+     *
+     * @throws IResourceStore.ResourceNotFoundException
+     *             mapped to 404 by {@code ResourceNotFoundExceptionMapper}
+     */
+    private void requireAgentExists(String agentId, Integer version) {
+        try {
+            agentStore.read(agentId, version);
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            throw sneakyThrow(e);
+        } catch (IllegalArgumentException e) {
+            // An id the datastore cannot even parse — the MongoDB driver rejects a
+            // non-hex or wrong-length id with "state should be: hexString has 24
+            // characters" before any lookup happens. That is still "there is no such
+            // agent", and answering with the driver's sentence would both mislead
+            // (the caller's mistake was the id, not its hex-ness) and leak which
+            // datastore is behind the API.
+            throw sneakyThrow(new IResourceStore.ResourceNotFoundException(
+                    String.format("Resource not found. (id=%s, version=%s)", LogSanitizer.sanitize(agentId), version)));
+        } catch (IResourceStore.ResourceStoreException e) {
+            // A store outage is not "agent missing" — let the deploy proceed and fail
+            // (or succeed) on its own terms rather than reporting a false 404.
+            log.warnf("Could not verify that Agent %s v%s exists before deploying: %s", agentId, version, e.getMessage());
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
@@ -248,6 +248,16 @@ public class RestAgentEngine implements IRestAgentEngine {
             response.resume(Response.status(Response.Status.FORBIDDEN).type(TEXT_PLAIN).entity(e.getMessage()).build());
         } catch (ResourceNotFoundException e) {
             response.resume(new NotFoundException());
+        } catch (ConversationNotFoundException e) {
+            // Must be caught explicitly, for the same reason as the two branches
+            // below: say() is resumed through an AsyncResponse, so the exception
+            // never reaches ConversationNotFoundExceptionMapper and the generic
+            // handler at the bottom turned "no such conversation" into a 500 with
+            // an error id. Every GET on the same conversation already answers 404,
+            // so posting to a deleted or mistyped id was the one place left that
+            // claimed the server had broken.
+            LOGGER.warnf("No such conversation: %s", sanitize(conversationId));
+            response.resume(Response.status(Response.Status.NOT_FOUND).type(TEXT_PLAIN).entity(e.getMessage()).build());
         } catch (QuotaExceededException e) {
             // Must be caught explicitly: say() is resumed through an AsyncResponse, so
             // the exception never reaches QuotaExceededExceptionMapper — without this

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -5,6 +5,12 @@
 package ai.labs.eddi.engine.internal;
 
 import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.api.IConversationService.AgentMismatchException;
+import ai.labs.eddi.engine.api.IConversationService.AgentNotReadyException;
+import ai.labs.eddi.engine.api.IConversationService.ConversationAwaitingApprovalException;
+import ai.labs.eddi.engine.api.IConversationService.ConversationEndedException;
+import ai.labs.eddi.engine.api.IConversationService.ConversationNotFoundException;
+import ai.labs.eddi.engine.api.IConversationService.StreamingResponseHandler;
 import ai.labs.eddi.engine.api.IRestAgentEngineStreaming;
 import ai.labs.eddi.engine.gdpr.ProcessingRestrictedException;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
@@ -135,7 +141,7 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
 
         try {
             conversationService.sayStreaming(conversationId, returnDetailed, returnCurrentStepOnly, returningFields, inputData,
-                    new IConversationService.StreamingResponseHandler() {
+                    new StreamingResponseHandler() {
                         @Override
                         public void onTaskStart(TaskId taskId, String taskType, int index) {
                             stream.send("task_start",
@@ -257,22 +263,22 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
     private String buildKnownConditionOrOpaqueErrorEvent(String context, Exception e) {
         String code;
         String message;
-        if (e instanceof IConversationService.ConversationAwaitingApprovalException) {
+        if (e instanceof ConversationAwaitingApprovalException) {
             code = "awaiting_approval";
             message = e.getMessage();
-        } else if (e instanceof IConversationService.ConversationNotFoundException) {
+        } else if (e instanceof ConversationNotFoundException) {
             // The twin answers 404 here. This message is a fixed template carrying
             // only the caller's own (sanitized) conversationId, so it is echoed
             // rather than replaced — no new disclosure.
             code = "conversation_not_found";
             message = e.getMessage();
-        } else if (e instanceof IConversationService.ConversationEndedException) {
+        } else if (e instanceof ConversationEndedException) {
             code = "conversation_ended";
             message = "Conversation has ended";
-        } else if (e instanceof IConversationService.AgentNotReadyException) {
+        } else if (e instanceof AgentNotReadyException) {
             code = "agent_not_ready";
             message = "Agent is not deployed or not ready";
-        } else if (e instanceof IConversationService.AgentMismatchException) {
+        } else if (e instanceof AgentMismatchException) {
             code = "agent_mismatch";
             message = "Agent version mismatch";
         } else if (e instanceof QuotaExceededException) {

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -260,6 +260,12 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
         if (e instanceof IConversationService.ConversationAwaitingApprovalException) {
             code = "awaiting_approval";
             message = e.getMessage();
+        } else if (e instanceof IConversationService.ConversationNotFoundException) {
+            // The twin answers 404 here. This message is a fixed template carrying
+            // only the caller's own (sanitized) conversationId, so it is echoed
+            // rather than replaced — no new disclosure.
+            code = "conversation_not_found";
+            message = e.getMessage();
         } else if (e instanceof IConversationService.ConversationEndedException) {
             code = "conversation_ended";
             message = "Conversation has ended";

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -501,10 +501,44 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
         return Double.isFinite(v) ? v : 0.0;
     }
 
+    /**
+     * Escapes a string for embedding in the hand-built JSON of an SSE event.
+     *
+     * <p>
+     * The replace-chain this grew from covered {@code \ " \n \r \t} and left every
+     * other control character raw, which is invalid inside a JSON string (RFC 8259
+     * §7) and makes the event unparseable for a strict client. The values reaching
+     * here are not all ours: a tool name comes from an LLM, an error summary from
+     * an exception message, and a conversation id straight off the request path.
+     * U+2028 and U+2029 are legal JSON but terminate a line in JavaScript, so they
+     * are escaped too rather than shipped to a browser.
+     * </p>
+     */
     private String escapeJson(String text) {
-        if (text == null)
+        if (text == null) {
             return "";
-        return text.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t");
+        }
+        var sb = new StringBuilder(text.length() + 16);
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            switch (c) {
+                case '\\' -> sb.append("\\\\");
+                case '"' -> sb.append("\\\"");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                default -> {
+                    if (c < 0x20 || c == '\u2028' || c == '\u2029') {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
     }
 
     private String toJsonArray(Object obj) {

--- a/src/main/java/ai/labs/eddi/engine/memory/rest/RestConversationStore.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/rest/RestConversationStore.java
@@ -56,6 +56,12 @@ public class RestConversationStore implements IRestConversationStore {
     public static final String DESCRIPTOR_TYPE = "ai.labs.conversation";
 
     /**
+     * Conversation descriptors are written once and then updated in place, so they
+     * never leave version 0 — every other read in this class hard-codes it too.
+     */
+    private static final int CONVERSATION_DESCRIPTOR_VERSION = 0;
+
+    /**
      * Upper bound on how many descriptors an owner-filtered listing will scan
      * before giving up, so a caller who owns few/none of a large shared store
      * cannot turn one list request into a full-collection scan. This is the single
@@ -313,8 +319,10 @@ public class RestConversationStore implements IRestConversationStore {
             // and must NOT leak the unredacted tool arguments or the frozen LLM
             // transcript of a paused conversation — those stay behind the approver-only
             // detail=full gate. Mirrors fix #4's confinement on the Simple surface.
-            return redactRawPendingToolCallsForRead(
-                    conversationMemoryStore.loadConversationMemorySnapshot(conversationId));
+            // requireSnapshot, not the raw load: a missing conversation returned null
+            // here, which JAX-RS renders as 204 No Content — indistinguishable from a
+            // conversation that exists and happens to be empty.
+            return redactRawPendingToolCallsForRead(requireSnapshot(conversationId));
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
             throw sneakyThrow(e);
         }
@@ -329,12 +337,43 @@ public class RestConversationStore implements IRestConversationStore {
         conversationAccessGuard.requireConversationOwner(conversationId);
 
         try {
-            return convertSimpleConversationMemory(conversationMemoryStore.loadConversationMemorySnapshot(conversationId), returnDetailed,
-                    returnCurrentStepOnly);
+            return convertSimpleConversationMemory(requireSnapshot(conversationId), returnDetailed, returnCurrentStepOnly);
 
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
             throw sneakyThrow(e);
         }
+    }
+
+    /**
+     * The snapshot, or a 404 — never a {@code null} for the caller to dereference.
+     *
+     * <p>
+     * {@code loadConversationMemorySnapshot} answers {@code null} for a
+     * conversation that is not there, and the read paths went straight on to call
+     * {@code getEnvironment()} on it. So a deleted or mistyped conversation id
+     * produced a {@link NullPointerException}, which reached the client as
+     * {@code 500 Internal Server Error} plus an error id — from endpoints whose own
+     * {@code @APIResponse} promised a 404, and which the troubleshooting
+     * documentation tells people to call precisely when something has already gone
+     * wrong.
+     * </p>
+     *
+     * <p>
+     * Throws the checked {@code ResourceNotFoundException} rather than
+     * {@code ConversationNotFoundException}, which {@code ConversationService}'s
+     * twin uses: both read endpoints here already declare it on
+     * {@link IRestConversationStore}, so this is the contract they publish. Both
+     * map to 404.
+     * </p>
+     */
+    private ConversationMemorySnapshot requireSnapshot(String conversationId)
+            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+        var snapshot = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
+        if (snapshot == null) {
+            throw new IResourceStore.ResourceNotFoundException(
+                    String.format("No conversation found! (conversationId=%s)", sanitize(conversationId)));
+        }
+        return snapshot;
     }
 
     @Override
@@ -342,8 +381,8 @@ public class RestConversationStore implements IRestConversationStore {
             throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
         checkNotNull(conversationId, "conversationId");
         // Deletion is irreversible, so the gate runs before anything is touched —
-        // including the soft-delete path, whose DocumentDescriptorInterceptor marks
-        // the descriptor deleted even when deletePermanently is false.
+        // the soft-delete path included, which still removes the conversation from
+        // every listing.
         conversationAccessGuard.requireConversationOwner(conversationId);
 
         if (deletePermanently) {
@@ -370,11 +409,47 @@ public class RestConversationStore implements IRestConversationStore {
             conversationMemoryStore.deleteConversationMemorySnapshot(conversationId);
             conversationDescriptorStore.deleteAllDescriptor(conversationId);
             log.info(format("Conversation has been permanently deleted (conversationId=%s)", sanitize(conversationId)));
+        } else {
+            softDelete(conversationId);
         }
+    }
 
-        // DocumentDescriptorInterceptor will mark the DocumentDescriptor of this
-        // resource as deleted,
-        // regardless of whether it has been permanently deleted or not
+    /**
+     * Retires the conversation's descriptor so the conversation disappears from
+     * every listing, while its memory snapshot and attachments stay on the server.
+     *
+     * <p>
+     * This branch used to do <em>nothing at all</em>. A comment claimed a
+     * {@code DocumentDescriptorInterceptor} would mark the descriptor deleted
+     * "regardless of whether it has been permanently deleted or not", but no such
+     * interceptor exists anywhere in the code base — so {@code DELETE
+     * /conversationstore/conversations/{id}} (whose {@code deletePermanently}
+     * defaults to {@code false}) answered 204 and left the row untouched, still
+     * {@code "deleted": false} and still listed. The Manager's delete dialog
+     * describes exactly the behaviour implemented here and then reports
+     * "Conversation deleted", so the honest-looking answer was the wrong one: users
+     * saw a success toast next to a conversation that was still there.
+     * </p>
+     *
+     * <p>
+     * {@code deleteDescriptor} archives the descriptor into its history collection
+     * with {@code deleted=true} and drops the live row, which is what the
+     * {@code includeDeleted=false} listings filter on. The snapshot itself is
+     * deliberately untouched — that is the whole distinction from the permanent
+     * path, and it is what lets the retention sweep and GDPR erasure still find the
+     * data.
+     * </p>
+     */
+    private void softDelete(String conversationId) throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+        try {
+            conversationDescriptorStore.deleteDescriptor(conversationId, CONVERSATION_DESCRIPTOR_VERSION);
+            log.info(format("Conversation has been deleted (conversationId=%s)", sanitize(conversationId)));
+        } catch (IResourceStore.ResourceModifiedException e) {
+            // The descriptor moved under us — surface it rather than reporting a
+            // deletion that did not happen.
+            throw new IResourceStore.ResourceStoreException(
+                    format("Could not delete conversation %s: its descriptor was modified concurrently", sanitize(conversationId)), e);
+        }
     }
 
     @Scheduled(every = "24h")
@@ -435,7 +510,7 @@ public class RestConversationStore implements IRestConversationStore {
 
         for (var endedConversationId : endedConversationIds) {
             try {
-                var descriptor = documentDescriptorStore.readDescriptor(endedConversationId, 0);
+                var descriptor = documentDescriptorStore.readDescriptor(endedConversationId, CONVERSATION_DESCRIPTOR_VERSION);
                 if (descriptor.getLastModifiedOn().before(deleteOlderThanThisDate)) {
                     documentDescriptorStore.deleteAllDescriptor(endedConversationId);
                     conversationDescriptorStore.deleteAllDescriptor(endedConversationId);
@@ -471,7 +546,7 @@ public class RestConversationStore implements IRestConversationStore {
             conversationStatus.setAgentId(agentId);
             conversationStatus.setAgentVersion(agentVersion);
             conversationStatus.setConversationState(snapshot.getConversationState());
-            var conversationDescriptor = conversationDescriptorStore.readDescriptor(conversationId, 0);
+            var conversationDescriptor = conversationDescriptorStore.readDescriptor(conversationId, CONVERSATION_DESCRIPTOR_VERSION);
             conversationStatus.setLastInteraction(conversationDescriptor.getLastModifiedOn());
             conversationStatuses.add(conversationStatus);
         }
@@ -498,9 +573,10 @@ public class RestConversationStore implements IRestConversationStore {
                     conversationMemoryStore.setConversationState(conversationId, ConversationState.ENDED);
                 }
 
-                ConversationDescriptor conversationDescriptor = conversationDescriptorStore.readDescriptor(conversationId, 0);
+                ConversationDescriptor conversationDescriptor = conversationDescriptorStore.readDescriptor(conversationId,
+                        CONVERSATION_DESCRIPTOR_VERSION);
                 conversationDescriptor.setConversationState(ConversationState.ENDED);
-                conversationDescriptorStore.setDescriptor(conversationId, 0, conversationDescriptor);
+                conversationDescriptorStore.setDescriptor(conversationId, CONVERSATION_DESCRIPTOR_VERSION, conversationDescriptor);
 
                 log.info(format("conversation (%s) has been set to ENDED", conversationId));
             }

--- a/src/main/java/ai/labs/eddi/engine/memory/rest/RestConversationStore.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/rest/RestConversationStore.java
@@ -6,7 +6,10 @@ package ai.labs.eddi.engine.memory.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
-import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.datastore.IResourceStore.ResourceModifiedException;
+import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
+import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
@@ -262,19 +265,19 @@ public class RestConversationStore implements IRestConversationStore {
 
             return retConversationDescriptors;
 
-        } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
+        } catch (ResourceStoreException | ResourceNotFoundException e) {
             throw sneakyThrow(e);
         }
     }
 
     private List<ConversationDescriptor> readConversationDescriptors(Integer index, Integer limit, String filter)
-            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+            throws ResourceStoreException, ResourceNotFoundException {
 
         return conversationDescriptorStore.readDescriptors(DESCRIPTOR_TYPE, filter, index, limit, false);
     }
 
-    private void populateDataToDescriptor(ConversationDescriptor conversationDescriptor, IResourceStore.IResourceId resourceId)
-            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+    private void populateDataToDescriptor(ConversationDescriptor conversationDescriptor, IResourceId resourceId)
+            throws ResourceStoreException, ResourceNotFoundException {
 
         try {
             var memorySnapshot = conversationMemoryStore.loadConversationMemorySnapshot(resourceId.getId());
@@ -298,7 +301,7 @@ public class RestConversationStore implements IRestConversationStore {
                 conversationDescriptor.setAgentName(documentDescriptor.getName());
             }
 
-        } catch (IResourceStore.ResourceNotFoundException e) {
+        } catch (ResourceNotFoundException e) {
             String message = "Resource referenced in descriptor does not exist (anymore) [%s, %s]. ";
             message += "Ignoring this resource.";
             log.warn(format(message, resourceId.getId(), resourceId.getVersion()));
@@ -323,7 +326,7 @@ public class RestConversationStore implements IRestConversationStore {
             // here, which JAX-RS renders as 204 No Content — indistinguishable from a
             // conversation that exists and happens to be empty.
             return redactRawPendingToolCallsForRead(requireSnapshot(conversationId));
-        } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
+        } catch (ResourceStoreException | ResourceNotFoundException e) {
             throw sneakyThrow(e);
         }
     }
@@ -339,7 +342,7 @@ public class RestConversationStore implements IRestConversationStore {
         try {
             return convertSimpleConversationMemory(requireSnapshot(conversationId), returnDetailed, returnCurrentStepOnly);
 
-        } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
+        } catch (ResourceStoreException | ResourceNotFoundException e) {
             throw sneakyThrow(e);
         }
     }
@@ -367,10 +370,10 @@ public class RestConversationStore implements IRestConversationStore {
      * </p>
      */
     private ConversationMemorySnapshot requireSnapshot(String conversationId)
-            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+            throws ResourceStoreException, ResourceNotFoundException {
         var snapshot = conversationMemoryStore.loadConversationMemorySnapshot(conversationId);
         if (snapshot == null) {
-            throw new IResourceStore.ResourceNotFoundException(
+            throw new ResourceNotFoundException(
                     String.format("No conversation found! (conversationId=%s)", sanitize(conversationId)));
         }
         return snapshot;
@@ -378,7 +381,7 @@ public class RestConversationStore implements IRestConversationStore {
 
     @Override
     public void deleteConversationLog(String conversationId, Boolean deletePermanently)
-            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+            throws ResourceStoreException, ResourceNotFoundException {
         checkNotNull(conversationId, "conversationId");
         // Deletion is irreversible, so the gate runs before anything is touched —
         // the soft-delete path included, which still removes the conversation from
@@ -440,14 +443,14 @@ public class RestConversationStore implements IRestConversationStore {
      * data.
      * </p>
      */
-    private void softDelete(String conversationId) throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+    private void softDelete(String conversationId) throws ResourceStoreException, ResourceNotFoundException {
         try {
             conversationDescriptorStore.deleteDescriptor(conversationId, CONVERSATION_DESCRIPTOR_VERSION);
             log.info(format("Conversation has been deleted (conversationId=%s)", sanitize(conversationId)));
-        } catch (IResourceStore.ResourceModifiedException e) {
+        } catch (ResourceModifiedException e) {
             // The descriptor moved under us — surface it rather than reporting a
             // deletion that did not happen.
-            throw new IResourceStore.ResourceStoreException(
+            throw new ResourceStoreException(
                     format("Could not delete conversation %s: its descriptor was modified concurrently", sanitize(conversationId)), e);
         }
     }
@@ -467,7 +470,7 @@ public class RestConversationStore implements IRestConversationStore {
                     log.info(format("Successfully deleted %s conversations, which were older than %s days", amountOfEndedConversations,
                             deleteEndedConversationsOnceOlderThanDays));
                 }
-            } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
+            } catch (ResourceStoreException | ResourceNotFoundException e) {
                 log.error(e.getLocalizedMessage(), e);
             }
             return null;
@@ -496,7 +499,7 @@ public class RestConversationStore implements IRestConversationStore {
 
     @Override
     public Integer permanentlyDeleteEndedConversationLogs(Integer deleteOlderThanDays)
-            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+            throws ResourceStoreException, ResourceNotFoundException {
 
         if (deleteOlderThanDays == null || deleteOlderThanDays < MIN_RETENTION_DAYS) {
             throw new BadRequestException(
@@ -518,7 +521,7 @@ public class RestConversationStore implements IRestConversationStore {
                     conversationMemoryStore.deleteConversationMemorySnapshot(endedConversationId);
                     amountOfEndedConversations++;
                 }
-            } catch (IResourceStore.ResourceNotFoundException e) {
+            } catch (ResourceNotFoundException e) {
                 conversationDescriptorStore.deleteAllDescriptor(endedConversationId);
                 deleteAttachmentsForConversation(endedConversationId);
                 conversationMemoryStore.deleteConversationMemorySnapshot(endedConversationId);
@@ -531,7 +534,7 @@ public class RestConversationStore implements IRestConversationStore {
 
     @Override
     public List<ConversationStatus> getActiveConversations(String agentId, Integer agentVersion)
-            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+            throws ResourceStoreException, ResourceNotFoundException {
         checkNotNull(agentId, "agentId");
         checkNotNull(agentVersion, "agentVersion");
 
@@ -582,7 +585,7 @@ public class RestConversationStore implements IRestConversationStore {
             }
 
             return Response.ok().build();
-        } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
+        } catch (ResourceStoreException | ResourceNotFoundException e) {
             throw sneakyThrow(e);
         }
     }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/builder/ModelParameterValues.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/builder/ModelParameterValues.java
@@ -11,6 +11,7 @@ import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 import java.util.function.DoubleConsumer;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
@@ -154,6 +155,31 @@ final class ModelParameterValues {
     }
 
     /**
+     * Boolean variant of {@link #applyInt}, for tri-state provider options where
+     * <em>unset</em> is a third, meaningful value.
+     * <p>
+     * Deliberately not {@code Boolean.parseBoolean(parameters.get(key))}: that maps
+     * an absent key, a typo and an explicit {@code "false"} all to {@code false},
+     * which would silently pin the option instead of leaving the provider default —
+     * the exact difference between "do not think" and "let the model decide" on
+     * Ollama.
+     */
+    static void applyBoolean(Map<String, String> parameters, String key, Consumer<Boolean> setter) {
+        String raw = rawValue(parameters, key);
+        if (raw == null) {
+            return;
+        }
+        if ("true".equalsIgnoreCase(raw)) {
+            setter.accept(Boolean.TRUE);
+        } else if ("false".equalsIgnoreCase(raw)) {
+            setter.accept(Boolean.FALSE);
+        } else {
+            LOGGER.warnf("LLM parameter '%s' is not a boolean ('%s') — leaving the provider default in place.",
+                    sanitize(key), sanitize(raw));
+        }
+    }
+
+    /**
      * The trimmed value, or {@code null} when the key is absent, empty or nothing
      * but whitespace.
      * <p>
@@ -176,7 +202,7 @@ final class ModelParameterValues {
 
     private static <T> T rejected(String key, String raw, String expected) {
         LOGGER.warnv("LLM parameter ''{0}'' is not a valid {1} (''{2}'') — falling back to the model default.",
-                key, expected, raw);
+                sanitize(key), expected, sanitize(raw));
         return null;
     }
 }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/builder/OllamaLanguageModelBuilder.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/builder/OllamaLanguageModelBuilder.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 
+import static ai.labs.eddi.modules.llm.impl.builder.ModelParameterValues.applyBoolean;
 import static ai.labs.eddi.modules.llm.impl.builder.ModelParameterValues.applyDouble;
 import static ai.labs.eddi.modules.llm.impl.builder.ModelParameterValues.applyInt;
 import static ai.labs.eddi.modules.llm.impl.builder.ModelParameterValues.applyLong;
@@ -44,10 +45,33 @@ public class OllamaLanguageModelBuilder implements ILanguageModelBuilder {
     private static final String KEY_TOP_P = "topP";
     private static final String KEY_TOP_K = "topK";
 
+    /**
+     * Ollama's own {@code think} switch — tri-state on purpose.
+     * <p>
+     * {@code "true"} asks the model to reason and return the reasoning in a
+     * separate {@code thinking} field; {@code "false"} turns reasoning off;
+     * <em>unset</em> leaves the model's own default, which for a reasoning model
+     * (gemma3n, deepseek-r1, qwen3 …) means it thinks. That default is what makes a
+     * first Ollama agent look broken: streaming a reasoning model emits a long run
+     * of chunks whose {@code content} is empty and whose {@code thinking} carries
+     * the text, so the chat window sits silent for many seconds before the answer
+     * appears all at once. Setting {@code think: "false"} makes such a model answer
+     * immediately.
+     */
+    private static final String KEY_THINK = "think";
+
+    /**
+     * Whether the reasoning text is surfaced rather than discarded. Independent of
+     * {@link #KEY_THINK} — it only controls parsing of the {@code thinking} field
+     * the server sends, so it is off by default and reasoning stays out of the
+     * conversation transcript unless asked for.
+     */
+    private static final String KEY_RETURN_THINKING = "returnThinking";
+
     @Override
     public Set<String> recognisedParameters() {
         return Set.of(KEY_MODEL, KEY_TIMEOUT, KEY_LOG_REQUESTS, KEY_LOG_RESPONSES, KEY_BASE_URL,
-                KEY_TEMPERATURE, KEY_MAX_TOKENS, KEY_TOP_P, KEY_TOP_K);
+                KEY_TEMPERATURE, KEY_MAX_TOKENS, KEY_TOP_P, KEY_TOP_K, KEY_THINK, KEY_RETURN_THINKING);
     }
 
     @Override
@@ -65,6 +89,8 @@ public class OllamaLanguageModelBuilder implements ILanguageModelBuilder {
         applyInt(parameters, KEY_MAX_TOKENS, builder::numPredict);
         applyDouble(parameters, KEY_TOP_P, builder::topP);
         applyInt(parameters, KEY_TOP_K, builder::topK);
+        applyBoolean(parameters, KEY_THINK, builder::think);
+        applyBoolean(parameters, KEY_RETURN_THINKING, builder::returnThinking);
         if (!isNullOrEmpty(parameters.get(KEY_LOG_REQUESTS))) {
             builder.logRequests(Boolean.parseBoolean(parameters.get(KEY_LOG_REQUESTS)));
         }
@@ -90,6 +116,8 @@ public class OllamaLanguageModelBuilder implements ILanguageModelBuilder {
         applyInt(parameters, KEY_MAX_TOKENS, builder::numPredict);
         applyDouble(parameters, KEY_TOP_P, builder::topP);
         applyInt(parameters, KEY_TOP_K, builder::topK);
+        applyBoolean(parameters, KEY_THINK, builder::think);
+        applyBoolean(parameters, KEY_RETURN_THINKING, builder::returnThinking);
         if (!isNullOrEmpty(parameters.get(KEY_LOG_REQUESTS))) {
             builder.logRequests(Boolean.parseBoolean(parameters.get(KEY_LOG_REQUESTS)));
         }

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/builder/OllamaLanguageModelBuilder.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/builder/OllamaLanguageModelBuilder.java
@@ -49,22 +49,28 @@ public class OllamaLanguageModelBuilder implements ILanguageModelBuilder {
      * Ollama's own {@code think} switch — tri-state on purpose.
      * <p>
      * {@code "true"} asks the model to reason and return the reasoning in a
-     * separate {@code thinking} field; {@code "false"} turns reasoning off;
-     * <em>unset</em> leaves the model's own default, which for a reasoning model
-     * (gemma3n, deepseek-r1, qwen3 …) means it thinks. That default is what makes a
-     * first Ollama agent look broken: streaming a reasoning model emits a long run
-     * of chunks whose {@code content} is empty and whose {@code thinking} carries
-     * the text, so the chat window sits silent for many seconds before the answer
-     * appears all at once. Setting {@code think: "false"} makes such a model answer
-     * immediately.
+     * separate {@code thinking} field, which langchain4j discards unless
+     * {@link #KEY_RETURN_THINKING} is also on. {@code "false"} turns reasoning off.
+     * <em>Unset</em> leaves it to Ollama and the model, and the two outcomes differ
+     * in where the reasoning ends up: a model that reports it separately makes the
+     * chat window sit silent for as long as it thinks (the reasoning is not part of
+     * the streamed content, and nothing renders until the answer starts), while an
+     * older reasoning model instead prepends {@code <think>…</think>} to the
+     * content itself, so the tags stream into the reply where the user can see
+     * them.
+     * <p>
+     * Either way it is the first thing that makes a local reasoning model (gemma3n,
+     * deepseek-r1, qwen3 …) look broken. {@code think: "false"} makes such a model
+     * answer immediately.
      */
     private static final String KEY_THINK = "think";
 
     /**
-     * Whether the reasoning text is surfaced rather than discarded. Independent of
-     * {@link #KEY_THINK} — it only controls parsing of the {@code thinking} field
-     * the server sends, so it is off by default and reasoning stays out of the
-     * conversation transcript unless asked for.
+     * Whether the separate {@code thinking} field is parsed and surfaced rather
+     * than discarded. Independent of {@link #KEY_THINK} — it does not enable
+     * reasoning, and it has no effect on reasoning a model embedded in the ordinary
+     * content, which is not a {@code thinking} field to parse. Off by default, so
+     * reasoning stays out of the transcript unless asked for.
      */
     private static final String KEY_RETURN_THINKING = "returnThinking";
 

--- a/src/test/java/ai/labs/eddi/configs/rest/StrictConfigurationBodyInterceptorTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rest/StrictConfigurationBodyInterceptorTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.rest;
 
+import ai.labs.eddi.configs.output.model.OutputConfigurationSet;
 import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
 import ai.labs.eddi.engine.model.InputData;
@@ -80,6 +81,92 @@ class StrictConfigurationBodyInterceptorTest {
         assertTrue(entity.contains("behaviorGroupz"), "the offending field must be named: " + entity);
         assertTrue(entity.contains("behaviorGroups"), "the legal fields must be listed: " + entity);
         verify(context, never()).proceed();
+    }
+
+    @Test
+    @DisplayName("a value of the wrong shape is a 400 that says where and what, not an empty body")
+    void wrongValueShapeIsExplained() throws Exception {
+        // Exactly the payload docs/developer-quickstart.md used to publish:
+        // valueAlternatives documented as a list of strings, modelled as a list of
+        // typed OutputItems. RESTEasy answered 400 with content-length: 0 — no
+        // field, no expectation, no indication the body was even the problem.
+        var context = context(OutputConfigurationSet.class, """
+                {
+                  "outputSet": [
+                    {
+                      "action": "welcome_action",
+                      "timesOccurred": 0,
+                      "outputs": [ { "valueAlternatives": [ "Hello!" ] } ]
+                    }
+                  ]
+                }
+                """);
+
+        var thrown = assertThrows(BadRequestException.class, () -> interceptor.aroundReadFrom(context));
+
+        assertEquals(400, thrown.getResponse().getStatus());
+        String entity = String.valueOf(thrown.getResponse().getEntity());
+        assertFalse(entity.isBlank(), "the response must carry a message at all");
+        assertTrue(entity.contains("valueAlternatives"),
+                "the failing JSON path must be named: " + entity);
+        assertTrue(entity.contains("jsonSchema"),
+                "the reader needs somewhere to look up the right shape: " + entity);
+        // Naming only the expectation leaves the reader to work out which value on
+        // the line was wrong.
+        assertTrue(entity.contains("expected an object with a 'type' field"),
+                "the message must say what belongs there: " + entity);
+        assertTrue(entity.contains("found a string"),
+                "the message must say what was there instead: " + entity);
+        // The single most useful thing here: OutputItem is polymorphic, and the
+        // legal discriminators are exactly what the author could not guess.
+        assertTrue(entity.contains("text") && entity.contains("quickReply"),
+                "the legal type ids must be listed: " + entity);
+        verify(context, never()).proceed();
+    }
+
+    @Test
+    @DisplayName("an unknown polymorphic 'type' names it, and lists the ones that exist")
+    void unknownTypeIdIsExplained() throws Exception {
+        var context = context(OutputConfigurationSet.class, """
+                {
+                  "outputSet": [
+                    {
+                      "action": "welcome_action",
+                      "timesOccurred": 0,
+                      "outputs": [ { "valueAlternatives": [ { "type": "txt", "text": "Hello!" } ] } ]
+                    }
+                  ]
+                }
+                """);
+
+        var thrown = assertThrows(BadRequestException.class, () -> interceptor.aroundReadFrom(context));
+        String entity = String.valueOf(thrown.getResponse().getEntity());
+
+        assertTrue(entity.contains("'txt' is not a known 'type'"),
+                "the rejected id must be quoted back: " + entity);
+        assertTrue(entity.contains("text"), "the legal ids must be listed: " + entity);
+        assertFalse(entity.contains("ai.labs.eddi"),
+                "an API error must not leak internal class names: " + entity);
+    }
+
+    @Test
+    @DisplayName("the wrong-shape message stays free of Java type names")
+    void wrongShapeMessageIsNotAStackTrace() throws Exception {
+        var context = context(OutputConfigurationSet.class, """
+                { "outputSet": [ { "action": "a", "timesOccurred": "not-a-number" } ] }
+                """);
+
+        var thrown = assertThrows(BadRequestException.class, () -> interceptor.aroundReadFrom(context));
+        String entity = String.valueOf(thrown.getResponse().getEntity());
+
+        assertFalse(entity.contains("ai.labs.eddi"),
+                "an API error must not leak internal class names: " + entity);
+        assertFalse(entity.contains("com.fasterxml"),
+                "an API error must not leak Jackson internals: " + entity);
+        // A Java type name adds nothing a JSON author can act on, and "expected a
+        // int here" reads as a bug in the message rather than in the payload.
+        assertTrue(entity.contains("expected a whole number here"),
+                "the expectation must be stated in JSON terms: " + entity);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/rules/model/RuleGroupConfigurationJsonTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rules/model/RuleGroupConfigurationJsonTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.rules.model;
+
+import ai.labs.eddi.datastore.serialization.SerializationCustomizer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the wire name of a behavior group's rule list.
+ *
+ * <p>
+ * The accessors are {@code getRules}/{@code setRules}, so Jackson used to
+ * serialise the list as {@code rules} while everything a human writes says
+ * {@code behaviorRules} — the shipped reference configuration, the ZIP import
+ * fixtures, the documentation, and the Manager's rules editor, which types the
+ * field that way. Writes worked either way thanks to the alias, so the mismatch
+ * surfaced only on reads: a rule set posted as {@code behaviorRules} came back
+ * as {@code rules}, and the Manager rendered every group as "No rules in this
+ * group" regardless of what it contained. The Manager's own MSW mocks returned
+ * {@code behaviorRules}, so its test suite agreed with the fiction rather than
+ * with the server.
+ * </p>
+ *
+ * <p>
+ * These tests are the contract: {@code behaviorRules} out, both names in.
+ * </p>
+ */
+@DisplayName("RuleGroupConfiguration JSON shape")
+class RuleGroupConfigurationJsonTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false);
+    }
+
+    private static RuleSetConfiguration oneGroupWithOneRule() {
+        var rule = new RuleConfiguration();
+        rule.setName("Welcome");
+        rule.getActions().add("welcome_action");
+
+        var group = new RuleGroupConfiguration();
+        group.setName("Greetings");
+        group.setRules(List.of(rule));
+
+        var ruleSet = new RuleSetConfiguration();
+        ruleSet.getBehaviorGroups().add(group);
+        return ruleSet;
+    }
+
+    @Test
+    @DisplayName("serialises the rule list as behaviorRules")
+    void serialisesAsBehaviorRules() throws Exception {
+        String json = mapper.writeValueAsString(oneGroupWithOneRule());
+
+        assertTrue(json.contains("\"behaviorRules\""), "expected behaviorRules in: " + json);
+        assertFalse(json.contains("\"rules\""), "the old spelling must not be emitted: " + json);
+    }
+
+    @Test
+    @DisplayName("accepts behaviorRules on the way in")
+    void acceptsBehaviorRules() throws Exception {
+        var parsed = mapper.readValue("""
+                { "behaviorGroups": [ { "name": "Greetings",
+                    "behaviorRules": [ { "name": "Welcome", "actions": ["welcome_action"] } ] } ] }
+                """, RuleSetConfiguration.class);
+
+        assertEquals("Welcome", parsed.getBehaviorGroups().getFirst().getRules().getFirst().getName());
+    }
+
+    @Test
+    @DisplayName("still accepts rules, so documents written before the rename keep loading")
+    void stillAcceptsTheOldSpelling() throws Exception {
+        var parsed = mapper.readValue("""
+                { "behaviorGroups": [ { "name": "Greetings",
+                    "rules": [ { "name": "Welcome", "actions": ["welcome_action"] } ] } ] }
+                """, RuleSetConfiguration.class);
+
+        assertEquals("Welcome", parsed.getBehaviorGroups().getFirst().getRules().getFirst().getName());
+    }
+
+    @Test
+    @DisplayName("round-trips: what a client posts is what it reads back")
+    void roundTrips() throws Exception {
+        String posted = """
+                { "behaviorGroups": [ { "name": "Greetings",
+                    "behaviorRules": [ { "name": "Welcome", "actions": ["welcome_action"] } ] } ] }
+                """;
+
+        String readBack = mapper.writeValueAsString(mapper.readValue(posted, RuleSetConfiguration.class));
+
+        assertTrue(readBack.contains("\"behaviorRules\""),
+                "a client that posted behaviorRules must not get a different key back: " + readBack);
+    }
+}

--- a/src/test/java/ai/labs/eddi/docs/DocumentedRestPathsTest.java
+++ b/src/test/java/ai/labs/eddi/docs/DocumentedRestPathsTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.docs;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Keeps the documentation's REST paths on the v6 spelling.
+ * <p>
+ * The v5→v6 rename gave every configuration store a new path and a new
+ * {@code eddi://} namespace, and {@code LegacyPathRewriteFilter} keeps the old
+ * ones answering so that existing clients do not break. That compatibility is
+ * exactly what let the documentation rot invisibly: a reader following
+ * {@code POST /packagestore/packages} got a {@code 201}, so nothing anywhere
+ * said the page was five years out of date — until the payload shape had
+ * drifted too, at which point the same page produced a {@code 400} with no body
+ * and no way to tell which half was wrong.
+ * <p>
+ * That is not hypothetical. A developer working through
+ * {@code developer-quickstart.md} in August 2026 hit four different failures in
+ * seven steps, every one of them the documentation rather than the server, and
+ * had to reverse-engineer the real payloads from the OpenAPI page.
+ * <p>
+ * So: legacy spellings stay supported on the wire and stay banned in prose.
+ * {@link #legacyChangeRecords} lists the files that legitimately quote the old
+ * names — a changelog describing the rename has to be able to name what was
+ * renamed.
+ *
+ * @see ai.labs.eddi.engine.runtime.rest.interceptors.LegacyPathRewriteFilter
+ */
+@DisplayName("documented REST paths")
+class DocumentedRestPathsTest {
+
+    /**
+     * Legacy spelling → the v6 spelling that replaced it, in the message.
+     * <p>
+     * Keyed on the store path rather than the full URI so that both forms are
+     * caught by one entry: the bare REST path ({@code /behaviorstore/behaviorsets})
+     * and the resource URI that contains it
+     * ({@code eddi://ai.labs.behavior/behaviorstore/behaviorsets/…}).
+     */
+    private static final Map<String, String> LEGACY_TO_V6 = new LinkedHashMap<>();
+
+    static {
+        LEGACY_TO_V6.put("/regulardictionarystore/regulardictionaries", "/dictionarystore/dictionaries");
+        LEGACY_TO_V6.put("/behaviorstore/behaviorsets", "/rulestore/rulesets");
+        LEGACY_TO_V6.put("/httpcallsstore/httpcalls", "/apicallstore/apicalls");
+        LEGACY_TO_V6.put("/langchainstore/langchains", "/llmstore/llms");
+        LEGACY_TO_V6.put("/packagestore/packages", "/workflowstore/workflows");
+        LEGACY_TO_V6.put("/botstore/bots", "/agentstore/agents");
+    }
+
+    /**
+     * Documents whose subject IS the rename, so they have to spell out both sides
+     * of it. Repository-relative, forward-slashed.
+     */
+    private static Set<String> legacyChangeRecords() {
+        return Set.of("docs/changelog.md", "HANDOFF.md");
+    }
+
+    private static final Set<String> SKIPPED_DIRS = Set.of("target", ".git", "node_modules", ".claude", ".mvn");
+
+    @Test
+    @DisplayName("no markdown file documents a pre-v6 store path")
+    void noLegacyStorePathsInDocumentation() {
+        Path root = repoRoot();
+        var offences = new TreeSet<String>();
+
+        for (Path file : markdownFiles(root)) {
+            String relative = root.relativize(file).toString().replace('\\', '/');
+            if (legacyChangeRecords().contains(relative)) {
+                continue;
+            }
+
+            String text = read(file);
+            String[] lines = text.split("\r?\n", -1);
+            for (int i = 0; i < lines.length; i++) {
+                if (namesTheSpellingAsLegacy(lines[i])) {
+                    continue;
+                }
+                for (var entry : LEGACY_TO_V6.entrySet()) {
+                    if (lines[i].contains(entry.getKey())) {
+                        offences.add(String.format("%s:%d uses '%s' — write '%s'",
+                                relative, i + 1, entry.getKey(), entry.getValue()));
+                    }
+                }
+            }
+        }
+
+        assertTrue(offences.isEmpty(),
+                "Documentation must use the v6 store paths. The pre-v6 ones still answer, because "
+                        + "LegacyPathRewriteFilter rewrites them, so a reader following these gets a plausible "
+                        + "response from the wrong half of the API and no warning at all:\n  "
+                        + String.join("\n  ", offences));
+    }
+
+    /**
+     * A line whose subject <em>is</em> the old spelling may name it.
+     * <p>
+     * "Legacy URIs are auto-normalized during import, but new configs should use
+     * the v6 format" is a sentence that cannot be written without the legacy URI in
+     * it, and banning it would push authors toward vaguer guidance rather than
+     * clearer. The marker is deliberately crude — a line that says "legacy" is
+     * exempt — because the failure it guards against is a stale
+     * <em>instruction</em> ("POST to /packagestore/packages"), and such a line
+     * never calls itself legacy.
+     */
+    private static boolean namesTheSpellingAsLegacy(String line) {
+        return line.toLowerCase(Locale.ROOT).contains("legacy");
+    }
+
+    private static Path repoRoot() {
+        // Surefire runs with the project basedir as the working directory.
+        Path root = Path.of("").toAbsolutePath();
+        assertTrue(Files.isRegularFile(root.resolve("pom.xml")),
+                "expected the working directory to be the project root, was " + root);
+        return root;
+    }
+
+    private static String read(Path file) {
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Every markdown file, with {@link #SKIPPED_DIRS} <em>pruned</em> rather than
+     * walked and filtered — {@code target/}, {@code .git/} and this repository's
+     * agent worktrees under {@code .claude/} are each large enough that the
+     * difference is seconds per run.
+     */
+    private static List<Path> markdownFiles(Path root) {
+        List<Path> found = new ArrayList<>();
+        try {
+            Files.walkFileTree(root, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (!dir.equals(root) && SKIPPED_DIRS.contains(dir.getFileName().toString())) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (attrs.isRegularFile() && file.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".md")) {
+                        found.add(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                    return FileVisitResult.CONTINUE; // an unreadable entry is not this test's business
+                }
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return found;
+    }
+}

--- a/src/test/java/ai/labs/eddi/docs/DocumentedRestPathsTest.java
+++ b/src/test/java/ai/labs/eddi/docs/DocumentedRestPathsTest.java
@@ -81,6 +81,40 @@ class DocumentedRestPathsTest {
 
     private static final Set<String> SKIPPED_DIRS = Set.of("target", ".git", "node_modules", ".claude", ".mvn");
 
+    /**
+     * Payload keys that no longer parse at all, unlike the paths above.
+     * <p>
+     * {@code packageExtensions} was the v5 name for {@code workflowSteps}. Strict
+     * configuration parsing rejects it with a 400 naming the field, so every
+     * documented workflow payload carrying it was an instruction that could not
+     * work — five pages still had one when this test was written, because the v6
+     * sweep had corrected the store paths and left the payload shapes alone.
+     */
+    @Test
+    @DisplayName("no markdown file documents a payload key the API rejects")
+    void noRejectedPayloadKeysInDocumentation() {
+        Path root = repoRoot();
+        var offences = new TreeSet<String>();
+
+        for (Path file : markdownFiles(root)) {
+            String relative = root.relativize(file).toString().replace('\\', '/');
+            if (legacyChangeRecords().contains(relative)) {
+                continue;
+            }
+
+            String[] lines = read(file).split("\r?\n", -1);
+            for (int i = 0; i < lines.length; i++) {
+                if (lines[i].contains("\"packageExtensions\"")) {
+                    offences.add(String.format("%s:%d uses 'packageExtensions' — write 'workflowSteps'", relative, i + 1));
+                }
+            }
+        }
+
+        assertTrue(offences.isEmpty(),
+                "These payloads are rejected by the server with a 400, so the pages carrying them cannot be followed:\n  "
+                        + String.join("\n  ", offences));
+    }
+
     @Test
     @DisplayName("no markdown file documents a pre-v6 store path")
     void noLegacyStorePathsInDocumentation() {
@@ -96,11 +130,8 @@ class DocumentedRestPathsTest {
             String text = read(file);
             String[] lines = text.split("\r?\n", -1);
             for (int i = 0; i < lines.length; i++) {
-                if (namesTheSpellingAsLegacy(lines[i])) {
-                    continue;
-                }
                 for (var entry : LEGACY_TO_V6.entrySet()) {
-                    if (lines[i].contains(entry.getKey())) {
+                    if (lines[i].contains(entry.getKey()) && !allowedMentions().contains(relative + " → " + entry.getKey())) {
                         offences.add(String.format("%s:%d uses '%s' — write '%s'",
                                 relative, i + 1, entry.getKey(), entry.getValue()));
                     }
@@ -116,18 +147,18 @@ class DocumentedRestPathsTest {
     }
 
     /**
-     * A line whose subject <em>is</em> the old spelling may name it.
+     * The exact places a pre-v6 path may still be named, as {@code file → path}.
      * <p>
-     * "Legacy URIs are auto-normalized during import, but new configs should use
-     * the v6 format" is a sentence that cannot be written without the legacy URI in
-     * it, and banning it would push authors toward vaguer guidance rather than
-     * clearer. The marker is deliberately crude — a line that says "legacy" is
-     * exempt — because the failure it guards against is a stale
-     * <em>instruction</em> ("POST to /packagestore/packages"), and such a line
-     * never calls itself legacy.
+     * A first attempt exempted any line containing the word "legacy", which is too
+     * coarse to be a rule: {@code Legacy endpoint: POST /packagestore/packages}
+     * would have passed it while still being a stale instruction, which is the one
+     * thing this test exists to stop. An explicit pair has to be added
+     * deliberately, and shows up in review as what it is.
      */
-    private static boolean namesTheSpellingAsLegacy(String line) {
-        return line.toLowerCase(Locale.ROOT).contains("legacy");
+    private static Set<String> allowedMentions() {
+        // AGENTS.md §5.5 explains that legacy URIs are auto-normalized on import,
+        // which cannot be written without naming one.
+        return Set.of("AGENTS.md → /botstore/bots");
     }
 
     private static Path repoRoot() {

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationNotFoundMessageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationNotFoundMessageTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal;
+
+import ai.labs.eddi.engine.api.IConversationService.ConversationNotFoundException;
+import ai.labs.eddi.engine.memory.IConversationMemory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The "no such conversation" message carries a caller-supplied id, and does not
+ * stay server-side.
+ *
+ * <p>
+ * {@code RestAgentEngineStreaming} echoes a
+ * {@link ConversationNotFoundException}'s text into an SSE {@code error} event
+ * so the client gets a machine-readable {@code conversation_not_found} code
+ * rather than an opaque blob. That makes the conversation id — a path
+ * parameter, so entirely the caller's — part of a response body and of every
+ * log line the exception reaches. It has to be sanitized where it is built, and
+ * only one of the two construction sites was doing it.
+ * </p>
+ */
+@DisplayName("ConversationNotFoundException message safety")
+class ConversationNotFoundMessageTest {
+
+    /**
+     * What a request to {@code /agents/conv%00%08%1F%E2%80%A8%0D%0AX/stream}
+     * delivers once the container has percent-decoded the path.
+     */
+    private static final String HOSTILE_ID = "conv\u0000\u0008\u001F\u2028\r\nX";
+
+    @Test
+    @DisplayName("the id is stripped of control characters before it reaches the message")
+    void sanitizesTheConversationId() {
+        var thrown = assertThrows(ConversationNotFoundException.class,
+                () -> ConversationStepRunner.checkConversationMemoryNotNull(null, HOSTILE_ID));
+
+        String message = thrown.getMessage();
+        assertTrue(message.contains("conv"), "the readable part of the id survives: " + message);
+
+        for (int i = 0; i < message.length(); i++) {
+            char c = message.charAt(i);
+            assertFalse(Character.isISOControl(c), "no ISO control character may reach the message, found U+"
+                    + String.format("%04X", (int) c) + " in: " + message);
+            assertFalse(c == '\u2028' || c == '\u2029',
+                    "U+2028/U+2029 terminate a line in JavaScript and this reaches a browser: " + message);
+        }
+    }
+
+    @Test
+    @DisplayName("a present conversation memory throws nothing")
+    void passesThroughWhenPresent() {
+        assertDoesNotThrow(
+                () -> ConversationStepRunner.checkConversationMemoryNotNull(mock(IConversationMemory.class), HOSTILE_ID));
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationExtendedTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
@@ -72,7 +73,7 @@ class RestAgentAdministrationExtendedTest {
         lenient().when(deploymentStore.readDeploymentInfos(any())).thenReturn(List.of());
         lenient().when(agentFactory.getAllLatestAgents(any())).thenReturn(List.of());
         lenient().when(tenantQuotaService.checkAgentQuota(any(), anyInt())).thenReturn(QuotaCheckResult.OK);
-        admin = new RestAgentAdministration(runtime, agentFactory, deploymentStore,
+        admin = new RestAgentAdministration(runtime, agentFactory, mock(IAgentStore.class), deploymentStore,
                 conversationMemoryStore, restConversationStore, documentDescriptorStore,
                 deploymentListener, scheduleStore, tenantQuotaService);
     }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationQuotaTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationQuotaTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
@@ -73,7 +74,7 @@ class RestAgentAdministrationQuotaTest {
         lenient().when(deploymentStore.readDeploymentInfos(any())).thenReturn(List.of());
         lenient().when(tenantQuotaService.checkAgentQuota(anyString(), anyInt())).thenReturn(QuotaCheckResult.OK);
 
-        admin = new RestAgentAdministration(runtime, agentFactory, deploymentStore,
+        admin = new RestAgentAdministration(runtime, agentFactory, mock(IAgentStore.class), deploymentStore,
                 mock(IConversationMemoryStore.class), mock(IRestConversationStore.class),
                 mock(IDocumentDescriptorStore.class), mock(IDeploymentListener.class),
                 mock(IScheduleStore.class), tenantQuotaService);

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationTest.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
@@ -41,6 +43,7 @@ class RestAgentAdministrationTest {
 
     private IRuntime runtime;
     private IAgentFactory agentFactory;
+    private IAgentStore agentStore;
     private IDeploymentStore deploymentStore;
     private IConversationMemoryStore conversationMemoryStore;
     private IRestConversationStore restConversationStore;
@@ -66,7 +69,8 @@ class RestAgentAdministrationTest {
         lenient().when(deploymentStore.readDeploymentInfos(any())).thenReturn(List.of());
         lenient().when(agentFactory.getAllLatestAgents(any())).thenReturn(List.of());
         lenient().when(tenantQuotaService.checkAgentQuota(any(), anyInt())).thenReturn(QuotaCheckResult.OK);
-        restAgentAdmin = new RestAgentAdministration(runtime, agentFactory, deploymentStore,
+        agentStore = mock(IAgentStore.class);
+        restAgentAdmin = new RestAgentAdministration(runtime, agentFactory, agentStore, deploymentStore,
                 conversationMemoryStore, restConversationStore, documentDescriptorStore,
                 deploymentListener, scheduleStore, tenantQuotaService);
     }
@@ -117,6 +121,57 @@ class RestAgentAdministrationTest {
             assertThrows(InternalServerErrorException.class,
                     () -> restAgentAdmin.deployAgent(
                             Deployment.Environment.test, "agent-1", 1, true, true));
+        }
+
+        @Test
+        @DisplayName("an agent that does not exist is a 404, not an accepted deploy")
+        void unknownAgentIsNotFound() throws Exception {
+            when(agentStore.read("no-such-agent", 1))
+                    .thenThrow(new IResourceStore.ResourceNotFoundException("no such agent"));
+
+            assertThrows(IResourceStore.ResourceNotFoundException.class,
+                    () -> restAgentAdmin.deployAgent(
+                            Deployment.Environment.test, "no-such-agent", 1, true, false));
+
+            // Nothing was queued: answering 202 and then failing on the runtime
+            // executor is precisely the shape this replaces, because no status code
+            // can reach the caller from there.
+            verify(runtime, never()).submitCallable(any(Callable.class), any());
+        }
+
+        @Test
+        @DisplayName("an id the datastore cannot parse is a 404 in EDDI's words, not the driver's")
+        void unparseableAgentIdIsNotFound() throws Exception {
+            // The MongoDB driver rejects a non-hex or wrong-length id before any
+            // lookup: "state should be: hexString has 24 characters". Surfacing that
+            // blames the wrong thing and names the datastore behind the API.
+            when(agentStore.read("agent-abc-123", 1))
+                    .thenThrow(new IllegalArgumentException("state should be: hexString has 24 characters"));
+
+            var thrown = assertThrows(IResourceStore.ResourceNotFoundException.class,
+                    () -> restAgentAdmin.deployAgent(
+                            Deployment.Environment.test, "agent-abc-123", 1, true, false));
+
+            assertTrue(thrown.getMessage().contains("agent-abc-123"),
+                    "the message must name the id that was not found: " + thrown.getMessage());
+            assertFalse(thrown.getMessage().contains("hexString"),
+                    "the driver's wording must not reach the caller: " + thrown.getMessage());
+            verify(runtime, never()).submitCallable(any(Callable.class), any());
+        }
+
+        @Test
+        @DisplayName("a store outage does not masquerade as a missing agent")
+        void storeOutageStillDeploys() throws Exception {
+            when(agentStore.read("agent-1", 1))
+                    .thenThrow(new IResourceStore.ResourceStoreException("mongo down"));
+            when(agentFactory.getAgent(any(), anyString(), anyInt())).thenReturn(null);
+            when(runtime.submitCallable(any(Callable.class), any()))
+                    .thenReturn(CompletableFuture.completedFuture(null));
+
+            Response response = restAgentAdmin.deployAgent(
+                    Deployment.Environment.test, "agent-1", 1, true, false);
+
+            assertEquals(202, response.getStatus());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
@@ -78,6 +79,39 @@ class RestAgentEngineStreamingTest {
             assertEquals("hello", method.invoke(streaming, "hello"));
             assertEquals("say \\\"hi\\\"", method.invoke(streaming, "say \"hi\""));
             assertEquals("line1\\nline2", method.invoke(streaming, "line1\nline2"));
+        }
+
+        /**
+         * The replace-chain this grew from covered five characters and left every other
+         * control character raw inside a JSON string, which is invalid per RFC 8259 §7
+         * — so a strict client cannot parse the event at all. None of the values
+         * reaching {@code escapeJson} are ours: a tool name comes from an LLM, an error
+         * summary from an exception message, a conversation id straight off the request
+         * path.
+         */
+        @Test
+        @DisplayName("escapes every control character, so the event stays parseable JSON")
+        void escapesAllControlCharacters() throws Exception {
+            Method method = RestAgentEngineStreaming.class.getDeclaredMethod("escapeJson", String.class);
+            method.setAccessible(true);
+
+            assertEquals("a\\u0000b", method.invoke(streaming, "a\u0000b"));
+            // Backspace and form-feed have their own two-character JSON escapes;
+            // the six-character form is only for the control characters that do
+            // not. (Spelling it out here on purpose: a literal backslash-u in a
+            // Java comment is processed by the lexer and fails to compile.)
+            assertEquals("a\\bb", method.invoke(streaming, "a\bb"));
+            assertEquals("a\\fb", method.invoke(streaming, "a\fb"));
+            assertEquals("a\\u001fb", method.invoke(streaming, "a\u001fb"));
+            // Legal JSON, but a line terminator in JavaScript — and this goes to a
+            // browser.
+            assertEquals("a\\u2028b", method.invoke(streaming, "a\u2028b"));
+            assertEquals("a\\u2029b", method.invoke(streaming, "a\u2029b"));
+
+            // The whole point: what comes out has to survive a real JSON parser.
+            String hostile = "conv\u0000\u0008\u001f\u2028\"x\\y";
+            String event = String.format("{\"message\":\"%s\"}", method.invoke(streaming, hostile));
+            assertEquals(hostile, new ObjectMapper().readTree(event).get("message").asText());
             assertEquals("col1\\tcol2", method.invoke(streaming, "col1\tcol2"));
             assertEquals("path\\\\file", method.invoke(streaming, "path\\file"));
         }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.internal;
 import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
 import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.api.IConversationService.ConversationNotFoundException;
 import ai.labs.eddi.engine.api.IConversationService.*;
 import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.gdpr.ProcessingRestrictedException;
@@ -376,7 +377,7 @@ class RestAgentEngineTest {
             var asyncResponse = mock(AsyncResponse.class);
             var inputData = new InputData("Hello", Map.of());
 
-            doThrow(new IConversationService.ConversationNotFoundException("No conversation found! (conversationId=conv-gone)"))
+            doThrow(new ConversationNotFoundException("No conversation found! (conversationId=conv-gone)"))
                     .when(conversationService).say(anyString(), any(), any(), any(), any(), anyBoolean(), any());
 
             restAgentEngine.sayWithinContext("conv-gone", false, false,

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
@@ -371,6 +371,29 @@ class RestAgentEngineTest {
         }
 
         @Test
+        @DisplayName("should resume with 404, not 500, when the conversation does not exist")
+        void conversationNotFound() throws Exception {
+            var asyncResponse = mock(AsyncResponse.class);
+            var inputData = new InputData("Hello", Map.of());
+
+            doThrow(new IConversationService.ConversationNotFoundException("No conversation found! (conversationId=conv-gone)"))
+                    .when(conversationService).say(anyString(), any(), any(), any(), any(), anyBoolean(), any());
+
+            restAgentEngine.sayWithinContext("conv-gone", false, false,
+                    List.of(), inputData, asyncResponse);
+
+            // Same shape as the quota branch above: say() is resumed via
+            // AsyncResponse, so ConversationNotFoundExceptionMapper never runs and
+            // this fell through to the generic handler as a 500 — while every GET
+            // on the same conversation already answered 404.
+            var captor = ArgumentCaptor.forClass(Response.class);
+            verify(asyncResponse).resume(captor.capture());
+            Response resumed = captor.getValue();
+            assertEquals(404, resumed.getStatus());
+            assertEquals("No conversation found! (conversationId=conv-gone)", resumed.getEntity());
+        }
+
+        @Test
         @DisplayName("should resume with NotFoundException for resource not found")
         void resourceNotFound() throws Exception {
             var asyncResponse = mock(AsyncResponse.class);

--- a/src/test/java/ai/labs/eddi/engine/memory/rest/RestConversationStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/rest/RestConversationStoreTest.java
@@ -142,6 +142,49 @@ class RestConversationStoreTest {
     }
 
     @Nested
+    @DisplayName("reads of a conversation that is not there")
+    class MissingConversationReads {
+
+        /**
+         * {@code loadConversationMemorySnapshot} answers {@code null} rather than
+         * throwing, and these two surfaces passed it straight on. The raw read returned
+         * it, which JAX-RS renders as 204 No Content — indistinguishable from an empty
+         * conversation that does exist — and the simple read dereferenced it into a 500
+         * with an error id. Both endpoints document a 404, which is also what the
+         * troubleshooting guide tells people to expect when they are already trying to
+         * work out what went wrong.
+         */
+        @Test
+        @DisplayName("the raw read is a 404, not an empty 204")
+        void rawReadIsNotFound() throws Exception {
+            when(conversationMemoryStore.loadConversationMemorySnapshot("gone")).thenReturn(null);
+
+            assertThrows(IResourceStore.ResourceNotFoundException.class,
+                    () -> restConversationStore.readRawConversationLog("gone"));
+        }
+
+        @Test
+        @DisplayName("the simple read is a 404, not a 500")
+        void simpleReadIsNotFound() throws Exception {
+            when(conversationMemoryStore.loadConversationMemorySnapshot("gone")).thenReturn(null);
+
+            assertThrows(IResourceStore.ResourceNotFoundException.class,
+                    () -> restConversationStore.readSimpleConversationLog("gone", false, true, null));
+        }
+
+        @Test
+        @DisplayName("the message names the conversation asked for")
+        void messageNamesTheConversation() throws Exception {
+            when(conversationMemoryStore.loadConversationMemorySnapshot("gone")).thenReturn(null);
+
+            var thrown = assertThrows(IResourceStore.ResourceNotFoundException.class,
+                    () -> restConversationStore.readRawConversationLog("gone"));
+
+            assertTrue(thrown.getMessage().contains("gone"), thrown.getMessage());
+        }
+    }
+
+    @Nested
     @DisplayName("deleteConversationLog")
     class DeleteConversationLog {
 
@@ -191,6 +234,50 @@ class RestConversationStoreTest {
 
             verify(conversationMemoryStore, never()).deleteConversationMemorySnapshot("conv-1");
             verify(conversationDescriptorStore, never()).deleteAllDescriptor(any());
+        }
+
+        @Test
+        @DisplayName("soft delete retires the descriptor, so the conversation stops being listed")
+        void softDelete_retiresDescriptor() throws Exception {
+            // The whole point of the non-permanent branch. It used to do nothing at
+            // all — the endpoint answered 204, the descriptor stayed deleted=false,
+            // and the Manager's "Conversation deleted" toast sat next to a row that
+            // was still there.
+            restConversationStore.deleteConversationLog("conv-1", false);
+
+            verify(conversationDescriptorStore).deleteDescriptor("conv-1", 0);
+        }
+
+        @Test
+        @DisplayName("a permanent delete does not also soft-delete")
+        void permanentDelete_doesNotAlsoSoftDelete() throws Exception {
+            restConversationStore.deleteConversationLog("conv-1", true);
+
+            // deleteAllDescriptor already removed every version; calling
+            // deleteDescriptor afterwards would only raise a spurious not-found.
+            verify(conversationDescriptorStore, never()).deleteDescriptor(anyString(), anyInt());
+        }
+
+        @Test
+        @DisplayName("a concurrent modification is reported, not swallowed")
+        void softDelete_concurrentModificationSurfaces() throws Exception {
+            doThrow(new IResourceStore.ResourceModifiedException("moved"))
+                    .when(conversationDescriptorStore).deleteDescriptor("conv-race", 0);
+
+            assertThrows(IResourceStore.ResourceStoreException.class,
+                    () -> restConversationStore.deleteConversationLog("conv-race", false));
+        }
+
+        @Test
+        @DisplayName("the ownership gate still runs before a soft delete")
+        void softDelete_checksOwnershipFirst() {
+            doThrow(new ForbiddenException("not yours"))
+                    .when(conversationAccessGuard).requireConversationOwner("conv-other");
+
+            assertThrows(ForbiddenException.class,
+                    () -> restConversationStore.deleteConversationLog("conv-other", false));
+
+            verifyNoInteractions(conversationDescriptorStore);
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/memory/rest/RestConversationStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/rest/RestConversationStoreTest.java
@@ -7,7 +7,9 @@ package ai.labs.eddi.engine.memory.rest;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
-import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.IResourceStore.ResourceModifiedException;
+import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
+import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
@@ -159,7 +161,7 @@ class RestConversationStoreTest {
         void rawReadIsNotFound() throws Exception {
             when(conversationMemoryStore.loadConversationMemorySnapshot("gone")).thenReturn(null);
 
-            assertThrows(IResourceStore.ResourceNotFoundException.class,
+            assertThrows(ResourceNotFoundException.class,
                     () -> restConversationStore.readRawConversationLog("gone"));
         }
 
@@ -168,7 +170,7 @@ class RestConversationStoreTest {
         void simpleReadIsNotFound() throws Exception {
             when(conversationMemoryStore.loadConversationMemorySnapshot("gone")).thenReturn(null);
 
-            assertThrows(IResourceStore.ResourceNotFoundException.class,
+            assertThrows(ResourceNotFoundException.class,
                     () -> restConversationStore.readSimpleConversationLog("gone", false, true, null));
         }
 
@@ -177,7 +179,7 @@ class RestConversationStoreTest {
         void messageNamesTheConversation() throws Exception {
             when(conversationMemoryStore.loadConversationMemorySnapshot("gone")).thenReturn(null);
 
-            var thrown = assertThrows(IResourceStore.ResourceNotFoundException.class,
+            var thrown = assertThrows(ResourceNotFoundException.class,
                     () -> restConversationStore.readRawConversationLog("gone"));
 
             assertTrue(thrown.getMessage().contains("gone"), thrown.getMessage());
@@ -261,10 +263,10 @@ class RestConversationStoreTest {
         @Test
         @DisplayName("a concurrent modification is reported, not swallowed")
         void softDelete_concurrentModificationSurfaces() throws Exception {
-            doThrow(new IResourceStore.ResourceModifiedException("moved"))
+            doThrow(new ResourceModifiedException("moved"))
                     .when(conversationDescriptorStore).deleteDescriptor("conv-race", 0);
 
-            assertThrows(IResourceStore.ResourceStoreException.class,
+            assertThrows(ResourceStoreException.class,
                     () -> restConversationStore.deleteConversationLog("conv-race", false));
         }
 
@@ -472,7 +474,7 @@ class RestConversationStoreTest {
             when(conversationMemoryStore.getEndedConversationIds())
                     .thenReturn(List.of("conv-orphan"));
             when(documentDescriptorStore.readDescriptor("conv-orphan", 0))
-                    .thenThrow(new IResourceStore.ResourceNotFoundException("not found"));
+                    .thenThrow(new ResourceNotFoundException("not found"));
 
             Integer result = restConversationStore.permanentlyDeleteEndedConversationLogs(30);
 
@@ -1310,9 +1312,9 @@ class RestConversationStoreTest {
             status.setConversationId("conv-err");
 
             when(conversationDescriptorStore.readDescriptor("conv-err", 0))
-                    .thenThrow(new IResourceStore.ResourceStoreException("DB error"));
+                    .thenThrow(new ResourceStoreException("DB error"));
 
-            assertThrows(IResourceStore.ResourceStoreException.class,
+            assertThrows(ResourceStoreException.class,
                     () -> restConversationStore.endActiveConversations(List.of(status)));
         }
     }

--- a/src/test/java/ai/labs/eddi/integration/RulesCrudIT.java
+++ b/src/test/java/ai/labs/eddi/integration/RulesCrudIT.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Integration test for Behavior Rules CRUD operations.
@@ -60,8 +62,16 @@ public class RulesCrudIT extends BaseIntegrationIT {
     @Order(3)
     @DisplayName("Update behavior rule set")
     void updateBehavior() {
-        assertUpdate(TEST_JSON2, ROOT_PATH, RESOURCE_URI, resourceId).then().assertThat().body("behaviorGroups[0].rules[0].name",
-                equalTo("Welcome_changed"));
+        // behaviorRules, not rules. The fixtures — like every other authored
+        // artefact — have always written behaviorRules, while the response came
+        // back saying rules, because RuleGroupConfiguration's getRules/setRules
+        // pair gave Jackson that implicit name. This assertion was the only place
+        // in the repository that agreed with the response instead of the request,
+        // which is why nothing caught the Manager rendering every rule group as
+        // empty.
+        assertUpdate(TEST_JSON2, ROOT_PATH, RESOURCE_URI, resourceId).then().assertThat()
+                .body("behaviorGroups[0].behaviorRules[0].name", equalTo("Welcome_changed"))
+                .body("behaviorGroups[0].rules", nullValue());
     }
 
     @Test
@@ -69,5 +79,40 @@ public class RulesCrudIT extends BaseIntegrationIT {
     @DisplayName("Delete behavior rule set")
     void deleteBehavior() {
         assertDelete(ROOT_PATH, resourceId[0]);
+    }
+
+    /**
+     * The compatibility half of the same change, over HTTP rather than through the
+     * mapper: a client that learned the old spelling must keep working, and must
+     * get the canonical one back.
+     * <p>
+     * Ordered last and cleaning up after itself so it cannot disturb the CRUD
+     * sequence above, which shares {@code resourceId} across ordered methods.
+     */
+    @Test
+    @Order(5)
+    @DisplayName("A rule set posted with the legacy 'rules' key is accepted, and reads back as 'behaviorRules'")
+    void legacyRulesKeyIsStillAccepted() {
+        String legacyBody = """
+                {
+                  "behaviorGroups": [
+                    {
+                      "name": "Smalltalk",
+                      "rules": [ { "name": "Welcome", "actions": ["welcome"], "conditions": [] } ]
+                    }
+                  ]
+                }
+                """;
+
+        var created = new ResourceId[1];
+        assertCreate(legacyBody, ROOT_PATH, RESOURCE_URI, created);
+        try {
+            given().get(ROOT_PATH + created[0].id() + VERSION_STRING + created[0].version())
+                    .then().assertThat().statusCode(200)
+                    .body("behaviorGroups[0].behaviorRules[0].name", equalTo("Welcome"))
+                    .body("behaviorGroups[0].rules", nullValue());
+        } finally {
+            deleteResourceQuietly(ROOT_PATH, created[0].id(), created[0].version());
+        }
     }
 }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/builder/LanguageModelBuildersTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/builder/LanguageModelBuildersTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.modules.llm.impl.builder;
 
+import dev.langchain4j.model.ollama.OllamaChatRequestParameters;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import org.junit.jupiter.api.DisplayName;
@@ -200,6 +201,69 @@ class LanguageModelBuildersTest {
                     "maxTokens maps onto Ollama's num_predict");
             assertEquals(0.77, defaults.topP(), 1e-9);
             assertEquals(Integer.valueOf(23), defaults.topK());
+        }
+
+        /**
+         * The knob that decides whether a first local-LLM agent looks alive.
+         * <p>
+         * A reasoning model left on its own default thinks before it answers, and the
+         * reasoning is not part of the streamed content — so the chat window shows
+         * nothing for many seconds and then the whole answer at once, which reads as a
+         * hang. Asserted through {@code defaultRequestParameters}, since that is what
+         * the outgoing request is built from.
+         */
+        @Test
+        @DisplayName("think reaches the model, and unset leaves the model's own default")
+        void thinkReachesTheModel() {
+            Map<String, String> params = new HashMap<>();
+            params.put("model", "gemma3n:e4b");
+            params.put("baseUrl", "http://localhost:11434");
+
+            var unset = (OllamaChatRequestParameters) builder.build(params).defaultRequestParameters();
+            assertNull(unset.think(), "unset must stay unset — it is a third, meaningful state");
+
+            params.put("think", "false");
+            var off = (OllamaChatRequestParameters) builder.build(params).defaultRequestParameters();
+            assertEquals(Boolean.FALSE, off.think());
+
+            params.put("think", "true");
+            var on = (OllamaChatRequestParameters) builder.build(params).defaultRequestParameters();
+            assertEquals(Boolean.TRUE, on.think());
+        }
+
+        @Test
+        @DisplayName("think reaches the streaming model too — the only place it is visible")
+        void thinkReachesTheStreamingModel() {
+            Map<String, String> params = new HashMap<>();
+            params.put("model", "gemma3n:e4b");
+            params.put("baseUrl", "http://localhost:11434");
+            params.put("think", "false");
+
+            var defaults = (OllamaChatRequestParameters) builder.buildStreaming(params).defaultRequestParameters();
+
+            assertEquals(Boolean.FALSE, defaults.think());
+        }
+
+        @Test
+        @DisplayName("think and returnThinking are recognised, so neither is warned about as unread")
+        void thinkingParametersAreRecognised() {
+            assertTrue(builder.recognisedParameters().contains("think"));
+            assertTrue(builder.recognisedParameters().contains("returnThinking"));
+        }
+
+        @Test
+        @DisplayName("an unparseable think leaves the default rather than pinning it to false")
+        void unparseableThinkIsIgnored() {
+            Map<String, String> params = new HashMap<>();
+            params.put("model", "gemma3n:e4b");
+            params.put("baseUrl", "http://localhost:11434");
+            params.put("think", "yes please");
+
+            var defaults = (OllamaChatRequestParameters) builder.build(params).defaultRequestParameters();
+
+            // Boolean.parseBoolean would have made this false, silently turning
+            // reasoning off on a typo.
+            assertNull(defaults.think());
         }
 
         @Test


### PR DESCRIPTION
Following `docs/developer-quickstart.md` against `labsai/eddi:6.3.0` produces four failures in seven steps. All of them are ours — the documentation in most cases, the API in the rest.

Every item below was reproduced against a real 6.3.0 container before being fixed, and each fix verified against an image built from this branch, including running the rewritten quickstart verbatim against a clean database.

## Documentation, and why the compatibility layer hid it

The v5→v6 rename gave every store a new path, and `LegacyPathRewriteFilter` keeps the old ones answering. That is right for clients and was poison for the docs: `POST /packagestore/packages` still returns `201`, so nothing signalled that the page was years stale — until the *payload* shape had drifted too, at which point the same page produced a `400` with an empty body and no way to tell which half was wrong.

`developer-quickstart.md`'s API walkthrough is rewritten against the running server: `/dictionarystore/dictionaries`, `/rulestore/rulesets`, `/workflowstore/workflows` with `workflowSteps`, agents with `workflows`, `valueAlternatives` as typed output items rather than bare strings, and the two-call start/say sequence (the start endpoint takes a **context map**, never a message). It now also documents the `descriptors` listings — without which there is no published way to find what you just created — and the descriptor `PATCH` that stops everything being called "Unnamed Agent".

Legacy spellings are swept out of eleven other pages, and **`DocumentedRestPathsTest` fails the build on any that come back**. Writing that test found three more in `AGENTS.md` and `planning/manager-ui-handoff.md`.

Also corrected on the same page: prerequisites (`./mvnw`, not a separate Maven; MongoDB 7), `docker compose up -d` rather than `docker-compose up`, `/manage` for the dashboard, an `examples/` folder that has never existed, and a Troubleshooting section pointing at three endpoints that do not exist.

## Five API behaviours the walkthrough exposed

### `DELETE /conversationstore/conversations/{id}` did nothing

`deletePermanently` defaults to `false`, and that branch was a comment claiming a `DocumentDescriptorInterceptor` would mark the descriptor deleted "regardless of whether it has been permanently deleted or not". **No such interceptor exists anywhere in the code base.** The endpoint answered `204`, the row stayed `"deleted": false`, and it stayed listed — beneath a Manager toast reading "Conversation deleted".

Now implemented: the descriptor is retired, the snapshot and attachments are deliberately kept, which is the whole distinction from the permanent path.

### Deploying an agent that does not exist returned `202 Accepted`

`POST /administration/{env}/deploy/{agentId}` has always advertised a 404 and never produced one. Without `waitForCompletion`, any id at all was accepted; the deployment then failed on the runtime executor, where no status code can reach the caller, so the only signal was a log line. A CI pipeline, the Manager and the setup API all read 202 as success and move on to start a conversation that can never exist.

The agent store is now consulted on the request thread. An id the datastore cannot parse is a 404 too, rather than the driver's `state should be: hexString has 24 characters`. A store *outage* still deploys — that is not evidence the agent is missing.

### A malformed configuration body was a `400` with no body

Strictness covered unknown *field names* only. A value of the wrong *shape* — the quickstart's own `"valueAlternatives": ["Hello!"]` — fell through to RESTEasy, which answers `400` with `content-length: 0`. No field, no expectation, no indication the body was even the problem.

Before and after, same request:

```text
(nothing — content-length: 0)
```
```text
Cannot read OutputConfigurationSet at outputSet[0].outputs[0].valueAlternatives[0]:
expected an object with a 'type' field, found a string. Known types: [agentFace,
applicationLink, button, image, inputField, other, quickReply, text]. Check this
field against the resource's JSON Schema at GET /<store>/<resource>/jsonSchema.
```

A wrong discriminator gets the same treatment (`'txt' is not a known 'type'. Known types: […]`), and the legal ids are read off the Jackson type resolver, so a new `@JsonSubTypes` entry cannot leave the list stale. Both messages render the failing position as a JSON path instead of Jackson's `ai.labs.eddi.configs…["outputSet"]->java.util.ArrayList[0]->…`, which named classes the caller cannot see and published the internal package layout to every API client.

### Behavior rules read back under a different key than they are written with

`RuleGroupConfiguration`'s accessors are `getRules`/`setRules`, so Jackson serialised the list as `rules` — while the shipped reference config, the ZIP fixtures, the documentation and the Manager's rules editor all say `behaviorRules`. The alias made writes work either way, which is why this only ever bit on **reads**: post `behaviorRules`, get `rules` back, and the Manager renders every group as "No rules in this group" no matter what it contains. Its MSW mocks return `behaviorRules`, so its suite agreed with the fiction rather than the server.

Now `behaviorRules` out, both names in — every stored document keeps loading. Paired with labsai/EDDI-Manager#189 (merged), which makes the editor accept either spelling so a current Manager still works against an older EDDI.

### A conversation that does not exist was a `500`

Nine endpoints, all documenting a 404, none producing one:

- `loadConversationMemorySnapshot` returns `null` rather than throwing, and the read paths dereferenced it.
- `GET /conversationstore/conversations/{id}` returned that `null` straight out, which JAX-RS renders as `204 No Content` — indistinguishable from a conversation that exists and is empty.
- `GET /agents/{id}/status` threw `ConversationNotFoundException`, which nothing mapped. It never got that far: `cacheConversationState` put the `null` into Caffeine first, which rejects null values, so the NPE came from inside the cache one line before the check that would have said "no such conversation".
- `POST /agents/{id}` and `/rerun` were the same bug again. `sayInternal` already carried two comments explaining that "say() is resumed through an AsyncResponse, so the exception never reaches [the mapper]" — one for quota denials, one for backpressure. This was the third instance.

Every conversation endpoint is now consistent:

```text
say (text/plain) -> 404   No conversation found! (conversationId=…)
say (json)       -> 404
rerun            -> 404
stream           -> event:error {"code":"conversation_not_found", …}
5 read endpoints -> 404
```

The streaming twin reports a typed error event rather than a status by design: `buildKnownConditionOrOpaqueErrorEvent` exists to map the conditions `sayStreaming` rejects synchronously onto machine-readable codes, and its javadoc already listed the twin's 404 among them.

## Ollama

`docker-compose.ollama.yml` puts Ollama on the same Docker network, so the base URL is `http://ollama:11434` — plain container DNS, identical on every host — and sets `EDDI_OLLAMA_DEFAULT_BASE_URL` so the agent wizard and setup API pre-fill something that resolves. Inside the `eddi` container `localhost` is the container, which is the most common way a first local-LLM agent fails. EDDI waits for the model pull to complete, not merely for Ollama to answer, so the first message cannot hit `model not found`. Verified end to end: model pulled, agent deployed, real turn answered.

The builder also gained Ollama's `think` and `returnThinking`. Where a reasoning model's output goes depends on the model — a separate `thinking` field, which is not part of the streamed content and leaves the window silent until the answer starts, or `<think>…</think>` prepended to the content itself. `think` is tri-state: `applyBoolean` leaves an absent or unparseable value alone rather than letting `Boolean.parseBoolean` turn a typo into "reasoning off".

## Found during review

The v6 sweep rewrote store **paths** and left payload **shapes** alone, so five pages still documented `packageExtensions`, which strict parsing rejects outright — pages that produced exactly the 400 this PR is about. `putting-it-all-together.md` also nested a dictionary as a top-level workflow step, which never loads: the parser reads dictionaries from its own `extensions`.

Chasing that pattern surfaced two more:

- `open-webui-integration.md` declared a step of type `eddi://ai.labs.langchain`. No module registers that name — `LlmModule` registers `ai.labs.llm` — so the workflow fails to load.
- The quickstart still documented rule sets reading back as `rules`, which is **the behaviour this PR changes**.

`DocumentedRestPathsTest` gained a second guard for the rejected payload key, and its "any line saying legacy is exempt" heuristic was replaced with an explicit `file → path` allow-list: `Legacy endpoint: POST /packagestore/packages` would otherwise have slipped through the one rule it exists to enforce.

Also from review:

- An agent-scoped read path still answering 500 while its siblings answered 404.
- A CodeQL log-injection alert on the new deploy check.
- `ConversationNotFoundException` had two construction sites; one sanitized the conversation id and one did not — and this PR is what made that matter, by echoing the message into an SSE event and so turning a raw path parameter into part of a response body. Fixed at the source.
- `escapeJson` covered five characters and left every other control character raw inside a JSON string, which is invalid per RFC 8259 §7. Frame injection was never reachable (CR and LF were escaped), but a strict client cannot parse such an event. Now a full escaper, including U+2028/U+2029 — legal JSON, but line terminators in JavaScript, and this reaches a browser.
- Nested exception types converted to imported simple names per AGENTS.md §4.7, across the whole file rather than only the new lines. Worth noting for a repo-wide follow-up: `ImportStyleTest` matches package-qualified names like `java.util.List`, so nested-type references pass it silently.

Two findings were declined with reasoning rather than applied: the changelog's format, which its own header defines as a working log of implementation reasoning; and "end to end", which is adverbial there and so takes no hyphen.

## Not reproduced

A `307` observed while streaming against a local Ollama model. Nothing in EDDI emits a 307, langchain4j normalises the trailing slash before appending `api/chat`, and the Manager's streaming client follows redirects. It needs the actual request/response pair — most likely from the Ollama side — before anything can be claimed about it. The overlay above removes the class of host-networking problems it may belong to.

## Related, and not fixable here

Dictionaries, behavior rules and API calls do not appear in their `descriptors` listings on 6.3.0 — three stores queried a descriptor type that did not match the namespace they write to. That is `60188c2bd`, which landed **after** 6.3.0 and is **not in `labsai/eddi:latest`** (image built 2026-08-20), which is what EDDI-Manager's full-stack e2e tier runs against. Reproduced on 6.3.0, confirmed absent on `main`. Publishing a new image closes labsai/EDDI#712 and unblocks that tier.

## Testing

- Unit tests over the touched areas green (504 in the final round); Checkstyle green.
- **Integration Tests green** — they caught the one thing unit tests could not: `RulesCrudIT` asserted on `behaviorGroups[0].rules[0].name`, the *old* wire name. The fixtures have always posted `behaviorRules`, so that assertion was the single place in the repository agreeing with the response instead of the request — which is precisely why nothing caught the Manager rendering every rule group empty. A new case posts the legacy spelling over HTTP and reads back the canonical one.
- Every behaviour change is mutation-checked: revert the fix, watch the new test fail.
- `LanguageModelBuildersTest` cannot run locally — every builder in it, touched or not, fails with "Unable to establish loopback connection" because the JDK HTTP client cannot open a selector in that environment. CI is the gate for that class.
