### PR TITLE
fix(tenancy): the quota counters were tested against the wall clock

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,56 @@
 
 
 
+## 🧪 fix(tenancy): the quota counters were tested against the wall clock (2026-08-25)
+
+**Repo:** EDDI (`fix/tenant-quota-minute-boundary-flake`)
+
+`MongoTenantQuotaStoreContainerTest.allThreeCountersInterleaved` failed CI on a PR that
+touched nothing in this package: `expected: <2> but was: <1>`. Not a regression — a latent
+flake that had been there since the tests were written.
+
+### Why it failed
+
+The quota counters live in wall-clock-aligned windows. `tryIncrementApiCalls` derives its
+window as `Instant.now().truncatedTo(ChronoUnit.MINUTES)` and `rollWindowIfExpired` resets
+the counter when that value changes. So a test that increments twice and asserts 2 is really
+asserting that both calls landed in the same minute — and nothing made that true. Two calls
+milliseconds apart straddle `:00` roughly once every six hundred runs.
+
+The day and month windows have the same shape, so `conversationsToday` and the cost month
+carried the same hazard at lower odds.
+
+### The fix
+
+`Clock` injected into `MongoTenantQuotaStore` and `PostgresTenantQuotaStore`, defaulting to
+`Clock.systemUTC()` in the CDI constructor so production behaviour is unchanged. Every
+`Instant.now()` and `YearMonth.now(ZoneOffset.UTC)` in both stores now reads that field —
+5 + 3 in Mongo, 6 + 3 in Postgres.
+
+`MongoTenantQuotaStoreContainerTest` and `TenantQuotaStoreParityTest` pin the clock at
+`2026-06-15T12:30:30Z`, deliberately mid-window on every axis so no assertion can pass by
+sitting exactly on a boundary. `InMemoryTenantQuotaStore` needs no clock: it has no window
+logic at all, which is why the parity test never flaked on that arm.
+
+`TenantQuotaStoreParityTest` was exposed the same way — it increments `limit` times and
+asserts the counter equals `limit` — so it is fixed here too rather than left to fail later.
+
+### The new test
+
+`minuteBoundaryRollsTheCounter` steps a clock from `12:30:59Z` to `12:31:00Z` between two
+increments and asserts the counter rolls to 1 rather than reaching 2. That converts the
+hazard into an assertion of the intended behaviour, and it pins the wiring: reverting a
+single `clock.instant()` to `Instant.now()` fails it with `expected: <1> but was: <2>`,
+which is how the fix was verified rather than assumed.
+
+### Not changed
+
+The rollover tests still force expiry by writing `dayStart`/`minuteStart` to `0L` directly.
+That is both deterministic and closer to what the rollover path actually reads, so a clock
+was not the right tool there.
+
+---
+
 ## 🩹 fix(api,docs): everything a new user hit walking the developer quickstart (2026-08-25)
 
 **Repo:** EDDI (`fix/quickstart-truth-and-api-honesty`)

--- a/src/main/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStore.java
@@ -23,6 +23,7 @@ import org.bson.Document;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
@@ -72,6 +73,23 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
     private final MongoCollection<Document> quotas;
     private final MongoCollection<Document> usage;
 
+    /**
+     * The source of "now" for every rolling window.
+     * <p>
+     * A field rather than {@code Instant.now()} at each use because the windows are
+     * wall-clock aligned — {@code truncatedTo(MINUTES)}, {@code truncatedTo(DAYS)},
+     * {@code YearMonth.now()} — so a test that increments a counter twice is
+     * asserting that both calls landed in the same window, and nothing made that
+     * true. Two calls milliseconds apart straddle a minute boundary roughly once
+     * every six hundred runs, and the counter reads 1 where the test expects 2.
+     * That is not a rare correctness question, it is a rare scheduling one, and it
+     * failed CI.
+     * <p>
+     * Production always gets {@link Clock#systemUTC()}. Only tests pass anything
+     * else.
+     */
+    private final Clock clock;
+
     @Inject
     public MongoTenantQuotaStore(MongoDatabase database,
             @ConfigProperty(name = "eddi.tenant.default-id", defaultValue = "default") String defaultTenantId,
@@ -83,6 +101,7 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
 
         this.quotas = database.getCollection(QUOTAS_COLLECTION);
         this.usage = database.getCollection(USAGE_COLLECTION);
+        this.clock = Clock.systemUTC();
 
         ensureUniqueTenantIdIndex(quotas, QUOTAS_COLLECTION);
         ensureUniqueTenantIdIndex(usage, USAGE_COLLECTION);
@@ -109,8 +128,21 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
      * Test-only constructor — no CDI injection, no bootstrap.
      */
     MongoTenantQuotaStore(MongoDatabase database) {
+        this(database, Clock.systemUTC());
+    }
+
+    /**
+     * Test-only constructor taking the clock, so a test can pin "now".
+     * <p>
+     * A fixed clock is the difference between asserting that two increments landed
+     * in one window and hoping they did. Tests that need a window to expire set the
+     * stored {@code dayStart}/{@code minuteStart} to a stale value directly, which
+     * is both deterministic and closer to what the rollover path actually reads.
+     */
+    MongoTenantQuotaStore(MongoDatabase database, Clock clock) {
         this.quotas = database.getCollection(QUOTAS_COLLECTION);
         this.usage = database.getCollection(USAGE_COLLECTION);
+        this.clock = clock;
 
         ensureUniqueTenantIdIndex(quotas, QUOTAS_COLLECTION);
         ensureUniqueTenantIdIndex(usage, USAGE_COLLECTION);
@@ -204,7 +236,7 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
             return QuotaCheckResult.OK;
         }
 
-        long dayStart = Instant.now().truncatedTo(ChronoUnit.DAYS).toEpochMilli();
+        long dayStart = clock.instant().truncatedTo(ChronoUnit.DAYS).toEpochMilli();
 
         if (tryConsumeSlot(tenantId, FIELD_CONVERSATIONS_TODAY, FIELD_DAY_START, dayStart, limit)) {
             return QuotaCheckResult.OK;
@@ -225,7 +257,7 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
             return QuotaCheckResult.OK;
         }
 
-        long minuteStart = Instant.now().truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
+        long minuteStart = clock.instant().truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
 
         if (tryConsumeSlot(tenantId, FIELD_API_CALLS_THIS_MINUTE, FIELD_MINUTE_START, minuteStart, limit)) {
             return QuotaCheckResult.OK;
@@ -242,7 +274,7 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
 
     @Override
     public QuotaCheckResult tryAddCost(String tenantId, double cost, double limit) {
-        String monthKey = YearMonth.now(ZoneOffset.UTC).toString();
+        String monthKey = YearMonth.now(clock.withZone(ZoneOffset.UTC)).toString();
 
         // Fast path: the document already carries the current month.
         Document result = addCostWithinMonth(tenantId, monthKey, cost);
@@ -291,7 +323,7 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
      * a second insert.
      */
     private void ensureUsageDocument(String tenantId) {
-        long now = Instant.now().toEpochMilli();
+        long now = clock.instant().toEpochMilli();
         usage.updateOne(
                 Filters.eq(FIELD_TENANT_ID, tenantId),
                 Updates.combine(
@@ -368,7 +400,7 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
         if (doc == null) {
             return 0.0;
         }
-        YearMonth currentMonth = YearMonth.now(ZoneOffset.UTC);
+        YearMonth currentMonth = YearMonth.now(clock.withZone(ZoneOffset.UTC));
         String monthKey = doc.getString(FIELD_COST_MONTH);
         if (monthKey == null || !monthKey.equals(currentMonth.toString())) {
             return 0.0; // Stale month
@@ -397,13 +429,13 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
     private UsageSnapshot toSnapshot(String tenantId, Document doc) {
         Instant minuteStart = doc.getLong("minuteStart") != null
                 ? Instant.ofEpochMilli(doc.getLong("minuteStart"))
-                : Instant.now();
+                : clock.instant();
         Instant dayStart = doc.getLong("dayStart") != null
                 ? Instant.ofEpochMilli(doc.getLong("dayStart"))
-                : Instant.now();
+                : clock.instant();
         YearMonth costMonth = doc.getString("costMonth") != null
                 ? YearMonth.parse(doc.getString("costMonth"))
-                : YearMonth.now(ZoneOffset.UTC);
+                : YearMonth.now(clock.withZone(ZoneOffset.UTC));
         return new UsageSnapshot(
                 tenantId,
                 doc.getInteger("conversationsToday", 0),

--- a/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
@@ -17,6 +17,7 @@ import org.jboss.logging.Logger;
 
 import javax.sql.DataSource;
 import java.sql.*;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
@@ -138,6 +139,17 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             """;
 
     private final Instance<DataSource> dataSourceInstance;
+
+    /**
+     * The source of "now" for every rolling window. See
+     * {@code MongoTenantQuotaStore#clock} — same windows, same wall-clock
+     * alignment, same reason a test cannot assert two increments add up without
+     * pinning it.
+     * <p>
+     * Production always gets {@link Clock#systemUTC()}. Only tests pass anything
+     * else.
+     */
+    private final Clock clock;
     private volatile boolean schemaInitialized = false;
 
     // Bootstrap config — stored as fields for lazy initialization in ensureSchema()
@@ -156,15 +168,24 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
         this.dataSourceInstance = dataSourceInstance;
         this.defaultTenantId = defaultTenantId;
         this.defaultQuota = new TenantQuota(defaultTenantId, maxConvPerDay, maxAgents, maxApiCalls, maxCost, enabled);
+        this.clock = Clock.systemUTC();
     }
 
     /**
      * Test-only constructor — no CDI injection, no bootstrap.
      */
     PostgresTenantQuotaStore(Instance<DataSource> dataSourceInstance) {
+        this(dataSourceInstance, Clock.systemUTC());
+    }
+
+    /**
+     * Test-only constructor taking the clock, so a test can pin "now".
+     */
+    PostgresTenantQuotaStore(Instance<DataSource> dataSourceInstance, Clock clock) {
         this.dataSourceInstance = dataSourceInstance;
         this.defaultTenantId = null;
         this.defaultQuota = null;
+        this.clock = clock;
     }
 
     private synchronized void ensureSchema() {
@@ -350,8 +371,8 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             return QuotaCheckResult.OK;
         }
 
-        long dayStartMs = Instant.now().truncatedTo(ChronoUnit.DAYS).toEpochMilli();
-        long minuteStartMs = Instant.now().truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
+        long dayStartMs = clock.instant().truncatedTo(ChronoUnit.DAYS).toEpochMilli();
+        long minuteStartMs = clock.instant().truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
 
         ensureSchema();
         try (Connection conn = dataSourceInstance.get().getConnection()) {
@@ -386,8 +407,8 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             return QuotaCheckResult.OK;
         }
 
-        long minuteStartMs = Instant.now().truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
-        long dayStartMs = Instant.now().truncatedTo(ChronoUnit.DAYS).toEpochMilli();
+        long minuteStartMs = clock.instant().truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
+        long dayStartMs = clock.instant().truncatedTo(ChronoUnit.DAYS).toEpochMilli();
 
         ensureSchema();
         try (Connection conn = dataSourceInstance.get().getConnection()) {
@@ -416,9 +437,9 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
 
     @Override
     public QuotaCheckResult tryAddCost(String tenantId, double cost, double limit) {
-        String monthKey = YearMonth.now(ZoneOffset.UTC).toString();
-        long dayStartMs = Instant.now().truncatedTo(ChronoUnit.DAYS).toEpochMilli();
-        long minuteStartMs = Instant.now().truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
+        String monthKey = YearMonth.now(clock.withZone(ZoneOffset.UTC)).toString();
+        long dayStartMs = clock.instant().truncatedTo(ChronoUnit.DAYS).toEpochMilli();
+        long minuteStartMs = clock.instant().truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
 
         ensureSchema();
         try (Connection conn = dataSourceInstance.get().getConnection()) {
@@ -508,7 +529,7 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
                     String monthKey = rs.getString("cost_month");
-                    if (monthKey != null && monthKey.equals(YearMonth.now(ZoneOffset.UTC).toString())) {
+                    if (monthKey != null && monthKey.equals(YearMonth.now(clock.withZone(ZoneOffset.UTC)).toString())) {
                         return rs.getDouble("monthly_cost_usd");
                     }
                 }
@@ -554,6 +575,6 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
                 Instant.ofEpochMilli(rs.getLong("day_start")),
                 rs.getString("cost_month") != null
                         ? YearMonth.parse(rs.getString("cost_month"))
-                        : YearMonth.now(ZoneOffset.UTC));
+                        : YearMonth.now(clock.withZone(ZoneOffset.UTC)));
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreContainerTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreContainerTest.java
@@ -17,7 +17,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.YearMonth;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -46,6 +49,22 @@ class MongoTenantQuotaStoreContainerTest extends MongoTestBase {
     private static final String USAGE_COLLECTION = "tenant_usage";
     private static final String TENANT_ID = "tenant-container";
 
+    /**
+     * "Now", pinned.
+     * <p>
+     * The counters live in wall-clock-aligned windows, so every assertion that two
+     * increments add up is really an assertion that both landed in the same window
+     * — and with the real clock nothing made that true. Two calls milliseconds
+     * apart straddle a minute boundary about once in six hundred runs, the counter
+     * reads 1 where the test expects 2, and CI fails on a change that touched none
+     * of this.
+     * <p>
+     * Deliberately mid-window on every axis — 12:30:30 on the 15th — so no
+     * assertion here can pass by sitting exactly on a boundary either.
+     */
+    private static final Instant FIXED_NOW = Instant.parse("2026-06-15T12:30:30Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+
     private MongoTenantQuotaStore sut;
     private MongoCollection<Document> usage;
 
@@ -54,7 +73,7 @@ class MongoTenantQuotaStoreContainerTest extends MongoTestBase {
         dropCollections("tenant_quotas", USAGE_COLLECTION);
         // Re-created per test: the constructor is what (re)builds the unique index
         // that the dropped collection just lost.
-        sut = new MongoTenantQuotaStore(getDatabase());
+        sut = new MongoTenantQuotaStore(getDatabase(), FIXED_CLOCK);
         usage = getDatabase().getCollection(USAGE_COLLECTION);
     }
 
@@ -186,6 +205,56 @@ class MongoTenantQuotaStoreContainerTest extends MongoTestBase {
         }
 
         @Test
+        @DisplayName("the minute boundary itself rolls the counter — the flake, made deterministic")
+        void minuteBoundaryRollsTheCounter() {
+            // This is the scenario that used to arrive by luck.
+            // `allThreeCountersInterleaved`
+            // increments twice and expects 2, which only holds while both calls sit in one
+            // wall-clock minute; when CI happened to run them either side of :00 the
+            // counter
+            // read 1 and a PR that touched nothing here went red.
+            //
+            // Advancing the clock deliberately asserts the behaviour that was previously
+            // just a hazard: the same two calls, straddling the boundary on purpose, must
+            // roll rather than accumulate. It also pins the wiring — with the store reading
+            // Instant.now() directly instead of its clock field, the counter would reach 2
+            // and this fails.
+            var steppingClock = new Clock() {
+                private Instant now = Instant.parse("2026-06-15T12:30:59Z");
+
+                @Override
+                public ZoneId getZone() {
+                    return ZoneOffset.UTC;
+                }
+
+                @Override
+                public Clock withZone(ZoneId zone) {
+                    return this;
+                }
+
+                @Override
+                public Instant instant() {
+                    return now;
+                }
+
+                void advanceTo(String iso) {
+                    now = Instant.parse(iso);
+                }
+            };
+            var stepping = new MongoTenantQuotaStore(getDatabase(), steppingClock);
+
+            assertTrue(stepping.tryIncrementApiCalls(TENANT_ID, 5).allowed());
+            assertEquals(1, stepping.getUsage(TENANT_ID).apiCallsThisMinute());
+
+            steppingClock.advanceTo("2026-06-15T12:31:00Z");
+
+            assertTrue(stepping.tryIncrementApiCalls(TENANT_ID, 5).allowed());
+            assertEquals(1, stepping.getUsage(TENANT_ID).apiCallsThisMinute(),
+                    "a new minute starts a new budget rather than continuing the old count");
+            assertEquals(1, usageDocumentCount(), "and still one document for the tenant");
+        }
+
+        @Test
         @DisplayName("an expired minute window resets the api-call counter")
         void expiredMinuteWindowResets() {
             assertTrue(sut.tryIncrementApiCalls(TENANT_ID, 1).allowed());
@@ -206,7 +275,7 @@ class MongoTenantQuotaStoreContainerTest extends MongoTestBase {
                     .append("apiCallsThisMinute", 0)
                     .append("minuteStart", 0L)
                     .append("monthlyCostUsd", 40.0)
-                    .append("costMonth", YearMonth.now(ZoneOffset.UTC).minusMonths(1).toString()));
+                    .append("costMonth", YearMonth.now(FIXED_CLOCK).minusMonths(1).toString()));
 
             QuotaCheckResult result = assertDoesNotThrow(() -> sut.tryAddCost(TENANT_ID, 5.0, 100.0));
 

--- a/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaStoreParityTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaStoreParityTest.java
@@ -14,6 +14,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -47,12 +50,19 @@ class TenantQuotaStoreParityTest extends MongoTestBase {
      * Store factories, invoked lazily inside each test so that container startup
      * never happens during argument resolution.
      */
+    /** Mid-window on every axis, so nothing passes by sitting on a boundary. */
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-06-15T12:30:30Z"), ZoneOffset.UTC);
+
     static Stream<Arguments> stores() {
         Supplier<ITenantQuotaStore> inMemory = () -> new InMemoryTenantQuotaStore(
                 new TenantQuota("unused", -1, -1, -1, -1.0, true));
-        Supplier<ITenantQuotaStore> mongo = () -> new MongoTenantQuotaStore(getDatabase());
+        // Pinned, for the reason MongoTenantQuotaStoreContainerTest pins it: the
+        // counter assertions below increment N times and expect N, which only holds
+        // if every call landed in the same wall-clock minute. The in-memory store has
+        // no windows at all, so it needs no clock and cannot drift.
+        Supplier<ITenantQuotaStore> mongo = () -> new MongoTenantQuotaStore(getDatabase(), FIXED_CLOCK);
         Supplier<ITenantQuotaStore> postgres = () -> new PostgresTenantQuotaStore(
-                PostgresTestBase.createDataSourceInstance());
+                PostgresTestBase.createDataSourceInstance(), FIXED_CLOCK);
 
         return Stream.of(
                 Arguments.of("in-memory", inMemory),


### PR DESCRIPTION
`MongoTenantQuotaStoreContainerTest.allThreeCountersInterleaved` failed CI on [#718](https://github.com/labsai/EDDI/pull/718), which touched nothing in this package: `expected: <2> but was: <1>`. Not a regression — a latent flake that has been there since the tests were written.

## Why it failed

The quota counters live in **wall-clock-aligned** windows. `tryIncrementApiCalls` derives its window as `Instant.now().truncatedTo(ChronoUnit.MINUTES)`, and `rollWindowIfExpired` resets the counter when that value changes.

So a test that increments twice and asserts `2` is really asserting that both calls landed in the same wall-clock minute — and nothing made that true. Two calls milliseconds apart straddle `:00` roughly once every six hundred runs. The day and month windows have the same shape, so `conversationsToday` and the cost month carried the same hazard at lower odds.

## The fix

`Clock` injected into `MongoTenantQuotaStore` and `PostgresTenantQuotaStore`, defaulting to `Clock.systemUTC()` in the CDI constructor — **production behaviour is unchanged**. Every `Instant.now()` and `YearMonth.now(ZoneOffset.UTC)` in both stores now reads that field (5 + 3 in Mongo, 6 + 3 in Postgres).

Both container tests pin the clock at `2026-06-15T12:30:30Z`, deliberately mid-window on every axis so no assertion can pass by sitting exactly on a boundary.

`TenantQuotaStoreParityTest` is fixed here too rather than left to fail later: it increments `limit` times and asserts the counter equals `limit`, which is the identical exposure on its mongo and postgres arms. `InMemoryTenantQuotaStore` needs no clock — it has no window logic at all, which is why that arm never flaked.

## The new test

`minuteBoundaryRollsTheCounter` steps a clock from `12:30:59Z` to `12:31:00Z` between two increments and asserts the counter **rolls to 1** rather than reaching 2. That turns the hazard into an assertion of the intended behaviour, which did not previously exist.

It also pins the wiring. Reverting a single `clock.instant()` back to `Instant.now()` fails it with `expected: <1> but was: <2>` — that is how this fix was verified rather than assumed.

## Not changed

The existing rollover tests still force expiry by writing `dayStart`/`minuteStart` to `0L` directly. That is both deterministic and closer to what the rollover path actually reads, so a clock was not the right tool there.

## Tests

71 green locally: `MongoTenantQuotaStoreContainerTest`, `MongoTenantQuotaStoreTest`, `TenantQuotaStoreParityTest` (all three store arms, containers included), plus `ImportStyleTest`, `DocumentationLinksTest`, `StrictBoundaryShippedConfigsTest`, `RuleSetStoreShippedRulesetsTest` and `DocumentedRestPathsTest`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota tracking across minute and monthly time boundaries.
  * Ensured API-call counters roll over reliably while preserving tenant usage records.
  * Increased consistency of quota reporting across MongoDB and PostgreSQL storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->