### PR TITLE
feat(security): per-user workspaces and resource sharing

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -60,6 +60,7 @@
 ## Security & Compliance
 
 - [Security](security.md)
+- [Workspaces (per-user isolation & sharing)](workspaces.md)
 - [Secrets Vault](secrets-vault.md)
 - [Global Variables](global-variables.md)
 - [Audit Ledger](audit-ledger.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,132 @@
 
 
 
+## 🔐 feat(security): per-user workspaces and resource sharing (2026-08-29)
+
+**Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)
+
+Configuration resources — agents, workflows, rule sets, LLM configs, output sets,
+dictionaries, api calls, mcp calls, RAG, prompt snippets, channels, connections,
+agent groups — had **no ownership at all**. `DocumentDescriptor` inherits a
+`createdBy` field from `ResourceDescriptor` and nothing ever wrote it, so the
+authoring surface was one shared workspace gated only by
+`@RolesAllowed({"eddi-admin","eddi-editor"})`. Any editor could read, edit,
+undeploy and delete anyone's work, and `eddi-user` could `POST
+/agents/{anyId}/start`.
+
+Off by default (`eddi.workspaces.enabled=false`). Full operator guide:
+[`docs/workspaces.md`](workspaces.md).
+
+### The model
+
+**Spaces are the boundary, grants are the exception.** Every descriptor gains
+`ownerId`, `spaceId` (`user:<principal>` or `team:<keycloak group>`),
+`visibility` (`private` / `space` / `published`) and a list of `ResourceGrant`.
+A single ACL-per-resource model makes the common case tedious; a pure space model
+makes the common exception impossible.
+
+**`AccessLevel` is USE < VIEW < EDIT < OWN.** The `USE`/`VIEW` split is the one
+that earns its complexity: letting a colleague *talk to* an agent is a different
+act from letting them read its system prompt, tool list and vault references, and
+the first is by far the more common share. `EDIT` deliberately excludes delete and
+re-share — a teammate sharing a space can change a colleague's agent but not
+remove it.
+
+### Design decisions
+
+- **One materialised `accessIndex` field, not a query over structured fields.**
+  `IResourceFilter` ANDs groups and ORs within a group, and cannot nest — so the
+  real policy (`owner OR (space AND visibility=space) OR granted OR published`) is
+  not expressible as a query at all. Collapsing it to pipe-delimited tokens at
+  write time makes a listing one indexed OR-group. `DescriptorAccess` holds both
+  halves so it stays checkable that they agree; `DescriptorAccessTest` asserts
+  agreement across the whole matrix.
+- **Every identity predicate is anchored and escaped.** Both backends treat a
+  `String` filter as a **regular expression** — `MongoResourceStorage` builds
+  `Filters.regex`, `PostgresResourceStorage` emits `~`. An unescaped predicate for
+  `alice` also matches `malice`, and an unescaped `.` in an email matches any
+  character. `Subjects` escapes only the metacharacters PCRE and POSIX ERE agree
+  on: escaping an ordinary character is *undefined* in POSIX ERE, so escaping
+  defensively would be less portable, not more.
+- **Filtered in the query, not on the page.** `RestConversationStore` post-filters
+  conversations with a `MAX_OWNER_SCAN` budget because no predicate exists there.
+  Config listings must not repeat that: `accessIndex` joined
+  `DescriptorStore.INDEXED_FIELDS`, which matters especially because the
+  `descriptors` collection is shared with conversation descriptors and grows with
+  conversation volume.
+- **`AccessScope` is an explicit argument, never ambient state.** Internal callers
+  that operate below the access model — the export service, the orphan sweep, the
+  startup migration — write `unrestricted()` at the call site. Reading scope from
+  a thread-local would make "unfiltered" the behaviour of any path that forgot to
+  set it, which is the shape most fail-open authorization bugs have.
+- **Cascades check before they cascade.** `deleteAgent`/`deleteWorkflow` tear down
+  referenced resources *before* the guarded `restVersionInfo.delete`, so both now
+  call `requireOwnAccess` first. Checking only at the end would have let an
+  unauthorised caller destroy the graph on the way to being refused.
+- **Sharing walks the graph, and stops at what you do not own.**
+  `ConfigGraphResolver` resolves agent → workflows → steps → parser dictionaries;
+  a referenced resource the sharer only borrowed is skipped and named in the
+  response's `skipped` list rather than silently widened. Bounded at 500 resources
+  against cyclic configs, and the cut-off is logged rather than silent.
+- **The channel-uniqueness sweep stays global but stopped naming names.** A
+  `channelId` collides with every integration in the deployment, so scoping the
+  check would let two workspaces bind the same Slack channel. Its error message no
+  longer names the conflicting integration, which had turned a uniqueness check
+  into an enumeration oracle.
+
+### Enforcement surfaces
+
+`RestVersionInfo` (all fifteen types, inherited by the MCP admin tools),
+the store methods that bypass it for filter arguments (`readOutputSet`,
+`readOutputKeys`, `readExpressions`, `readSnippet`, the patch and duplicate
+paths), the workflow-fan-out helpers (`RestAction`, `RestExpression`,
+`RestOutputActions` — all keyed on the workflow the caller named), the group
+workspace endpoints (decided against the *group's* descriptor, since a workspace
+has none of its own), deploy/undeploy, and `POST /agents/{id}/start`.
+
+### Backward compatibility
+
+- Default off; `eddi.workspaces.enabled=true` with `authorization.enabled=false`
+  logs that it has no effect rather than denying everyone everything.
+- Ownership is **recorded** whenever authentication is on, independent of
+  enforcement, so an operator can accumulate attribution, verify it, and only then
+  enforce.
+- `WorkspaceAccessIndexMigration` backfills every pre-existing descriptor with the
+  `legacy` token. Required, not optional: neither backend can express "this field
+  is absent", so an unstamped descriptor would match no access predicate and
+  vanish from every listing. It deliberately **does not invent owners**.
+- `eddi.workspaces.legacy-visibility=shared` (default) keeps pre-existing
+  resources visible to everyone, so an upgrade hides nothing.
+
+### Keycloak
+
+`keycloak/eddi-realm.json` gains a `groups` protocol mapper on both clients, a
+sample `/engineering` group, and — unrelated but overdue — the **`eddi-approver`
+role, which `OwnershipValidator` and `HitlAccessGuard` have been checking for
+without it ever being defined in the shipped realm.**
+
+### Verification
+
+`./mvnw compile`, `./mvnw test-compile`, the repo-wide guards (`ImportStyleTest`,
+`DocumentationLinks`, `StrictBoundary*`, `ShippedRulesets`) and 49 new tests
+across `SubjectsTest`, `DescriptorAccessTest`, `ResourceAccessGuardTest`,
+`RestVersionInfoAccessTest` and `ResourceSharingServiceTest`.
+
+Two mutation checks confirm the tests are not vacuous: removing the token
+delimiters from `Subjects.tokenPattern` fails `doesNotMatchSubstring`, and
+defaulting a missing visibility to `published` fails
+`missingVisibilityDefaultsToSpace`.
+
+### Not done
+
+The EDDI-Manager UI (space switcher, owner column, share dialog, published
+catalog) is a separate repo and a separate change. Until it lands, sharing is
+driven through the REST endpoints above.
+
+---
+
+
+
 ## 🔐 refactor(engine): split the engine's config reads off the authoring surface (2026-08-29)
 
 **Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -99,6 +99,24 @@ parameter now exists there and threads through a new
 resource type can pick it up the same way. It narrows in the query, never
 client-side: page 2 of "everything" is not page 2 of "this space".
 
+### `WorkspacesIT` — the wiring, over real HTTP
+
+Everything the new endpoint and the `?space=` parameter can get wrong is
+wiring: whether a query parameter binds, whether Jackson emits the field names
+a client is typed against, whether a path is routed at all. None of that is
+visible to a unit test holding the resource class directly, and two of them had
+already been wrong once.
+
+The disabled payload is pinned here deliberately, because EDDI-Manager's MSW
+default handler answers `GET /workspaces` with exactly that shape. If the
+contract moves, that mock keeps every frontend test green while the real thing
+has changed — so the shape is asserted on the side that owns it.
+
+One assertion is worth naming: `?space=.*` must return **nothing**. Both
+storage backends treat a String filter as a regular expression, so an
+unescaped identity predicate is a vulnerability rather than a style note, and
+`.*` selecting everything is exactly what that bug looks like.
+
 ### Deliberately not changed
 
 `ConverseWithAgentTool` / `CreateSubAgentTool` reach `startConversation` with a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,105 @@
 
 
 
+## 🔎 fix(security): third-pass review — group-share regression, ACL leak in listings, USE-gate side doors (2026-08-29)
+
+**Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)
+
+A fresh critical pass over the whole branch, this time including the API/UX
+surface. Four defects found and fixed, each with a test that fails without the
+fix; the rest of the pass is recorded as verified-clean or explicitly open.
+
+### Fixed
+
+- **Sharing a group silently dropped the member agents (critical, my own
+  regression).** The nested-group fix from the previous pass made the seeding
+  recursion and the poll loop share one visited-set, so every member agent was
+  pre-marked "done" and excluded from the share result: recipients of a group
+  share could open the workflows but not talk to any member agent. It survived
+  because `ResourceSharingServiceTest` mocks the resolver and the resolver itself
+  had **no test** — the exact blind spot reviews exist to find.
+  `ConfigGraphResolver` now uses two sets (`seededRoots` for recursion,
+  `dequeued` for the loop), the dead `referencedFromAgent` helper is gone, and
+  `ConfigGraphResolverTest` runs the real traversal over in-memory stores —
+  agent graphs, groups, nested groups, self-referential groups. Mutation-checked:
+  re-merging the two sets fails three of the five tests.
+- **The ACL still leaked through every listing.** `describe()` discloses grants
+  only at OWN — but listings and direct descriptor reads serialised the raw
+  `DocumentDescriptor`, `grants` and `accessIndex` included, and a `published`
+  resource is listable by everyone. The restraint on the sharing endpoint was
+  theatre. `ResourceAccessGuard.redactForCaller` now strips both fields for
+  non-owners at every descriptor exit: `RestVersionInfo.readDescriptors` (all
+  fifteen types), the cross-type descriptor endpoint, and the two
+  reverse-reference listings. Owner, space and visibility stay — the Manager's
+  owner column needs them, and "owned by alice" is what a recipient needs to know
+  whom to ask.
+- **Schedules and triggers were standing side doors around the USE gate.** Both
+  are authored by a user naming an agent id, and both *fire* system-initiated —
+  deliberately below the gate, because no interactive caller exists then. So any
+  editor could converse with a private agent by scheduling it or pointing a
+  trigger at it. The gate now applies at authoring time — schedule create/update
+  (the re-point path) and trigger create/update, on every referenced deployment.
+- **The schedule store turned the 403 into a 500.** Found by the new gate test,
+  not by reading: `createSchedule`'s blanket `catch (Exception)` swallowed the
+  guard's `ForbiddenException` and rethrew `InternalServerErrorException` — the
+  caller could not tell "you may not schedule that agent" from "the server
+  broke". Both create and update now rethrow the refusal.
+- **`@Consumes(APPLICATION_JSON)` on the body-less share POST** made strict
+  clients and generated SDKs manufacture a Content-Type for an entity that does
+  not exist. Removed.
+
+### Verified clean this pass
+
+- All fifteen `duplicate*` endpoints read through the guarded
+  `restVersionInfo.read` — duplication is not a read bypass anywhere.
+- The setup-API concern dissolves on inspection: its credential-less loopback
+  calls already 401 under `authorization.enabled=true` (pre-existing, see the
+  loopback-auth note), and enforcement *requires* auth — so no unowned-agent hole
+  opens through the wizard path under enforcement.
+- The `ForbiddenException`-to-403 mapping is the same one `OwnershipValidator`
+  has always relied on; no new mapper needed.
+
+### Known open, deliberately not implemented here
+
+- **OpenAI `/v1` adapter bypasses USE**: one shared API key converses with every
+  deployed agent. Whether `/v1` should serve only `published` agents under
+  enforcement is a product decision (it would change what Open WebUI users see),
+  not something to half-implement from a review.
+- **Group membership is not USE-checked at group creation** — recruiting a
+  colleague's private agent into a group reaches it through the (deliberately
+  ungated) member-turn path. Same class as the schedule/trigger doors, but group
+  flows are collaborative by design; needs its own decision.
+- **Built-in sub-agent tools** (`ConverseWithAgentTool`, `CreateSubAgentTool`)
+  let a prompted LLM converse with agents by id under the conversation's
+  identity. Runtime-side, partially mitigated by tool governance; out of scope
+  for the authoring-surface model.
+- **Enumeration surfaces**: capability registry, deployment listing, and the
+  `getCurrentResourceId` endpoints remain unscoped existence/version oracles
+  (pre-existing).
+- **Manager-facing API gaps** for the upcoming UI: listings have no server-side
+  `space` filter (the space switcher would need one to page correctly), and
+  `ShareResult` returns ids, not names.
+- **Keycloak nesting semantics**: membership in `/engineering/backend` does not
+  confer the `/engineering` space — Keycloak's group-membership claim lists the
+  groups a user is actually in. Documented behaviour, worth knowing before teams
+  adopt nested groups.
+
+### Verification
+
+Targeted suites for every touched area plus `ImportStyleTest` and the doc-link
+guard, then two full unit runs (the first raced a parallel build over `target/`
+and produced phantom `NoClassDefFound`s — the piped-mvnw lesson again, now in
+concurrent form; the uncontended rerun was clean apart from the known
+environmental failures). Mutation checks: the resolver two-set fix and the
+schedule USE gate both have tests that fail with the defect reintroduced. The
+full run also caught that `readDescriptor` returned whatever
+`redactForCaller` returned — the call site now ignores the decorator's return
+value, so no double (or future decorator) can null the response.
+
+---
+
+
+
 ## 🔐 fix(security): close the bypasses an adversarial review found in workspaces (2026-08-29)
 
 **Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,111 @@
 
 
 
+## 🔒 fix(security): close two standing bypasses of the USE gate; add a workspace capability endpoint (2026-08-29)
+
+**Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)
+
+An adversarial review pass over the whole workspaces PR (Fable, read-only)
+found two ways past the very control the PR introduces. Both were the same
+shape as holes the PR had already closed elsewhere, which is what made them
+oversights rather than decisions.
+
+### Channel integrations were a standing bypass (high)
+
+Triggers, schedules and group membership all check `requireAgentUseAccess` on
+the agents they *reference*, because those references are standing invitations:
+once written, they reach the target as a system-initiated conversation, which
+sits deliberately below the USE gate. `RestChannelIntegrationStore` wired the
+guard into `RestVersionInfo` — covering the channel config's own CRUD — and
+never checked the targets.
+
+So an editor holding Slack credentials could point a channel's `ChannelTarget`
+at a colleague's **private** agent, and every message in that Slack room would
+converse with it and relay the replies, having never held access to it.
+`TargetType.GROUP` was identical.
+
+`requireUseOnTargets` now runs before the write in `createChannel` and
+`updateChannel`. `ResourceAccessGuard.requireAgentUseAccess` was generalised to
+`requireUseAccess(id, label)` so a GROUP target is refused as a *group* rather
+than being told to go ask the owner of an agent.
+
+### Template preview leaked every snippet in the deployment (high)
+
+`RestTemplatePreview` redacted snippet **contents** from the variable-reference
+panel for callers who do not see everything — and then rendered the caller's
+template against the *unredacted* map. The comment justifying that
+("it renders only what the caller's own template actually references, which is
+their own composition") was simply wrong: the caller supplies the template, and
+the panel hands them the names. One call lists every snippet name, a second
+call whose body is `{snippets.<name>}` prints the content. Snippets are a
+guarded configuration type, so this disclosed colleagues' prompt building
+blocks cross-workspace through an endpoint any editor can reach.
+
+The redaction moved into the map the engine renders against. Names stay — a
+preview that cannot say which references resolve is not a preview — and the
+value renders as `<redacted>`. The regression test was mutation-checked: revert
+the fix and it fails with the real content in the assertion.
+
+### A2A conversed with agents that were never exposed (medium)
+
+`AgentCardService` states the gate for the A2A surface is `isA2aEnabled()` on
+the agent. Discovery enforced it; `A2ATaskHandler.handleTaskSend` did not, so a
+peer that knew an id could talk to any agent, opted in or not. It now refuses
+through `getAgentCard`, which returns null for both "no such agent" and "not
+enabled" — the same answer discovery gives. A2A remains outside the workspace
+model on purpose; this only enforces the gate it already claimed.
+
+### Redaction decided against a possibly stale version (low)
+
+`readDescriptor` gated on the **current** descriptor and then redacted against
+the **addressed** one. Sharing writes land on the current version only, so an
+older version can still name a previous owner and carry that era's grants.
+`requireAccess` now returns the level it granted, and the versioned read passes
+it to the new `redactUnlessOwner`. Two answers to "does this caller own it" in
+one request path is a smell whatever its impact.
+
+### `GET /workspaces` — because a client cannot work this out
+
+A deployment with workspaces **off** returns descriptors that look exactly like
+one where everything predates ownership: no owner, no space, no visibility.
+Ownership is still *recorded* while enforcement is off — deliberately, so
+attribution accumulates before an operator flips the switch — which means the
+fields being present proves nothing either. A UI guessing from the data offers
+a Share dialog that silently cannot work.
+
+`RestWorkspaces` answers for the calling user only: whether enforcement is
+active, their principal (the value stamped as `ownerId`, not a display name),
+their default write space, every space they can reach, and whether they see
+everything. It never takes a principal as a parameter, so it cannot enumerate
+somebody else's group membership.
+
+Serving the space list also removes the Manager's client-side reimplementation
+of `Subjects`' encoding. That mirror could only fail silently: an id encoded
+differently selects a workspace matching nothing, which renders as "you have no
+agents" rather than as an error.
+
+### `?space=` on the agent listing
+
+The Manager's space switcher sent `?space=` to `/agentstore/agents/descriptors`,
+which did not accept it — the switcher changed the URL and nothing else. The
+parameter now exists there and threads through a new
+`RestVersionInfo.readDescriptors(filter, index, limit, space)`, so every
+resource type can pick it up the same way. It narrows in the query, never
+client-side: page 2 of "everything" is not page 2 of "this space".
+
+### Deliberately not changed
+
+`ConverseWithAgentTool` / `CreateSubAgentTool` reach `startConversation` with a
+target the *model* picks at runtime, and `DynamicAgentConfig.permissiveDefault()`
+allows any target. Unlike channels, triggers and groups there is no
+authoring-time reference to check, so closing it means a runtime gate on the
+chatting user's identity — which would change delegation semantics for existing
+deployments. Recorded here as an open decision rather than changed quietly.
+
+---
+
+
+
 ## 🔑 fix(security): authenticate EDDI's own loopback calls; close the last USE side doors (2026-08-29)
 
 **Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,71 @@
 
 
 
+## 🔍 fix(workspaces): findings from the final adversarial pass (2026-08-29)
+
+**Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)
+
+A sixth review pass over the whole branch, after `callerLevel` landed. It
+confirmed the earlier fixes and found four things worth acting on — three of
+which are about tests that could not fail.
+
+### The migration recorded itself complete after a failed write
+
+`stampIfNeeded` caught every `setDescriptor` exception, logged a warning and
+returned `false` — which was indistinguishable from "already correct". So a run
+where every write threw still recorded the migration as done, and the class's
+own comment says exactly what that costs: descriptors with no access index are
+invisible in every listing once enforcement is on, with no way to re-run short
+of deleting the log row by hand.
+
+Three outcomes now, not a boolean: `STAMPED`, `SKIPPED` (already correct, or
+carrying nothing addressable — neither retryable) and `FAILED`, which holds the
+migration open. The `MAX_PAGES` exhaustion path did the same thing by a
+different route and is now also treated as incomplete. The existing test covered
+a failed *read* only; the write case is now covered and mutation-checked.
+
+### Nothing failed if a listing stopped calling the guard
+
+`ResourceAccessGuardTest` proves `redactForCaller` strips what it should.
+`AccessScopeTest` proves a space predicate narrows. Neither notices if an
+endpoint stops invoking them — and every test in that area handed the store a
+*mocked* guard, so deleting `descriptors.forEach(accessGuard::redactForCaller)`,
+or replacing `listingScope().withinSpace(space)` with `listingScope()`, left the
+whole suite green.
+
+The same shape as the mix-in test that registered its own mix-in: the unit under
+test was the collaborator, not the wiring. `ListingRedactionWiringTest` uses a
+**real** guard with a restrictive identity and asserts on what actually comes
+back. All three mutations now fail it.
+
+### Grants were disclosed to everyone while enforcement was off
+
+`seesEverything()` is true for every caller in that state, so keying grant
+disclosure on the granted level alone handed every editor the full grant
+audience — real principal and team names — of every resource. Not hypothetical:
+ownership and grants are recorded whenever authentication is on, and the
+documented rollout is to let attribution accumulate *before* switching
+enforcement on. A deployment part-way along that path was broadcasting the
+audience lists it had just built.
+
+Disclosure now asks the question structurally — does this caller actually own it,
+or hold the admin role — which does not depend on the enforcement flag and is
+therefore correct in both states.
+
+### Two assertions in `WorkspacesIT` that could not fail
+
+`?space=.*` asserted `hasSize(0)`, but the IT profile disables authorization, so
+no descriptor is ever stamped with a `spaceId` — an empty result proved only
+that the field was absent, and the test would have passed with the escaping
+removed entirely. It now pins what it can (a metacharacter-laden value is
+handled, not 500) and says plainly where the escaping is actually covered.
+`everyItem(nullValue())` over a page this suite never seeds was vacuous the same
+way; it now creates an agent first.
+
+---
+
+
+
 ## 🪪 feat(workspaces): report the caller's access level on listed descriptors (2026-08-29)
 
 **Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,125 @@
 
 
 
+## 🔑 fix(security): authenticate EDDI's own loopback calls; close the last USE side doors (2026-08-29)
+
+**Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)
+
+Closing every remaining finding from the review passes, and answering the
+question they were blocking: **does the Platform Operator work under per-user
+workspaces?**
+
+### The Operator: yes, and here is what it took
+
+In `caller-identity` mode the Operator's generated tools send
+`Authorization: Bearer ${caller:token}`, which `CallerIdentityResolver` replaces
+with the bearer of whoever is chatting. Every action it takes therefore runs as
+the real user — it lists what they can see, edits what they may edit, and
+anything it creates is stamped as theirs. That is exactly the behaviour
+workspaces want and it needed no change at all.
+
+Two things did.
+
+**EDDI's internal loopback calls carried no credentials (critical).**
+`AgentSetupService` — behind the agent wizard, the `setup-api` endpoint, and
+therefore the Operator's agent-creation tools — re-enters EDDI's own REST API
+through `RestInterfaceFactory`, as does most of `McpAdminTools`. That client sent
+no `Authorization` header while `/*` sits behind the `authenticated` HTTP policy,
+so **every one of those paths answered 401 whenever
+`authorization.enabled=true`** — the exact configuration workspaces require. The
+wizard, setup-api and the operator's entire write capability were unusable on any
+Keycloak-protected deployment, and the failure surfaced as a server fault rather
+than a missing credential.
+
+New `LoopbackCallerAuthFilter` forwards the caller's own token across the hop.
+Registered only on the **one-argument** `RestInterfaceFactory.get(Class)`, which
+addresses `127.0.0.1` on this process's own port: the destination is not merely
+same-origin, it is this very process. The two-argument overload that names an
+arbitrary remote instance for cross-instance sync deliberately does not get it —
+that is the case where forwarding a token would leak it. A pipeline thread's
+*bound* identity wins over a captured one, so a HITL resume stays attributed to
+the user whose turn it is rather than the administrator approving it.
+
+Two consequences beyond the 401: resources created through `setup-api` are now
+stamped with their **actual owner** instead of being left unowned, and the MCP
+tools that resolve stores this way genuinely do inherit `ResourceAccessGuard` —
+making true the claim an earlier pass had to walk back.
+
+**The Operator agent would have been invisible to everyone but its activator.**
+It is provisioned by whoever turns it on, so under enforcement it lands in that
+person's space and every other user gets 403 opening the drawer. Deliberately
+*not* fixed in code: auto-publishing an agent because of its name is how security
+bugs get written. The sharing API already covers it, and the deployment step is
+now documented — publish it once, or share it to a team at `USE` if the
+deployment would rather not expose the Operator's prompt.
+
+### The last USE side doors
+
+- **Group membership.** Same shape as the schedules and triggers closed last
+  pass: a group's member turns run system-initiated, below the gate, so
+  recruiting a colleague's private agent as a member reached it with the group
+  discussion as the read-out channel. Checked now at group create and update.
+- **The OpenAI-compatible `/v1` API.** One shared key reached any deployed agent
+  by id. It now applies the same gate — and since `/v1` has no verified principal
+  (one key, a user id from a trusted header), that admits **published agents
+  only** under enforcement. Deliberately not scoped to the header-supplied user
+  id: honouring a self-asserted identity would let one leaked key reach that
+  user's private agents. `listModels` filters to match, so a client never sees a
+  model it would be refused at chat time.
+
+### Manager-readiness
+
+- **`?space=` narrows any descriptor listing server-side**, so a space switcher
+  can page correctly — client-side filtering cannot, because page 2 of
+  "everything" is not page 2 of "this space". Implemented as its own AND-ed
+  filter group: folding it into the access group would OR it and turn a narrowing
+  into a widening, which `AccessScopeTest` pins down along with the anchoring that
+  stops `team:eng` matching `team:engineering`.
+- **Share results carry resource names** alongside ids, so a share dialog can say
+  "also granted on Support Rules" rather than on `1111111111111111111111` — the
+  difference between a confirmation a person can check and one they can only
+  accept. `updatedIds()` / `skippedIds()` keep the id-only shape for callers that
+  just count.
+
+### Deliberately still open
+
+- **Sub-agent tools** (`ConverseWithAgentTool`, `CreateSubAgentTool`) reach
+  agents by id under the conversation's identity. Runtime-side and governed by
+  tool approval rather than workspaces.
+- **Descriptor creation in a response filter** rather than in the stores. Much
+  less pressing now the loopback paths authenticate and stamp correctly, but
+  still the most leveraged follow-up.
+- **The access predicate is a regex scan.** A scaling ceiling, not a correctness
+  problem; the array-plus-`$in` fix needs a real PostgreSQL to verify.
+- **Enumeration oracles** on the capability registry, deployment listing and
+  `getCurrentResourceId`. Pre-existing; names and ids, not configuration.
+
+Across four passes every serious finding was the same shape — *a surface that
+reaches agents or descriptors without passing the guard*. They are now closed
+individually at each authoring entry point, which is correct but enumerative. The
+durable version is a USE check inside `ConversationService.startConversation`
+with an explicit flag for genuinely system-initiated callers; worth doing before
+this is described as a hard security boundary.
+
+### Verification
+
+Full unit suite green apart from this machine's environmental socket failures.
+New: `LoopbackCallerAuthFilterTest` (six cases, including bound-over-captured
+precedence and the fail-soft path) and `AccessScopeTest` (six, including that a
+space narrowing cannot widen).
+
+**What is still unproven, and it is the important part.** The loopback fix
+changes how every internal API call authenticates, and its correctness depends on
+a live security context, a real Keycloak and the HTTP stack — none of which exist
+in a unit test. Before enabling this anywhere that matters: staging, Keycloak on,
+two real accounts, Operator activated and published, then confirm each user sees
+only their own agents, the Operator can create one, and the created agent belongs
+to whoever asked for it.
+
+---
+
+
+
 ## 🔎 fix(security): third-pass review — group-share regression, ACL leak in listings, USE-gate side doors (2026-08-29)
 
 **Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,58 @@
 
 
 
+## 🔐 refactor(engine): split the engine's config reads off the authoring surface (2026-08-29)
+
+**Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)
+
+Prerequisite for per-user workspaces, and worth doing on its own merits. Two
+populations were reading configuration through the same beans and needed opposite
+answers from them.
+
+`ResourceClientLibrary.getResource` — the engine resolving an `eddi://` reference
+mid-turn — went through the `IRest*Store` facades, as did `AgentStoreService`,
+`WorkflowStoreService`, `WorkflowTraversal`, `AgentCardService` and
+`ChannelTargetRouter`. The identity on a conversation turn is **whoever is
+chatting**, who in general does not own the agent they are talking to. Any
+ownership check placed on the authoring surface would therefore have failed every
+turn on every shared agent — the agent would not have been able to load its own
+rule set.
+
+All of those now read `IResourceStore` beans directly. What stayed on the facades
+is exactly the set of operations a *person* performs: `duplicateResource` and
+`deleteResource` (the cascade behind `RestWorkflowStore` and the orphan purge
+behind `RestOrphanAdmin`). The class comment states the rule so the split does not
+silently erode: **a read added here belongs on the store side, a mutation on the
+facade side.**
+
+### Design decisions
+
+- **`AgentOrchestrator` lost a parameter rather than gaining a type.** It already
+  injected `IAgentStore`; the separate `IRestAgentStore` it passed down to
+  `HttpCallToolsProvider` and `McpToolsProvider` was redundant once those take the
+  store. Dropping it beats keeping two parameters of the same type.
+- **`AgentCardService.listA2AAgents` lists through `IDocumentDescriptorStore`
+  unrestricted, deliberately.** An Agent Card is published to A2A *peers* — remote
+  systems, not EDDI users — so there is no caller workspace to scope to. Its gate
+  is `isA2aEnabled()` plus whatever authenticates the A2A endpoints.
+- **The store reads throw checked exceptions the facades swallowed.**
+  `readFromStore` rethrows via `SneakyThrow`, exactly as the facades did, so
+  `WorkflowTraversal`'s degrade-and-continue behaviour on a missing reference is
+  unchanged.
+
+### Verification
+
+`./mvnw compile`, `./mvnw test-compile`, and 637 tests across the touched areas
+(`ResourceClientLibraryTest`, `AgentOrchestrator*`, `WorkflowTraversal*`,
+`RagContextProvider*`, `ChannelTargetRouter*`, `AgentCardServiceTest`,
+`DocumentDescriptorFilterTest`) — all green. `ResourceClientLibraryTest` now mocks
+both sides and asserts the split: reads verify against the stores, duplicate/delete
+against the facades.
+
+---
+
+
+
 ## 📝 docs(monitoring): reconcile the dashboard inventory with what is provisioned (2026-08-27)
 
 **Repo:** EDDI (`feat/grafana-full-metrics-dashboard`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,137 @@
 
 
 
+## 🔐 fix(security): close the bypasses an adversarial review found in workspaces (2026-08-29)
+
+**Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)
+
+Follow-up to the workspaces commit, from my own second pass plus a maximum-effort
+adversarial review. Every finding below was traced in the code before being fixed;
+nothing here is speculative hardening.
+
+### Bypasses — resources reachable without passing the guard
+
+- **Export was a complete read of any agent by id.** `RestExportService.exportAgent`
+  and `previewExport` read the agent and then every workflow, rule set, api call,
+  LLM config, output set, dictionary, mcp call, RAG config and snippet it
+  references — straight from the stores, gated only by the `eddi-editor` role. An
+  editor with no grant on anything could `POST /backup/export/{anyAgentId}` and
+  receive another user's system prompts, tool definitions, api-call headers and MCP
+  server configs. Exactly the capability the feature exists to remove, and
+  `docs/workspaces.md` already claimed export required VIEW. Both entry points now
+  require it, and the snippet sweep is scoped.
+- **`/descriptorstore/descriptors` was an unscoped inventory of everything.** The
+  cross-type listing called the unscoped overload, `readDescriptor` had no check,
+  and `patchDescriptor` — which renames a resource — had none either. One request
+  per type returned every descriptor in the deployment *and*, now that descriptors
+  carry them, every owner, space and grant. All three guarded.
+- **MCP conversation tools bypassed the USE gate.** `createConversation`,
+  `chatWithAgent` and `chat_managed` call `ConversationService.startConversation`
+  directly, gated only by `eddi-viewer` — the lowest tier. The REST equivalent was
+  403 while the MCP one held a full conversation with any private agent.
+- **Two reverse-reference listings were unscoped** —
+  `readAgentDescriptors(containingWorkflowUri=…)` and
+  `readWorkflowDescriptors(containingResourceUri=…)`. Anyone holding one resource
+  URI could enumerate everything referencing it, across all workspaces.
+- **RAG ingestion was a write gated by read access.** `published` grants VIEW to
+  everyone, so any editor could inject documents into a published RAG config's
+  knowledge base — prompt-injection into every agent retrieving from it. Now EDIT.
+- **Template preview returned every prompt snippet in the deployment.** Snippet
+  names stay (a preview that cannot say which references resolve is useless);
+  bodies are redacted for callers who do not already see everything.
+
+### Descriptor provenance — where ownership comes from
+
+- **Duplicating copied the source's ownership.**
+  `createDocumentDescriptorForDuplicate` wrote the source descriptor back verbatim,
+  so duplicating a *published* agent — which anyone may do — filed the copy under
+  the original owner, in their space, at their visibility. The duplicator could not
+  edit or delete what they had just created, and anyone could inject resources into
+  a victim's workspace attributed to them. It now builds a fresh descriptor, carries
+  name and description only, and stamps the duplicator. It also no longer mutates
+  the source object it read.
+- **Import trusted the archive.** A crafted `descriptor.json` could set `ownerId`,
+  `visibility: published`, arbitrary `grants` — and, worst, a hand-written
+  `accessIndex`, which is the one way to reach the token index without passing
+  through `Subjects` and its escaping. Ownership is stripped from imported
+  descriptors and the importing user stamped. Export strips the same fields, so a
+  ZIP no longer discloses principal and team names to whoever receives it.
+- **Three more descriptor-creating paths were unstamped** — the import create path,
+  both `UpgradeExecutor` direct-create paths, and the group descriptor sync.
+
+### Fail-open corrections
+
+- **A missing descriptor granted OWN to everyone.** `requireAccess` treated "no
+  descriptor" as "unowned" and, under the default `legacy-visibility=shared`,
+  returned OWN — read, edit, delete, deploy, undeploy. Not hypothetical: the setup
+  API reaches the stores over an unauthenticated loopback call and produces
+  descriptors with no owner. The fallback now admits **reading and using only** and
+  refuses EDIT and above regardless of policy, logged at WARN naming the resource.
+- **Listing and reading could disagree in the leaking direction.** `DescriptorAccess`
+  promises "listed but not readable cannot happen". Two shapes broke it: an
+  owner-less descriptor with a real space and `private` visibility fell through to
+  the `legacy` token — admitted to everyone — while `effectiveLevel` granted nobody
+  anything; and an unowned descriptor's grants were indexed but ignored by the
+  short-circuit. Fixed with `Subjects.TOKEN_NONE` (which `admittingTokens` never
+  emits) and by making the legacy admission a contribution rather than an early
+  return. The agreement test now sweeps the **full** cross-product of owner × space
+  × visibility × grant shape × caller × policy — ~1000 cases — and it was that sweep
+  that found the second shape.
+- **`transferOwnership(id, null, …)` un-owned a whole graph**, which under the
+  default policy means owned by everybody. Validated in the service, not only at the
+  REST edge, since the bean is reachable in-process.
+
+### Correctness
+
+- **The backfill migration queried four descriptor types that do not exist.** It
+  used the ZIP file-extension names — `ai.labs.behavior`, `ai.labs.httpcalls`,
+  `ai.labs.langchain`, `ai.labs.regulardictionary` — where listings use
+  `ai.labs.rules`, `ai.labs.apicalls`, `ai.labs.llm`, `ai.labs.dictionary`
+  (AGENTS.md §5.5). Those four queries matched nothing and the migration then
+  recorded itself complete, so **every pre-existing rule set, api call, LLM config
+  and dictionary would have vanished from every listing** the moment enforcement was
+  switched on — including from their owners, with no way to re-run short of deleting
+  the log row. The list is now derived from the stores' own `resourceURI` constants,
+  and `WorkspaceAccessIndexMigrationTest` asserts it. The migration also no longer
+  records completion when a page read failed.
+- **`ResourceSharingService` wrote back at the wrong version.** It re-resolved the
+  current version at write time and wrote a descriptor read at an earlier one; a
+  concurrent `PUT` in between left the descriptor naming the wrong version of its
+  own resource. It now writes at the version it read.
+- **The grant list is disclosed at OWN, not VIEW.** `published` grants VIEW to
+  everyone, so returning grants to any reader published every subject on the
+  resource — real principal and team names.
+- **Nested groups are followed** when sharing a group-of-groups, bounded by a
+  nesting limit as well as the visited set.
+
+### Corrections to my own claims
+
+- **The MCP coverage claim was wrong.** `ResourceAccessGuard` and `RestVersionInfo`
+  said the MCP admin tools "call those same beans in-process and therefore inherit
+  it". `McpAdminTools` resolves most stores through `IRestInterfaceFactory`, which
+  builds a REST client and makes a **loopback HTTP call**. Only the injected facades
+  inherit the guard. Corrected in both javadocs and in the documentation.
+- **`accessIndex` being in `INDEXED_FIELDS` does not make the access predicate
+  index-backed.** The predicate is an unanchored regex, which neither backend can
+  serve from a btree index. Not a regression — the type predicate this store has
+  always applied is a regex scan too — but the comment claimed otherwise. It now
+  states plainly what the index does and does not buy, and names the fix (tokens as
+  an array plus an operator on `IResourceFilter`), deliberately not attempted blind
+  because the PostgreSQL half cannot be verified without a PostgreSQL to run it on.
+
+### Verification
+
+Full unit suite: 20 373 tests. The only remaining failures are the environmental
+ones this machine always has (loopback sockets and event-loop creation) — none in
+any touched package. New tests: `WorkspaceAccessIndexMigrationTest`,
+`ResourceUtilitiesDuplicateOwnershipTest`, the widened `DescriptorAccessTest`
+cross-product sweep, and the missing-descriptor and principal-trimming cases in
+`ResourceAccessGuardTest`.
+
+---
+
+
+
 ## 🔐 feat(security): per-user workspaces and resource sharing (2026-08-29)
 
 **Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,66 @@
 
 
 
+## 🪪 feat(workspaces): report the caller's access level on listed descriptors (2026-08-29)
+
+**Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)
+
+Closing the gap the last review left open as a decision.
+
+### The gap
+
+A listing gave a recipient no way to tell what they could do with a row. The
+grant list is disclosed at `OWN` only — deliberately, since a published
+resource is readable by everyone and its grant audience is a list of real
+principal and team names — and `ownerId` alone does not answer it either: a
+resource shared with your team at `USE` and one shared at `EDIT` look identical.
+
+So the Manager offered every action on every row and let the server refuse. A
+colleague who shared an agent so you could *talk to* it produced a card with
+Share, Delete and Export on it, all of which 403. That reads as the product
+being broken rather than as the resource not being yours.
+
+### `callerLevel`
+
+`DocumentDescriptor` now carries the level the calling user holds, stamped by
+`ResourceAccessGuard` on the way out. It is unlike every other field on that
+class: it describes the *relationship* between the resource and whoever asked,
+so the same document serialises differently for two callers.
+
+That makes it dangerous in a way the other fields are not, and two properties
+are enforced rather than documented:
+
+- **It can never be stored.** `patchDescriptor` and
+  `ResourceSharingService.writeBack` both read a descriptor and write it back.
+  `redactForCaller` already documented that it must not be called on something
+  about to be written — but documenting is not preventing, and persisting one
+  caller's level would tell every later reader they hold whatever the last
+  writer happened to hold, an escalation nothing logs. A Jackson mix-in on the
+  persistence mapper drops it. Both storage backends reach storage through that
+  one mapper, so one registration covers MongoDB and PostgreSQL.
+- **It can never be set by a client.** `@JsonProperty(access = READ_ONLY)`, so a
+  PATCH body cannot assert its own access level into a read-modify-write.
+
+**Null when enforcement is off**, rather than `OWN`. Everyone may do everything
+in that state, so a level would be true and meaningless — and omitting it keeps
+a listing byte-identical to a deployment that has never heard of workspaces,
+which is the compatibility property this whole feature is built around. A client
+that wants to know asks `GET /workspaces` once instead of inferring it per row.
+
+### Verified by reverting, twice
+
+The first version of `PersistenceMixinsTest` built its own mapper by calling
+`PersistenceMixins.register(...)`. That tested the mix-in worked and **not** that
+anything used it: deleting the registration from `PersistenceMapperProducer`
+left the suite green. It now goes through the real producer, and both
+guarantees were re-checked by reverting them — the storage one fails with the
+stamped JSON in the message, the read-only one with `expected: <null> but was:
+<OWN>`.
+
+---
+
+
+
 ## 🔒 fix(security): close two standing bypasses of the USE gate; add a workspace capability endpoint (2026-08-29)
 
 **Repo:** EDDI (`feat/multi-user-spaces-and-sharing`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -117,6 +117,32 @@ storage backends treat a String filter as a regular expression, so an
 unescaped identity predicate is a vulnerability rather than a style note, and
 `.*` selecting everything is exactly what that bug looks like.
 
+### Coverage on the two classes that had none
+
+A JaCoCo pass over the workspace package found `RestResourceSharing` at **0%**
+— no unit test referenced it at all, only the new IT over HTTP — and
+`SpaceContext` at 64% instructions / 50% branches.
+
+Both are places where a mistake is silent rather than loud.
+`RestResourceSharing` is where loose query text becomes a decision about who can
+reach a resource: a level that parsed to something weaker, a subject nobody
+holds, a visibility guessed between three options that differ on who can read
+the thing. None of those look like errors afterwards — they look like a share
+that worked. `SpaceContext` reads the groups claim, which arrives as a JSON
+array through one code path, a `List<String>` through another and a bare string
+when single-valued; an unhandled shape does not throw, it just leaves the caller
+with no team spaces, and every resource shared with their team becomes invisible
+to them.
+
+Now 97.2% / 86.7% and 100% / 81%. The JSON-array handling was mutation-checked:
+removing the quote-stripping makes the space id `team:"engineering"`, which
+matches nothing — the test goes red with the quoted form in the message.
+
+One test was written wrong and corrected rather than the code: `parseOrNull`
+accepts *both* `private` and the `privateAccess` constant name, deliberately, so
+a client that read the constant out of generated code is not punished for it.
+The test now pins that leniency instead of asserting it away.
+
 ### Deliberately not changed
 
 `ConverseWithAgentTool` / `CreateSubAgentTool` reach `startConversation` with a

--- a/docs/security.md
+++ b/docs/security.md
@@ -74,6 +74,11 @@ docker run -e QUARKUS_OIDC_TENANT_ENABLED=true \
            labsai/eddi:latest
 ```
 
+> **Roles are deployment-wide.** `eddi-editor` grants authoring rights over
+> *every* configuration in the deployment. To scope agents, workflows and the
+> rest to the user or team that created them — and to share them deliberately —
+> see [Workspaces](workspaces.md).
+
 ### Auth Permissions
 
 When OIDC is enabled, the following permission rules apply (see `application.properties`):

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -181,6 +181,35 @@ nothing rather than granting it, and it narrows an administrator's view too. It
 is a query parameter rather than a client-side filter because page 2 of
 "everything" is not page 2 of "this space".
 
+### What a listing tells a client it may do
+
+Every descriptor a listing returns carries `callerLevel` — `USE`, `VIEW`,
+`EDIT` or `OWN` — describing what **the caller who asked** may do with that
+resource.
+
+```json
+{ "name": "Support Agent", "ownerId": "alice@example.com",
+  "spaceId": "team:engineering", "visibility": "space", "callerLevel": "USE" }
+```
+
+It is per-request, not per-resource: the same document serialises differently
+for two people. A client needs it because nothing else in the payload answers
+the question — the grant list is disclosed to the owner only, so a recipient
+otherwise cannot tell an agent they may edit from one they may only talk to, and
+the alternative is offering every action and letting the server refuse.
+
+Three properties are worth knowing:
+
+- **Absent when enforcement is off.** Everyone may do everything then, so a
+  level would be true and useless. Omitting it keeps a listing byte-identical to
+  a deployment that has never heard of workspaces.
+- **Never stored.** A value stamped for one caller would be wrong for every
+  other, so the persistence mapper drops it — not by convention, but by a
+  registered Jackson mix-in, because several paths read a descriptor and write
+  it back.
+- **Never accepted.** It is read-only on the wire, so nothing a client sends can
+  assert its own access level.
+
 ---
 
 ## What changes for users when you enable it

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -143,15 +143,47 @@ Two things it deliberately will not do:
 - **Starting a conversation** requires `USE`. An anonymous caller on the public
   production endpoints therefore reaches **published agents only**.
 
-That last one is the change most likely to surprise: an agent created after
-enforcement is on is not public until somebody publishes it. Agents that predate
-ownership stay reachable under `legacy-visibility=shared`, so switching the
-feature on does not silently take an existing public bot offline.
+- **Exporting** an agent requires `VIEW` on it. Export reads the agent *and*
+  every configuration it references, so leaving it ungated would have been a
+  complete read of any agent by id.
+- **Duplicating** a resource produces a copy owned by whoever duplicated it, in
+  their space, at `space` visibility — never a copy filed under the original
+  owner's name.
+- **Importing** a ZIP files everything under the importing user. A ZIP's
+  descriptors are treated as untrusted for ownership: an archive cannot decide
+  who owns a resource on your deployment, publish it, or grant access to
+  somebody. Exported ZIPs likewise carry no owner, space, visibility or grants,
+  so they do not disclose your principal and team names to whoever receives them.
 
-MCP inherits all of it — the admin tools call the same beans in-process — and
-the engine deliberately does not. A conversation turn runs under the chatting
-user's identity, and requiring them to own the agent's configuration would break
-every shared agent.
+That "starting a conversation" line is the change most likely to surprise: an
+agent created after enforcement is on is not public until somebody publishes it.
+Agents that predate ownership stay reachable under `legacy-visibility=shared`, so
+switching the feature on does not silently take an existing public bot offline.
+
+### Resources with no descriptor at all
+
+A few creation paths produce no descriptor — most notably the setup API, which
+reaches the stores over an internal loopback call with no credentials. Those
+resources have no recorded owner, and EDDI cannot invent one.
+
+They stay **readable and usable** under `legacy-visibility=shared`, so nothing
+breaks. They are **not** editable, deletable, deployable or shareable by
+non-admins: an absent record must not grant authority. Each refusal is logged at
+`WARN` naming the resource, so the gap is findable. Assign an owner with the
+ownership-transfer endpoint to close it.
+
+**MCP inherits it where it shares the beans.** Tools that hold an injected
+`IRest*Store` — the agent store in `McpConversationTools`, the group store in
+`McpGroupTools`, agent administration in `McpAdminTools` — call the same objects
+in-process and are checked identically. Tools that resolve a store through
+`IRestInterfaceFactory` make a **loopback HTTP call** instead, so the endpoint's
+own checks apply to a request that carries no credentials. That is a
+pre-existing limitation of EDDI's internal loopback calls (they already fail
+under `authorization.enabled=true`), not something workspaces introduce.
+
+**The engine deliberately does not inherit it.** A conversation turn runs under
+the chatting user's identity, and requiring them to own the agent's
+configuration would break every shared agent.
 
 ---
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -136,6 +136,53 @@ Two things it deliberately will not do:
 
 ---
 
+## Asking what applies to you
+
+A client cannot work out whether workspaces are enforced by looking at the data.
+Ownership is recorded whenever authentication is on — deliberately, so
+attribution accumulates before you flip enforcement — and a deployment with the
+feature *off* returns descriptors that look exactly like one where everything
+predates ownership. So the server says.
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" "$EDDI/workspaces"
+```
+
+```json
+{
+  "enabled": true,
+  "principal": "alice@example.com",
+  "defaultSpace": "user:alice@example.com",
+  "spaces": [
+    { "id": "user:alice@example.com", "kind": "personal", "label": "alice@example.com" },
+    { "id": "team:engineering", "kind": "team", "label": "engineering" }
+  ],
+  "seesEverything": false
+}
+```
+
+`principal` is the value stamped as `ownerId` — compare against it, not against
+a display name from the token; the two need not match. Space `id`s are opaque:
+they carry escaping a client must not re-derive, and one built differently
+selects a workspace matching nothing rather than failing. `label` is the decoded
+form, for display only.
+
+It answers only for the caller, and takes no principal parameter, so it cannot
+be used to enumerate somebody else's group membership.
+
+Listings accept the ids it returns:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN"   "$EDDI/agentstore/agents/descriptors?space=team:engineering"
+```
+
+`space` is a **narrowing only** — asking for a space you cannot reach returns
+nothing rather than granting it, and it narrows an administrator's view too. It
+is a query parameter rather than a client-side filter because page 2 of
+"everything" is not page 2 of "this space".
+
+---
+
 ## What changes for users when you enable it
 
 - **Listings** show only what the caller owns, shares a space with, has been

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -147,10 +147,15 @@ Two things it deliberately will not do:
   any colleague's live agent.
 - **Starting a conversation** requires `USE`. An anonymous caller on the public
   production endpoints therefore reaches **published agents only**.
-- **Schedules and triggers** are checked when they are *authored*: creating or
-  re-pointing one at an agent requires `USE` on that agent. The fire itself runs
-  system-initiated and is deliberately not re-checked — the vet happens where
-  the human is.
+- **Schedules, triggers and group membership** are checked when they are
+  *authored*: creating or re-pointing one at an agent requires `USE` on that
+  agent. The fire (or the group's member turn) runs system-initiated and is
+  deliberately not re-checked — the vet happens where the human is.
+- **The OpenAI-compatible `/v1` API** serves **published agents only** under
+  enforcement, and lists only those. It authenticates with one shared key and
+  takes the user id from a header, so there is no verified principal to scope
+  to — honouring that self-asserted id would let a single leaked key reach any
+  user's private agents.
 
 - **Exporting** an agent requires `VIEW` on it. Export reads the agent *and*
   every configuration it references, so leaving it ungated would have been a
@@ -168,6 +173,34 @@ That "starting a conversation" line is the change most likely to surprise: an
 agent created after enforcement is on is not public until somebody publishes it.
 Agents that predate ownership stay reachable under `legacy-visibility=shared`, so
 switching the feature on does not silently take an existing public bot offline.
+
+### The Platform Operator
+
+The Operator works with workspaces, but two things must be true.
+
+**1. It must authenticate as the chatting user.** Set its auth mode to
+`caller-identity`, so its tools send `Bearer ${caller:token}`. Then every action
+it takes runs with the real user's permissions: it lists what they can see,
+edits what they may edit, and anything it creates is owned by them. In `none`
+mode its tool calls carry no credentials and get 401 as soon as OIDC is on —
+before workspaces enter the picture at all.
+
+**2. The Operator agent itself must be reachable by everyone who uses it.** It
+is provisioned by whoever activates it, so under enforcement it lands in *that
+person's* space and every other user gets 403 when they open the drawer. It is a
+platform tool, not a personal one — publish it once after activation:
+
+```bash
+curl -X PUT -H "Authorization: Bearer $TOKEN"   "$EDDI/descriptorstore/descriptors/$OPERATOR_AGENT_ID/shares/visibility?visibility=published&cascade=true"
+```
+
+Publishing makes its configuration readable by everyone who can reach the API —
+its system prompt and tool definitions, though not its vault-referenced
+credentials. If that is more than you want, share it with a team at `USE`
+instead: `POST .../shares?subject=team:staff&level=USE&cascade=true`.
+
+The same applies to any agent meant to serve a whole deployment rather than one
+person.
 
 ### Resources with no descriptor at all
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,0 +1,172 @@
+# Workspaces — per-user isolation and sharing
+
+By default EDDI is a **single shared authoring workspace**: every holder of
+`eddi-editor` sees, edits and deletes every agent, workflow, rule set and LLM
+config in the deployment. That is the right shape for a single team and the
+wrong shape for a deployment where several people or several teams build
+independently.
+
+Turning workspaces on scopes **configuration resources** to the user or team
+that created them, and adds explicit sharing on top.
+
+> Conversations, user memories, attachments, HITL approvals and OAuth grants
+> were already per-user and are unaffected by this feature. See
+> [Security](security.md).
+
+---
+
+## Enabling it
+
+Two switches, and they mean different things.
+
+| Property | Default | What it does |
+| --- | --- | --- |
+| `authorization.enabled` | tracks `quarkus.oidc.tenant-enabled` | Authentication and role checks. Ownership is **recorded** whenever this is on. |
+| `eddi.workspaces.enabled` | `false` | Whether ownership is **enforced** — listings filtered, reads and writes checked. |
+| `eddi.workspaces.groups-claim` | `groups` | JWT claim carrying Keycloak group membership, which becomes team spaces. |
+| `eddi.workspaces.legacy-visibility` | `shared` | What happens to resources created before ownership was recorded: `shared` or `admin-only`. |
+| `eddi.workspaces.default-space` | *(empty)* | Empty = new resources land in the creator's personal space. Set to a group name for a team-first deployment. |
+
+**Recording and enforcing are deliberately separate.** Deploy the release,
+let attribution accumulate, confirm in the Manager that agents show the owners
+you expect, and only then set `eddi.workspaces.enabled=true`. Enforcing against
+data that was never stamped is what would hide people's own work from them.
+
+`eddi.workspaces.enabled=true` with `authorization.enabled=false` does nothing
+and says so at boot: with no authenticated principal there is nothing to scope
+resources to.
+
+### Keycloak
+
+Team spaces come from group membership, so the token has to carry it. The
+shipped realm (`keycloak/eddi-realm.json`) already includes a
+`oidc-group-membership-mapper` named `groups` on both clients, and a sample
+`/engineering` group. For an existing realm, add the mapper by hand:
+
+- **Clients → eddi-backend → Client scopes → dedicated → Add mapper → Group Membership**
+- Token Claim Name `groups`, Full group path **on**, add to access token and ID token.
+
+Without the mapper every user simply has a personal space and no teams. That is
+a correct answer, not a failure.
+
+Roles stay what they were — `eddi-admin`, `eddi-editor`, `eddi-user`,
+`eddi-viewer`, `eddi-approver`. **Roles say what you may do; spaces say what you
+may see.** Do not mint per-team roles: they do not compose, and they cannot
+express a one-off share.
+
+---
+
+## The model
+
+### Spaces
+
+Every resource is filed in exactly one space:
+
+- **Personal** — `user:<principal>`, one member.
+- **Team** — `team:<group path>`, everyone in that Keycloak group.
+
+A resource in a team space is visible and editable by the whole team. Deleting
+and re-sharing stay with whoever created it.
+
+### Visibility
+
+| Value | Who reaches it before any explicit share |
+| --- | --- |
+| `private` | The owner, and explicit grants only. |
+| `space` | Everyone whose spaces include the resource's space. **Default for new resources.** |
+| `published` | Everyone with access to the deployment, including anonymous callers on the public production chat endpoints. |
+
+### Access levels
+
+| Level | Can | Cannot |
+| --- | --- | --- |
+| `USE` | Start conversations with the deployed agent; see its name and description. | Read the configuration, its workflows, tools or vault references. |
+| `VIEW` | Read the resource and the config graph beneath it; export a copy. | Modify or deploy. |
+| `EDIT` | Update and deploy. | Delete, or change who else has access. |
+| `OWN` | Everything, including delete and re-share. | — |
+
+`USE` and `VIEW` are separate because letting a colleague *talk to* an agent is
+a different act from letting them *read how it was built* — and the first is by
+far the more common request.
+
+---
+
+## Sharing
+
+One endpoint family covers every resource type, keyed by resource id.
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  "$EDDI/descriptorstore/descriptors/$AGENT_ID/shares?subject=user:alice@example.com&level=USE"
+```
+
+```bash
+curl -X PUT -H "Authorization: Bearer $TOKEN" \
+  "$EDDI/descriptorstore/descriptors/$AGENT_ID/shares/visibility?visibility=published"
+```
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/descriptorstore/descriptors/{id}/shares` | Owner, space, visibility, grants, and the caller's effective level. |
+| `POST` | `/descriptorstore/descriptors/{id}/shares` | Grant `subject` (`user:…` or `team:…`) a `level`. |
+| `DELETE` | `/descriptorstore/descriptors/{id}/shares` | Revoke a subject's grant. |
+| `PUT` | `/descriptorstore/descriptors/{id}/shares/visibility` | Set `private` / `space` / `published`. |
+| `PUT` | `/descriptorstore/descriptors/{id}/shares/owner` | Transfer ownership. **Administrators only.** |
+
+**Sharing cascades by default.** An agent is a thin document pointing at
+workflows, which point at rule sets, LLM configs, output sets and api calls. A
+share that stopped at the agent would hand the recipient a name and a list of
+URIs they cannot resolve, so `cascade=true` (the default) walks the graph and
+applies the same change to everything beneath it. Pass `cascade=false` to touch
+exactly the one document.
+
+Two things it deliberately will not do:
+
+- **It will not pass on access you were lent.** A referenced resource you can
+  read but do not own is left alone and returned in the response's `skipped`
+  list.
+- **It will not share more than 500 resources from one root.** A cyclic or
+  generated config cannot turn one share into unbounded write amplification; the
+  cut-off is logged.
+
+---
+
+## What changes for users when you enable it
+
+- **Listings** show only what the caller owns, shares a space with, has been
+  granted, or that is published. Filtering happens in the query, so paging stays
+  correct.
+- **Reading, editing and deleting** a resource by id is checked even when the id
+  is guessed or pasted.
+- **Deploy and undeploy** require `EDIT`. Previously any editor could take down
+  any colleague's live agent.
+- **Starting a conversation** requires `USE`. An anonymous caller on the public
+  production endpoints therefore reaches **published agents only**.
+
+That last one is the change most likely to surprise: an agent created after
+enforcement is on is not public until somebody publishes it. Agents that predate
+ownership stay reachable under `legacy-visibility=shared`, so switching the
+feature on does not silently take an existing public bot offline.
+
+MCP inherits all of it — the admin tools call the same beans in-process — and
+the engine deliberately does not. A conversation turn runs under the chatting
+user's identity, and requiring them to own the agent's configuration would break
+every shared agent.
+
+---
+
+## Upgrading an existing deployment
+
+1. Deploy the release. `WorkspaceAccessIndexMigration` runs once at startup and
+   stamps every existing descriptor as legacy. It **does not invent owners** —
+   attribution cannot be reconstructed after the fact, and a confident wrong
+   answer is worse than an honest "unowned".
+2. Leave `eddi.workspaces.enabled=false`. New resources are attributed to their
+   creators from this point on.
+3. Check the owners look right.
+4. Set `eddi.workspaces.enabled=true`.
+5. Optionally move to `legacy-visibility=admin-only` once the pre-existing
+   resources have been assigned owners with the ownership-transfer endpoint.
+
+Rolling back is setting the flag to `false`. The recorded ownership is inert
+while enforcement is off.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -49,6 +49,11 @@ shipped realm (`keycloak/eddi-realm.json`) already includes a
 Without the mapper every user simply has a personal space and no teams. That is
 a correct answer, not a failure.
 
+Group nesting is literal: a member of `/engineering/backend` gets the
+`team:engineering/backend` space, **not** `team:engineering` — Keycloak's
+membership claim lists the groups a user is actually in, and EDDI does not
+invent ancestry. Share with the parent team explicitly if that is what you mean.
+
 Roles stay what they were — `eddi-admin`, `eddi-editor`, `eddi-user`,
 `eddi-viewer`, `eddi-approver`. **Roles say what you may do; spaces say what you
 may see.** Do not mint per-team roles: they do not compose, and they cannot
@@ -142,6 +147,10 @@ Two things it deliberately will not do:
   any colleague's live agent.
 - **Starting a conversation** requires `USE`. An anonymous caller on the public
   production endpoints therefore reaches **published agents only**.
+- **Schedules and triggers** are checked when they are *authored*: creating or
+  re-pointing one at an agent requires `USE` on that agent. The fire itself runs
+  system-initiated and is deliberately not re-checked — the vet happens where
+  the human is.
 
 - **Exporting** an agent requires `VIEW` on it. Export reads the agent *and*
   every configuration it references, so leaving it ungated would have been a

--- a/keycloak/eddi-realm.json
+++ b/keycloak/eddi-realm.json
@@ -84,6 +84,10 @@
           ]
         },
         "clientRole": false
+      },
+      {
+        "name": "eddi-approver",
+        "description": "May decide pending human-in-the-loop approvals they do not own"
       }
     ]
   },
@@ -107,7 +111,21 @@
       "publicClient": false,
       "bearerOnly": true,
       "standardFlowEnabled": false,
-      "directAccessGrantsEnabled": false
+      "directAccessGrantsEnabled": false,
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "config": {
+            "claim.name": "groups",
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
     },
     {
       "clientId": "eddi-frontend",
@@ -166,6 +184,18 @@
             "id.token.claim": "false",
             "access.token.claim": "true"
           }
+        },
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "config": {
+            "claim.name": "groups",
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
         }
       ]
     }
@@ -188,6 +218,9 @@
       "realmRoles": [
         "eddi-admin",
         "eddi-editor"
+      ],
+      "groups": [
+        "/engineering"
       ]
     },
     {
@@ -225,6 +258,13 @@
       "realmRoles": [
         "eddi-user"
       ]
+    }
+  ],
+  "groups": [
+    {
+      "name": "engineering",
+      "path": "/engineering",
+      "subGroups": []
     }
   ]
 }

--- a/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
@@ -13,6 +13,9 @@ import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.engine.security.spaces.DescriptorAccess;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
 import ai.labs.eddi.configs.llm.ILlmStore;
 import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
@@ -101,12 +104,15 @@ public class RestExportService extends AbstractBackupService implements IRestExp
      */
     private static final Pattern SNIPPET_REF_PATTERN = Pattern.compile("snippets\\.([a-zA-Z0-9_\\-]+)");
 
+    private final ResourceAccessGuard resourceAccessGuard;
+
     @Inject
     public RestExportService(IDocumentDescriptorStore documentDescriptorStore, IAgentStore agentStore, IWorkflowStore workflowStore,
             IDictionaryStore regularDictionaryStore, IRuleSetStore behaviorStore, IApiCallsStore httpCallsStore, ILlmStore llmStore,
             IPropertySetterStore propertySetterStore, IOutputStore outputStore, IMcpCallsStore mcpCallsStore, IRagStore ragStore,
             IPromptSnippetStore snippetStore, IJsonSerialization jsonSerialization, IZipArchive zipArchive,
-            SecretScrubber secretScrubber, IScheduleStore scheduleStore) {
+            SecretScrubber secretScrubber, IScheduleStore scheduleStore, ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         this.documentDescriptorStore = documentDescriptorStore;
         this.agentStore = agentStore;
         this.workflowStore = workflowStore;
@@ -155,6 +161,12 @@ public class RestExportService extends AbstractBackupService implements IRestExp
             // Validate agentId early before any path construction (CodeQL
             // java/path-injection)
             sanitizePathComponent(agentId, "agentId");
+
+            // Export reads the agent AND every configuration it references, straight from
+            // the stores — so without this it is a complete read of any agent by id, which
+            // is exactly the capability workspaces exist to remove. VIEW, because exporting
+            // is reading: it is what a recipient of a shared agent is entitled to do.
+            resourceAccessGuard.requireAccess(agentId, AccessLevel.VIEW, "agent");
 
             // Parse selective export filter — null means "export all"
             Set<String> selectedIds = parseSelectedResourceIds(selectedResourceIds);
@@ -296,6 +308,12 @@ public class RestExportService extends AbstractBackupService implements IRestExp
     public ExportPreview previewExport(String agentId, Integer agentVersion) {
         try {
             sanitizePathComponent(agentId, "agentId");
+
+            // Export reads the agent AND every configuration it references, straight from
+            // the stores — so without this it is a complete read of any agent by id, which
+            // is exactly the capability workspaces exist to remove. VIEW, because exporting
+            // is reading: it is what a recipient of a shared agent is entitled to do.
+            resourceAccessGuard.requireAccess(agentId, AccessLevel.VIEW, "agent");
 
             AgentConfiguration agentConfig = agentStore.read(agentId, agentVersion);
             DocumentDescriptor agentDescriptor = documentDescriptorStore.readDescriptor(agentId, agentVersion);
@@ -512,11 +530,40 @@ public class RestExportService extends AbstractBackupService implements IRestExp
         String filename = MessageFormat.format("{0}.descriptor.json", documentId);
         Path filePath = Paths.get(path.toString(), filename);
         deleteFileIfExists(filePath);
+        // Ownership does not travel between deployments: principal and team names mean
+        // something else — or nothing — on the receiving side, and writing them into a
+        // file that leaves the deployment discloses them. See
+        // DescriptorAccess.stripOwnership. Stripped on the copy that is written, not on
+        // the object returned, which callers still use to name the exported resource.
         try (BufferedWriter writer = Files.newBufferedWriter(filePath)) {
-            writer.write(jsonSerialization.serialize(documentDescriptor));
+            writer.write(jsonSerialization.serialize(DescriptorAccess.stripOwnership(copyForExport(documentDescriptor))));
         }
 
         return documentDescriptor;
+    }
+
+    /**
+     * A copy of the descriptor to write into the archive, so stripping ownership
+     * from the exported form cannot alter the object the caller goes on to use.
+     */
+    private static DocumentDescriptor copyForExport(DocumentDescriptor source) {
+        if (source == null) {
+            // The descriptor store can answer null; serialising that wrote "null" into the
+            // archive before this method existed, and still does. Not this method's
+            // business to change.
+            return null;
+        }
+        DocumentDescriptor copy = new DocumentDescriptor();
+        copy.setResource(source.getResource());
+        copy.setName(source.getName());
+        copy.setDescription(source.getDescription());
+        copy.setOriginId(source.getOriginId());
+        copy.setCreatedOn(source.getCreatedOn());
+        copy.setLastModifiedOn(source.getLastModifiedOn());
+        copy.setCreatedBy(source.getCreatedBy());
+        copy.setLastModifiedBy(source.getLastModifiedBy());
+        copy.setDeleted(source.isDeleted());
+        return copy;
     }
 
     private static <T> Map<IResourceId, T> readConfigs(IResourceStore<T> store, List<URI> configUris)
@@ -590,8 +637,11 @@ public class RestExportService extends AbstractBackupService implements IRestExp
         }
 
         try {
+            // Scoped: this sweeps every snippet in the deployment and the export only
+            // filters by referenced NAME afterwards, so an unscoped listing would let an
+            // agent that names a snippet pull in a colleague's snippet of the same name.
             List<DocumentDescriptor> descriptors = documentDescriptorStore.readDescriptors(
-                    "ai.labs.snippet", "", 0, IDescriptorStore.NO_LIMIT, false);
+                    "ai.labs.snippet", "", 0, IDescriptorStore.NO_LIMIT, false, resourceAccessGuard.listingScope());
             if (descriptors == null || descriptors.isEmpty()) {
                 return;
             }
@@ -628,7 +678,8 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                     Path descriptorPath = Paths.get(snippetsDir.toString(), descriptorFilename);
                     deleteFileIfExists(descriptorPath);
                     try (BufferedWriter writer = Files.newBufferedWriter(descriptorPath)) {
-                        writer.write(jsonSerialization.serialize(descriptor));
+                        // Same reason as writeDocumentDescriptor: ownership does not travel.
+                        writer.write(jsonSerialization.serialize(DescriptorAccess.stripOwnership(copyForExport(descriptor))));
                     }
                     exportedCount++;
                 } catch (IResourceStore.ResourceNotFoundException e) {

--- a/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
@@ -28,6 +28,8 @@ import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.engine.security.spaces.DescriptorAccess;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
 import ai.labs.eddi.configs.llm.IRestLlmStore;
@@ -99,13 +101,16 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     private final StructuralMatcher structuralMatcher;
     private final UpgradeExecutor upgradeExecutor;
 
+    private final ResourceAccessGuard resourceAccessGuard;
+
     private static final Logger LOGGER = Logger.getLogger(RestImportService.class);
 
     @Inject
     public RestImportService(IZipArchive zipArchive, IJsonSerialization jsonSerialization,
             IMigrationManager migrationManager,
             IDocumentDescriptorStore documentDescriptorStore, TemplateSyntaxMigrator templateSyntaxMigrator,
-            StructuralMatcher structuralMatcher, UpgradeExecutor upgradeExecutor) {
+            StructuralMatcher structuralMatcher, UpgradeExecutor upgradeExecutor, ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         this.zipArchive = zipArchive;
         this.jsonSerialization = jsonSerialization;
         this.migrationManager = migrationManager;
@@ -751,9 +756,11 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
             // Create the DocumentDescriptor that the DocumentDescriptorFilter would
             // normally create on a 201 response. Since we bypass the REST layer,
-            // the filter never runs, so we must create it manually.
+            // the filter never runs, so we must create it manually — including the
+            // ownership stamp, or every imported resource would be unowned.
             documentDescriptorStore.createDescriptor(
-                    resourceId.getId(), resourceId.getVersion(), createDocumentDescriptor(createdUri));
+                    resourceId.getId(), resourceId.getVersion(),
+                    resourceAccessGuard.stampNewDescriptor(createDocumentDescriptor(createdUri)));
 
             return createdUri;
         } catch (IResourceStore.ResourceStoreException e) {
@@ -1186,6 +1193,11 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                                 }
                                 // Update the resource URI to point to the new version
                                 existingDescriptor.setResource(newUri);
+                                // Only name and description are taken from the ZIP, so ownership is
+                                // unchanged here — but a descriptor written before the access index
+                                // existed acquires one on this write rather than staying unlistable
+                                // until the backfill migration runs.
+                                DescriptorAccess.rebuildIndex(existingDescriptor);
 
                                 if (currentDescriptorId.getVersion() < newResourceId.getVersion()) {
                                     // MERGE path: descriptor version is behind the resource version
@@ -1205,10 +1217,18 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                                 }
                             }
                         } catch (IResourceStore.ResourceNotFoundException e) {
-                            // No existing descriptor — create one for the new resource
+                            // No existing descriptor — create one for the new resource.
+                            //
+                            // The ZIP's descriptor is UNTRUSTED input as far as ownership goes: it
+                            // was written by another deployment, where the same principal and team
+                            // names mean something else, and honouring it would let a file decide
+                            // who owns a resource here and who it is shared with — publishing it,
+                            // or filing it under someone else's name, with none of the checks the
+                            // sharing API applies. Strip that, then stamp the importing user, so
+                            // an import is owned by whoever performed it.
                             zipDescriptor.setResource(newUri);
-                            documentDescriptorStore.createDescriptor(
-                                    newResourceId.getId(), newResourceId.getVersion(), zipDescriptor);
+                            documentDescriptorStore.createDescriptor(newResourceId.getId(), newResourceId.getVersion(),
+                                    resourceAccessGuard.stampNewDescriptor(DescriptorAccess.stripOwnership(zipDescriptor)));
                         }
                     }
                 }

--- a/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IResourceSource;
 import ai.labs.eddi.backup.IResourceSource.*;
 import ai.labs.eddi.backup.model.ImportPreview;
@@ -82,13 +83,17 @@ public class UpgradeExecutor {
     private final StructuralMatcher structuralMatcher;
     private final IDocumentDescriptorStore documentDescriptorStore;
 
+    private final ResourceAccessGuard resourceAccessGuard;
+
     @Inject
     public UpgradeExecutor(IRestAgentStore agentStore,
             IRestWorkflowStore workflowStore,
             IRestPromptSnippetStore snippetStore,
             IJsonSerialization jsonSerialization,
             StructuralMatcher structuralMatcher,
-            IDocumentDescriptorStore documentDescriptorStore) {
+            IDocumentDescriptorStore documentDescriptorStore,
+            ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         this.agentStore = agentStore;
         this.workflowStore = workflowStore;
         this.snippetStore = snippetStore;
@@ -402,9 +407,10 @@ public class UpgradeExecutor {
         URI createdUri = RestUtilities.createURI(ops.resourceUri(), resourceId.getId(), ops.versionQueryParam(), resourceId.getVersion());
 
         // Create the DocumentDescriptor that the DocumentDescriptorFilter would
-        // normally create on a 201 response.
-        documentDescriptorStore.createDescriptor(
-                resourceId.getId(), resourceId.getVersion(), createDocumentDescriptor(createdUri));
+        // normally create on a 201 response — including the ownership stamp, or a
+        // resource created by an upgrade would be unowned and unlistable.
+        documentDescriptorStore.createDescriptor(resourceId.getId(), resourceId.getVersion(),
+                resourceAccessGuard.stampNewDescriptor(createDocumentDescriptor(createdUri)));
 
         return createdUri;
     }
@@ -423,9 +429,9 @@ public class UpgradeExecutor {
                     IRestWorkflowStore.versionQueryParam, resourceId.getVersion());
 
             // Create the DocumentDescriptor that the DocumentDescriptorFilter would
-            // normally create on a 201 response.
-            documentDescriptorStore.createDescriptor(
-                    resourceId.getId(), resourceId.getVersion(), createDocumentDescriptor(createdUri));
+            // normally create on a 201 response — ownership stamp included.
+            documentDescriptorStore.createDescriptor(resourceId.getId(), resourceId.getVersion(),
+                    resourceAccessGuard.stampNewDescriptor(createDocumentDescriptor(createdUri)));
 
             return createdUri;
         } catch (Exception e) {

--- a/src/main/java/ai/labs/eddi/configs/agents/IRestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/IRestAgentStore.java
@@ -35,6 +35,16 @@ public interface IRestAgentStore extends IRestVersionInfo {
     @Operation(operationId = "readAgentJsonSchema", description = "Read JSON Schema for Agent definition.")
     Response readJsonSchema();
 
+    /**
+     * @param space
+     *            narrows the listing to one space id ({@code user:<principal>} or
+     *            {@code team:<group>}) — the server side of the Manager's space
+     *            switcher, and the reason it is a query parameter rather than a
+     *            client-side filter: page 2 of "everything" is not page 2 of "this
+     *            space". A narrowing only: asking for a space you cannot reach
+     *            returns nothing rather than granting it. Blank means every space
+     *            you can reach.
+     */
     @GET
     @Path("descriptors")
     @Produces(MediaType.APPLICATION_JSON)
@@ -44,7 +54,9 @@ public interface IRestAgentStore extends IRestVersionInfo {
                                                   @QueryParam("index")
                                                   @DefaultValue("0") Integer index,
                                                   @QueryParam("limit")
-                                                  @DefaultValue("20") Integer limit);
+                                                  @DefaultValue("20") Integer limit,
+                                                  @QueryParam("space")
+                                                  @DefaultValue("") String space);
 
     @POST
     @Path("descriptors")

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.rest.RestWorkflowStore;
 import ai.labs.eddi.configs.rest.RestVersionInfo;
@@ -56,8 +57,9 @@ public class RestAgentStore implements IRestAgentStore {
     @Inject
     public RestAgentStore(IAgentStore agentStore, IRestWorkflowStore restWorkflowStore, IDocumentDescriptorStore documentDescriptorStore,
             IJsonSchemaCreator jsonSchemaCreator, IScheduleStore scheduleStore, CapabilityRegistryService capabilityRegistryService,
-            IDeploymentStore deploymentStore) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, agentStore, documentDescriptorStore);
+            IDeploymentStore deploymentStore,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, agentStore, documentDescriptorStore, resourceAccessGuard);
         this.documentDescriptorStore = documentDescriptorStore;
         this.agentStore = agentStore;
         this.restWorkflowStore = restWorkflowStore;
@@ -195,6 +197,7 @@ public class RestAgentStore implements IRestAgentStore {
 
     @Override
     public Response duplicateAgent(String id, Integer version, Boolean deepCopy) {
+        restVersionInfo.requireViewAccess(id);
         restVersionInfo.validateParameters(id, version);
         try {
             AgentConfiguration agentConfig = agentStore.read(id, version);
@@ -257,6 +260,8 @@ public class RestAgentStore implements IRestAgentStore {
 
     @Override
     public Response deleteAgent(String id, Integer version, Boolean permanent, Boolean cascade) {
+        // Before the cascade, not after — see RestVersionInfo.requireOwnAccess.
+        restVersionInfo.requireOwnAccess(id);
         if (cascade) {
             // Cascade-delete all schedules for this Agent first
             try {

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -123,8 +123,8 @@ public class RestAgentStore implements IRestAgentStore {
     }
 
     @Override
-    public List<DocumentDescriptor> readAgentDescriptors(String filter, Integer index, Integer limit) {
-        return restVersionInfo.readDescriptors(filter, index, limit);
+    public List<DocumentDescriptor> readAgentDescriptors(String filter, Integer index, Integer limit, String space) {
+        return restVersionInfo.readDescriptors(filter, index, limit, space);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.rest.RestWorkflowStore;
@@ -48,6 +49,7 @@ public class RestAgentStore implements IRestAgentStore {
     private final IJsonSchemaCreator jsonSchemaCreator;
     private final RestVersionInfo<AgentConfiguration> restVersionInfo;
     private final IDocumentDescriptorStore documentDescriptorStore;
+    private final ResourceAccessGuard resourceAccessGuard;
     private final IScheduleStore scheduleStore;
     private final CapabilityRegistryService capabilityRegistryService;
     private final IDeploymentStore deploymentStore;
@@ -59,6 +61,7 @@ public class RestAgentStore implements IRestAgentStore {
             IJsonSchemaCreator jsonSchemaCreator, IScheduleStore scheduleStore, CapabilityRegistryService capabilityRegistryService,
             IDeploymentStore deploymentStore,
             ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         restVersionInfo = new RestVersionInfo<>(resourceURI, agentStore, documentDescriptorStore, resourceAccessGuard);
         this.documentDescriptorStore = documentDescriptorStore;
         this.agentStore = agentStore;
@@ -97,6 +100,18 @@ public class RestAgentStore implements IRestAgentStore {
         }
     }
 
+    /**
+     * Drops descriptors the caller may not view. Mirrors
+     * {@code ResourceAccessGuard.requireAccess(id, VIEW, …)} exactly, so a caller
+     * never lists something they could not then read.
+     */
+    private List<DocumentDescriptor> visibleOnly(List<DocumentDescriptor> descriptors) {
+        if (descriptors == null || descriptors.isEmpty()) {
+            return descriptors;
+        }
+        return descriptors.stream().filter(d -> resourceAccessGuard.canAccess(d, AccessLevel.VIEW)).toList();
+    }
+
     @Override
     public Response readJsonSchema() {
         try {
@@ -121,8 +136,15 @@ public class RestAgentStore implements IRestAgentStore {
         }
 
         try {
-            return agentStore.getAgentDescriptorsContainingWorkflow(validatedResourceId.getId(), validatedResourceId.getVersion(),
-                    includePreviousVersions);
+            // Post-filtered rather than query-filtered: this is a reverse-reference lookup
+            // in the store, not a descriptor listing, so there is no AccessScope to hand
+            // it. Unfiltered it is a cross-workspace enumeration — anyone holding one
+            // resource URI could list every resource in the deployment that references it,
+            // with the full descriptor payload. The page can come back short; that is the
+            // right trade for a diagnostic listing bounded by how many things reference
+            // one resource.
+            return visibleOnly(agentStore.getAgentDescriptorsContainingWorkflow(validatedResourceId.getId(),
+                    validatedResourceId.getVersion(), includePreviousVersions));
         } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
             throw sneakyThrow(e);
         }
@@ -224,7 +246,7 @@ public class RestAgentStore implements IRestAgentStore {
             // URIs
             IResourceId newAgentId = restVersionInfo.createDocument(agentConfig);
             URI createdUri = RestUtilities.createURI(resourceURI, newAgentId.getId(), versionQueryParam, newAgentId.getVersion());
-            createDocumentDescriptorForDuplicate(documentDescriptorStore, id, version, createdUri);
+            createDocumentDescriptorForDuplicate(documentDescriptorStore, resourceAccessGuard, id, version, createdUri);
 
             return Response.created(createdUri).location(createdUri)
                     .header("X-Resource-URI", createdUri.toString()).build();

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -109,7 +109,8 @@ public class RestAgentStore implements IRestAgentStore {
         if (descriptors == null || descriptors.isEmpty()) {
             return descriptors;
         }
-        return descriptors.stream().filter(d -> resourceAccessGuard.canAccess(d, AccessLevel.VIEW)).toList();
+        return descriptors.stream().filter(d -> resourceAccessGuard.canAccess(d, AccessLevel.VIEW))
+                .map(resourceAccessGuard::redactForCaller).toList();
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStore.java
+++ b/src/main/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.apicalls.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
 import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
@@ -44,8 +45,9 @@ public class RestApiCallsStore implements IRestApiCallsStore {
     private final RestVersionInfo<ApiCallsConfiguration> restVersionInfo;
 
     @Inject
-    public RestApiCallsStore(IApiCallsStore httpCallsStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, httpCallsStore, documentDescriptorStore);
+    public RestApiCallsStore(IApiCallsStore httpCallsStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, httpCallsStore, documentDescriptorStore, resourceAccessGuard);
         this.httpCallsStore = httpCallsStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
     }

--- a/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.channels.IRestChannelIntegrationStore;
 import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.configs.channels.model.ChannelTarget;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.rest.RestVersionInfo;
 import ai.labs.eddi.datastore.IResourceStore;
@@ -55,8 +56,9 @@ public class RestChannelIntegrationStore implements IRestChannelIntegrationStore
 
     @Inject
     public RestChannelIntegrationStore(IChannelIntegrationStore channelStore,
-            IDocumentDescriptorStore documentDescriptorStore) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, channelStore, documentDescriptorStore);
+            IDocumentDescriptorStore documentDescriptorStore,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, channelStore, documentDescriptorStore, resourceAccessGuard);
         this.channelStore = channelStore;
         this.documentDescriptorStore = documentDescriptorStore;
     }
@@ -321,10 +323,14 @@ public class RestChannelIntegrationStore implements IRestChannelIntegrationStore
                             && existing.getPlatformConfig() != null
                             && channelType.equalsIgnoreCase(existing.getChannelType())
                             && channelId.equals(existing.getPlatformConfig().get("channelId"))) {
+                        // The sweep is deliberately unscoped: a channelId collides with every
+                        // integration in the deployment, not only the caller's own, so scoping it
+                        // would let two workspaces both bind the same Slack channel and route each
+                        // other's messages. What the message must NOT do is name the conflicting
+                        // integration — that would turn a uniqueness check into an enumeration
+                        // oracle for other people's channel integrations.
                         throw new BadRequestException(
-                                "Another channel integration ('"
-                                        + (existing.getName() != null ? existing.getName() : resId.getId())
-                                        + "') already uses channelId '" + channelId
+                                "Another channel integration already uses channelId '" + channelId
                                         + "' for type '" + channelType + "'.");
                     }
                 } catch (BadRequestException e) {

--- a/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStore.java
@@ -52,6 +52,7 @@ public class RestChannelIntegrationStore implements IRestChannelIntegrationStore
 
     private final IChannelIntegrationStore channelStore;
     private final IDocumentDescriptorStore documentDescriptorStore;
+    private final ResourceAccessGuard resourceAccessGuard;
     private final RestVersionInfo<ChannelIntegrationConfiguration> restVersionInfo;
 
     @Inject
@@ -61,6 +62,35 @@ public class RestChannelIntegrationStore implements IRestChannelIntegrationStore
         restVersionInfo = new RestVersionInfo<>(resourceURI, channelStore, documentDescriptorStore, resourceAccessGuard);
         this.channelStore = channelStore;
         this.documentDescriptorStore = documentDescriptorStore;
+        this.resourceAccessGuard = resourceAccessGuard;
+    }
+
+    /**
+     * Asserts the author may converse with everything this channel points at.
+     * <p>
+     * <h3>Why the channel's own permissions are not enough</h3> A channel target is
+     * a standing invitation: once configured, every inbound Slack message reaches
+     * {@code targetId} as a system-initiated conversation, which is deliberately
+     * below the USE gate. Without this check an editor could aim a channel they
+     * control at a colleague's private agent and relay its replies into a room of
+     * their choosing, having never held access to it. Mirrors the checks on
+     * triggers, schedules and group membership, which are the same shape of
+     * standing reference.
+     */
+    private void requireUseOnTargets(ChannelIntegrationConfiguration configuration) {
+        if (configuration == null || configuration.getTargets() == null) {
+            return;
+        }
+        for (var target : configuration.getTargets()) {
+            if (target == null || target.getTargetId() == null || target.getTargetId().isBlank()) {
+                continue;
+            }
+            if (target.getType() == ChannelTarget.TargetType.GROUP) {
+                resourceAccessGuard.requireUseAccess(target.getTargetId(), "group");
+            } else {
+                resourceAccessGuard.requireAgentUseAccess(target.getTargetId());
+            }
+        }
     }
 
     @Override
@@ -77,6 +107,7 @@ public class RestChannelIntegrationStore implements IRestChannelIntegrationStore
     public Response updateChannel(String id, Integer version,
                                   ChannelIntegrationConfiguration channelConfiguration) {
         validateConfiguration(channelConfiguration);
+        requireUseOnTargets(channelConfiguration);
         validateUniqueChannelId(channelConfiguration, id);
         Response response = restVersionInfo.update(id, version, channelConfiguration);
         syncDescriptor(id, channelConfiguration);
@@ -86,6 +117,7 @@ public class RestChannelIntegrationStore implements IRestChannelIntegrationStore
     @Override
     public Response createChannel(ChannelIntegrationConfiguration channelConfiguration) {
         validateConfiguration(channelConfiguration);
+        requireUseOnTargets(channelConfiguration);
         validateUniqueChannelId(channelConfiguration, null);
         Response response = restVersionInfo.create(channelConfiguration);
         URI location = response.getLocation();

--- a/src/main/java/ai/labs/eddi/configs/connections/rest/RestConnectionStore.java
+++ b/src/main/java/ai/labs/eddi/configs/connections/rest/RestConnectionStore.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.connections.IRestConnectionStore;
 import ai.labs.eddi.configs.connections.model.Binding;
 import ai.labs.eddi.configs.connections.model.ConnectionConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.rest.RestVersionInfo;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
@@ -49,8 +50,9 @@ public class RestConnectionStore implements IRestConnectionStore {
     public RestConnectionStore(IConnectionStore connectionStore, IDocumentDescriptorStore documentDescriptorStore,
             IJsonSchemaCreator jsonSchemaCreator, ConnectionRegistry connectionRegistry, IConnectionGrantStore grantStore,
             ISecretProvider secretProvider,
-            @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authorizationEnabled) {
-        this.restVersionInfo = new RestVersionInfo<>(resourceURI, connectionStore, documentDescriptorStore);
+            @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authorizationEnabled,
+            ResourceAccessGuard resourceAccessGuard) {
+        this.restVersionInfo = new RestVersionInfo<>(resourceURI, connectionStore, documentDescriptorStore, resourceAccessGuard);
         this.connectionStore = connectionStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
         this.connectionRegistry = connectionRegistry;

--- a/src/main/java/ai/labs/eddi/configs/descriptors/IDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/IDocumentDescriptorStore.java
@@ -4,12 +4,48 @@
  */
 package ai.labs.eddi.configs.descriptors;
 
-import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.AccessScope;
+
+import java.util.List;
 
 /**
  * @author ginccc
  */
 public interface IDocumentDescriptorStore extends IDescriptorStore<DocumentDescriptor> {
 
+    /**
+     * Lists descriptors, returning only what {@code scope} admits.
+     * <p>
+     * The scope is a required argument rather than something resolved inside this
+     * method, so a caller that genuinely operates below the access model — the
+     * export service walking a config graph, the orphan sweep, a startup migration
+     * — has to write {@link AccessScope#unrestricted()} at the call site rather
+     * than getting unfiltered results by omission.
+     * <p>
+     * {@link #readDescriptors(String, String, Integer, Integer, boolean)} without a
+     * scope remains unrestricted, for the same internal callers and for backward
+     * compatibility; new list endpoints should use this overload.
+     *
+     * @param scope
+     *            what the caller may see; {@code null} is treated as unrestricted
+     */
+    List<DocumentDescriptor> readDescriptors(String type, String filter, Integer index, Integer limit, boolean includeDeleted, AccessScope scope)
+            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException;
+
+    /**
+     * The current descriptor for a resource id, regardless of which version the
+     * caller happens to be addressing.
+     * <p>
+     * Ownership belongs to the resource, not to one of its versions, so every
+     * access decision resolves through here — otherwise reading version 3 of a
+     * resource whose version 4 was re-shared would be decided against stale
+     * sharing.
+     *
+     * @return the descriptor at the current version
+     */
+    DocumentDescriptor readCurrentDescriptor(String resourceId)
+            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException;
 }

--- a/src/main/java/ai/labs/eddi/configs/descriptors/IRestDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/IRestDocumentDescriptorStore.java
@@ -26,6 +26,14 @@ public interface IRestDocumentDescriptorStore {
     String DESCRIPTOR_STORE_PATH = "/descriptorstore/descriptors/";
     String resourceURI = "eddi://ai.labs.descriptor" + DESCRIPTOR_STORE_PATH;
 
+    /**
+     * @param space
+     *            narrows the listing to one space id ({@code user:<principal>} or
+     *            {@code team:<group>}) — the server side of the Manager's space
+     *            switcher. A narrowing only: asking for a space you cannot reach
+     *            returns nothing rather than granting it. Blank means every space
+     *            you can reach.
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Read list of descriptors.")
@@ -35,7 +43,9 @@ public interface IRestDocumentDescriptorStore {
                                              @QueryParam("index")
                                              @DefaultValue("0") Integer index,
                                              @QueryParam("limit")
-                                             @DefaultValue("20") Integer limit);
+                                             @DefaultValue("20") Integer limit,
+                                             @QueryParam("space")
+                                             @DefaultValue("") String space);
 
     @GET
     @Path("/{id}")

--- a/src/main/java/ai/labs/eddi/configs/descriptors/ResourceUtilities.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/ResourceUtilities.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.configs.descriptors;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.memory.descriptor.model.ConversationDescriptor;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.utils.RestUtilities;
 
 import jakarta.ws.rs.BadRequestException;
@@ -42,7 +43,25 @@ public class ResourceUtilities {
         throw new BadRequestException(Response.status(BAD_REQUEST).entity(message).type(MediaType.TEXT_PLAIN).build());
     }
 
-    public static void createDocumentDescriptorForDuplicate(IDocumentDescriptorStore documentDescriptorStore, String oldId, Integer oldVersion,
+    /**
+     * Creates the descriptor for a duplicated resource.
+     *
+     * <h3>A copy belongs to whoever made it</h3> The source descriptor is used as a
+     * template for name and description only — its ownership, space, visibility and
+     * grants are stripped and the duplicating caller is stamped instead.
+     * <p>
+     * Copying them would be wrong in both directions. Duplicating a colleague's
+     * <em>published</em> agent (which anyone may read, and therefore duplicate)
+     * would file the copy under <em>their</em> name, in <em>their</em> space,
+     * leaving the person who made it unable to edit or delete it — and letting
+     * anyone inject resources into someone else's workspace, attributed to them.
+     * <p>
+     * {@code DocumentDescriptorFilter} cannot rescue this: it only creates a
+     * descriptor when none exists, and this method has already created one by the
+     * time the filter runs.
+     */
+    public static void createDocumentDescriptorForDuplicate(IDocumentDescriptorStore documentDescriptorStore,
+                                                            ResourceAccessGuard resourceAccessGuard, String oldId, Integer oldVersion,
                                                             URI newResourceLocation)
             throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
 
@@ -50,16 +69,21 @@ public class ResourceUtilities {
 
         var newResourceId = RestUtilities.extractResourceId(newResourceLocation);
 
+        DocumentDescriptor duplicate = new DocumentDescriptor();
+        duplicate.setDescription(oldDescriptor.getDescription());
         if (!isNullOrEmpty(oldDescriptor.getName())) {
-            oldDescriptor.setName(oldDescriptor.getName() + COPY_APPENDIX);
+            duplicate.setName(oldDescriptor.getName() + COPY_APPENDIX);
+        } else {
+            duplicate.setName(oldDescriptor.getName());
         }
 
-        oldDescriptor.setResource(newResourceLocation);
+        duplicate.setResource(newResourceLocation);
         Date currentTime = new Date(System.currentTimeMillis());
-        oldDescriptor.setCreatedOn(currentTime);
-        oldDescriptor.setLastModifiedOn(currentTime);
+        duplicate.setCreatedOn(currentTime);
+        duplicate.setLastModifiedOn(currentTime);
 
-        documentDescriptorStore.createDescriptor(newResourceId.getId(), newResourceId.getVersion(), oldDescriptor);
+        documentDescriptorStore.createDescriptor(newResourceId.getId(), newResourceId.getVersion(),
+                resourceAccessGuard.stampNewDescriptor(duplicate));
 
     }
 

--- a/src/main/java/ai/labs/eddi/configs/descriptors/model/AccessLevel.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/model/AccessLevel.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.descriptors.model;
+
+/**
+ * How much of a shared resource a subject may do something with.
+ * <p>
+ * Ordered least to most: each level implies every level below it, which is what
+ * {@link #includes} tests. The ordinal is deliberately the ordering — do not
+ * reorder the constants without also fixing every persisted grant, since grants
+ * are stored by name and compared by rank.
+ *
+ * <h3>Why USE and VIEW are separate</h3> An agent's configuration names its
+ * system prompt, its tools, its MCP servers and its vault references. Letting a
+ * colleague <em>talk to</em> an agent is a different act from letting them
+ * <em>read how it was built</em>, and the first is by far the more common
+ * request. A model with a single "shared" flag has to answer both with the same
+ * permission, and in practice answers them with the more generous one.
+ *
+ * @author ginccc
+ */
+public enum AccessLevel {
+
+    /**
+     * Start conversations with the deployed agent, and see its name and
+     * description. Grants nothing about the configuration itself — not the agent
+     * document, not any workflow or rule set it references.
+     */
+    USE,
+
+    /**
+     * Read the resource and the configuration graph beneath it. Does not permit any
+     * modification, deployment, or re-sharing.
+     */
+    VIEW,
+
+    /**
+     * Everything {@link #VIEW} permits, plus updating the resource and deploying
+     * it. Deliberately excludes deletion and re-sharing: those change who can reach
+     * the resource at all, which stays with the owner.
+     */
+    EDIT,
+
+    /**
+     * Full control, including delete and changing who else has access. Held by the
+     * creator, and transferable by an administrator.
+     */
+    OWN;
+
+    /**
+     * Whether holding this level satisfies a requirement for {@code required}.
+     *
+     * @param required
+     *            the level the operation demands
+     * @return {@code true} when this level is at least as permissive
+     */
+    public boolean includes(AccessLevel required) {
+        return required != null && this.ordinal() >= required.ordinal();
+    }
+
+    /**
+     * Parses a stored level, tolerating case and returning {@code null} rather than
+     * throwing for a value written by a newer version of EDDI.
+     * <p>
+     * A grant whose level cannot be parsed must not be treated as {@link #OWN} by
+     * accident, and must not blow up a listing either — callers treat {@code null}
+     * as "grants nothing".
+     */
+    public static AccessLevel parseOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        for (AccessLevel level : values()) {
+            if (level.name().equalsIgnoreCase(value.trim())) {
+                return level;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/descriptors/model/DocumentDescriptor.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/model/DocumentDescriptor.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.configs.descriptors.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 /**
@@ -19,6 +21,7 @@ public class DocumentDescriptor extends ResourceDescriptor {
     private String visibility;
     private List<ResourceGrant> grants;
     private String accessIndex;
+    private String callerLevel;
 
     public String getName() {
         return name;
@@ -116,6 +119,46 @@ public class DocumentDescriptor extends ResourceDescriptor {
 
     public void setAccessIndex(String accessIndex) {
         this.accessIndex = accessIndex;
+    }
+
+    /**
+     * What the <em>calling</em> user may do with this resource — {@code USE},
+     * {@code VIEW}, {@code EDIT} or {@code OWN} — or {@code null} when workspaces
+     * are not being enforced.
+     *
+     * <h3>Per-request, not per-resource</h3> Every other field here describes the
+     * resource. This one describes the relationship between the resource and
+     * whoever asked, so the same document serialises differently for two callers.
+     * It exists because a client cannot work it out: the grant list is disclosed at
+     * {@code OWN} only, so a listing gives a recipient no way to tell whether they
+     * may edit a row, delete it, or merely converse with it — and the alternative
+     * is offering every action and letting the server refuse, which teaches the
+     * user the product is broken rather than that the resource is not theirs.
+     *
+     * <h3>Derived, and deliberately hard to persist by accident</h3> It is stamped
+     * on the way out by {@code ResourceAccessGuard} and is <b>never</b> stored:
+     * {@code PersistenceMapperProducer} registers a mix-in that drops it, so a
+     * descriptor that is read, stamped and written back cannot carry one caller's
+     * access level into another caller's read. It is also {@code READ_ONLY}, so
+     * nothing a client sends can set it.
+     * <p>
+     * Null when enforcement is off, rather than {@code OWN}. Everyone may do
+     * everything in that state, so a level would be true but meaningless — and
+     * omitting it keeps the wire identical to a deployment that has never heard of
+     * workspaces, which is the property this whole feature is built to preserve.
+     */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public String getCallerLevel() {
+        return callerLevel;
+    }
+
+    public void setCallerLevel(String callerLevel) {
+        this.callerLevel = callerLevel;
+    }
+
+    /** The parsed caller level, or {@code null} when unset or unrecognised. */
+    public AccessLevel callerAccessLevel() {
+        return AccessLevel.parseOrNull(callerLevel);
     }
 
     /** The parsed visibility, or {@code null} when unset or unrecognised. */

--- a/src/main/java/ai/labs/eddi/configs/descriptors/model/DocumentDescriptor.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/model/DocumentDescriptor.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.configs.descriptors.model;
 
+import java.util.List;
+
 /**
  * @author ginccc
  */
@@ -11,6 +13,12 @@ public class DocumentDescriptor extends ResourceDescriptor {
     private String name;
     private String description;
     private String originId; // resource ID from the exporting instance (for merge import)
+
+    private String ownerId;
+    private String spaceId;
+    private String visibility;
+    private List<ResourceGrant> grants;
+    private String accessIndex;
 
     public String getName() {
         return name;
@@ -34,5 +42,84 @@ public class DocumentDescriptor extends ResourceDescriptor {
 
     public void setOriginId(String originId) {
         this.originId = originId;
+    }
+
+    /**
+     * The principal that created this resource, as reported by
+     * {@code SecurityIdentity}. Null on resources created before ownership was
+     * recorded, and on resources created while authentication is disabled — both of
+     * which {@code ResourceAccessGuard} treats as unowned legacy data.
+     */
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    /**
+     * The space this resource belongs to: {@code user:<principal>} for a personal
+     * space, {@code team:<group>} for a team space, or {@code legacy} for rows the
+     * backfill migration stamped.
+     */
+    public String getSpaceId() {
+        return spaceId;
+    }
+
+    public void setSpaceId(String spaceId) {
+        this.spaceId = spaceId;
+    }
+
+    /**
+     * The {@link ResourceVisibility} wire name. Stored as a string so an unknown
+     * value written by a newer version deserialises instead of failing the
+     * descriptor; {@link #resourceVisibility()} does the parsing.
+     */
+    public String getVisibility() {
+        return visibility;
+    }
+
+    public void setVisibility(String visibility) {
+        this.visibility = visibility;
+    }
+
+    /** Explicit shares. Null and empty mean the same thing: no explicit shares. */
+    public List<ResourceGrant> getGrants() {
+        return grants;
+    }
+
+    public void setGrants(List<ResourceGrant> grants) {
+        this.grants = grants;
+    }
+
+    /**
+     * The materialised access-control index — every subject that may see this
+     * resource, as pipe-delimited tokens.
+     * <p>
+     * <b>Derived, never authored.</b> It exists because
+     * {@link ai.labs.eddi.datastore.IResourceFilter} can AND groups of filters and
+     * OR filters within a group, but cannot nest — so the real policy
+     * ({@code owner OR (space AND visibility=space) OR granted OR published}) is
+     * not expressible as a query. Collapsing it into one field at write time makes
+     * a listing one indexed OR-group.
+     * <p>
+     * Rebuilt from {@code ownerId}, {@code spaceId}, {@code visibility} and
+     * {@code grants} by {@code DescriptorAccess.rebuildIndex} on every write. It is
+     * authoritative for <em>listing</em> only; a read of a single resource is
+     * decided against the structured fields, so a stale index can hide a resource
+     * from a listing but can never expose one.
+     */
+    public String getAccessIndex() {
+        return accessIndex;
+    }
+
+    public void setAccessIndex(String accessIndex) {
+        this.accessIndex = accessIndex;
+    }
+
+    /** The parsed visibility, or {@code null} when unset or unrecognised. */
+    public ResourceVisibility resourceVisibility() {
+        return ResourceVisibility.parseOrNull(visibility);
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/descriptors/model/ResourceGrant.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/model/ResourceGrant.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.descriptors.model;
+
+import java.util.Date;
+
+/**
+ * One explicit share of one resource with one subject.
+ * <p>
+ * Grants live on the {@link DocumentDescriptor} rather than in their own
+ * collection. That is a deliberate departure from
+ * {@link ai.labs.eddi.connections.grants.ConnectionGrant}, which does have its
+ * own store, and the reason is the listing path: a separate collection would
+ * mean a second query on every descriptor listing, then an {@code id IN (…)}
+ * predicate that {@link ai.labs.eddi.datastore.IResourceFilter} cannot express.
+ * Keeping grants on the descriptor lets the whole access decision collapse into
+ * the single {@code accessIndex} field that listings actually filter on.
+ * <p>
+ * A grant is a mutable bean rather than a record because the descriptor is
+ * deserialised by the same Jackson-based document builder as every other
+ * configuration document, which the codebase drives through setters.
+ *
+ * @author ginccc
+ */
+public class ResourceGrant {
+
+    private String subject;
+    private String level;
+    private String grantedBy;
+    private Date grantedOn;
+
+    public ResourceGrant() {
+    }
+
+    public ResourceGrant(String subject, String level, String grantedBy, Date grantedOn) {
+        this.subject = subject;
+        this.level = level;
+        this.grantedBy = grantedBy;
+        this.grantedOn = grantedOn;
+    }
+
+    /**
+     * The principal or team this grant is for, as a qualified subject —
+     * {@code user:<principal>} or {@code team:<group path>}. Built and parsed by
+     * {@link ai.labs.eddi.engine.security.spaces.Subjects} so the encoding stays in
+     * one place.
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+     * The {@link AccessLevel} name. Stored as a string so an unknown value from a
+     * newer version deserialises rather than failing the whole descriptor.
+     */
+    public String getLevel() {
+        return level;
+    }
+
+    public void setLevel(String level) {
+        this.level = level;
+    }
+
+    public String getGrantedBy() {
+        return grantedBy;
+    }
+
+    public void setGrantedBy(String grantedBy) {
+        this.grantedBy = grantedBy;
+    }
+
+    public Date getGrantedOn() {
+        return grantedOn;
+    }
+
+    public void setGrantedOn(Date grantedOn) {
+        this.grantedOn = grantedOn;
+    }
+
+    /** The parsed level, or {@code null} when unset or unrecognised. */
+    public AccessLevel accessLevel() {
+        return AccessLevel.parseOrNull(level);
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/descriptors/model/ResourceVisibility.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/model/ResourceVisibility.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.descriptors.model;
+
+/**
+ * Who can reach a configuration resource before any explicit grant is
+ * considered.
+ * <p>
+ * Deliberately <em>not</em> named after
+ * {@link ai.labs.eddi.configs.properties.model.Property.Visibility}, whose
+ * {@code self / group / global} refers to <em>agent</em> groups and persistent
+ * user memory. The two vocabularies sit two packages apart and mean entirely
+ * different things; sharing words between them would be a durable source of
+ * confusion in configuration, in the API, and in the Manager UI.
+ *
+ * @author ginccc
+ */
+public enum ResourceVisibility {
+
+    /** Only the owner, plus whoever holds an explicit grant. */
+    privateAccess("private"),
+
+    /**
+     * Everyone whose accessible spaces include the resource's space. The default
+     * for newly created resources: a personal space keeps it personal, a team space
+     * shares it with that team, and neither needs the creator to do anything.
+     */
+    space("space"),
+
+    /**
+     * Everyone with access to this deployment. Use for shared templates and agents
+     * meant to be discovered rather than handed out.
+     */
+    published("published");
+
+    private final String wireName;
+
+    ResourceVisibility(String wireName) {
+        this.wireName = wireName;
+    }
+
+    /**
+     * The name used in JSON and in the access index. {@code private} is a Java
+     * keyword, so the constant cannot carry it — this is what closes that gap
+     * rather than exposing {@code privateAccess} to API clients.
+     */
+    public String wireName() {
+        return wireName;
+    }
+
+    /**
+     * Parses a stored or submitted visibility.
+     *
+     * @return the matching constant, or {@code null} when the value is absent or
+     *         unrecognised — callers decide the default rather than inheriting
+     *         {@link #published} by accident.
+     */
+    public static ResourceVisibility parseOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String trimmed = value.trim();
+        for (ResourceVisibility visibility : values()) {
+            if (visibility.wireName.equalsIgnoreCase(trimmed) || visibility.name().equalsIgnoreCase(trimmed)) {
+                return visibility;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/descriptors/mongo/DocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/mongo/DocumentDescriptorStore.java
@@ -42,7 +42,8 @@ public class DocumentDescriptorStore implements IDocumentDescriptorStore {
             throws ResourceStoreException, ResourceNotFoundException {
 
         var accessRestriction = scope == null ? null : scope.toQueryFilters();
-        return descriptorStore.readDescriptors(type, filter, index, limit, includeDeleted, accessRestriction);
+        var spaceRestriction = scope == null ? null : scope.toSpaceFilter();
+        return descriptorStore.readDescriptors(type, filter, index, limit, includeDeleted, accessRestriction, spaceRestriction);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/descriptors/mongo/DocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/mongo/DocumentDescriptorStore.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.datastore.DescriptorStore;
 import ai.labs.eddi.datastore.IResourceStorageFactory;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.engine.security.spaces.AccessScope;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -33,6 +34,21 @@ public class DocumentDescriptorStore implements IDocumentDescriptorStore {
             throws ResourceStoreException, ResourceNotFoundException {
 
         return descriptorStore.readDescriptors(type, filter, index, limit, includeDeleted);
+    }
+
+    @Override
+    public List<DocumentDescriptor> readDescriptors(String type, String filter, Integer index, Integer limit, boolean includeDeleted,
+                                                    AccessScope scope)
+            throws ResourceStoreException, ResourceNotFoundException {
+
+        var accessRestriction = scope == null ? null : scope.toQueryFilters();
+        return descriptorStore.readDescriptors(type, filter, index, limit, includeDeleted, accessRestriction);
+    }
+
+    @Override
+    public DocumentDescriptor readCurrentDescriptor(String resourceId) throws ResourceStoreException, ResourceNotFoundException {
+        var currentId = descriptorStore.getCurrentResourceId(resourceId);
+        return descriptorStore.readDescriptor(resourceId, currentId.getVersion());
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
@@ -60,12 +60,15 @@ public class RestDocumentDescriptorStore implements IRestDocumentDescriptorStore
 
     @Override
     public DocumentDescriptor readDescriptor(String id, Integer version) {
-        accessGuard.requireAccess(id, AccessLevel.VIEW, "resource");
+        // The level is decided against the CURRENT descriptor and carried into the
+        // redaction below, because the version being read may be an older one whose
+        // recorded owner and grants predate a transfer or a re-share.
+        AccessLevel callerLevel = accessGuard.requireAccess(id, AccessLevel.VIEW, "resource");
         try {
             // Redaction mutates in place; the return value is deliberately unused so the
             // response can never become whatever a decorator (or a test double) returns.
             DocumentDescriptor descriptor = documentDescriptorStore.readDescriptor(id, version);
-            accessGuard.redactForCaller(descriptor);
+            accessGuard.redactUnlessOwner(descriptor, callerLevel);
             return descriptor;
         } catch (IResourceStore.ResourceStoreException e) {
             log.error(e.getLocalizedMessage(), e);

--- a/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
@@ -40,14 +40,14 @@ public class RestDocumentDescriptorStore implements IRestDocumentDescriptorStore
     }
 
     @Override
-    public List<DocumentDescriptor> readDescriptors(String type, String filter, Integer index, Integer limit) {
+    public List<DocumentDescriptor> readDescriptors(String type, String filter, Integer index, Integer limit, String space) {
         try {
             // The cross-resource listing: it takes the descriptor type as a query
             // parameter rather than deriving it from a store, which makes it the one
             // endpoint that can enumerate every configuration type in the deployment. It
             // has to carry the caller's scope for the same reason each typed store does.
             List<DocumentDescriptor> descriptors = documentDescriptorStore.readDescriptors(type, filter, index, limit, false,
-                    accessGuard.listingScope());
+                    accessGuard.listingScope().withinSpace(space));
             descriptors.forEach(accessGuard::redactForCaller);
             return descriptors;
         } catch (IResourceStore.ResourceStoreException e) {

--- a/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
@@ -8,6 +8,8 @@ import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore;
 import ai.labs.eddi.configs.patch.PatchInstruction;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.descriptors.model.SimpleDocumentDescriptor;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
@@ -27,18 +29,24 @@ import java.util.List;
 @ApplicationScoped
 public class RestDocumentDescriptorStore implements IRestDocumentDescriptorStore {
     private final IDocumentDescriptorStore documentDescriptorStore;
+    private final ResourceAccessGuard accessGuard;
 
     private static final Logger log = Logger.getLogger(RestDocumentDescriptorStore.class);
 
     @Inject
-    public RestDocumentDescriptorStore(IDocumentDescriptorStore documentDescriptorStore) {
+    public RestDocumentDescriptorStore(IDocumentDescriptorStore documentDescriptorStore, ResourceAccessGuard accessGuard) {
         this.documentDescriptorStore = documentDescriptorStore;
+        this.accessGuard = accessGuard;
     }
 
     @Override
     public List<DocumentDescriptor> readDescriptors(String type, String filter, Integer index, Integer limit) {
         try {
-            return documentDescriptorStore.readDescriptors(type, filter, index, limit, false);
+            // The cross-resource listing: it takes the descriptor type as a query
+            // parameter rather than deriving it from a store, which makes it the one
+            // endpoint that can enumerate every configuration type in the deployment. It
+            // has to carry the caller's scope for the same reason each typed store does.
+            return documentDescriptorStore.readDescriptors(type, filter, index, limit, false, accessGuard.listingScope());
         } catch (IResourceStore.ResourceStoreException e) {
             log.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getLocalizedMessage(), e);
@@ -49,6 +57,7 @@ public class RestDocumentDescriptorStore implements IRestDocumentDescriptorStore
 
     @Override
     public DocumentDescriptor readDescriptor(String id, Integer version) {
+        accessGuard.requireAccess(id, AccessLevel.VIEW, "resource");
         try {
             return documentDescriptorStore.readDescriptor(id, version);
         } catch (IResourceStore.ResourceStoreException e) {
@@ -86,6 +95,11 @@ public class RestDocumentDescriptorStore implements IRestDocumentDescriptorStore
         // with a null operation, which used to be dereferenced — a client-side shape
         // error surfaced as a 500 error page naming a line of Java. Say what was
         // expected instead.
+        // Renaming somebody else's agent is a modification of it, even though the
+        // configuration document is untouched — the name is what everyone identifies it
+        // by in every listing.
+        accessGuard.requireAccess(id, AccessLevel.EDIT, "resource");
+
         if (patchInstruction == null || patchInstruction.getOperation() == null) {
             throw new BadRequestException("A patch body must be a PatchInstruction: "
                     + "{\"operation\":\"SET|DELETE\",\"document\":{\"name\":\"…\",\"description\":\"…\"}}");
@@ -115,6 +129,10 @@ public class RestDocumentDescriptorStore implements IRestDocumentDescriptorStore
                 }
             }
 
+            // Name/description only; ownership is untouched here. The index is rebuilt so
+            // a descriptor predating it converges on this write rather than waiting for
+            // the backfill migration.
+            accessGuard.stampModification(documentDescriptor);
             documentDescriptorStore.setDescriptor(id, version, documentDescriptor);
         } catch (IResourceStore.ResourceStoreException e) {
             log.error(e.getLocalizedMessage(), e);

--- a/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStore.java
@@ -46,7 +46,10 @@ public class RestDocumentDescriptorStore implements IRestDocumentDescriptorStore
             // parameter rather than deriving it from a store, which makes it the one
             // endpoint that can enumerate every configuration type in the deployment. It
             // has to carry the caller's scope for the same reason each typed store does.
-            return documentDescriptorStore.readDescriptors(type, filter, index, limit, false, accessGuard.listingScope());
+            List<DocumentDescriptor> descriptors = documentDescriptorStore.readDescriptors(type, filter, index, limit, false,
+                    accessGuard.listingScope());
+            descriptors.forEach(accessGuard::redactForCaller);
+            return descriptors;
         } catch (IResourceStore.ResourceStoreException e) {
             log.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getLocalizedMessage(), e);
@@ -59,7 +62,11 @@ public class RestDocumentDescriptorStore implements IRestDocumentDescriptorStore
     public DocumentDescriptor readDescriptor(String id, Integer version) {
         accessGuard.requireAccess(id, AccessLevel.VIEW, "resource");
         try {
-            return documentDescriptorStore.readDescriptor(id, version);
+            // Redaction mutates in place; the return value is deliberately unused so the
+            // response can never become whatever a decorator (or a test double) returns.
+            DocumentDescriptor descriptor = documentDescriptorStore.readDescriptor(id, version);
+            accessGuard.redactForCaller(descriptor);
+            return descriptor;
         } catch (IResourceStore.ResourceStoreException e) {
             log.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getLocalizedMessage(), e);

--- a/src/main/java/ai/labs/eddi/configs/dictionary/expression/RestAction.java
+++ b/src/main/java/ai/labs/eddi/configs/dictionary/expression/RestAction.java
@@ -49,12 +49,10 @@ public class RestAction implements IRestAction {
     @Override
     public List<String> readActions(String workflowId, Integer workflowVersion, String filter, Integer limit) {
         List<String> retActions = new LinkedList<>();
-        // These endpoints fan out from one workflow into whichever rule sets, api
-        // calls,
-        // output sets and dictionaries it references, reading those stores directly.
-        // The
-        // workflow is the entry point the caller named, so it is what access is decided
-        // against — without this the helper is an unguarded read of any workflow.
+        // This fans out from one workflow into whichever rule sets, api calls, output
+        // sets and dictionaries it references, reading those stores directly. The
+        // workflow is the entry point the caller named, so it is what access is
+        // decided against — without this the helper reads any workflow, unguarded.
         accessGuard.requireAccess(workflowId, AccessLevel.VIEW, "workflow");
         try {
             var workflowConfiguration = workflowStore.read(workflowId, workflowVersion);

--- a/src/main/java/ai/labs/eddi/configs/dictionary/expression/RestAction.java
+++ b/src/main/java/ai/labs/eddi/configs/dictionary/expression/RestAction.java
@@ -10,7 +10,9 @@ import ai.labs.eddi.configs.output.IOutputStore;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration.WorkflowStep;
 import ai.labs.eddi.configs.dictionary.IRestAction;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.utils.CollectionUtilities;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -32,9 +34,12 @@ public class RestAction implements IRestAction {
     private final IRuleSetStore behaviorStore;
     private final IApiCallsStore httpCallsStore;
     private final IOutputStore outputStore;
+    private final ResourceAccessGuard accessGuard;
 
     @Inject
-    public RestAction(IWorkflowStore workflowStore, IRuleSetStore behaviorStore, IApiCallsStore httpCallsStore, IOutputStore outputStore) {
+    public RestAction(IWorkflowStore workflowStore, IRuleSetStore behaviorStore, IApiCallsStore httpCallsStore, IOutputStore outputStore,
+            ResourceAccessGuard accessGuard) {
+        this.accessGuard = accessGuard;
         this.workflowStore = workflowStore;
         this.behaviorStore = behaviorStore;
         this.httpCallsStore = httpCallsStore;
@@ -44,6 +49,13 @@ public class RestAction implements IRestAction {
     @Override
     public List<String> readActions(String workflowId, Integer workflowVersion, String filter, Integer limit) {
         List<String> retActions = new LinkedList<>();
+        // These endpoints fan out from one workflow into whichever rule sets, api
+        // calls,
+        // output sets and dictionaries it references, reading those stores directly.
+        // The
+        // workflow is the entry point the caller named, so it is what access is decided
+        // against — without this the helper is an unguarded read of any workflow.
+        accessGuard.requireAccess(workflowId, AccessLevel.VIEW, "workflow");
         try {
             var workflowConfiguration = workflowStore.read(workflowId, workflowVersion);
 

--- a/src/main/java/ai/labs/eddi/configs/dictionary/expression/RestExpression.java
+++ b/src/main/java/ai/labs/eddi/configs/dictionary/expression/RestExpression.java
@@ -43,12 +43,10 @@ public class RestExpression implements IRestExpression {
     @Override
     public List<String> readExpressions(String workflowId, Integer workflowVersion, String filter, Integer limit) {
         List<String> retExpressions = new LinkedList<>();
-        // These endpoints fan out from one workflow into whichever rule sets, api
-        // calls,
-        // output sets and dictionaries it references, reading those stores directly.
-        // The
-        // workflow is the entry point the caller named, so it is what access is decided
-        // against — without this the helper is an unguarded read of any workflow.
+        // This fans out from one workflow into whichever rule sets, api calls, output
+        // sets and dictionaries it references, reading those stores directly. The
+        // workflow is the entry point the caller named, so it is what access is
+        // decided against — without this the helper reads any workflow, unguarded.
         accessGuard.requireAccess(workflowId, AccessLevel.VIEW, "workflow");
         try {
             WorkflowConfiguration workflowConfig = workflowStore.read(workflowId, workflowVersion);

--- a/src/main/java/ai/labs/eddi/configs/dictionary/expression/RestExpression.java
+++ b/src/main/java/ai/labs/eddi/configs/dictionary/expression/RestExpression.java
@@ -8,7 +8,9 @@ import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.configs.dictionary.IDictionaryStore;
 import ai.labs.eddi.configs.dictionary.IRestExpression;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.utils.CollectionUtilities;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -29,9 +31,11 @@ import java.util.Map;
 public class RestExpression implements IRestExpression {
     private final IWorkflowStore workflowStore;
     private final IDictionaryStore regularDictionaryStore;
+    private final ResourceAccessGuard accessGuard;
 
     @Inject
-    public RestExpression(IWorkflowStore workflowStore, IDictionaryStore regularDictionaryStore) {
+    public RestExpression(IWorkflowStore workflowStore, IDictionaryStore regularDictionaryStore, ResourceAccessGuard accessGuard) {
+        this.accessGuard = accessGuard;
         this.workflowStore = workflowStore;
         this.regularDictionaryStore = regularDictionaryStore;
     }
@@ -39,6 +43,13 @@ public class RestExpression implements IRestExpression {
     @Override
     public List<String> readExpressions(String workflowId, Integer workflowVersion, String filter, Integer limit) {
         List<String> retExpressions = new LinkedList<>();
+        // These endpoints fan out from one workflow into whichever rule sets, api
+        // calls,
+        // output sets and dictionaries it references, reading those stores directly.
+        // The
+        // workflow is the entry point the caller named, so it is what access is decided
+        // against — without this the helper is an unguarded read of any workflow.
+        accessGuard.requireAccess(workflowId, AccessLevel.VIEW, "workflow");
         try {
             WorkflowConfiguration workflowConfig = workflowStore.read(workflowId, workflowVersion);
             List<IResourceStore.IResourceId> resourceIds = readDictionaryResourceIds(workflowConfig);

--- a/src/main/java/ai/labs/eddi/configs/dictionary/rest/RestDictionaryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/dictionary/rest/RestDictionaryStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.dictionary.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.patch.PatchInstruction;
 import ai.labs.eddi.configs.dictionary.IDictionaryStore;
 import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
@@ -34,8 +35,9 @@ public class RestDictionaryStore implements IRestDictionaryStore {
 
     @Inject
     public RestDictionaryStore(IDictionaryStore regularDictionaryStore, IDocumentDescriptorStore documentDescriptorStore,
-            IJsonSchemaCreator jsonSchemaCreator) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, regularDictionaryStore, documentDescriptorStore);
+            IJsonSchemaCreator jsonSchemaCreator,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, regularDictionaryStore, documentDescriptorStore, resourceAccessGuard);
         this.regularDictionaryStore = regularDictionaryStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
     }
@@ -61,6 +63,7 @@ public class RestDictionaryStore implements IRestDictionaryStore {
 
     @Override
     public List<String> readExpressions(String id, Integer version, String filter, String order, Integer index, Integer limit) {
+        restVersionInfo.requireViewAccess(id);
         try {
             return regularDictionaryStore.readExpressions(id, version, filter, order, index, limit);
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
@@ -85,6 +88,7 @@ public class RestDictionaryStore implements IRestDictionaryStore {
 
     @Override
     public Response patchRegularDictionary(String id, Integer version, List<PatchInstruction<DictionaryConfiguration>> patchInstructions) {
+        restVersionInfo.requireEditAccess(id);
         try {
             var currentDictionaryConfiguration = regularDictionaryStore.read(id, version);
             var patchedDictionaryConfiguration = patchDocument(currentDictionaryConfiguration, patchInstructions);
@@ -122,6 +126,7 @@ public class RestDictionaryStore implements IRestDictionaryStore {
 
     @Override
     public Response duplicateRegularDictionary(String id, Integer version) {
+        restVersionInfo.requireViewAccess(id);
         restVersionInfo.validateParameters(id, version);
         try {
             var regularDictionaryConfiguration = regularDictionaryStore.read(id, version);

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
@@ -108,8 +108,32 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
         return restVersionInfo.read(id, version);
     }
 
+    /**
+     * Every member agent must be one the caller may actually converse with.
+     * <p>
+     * A group's member turns run system-initiated, deliberately below the USE gate
+     * — no interactive caller exists then. So recruiting an agent into a group is
+     * the moment to check: without this, adding a colleague's private agent as a
+     * member is a standing bypass of the gate on {@code /agents/{id}/start}, with
+     * the group discussion as the read-out channel.
+     * <p>
+     * Nested groups are checked as agents here; an id that names a group rather
+     * than an agent resolves against its own descriptor, which is the right subject
+     * either way.
+     */
+    private void requireUseOnMembers(AgentGroupConfiguration configuration) {
+        if (configuration == null || configuration.getMembers() == null) {
+            return;
+        }
+        for (var member : configuration.getMembers()) {
+            if (member != null && member.agentId() != null && !member.agentId().isBlank()) {
+                resourceAccessGuard.requireAgentUseAccess(member.agentId());
+            }
+        }
+    }
     @Override
     public Response updateGroup(String id, Integer version, AgentGroupConfiguration groupConfiguration) {
+        requireUseOnMembers(groupConfiguration);
         Response response = restVersionInfo.update(id, version, groupConfiguration);
         syncDescriptor(id, groupConfiguration);
         return response;
@@ -117,6 +141,7 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
 
     @Override
     public Response createGroup(AgentGroupConfiguration groupConfiguration) {
+        requireUseOnMembers(groupConfiguration);
         Response response = restVersionInfo.create(groupConfiguration);
         // Sync name/description from config onto the descriptor
         URI location = response.getLocation();

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.groups.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
 import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
@@ -52,8 +53,9 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
 
     @Inject
     public RestAgentGroupStore(IAgentGroupStore groupStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
-            IGroupWorkspaceStore workspaceStore, IScheduleStore scheduleStore) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, groupStore, documentDescriptorStore);
+            IGroupWorkspaceStore workspaceStore, IScheduleStore scheduleStore,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, groupStore, documentDescriptorStore, resourceAccessGuard);
         this.groupStore = groupStore;
         this.documentDescriptorStore = documentDescriptorStore;
         this.jsonSchemaCreator = jsonSchemaCreator;

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStore.java
@@ -46,6 +46,7 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
 
     private final IAgentGroupStore groupStore;
     private final IDocumentDescriptorStore documentDescriptorStore;
+    private final ResourceAccessGuard resourceAccessGuard;
     private final IJsonSchemaCreator jsonSchemaCreator;
     private final IGroupWorkspaceStore workspaceStore;
     private final IScheduleStore scheduleStore;
@@ -55,6 +56,7 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
     public RestAgentGroupStore(IAgentGroupStore groupStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
             IGroupWorkspaceStore workspaceStore, IScheduleStore scheduleStore,
             ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         restVersionInfo = new RestVersionInfo<>(resourceURI, groupStore, documentDescriptorStore, resourceAccessGuard);
         this.groupStore = groupStore;
         this.documentDescriptorStore = documentDescriptorStore;
@@ -236,6 +238,10 @@ public class RestAgentGroupStore implements IRestAgentGroupStore {
                 if (config.getDescription() != null) {
                     descriptor.setDescription(config.getDescription());
                 }
+                // Stamped like any other newly created resource: this path runs when the
+                // descriptor filter has not (yet) produced one, and an unstamped descriptor
+                // would leave the group unowned.
+                resourceAccessGuard.stampNewDescriptor(descriptor);
                 try {
                     documentDescriptorStore.createDescriptor(resourceId, version, descriptor);
                 } catch (IResourceStore.ResourceStoreException ignored) {

--- a/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspace.java
@@ -4,7 +4,9 @@
  */
 package ai.labs.eddi.configs.groups.rest;
 
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestGroupWorkspace;
 import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
@@ -59,21 +61,24 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
     private final IScheduleStore scheduleStore;
     private final TeamCadenceService teamCadenceService;
     private final SecurityIdentity identity;
+    private final ResourceAccessGuard accessGuard;
 
     @Inject
     public RestGroupWorkspace(IGroupWorkspaceStore workspaceStore, IAgentGroupStore groupStore,
-            IScheduleStore scheduleStore, TeamCadenceService teamCadenceService, SecurityIdentity identity) {
+            IScheduleStore scheduleStore, TeamCadenceService teamCadenceService, SecurityIdentity identity,
+            ResourceAccessGuard accessGuard) {
         this.workspaceStore = workspaceStore;
         this.groupStore = groupStore;
         this.scheduleStore = scheduleStore;
         this.teamCadenceService = teamCadenceService;
         this.identity = identity;
+        this.accessGuard = accessGuard;
     }
 
     @Override
     public Response readWorkspace(String groupId) {
         try {
-            requireGroupExists(groupId);
+            requireGroupAccess(groupId, AccessLevel.VIEW);
             GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
             teamCadenceService.reconcile(workspace);
             return Response.ok(workspace).build();
@@ -88,7 +93,7 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
     @Override
     public Response readBacklog(String groupId) {
         try {
-            requireGroupExists(groupId);
+            requireGroupAccess(groupId, AccessLevel.VIEW);
             GroupWorkspace workspace = workspaceStore.readOrCreate(groupId);
             teamCadenceService.reconcile(workspace);
             return Response.ok(workspace.getBacklog().getTasks()).build();
@@ -124,7 +129,7 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
                     .build();
         }
         try {
-            requireGroupExists(groupId);
+            requireGroupAccess(groupId, AccessLevel.EDIT);
             String subject = request.subject().trim();
             // Optimistic-concurrency retry (review finding): the cap and duplicate
             // checks run against THIS caller's snapshot; a plain whole-document
@@ -171,7 +176,7 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
                     .entity(Map.of("error", "cronExpression is required")).build();
         }
         try {
-            requireGroupExists(groupId);
+            requireGroupAccess(groupId, AccessLevel.EDIT);
             ZoneId zone = request.timeZone() != null && !request.timeZone().isBlank()
                     ? ZoneId.of(request.timeZone())
                     : ZoneId.of("UTC");
@@ -252,7 +257,7 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
     @Override
     public Response deleteCadence(String groupId, String cadenceId) {
         try {
-            requireGroupExists(groupId);
+            requireGroupAccess(groupId, AccessLevel.EDIT);
             GroupWorkspace workspace = workspaceStore.find(groupId);
             if (workspace == null) {
                 return Response.status(Response.Status.NOT_FOUND)
@@ -284,12 +289,23 @@ public class RestGroupWorkspace implements IRestGroupWorkspace {
         }
     }
 
-    /** 404 for a workspace under a group id that names no stored group config. */
-    private void requireGroupExists(String groupId) throws IResourceStore.ResourceNotFoundException,
+    /**
+     * 404 for a workspace under a group id that names no stored group config, and
+     * 403 when the caller may not reach that group.
+     * <p>
+     * A workspace has no descriptor of its own — its backlog, cadences and metrics
+     * belong to the group. So access is decided against the <em>group's</em>
+     * descriptor, which is what every one of these endpoints is really operating
+     * on. Existence is checked first deliberately: a caller who cannot see a group
+     * should not be able to distinguish "not yours" from "does not exist", and the
+     * group id is not a secret anyway once it appears in a URL the caller composed.
+     */
+    private void requireGroupAccess(String groupId, AccessLevel required) throws IResourceStore.ResourceNotFoundException,
             IResourceStore.ResourceStoreException {
         if (groupStore.getCurrentResourceId(groupId) == null) {
             throw new IResourceStore.ResourceNotFoundException("Group not found.");
         }
+        accessGuard.requireAccess(groupId, required, "group");
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/configs/llm/rest/RestLlmStore.java
+++ b/src/main/java/ai/labs/eddi/configs/llm/rest/RestLlmStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.llm.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.llm.ILlmStore;
 import ai.labs.eddi.configs.llm.IRestLlmStore;
 import ai.labs.eddi.configs.rest.RestVersionInfo;
@@ -30,8 +31,9 @@ public class RestLlmStore implements IRestLlmStore {
     private final RestVersionInfo<LlmConfiguration> restVersionInfo;
 
     @Inject
-    public RestLlmStore(ILlmStore httpCallsStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, httpCallsStore, documentDescriptorStore);
+    public RestLlmStore(ILlmStore httpCallsStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, httpCallsStore, documentDescriptorStore, resourceAccessGuard);
         this.httpCallsStore = httpCallsStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
     }

--- a/src/main/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStore.java
+++ b/src/main/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.mcpcalls.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
 import ai.labs.eddi.configs.mcpcalls.IRestMcpCallsStore;
@@ -48,8 +49,9 @@ public class RestMcpCallsStore implements IRestMcpCallsStore {
 
     @Inject
     public RestMcpCallsStore(IMcpCallsStore mcpCallsStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
-            McpToolProviderManager mcpToolProviderManager) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, mcpCallsStore, documentDescriptorStore);
+            McpToolProviderManager mcpToolProviderManager,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, mcpCallsStore, documentDescriptorStore, resourceAccessGuard);
         this.mcpCallsStore = mcpCallsStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
         this.mcpToolProviderManager = mcpToolProviderManager;

--- a/src/main/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigration.java
+++ b/src/main/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigration.java
@@ -4,7 +4,22 @@
  */
 package ai.labs.eddi.configs.migration;
 
+import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
+import ai.labs.eddi.configs.channels.IRestChannelIntegrationStore;
+import ai.labs.eddi.configs.connections.IRestConnectionStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
+import ai.labs.eddi.configs.groups.IRestAgentGroupStore;
+import ai.labs.eddi.configs.llm.IRestLlmStore;
+import ai.labs.eddi.configs.mcpcalls.IRestMcpCallsStore;
+import ai.labs.eddi.configs.output.IRestOutputStore;
+import ai.labs.eddi.configs.parser.IRestParserStore;
+import ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore;
+import ai.labs.eddi.configs.rag.IRestRagStore;
+import ai.labs.eddi.configs.rules.IRestRuleSetStore;
+import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.migration.model.MigrationLog;
 import ai.labs.eddi.engine.security.spaces.DescriptorAccess;
@@ -15,6 +30,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * One-shot startup migration: gives every pre-existing configuration descriptor
@@ -48,13 +64,43 @@ public class WorkspaceAccessIndexMigration {
     private static final String MIGRATION_KEY = "workspace-access-index-migration-complete";
 
     /**
-     * Descriptor types to backfill. Every configuration type that has a REST store,
+     * Descriptor types to backfill: every configuration type that has a REST store,
      * because every one of them is listed through the same access predicate.
+     *
+     * <h3>Derived, not hand-written</h3> The type a listing queries comes from
+     * {@link RestUtilities#extractDescriptorType} applied to each store's own
+     * {@code resourceURI}, and several of those differ from the file-extension
+     * names used in ZIP archives — {@code ai.labs.rules} not
+     * {@code ai.labs.behavior}, {@code ai.labs.apicalls} not
+     * {@code ai.labs.httpcalls}, {@code ai.labs.llm} not {@code ai.labs.langchain},
+     * {@code ai.labs.dictionary} not {@code ai.labs.regulardictionary} (AGENTS.md
+     * §5.5). Deriving the list from the constants is what keeps a hand-written
+     * near-miss from silently backfilling nothing for a type and then recording
+     * itself as complete — which would make every rule set, api call, LLM config
+     * and dictionary vanish from every listing the moment enforcement was switched
+     * on.
+     * <p>
+     * {@code WorkspaceAccessIndexMigrationTest} asserts this against the stores.
      */
-    private static final List<String> DESCRIPTOR_TYPES = List.of(
-            "ai.labs.agent", "ai.labs.workflow", "ai.labs.behavior", "ai.labs.httpcalls", "ai.labs.mcpcalls",
-            "ai.labs.langchain", "ai.labs.output", "ai.labs.property", "ai.labs.parser", "ai.labs.regulardictionary",
-            "ai.labs.rag", "ai.labs.snippet", "ai.labs.channel", "ai.labs.connection", "ai.labs.group");
+    static final List<String> DESCRIPTOR_TYPES = Stream.of(
+            IRestAgentStore.resourceURI,
+            IRestWorkflowStore.resourceURI,
+            IRestRuleSetStore.resourceURI,
+            IRestApiCallsStore.resourceURI,
+            IRestMcpCallsStore.resourceURI,
+            IRestLlmStore.resourceURI,
+            IRestOutputStore.resourceURI,
+            IRestPropertySetterStore.resourceURI,
+            IRestParserStore.resourceURI,
+            IRestDictionaryStore.resourceURI,
+            IRestRagStore.resourceURI,
+            IRestPromptSnippetStore.resourceURI,
+            IRestChannelIntegrationStore.resourceURI,
+            IRestConnectionStore.resourceURI,
+            IRestAgentGroupStore.resourceURI)
+            .map(RestUtilities::extractDescriptorType)
+            .distinct()
+            .toList();
 
     /**
      * Page size for the sweep. Bounded so a large deployment does not load it all.
@@ -86,6 +132,7 @@ public class WorkspaceAccessIndexMigration {
 
         int stamped = 0;
         int scanned = 0;
+        boolean complete = true;
         for (String type : DESCRIPTOR_TYPES) {
             for (int page = 0; page < MAX_PAGES; page++) {
                 List<DocumentDescriptor> batch;
@@ -96,6 +143,7 @@ public class WorkspaceAccessIndexMigration {
                     batch = descriptorStore.readDescriptors(type, "", page, BATCH_SIZE, true);
                 } catch (Exception e) {
                     LOGGER.warnf("Could not read %s descriptors on page %d during access-index backfill: %s", type, page, e.getMessage());
+                    complete = false;
                     break;
                 }
                 if (batch == null || batch.isEmpty()) {
@@ -111,6 +159,17 @@ public class WorkspaceAccessIndexMigration {
                     break;
                 }
             }
+        }
+
+        if (!complete) {
+            // Deliberately NOT recording completion: a partial backfill that marks itself
+            // done leaves descriptors with no access index, and those are invisible in
+            // every listing once enforcement is on — with no way to re-run short of
+            // deleting the log row by hand. Retrying on the next startup is cheap;
+            // the stamp is idempotent.
+            LOGGER.warnv("Workspace access-index backfill INCOMPLETE ({0} scanned, {1} stamped) — it will retry on the next startup.",
+                    scanned, stamped);
+            return;
         }
 
         LOGGER.infov("Workspace access-index backfill complete: {0} descriptor(s) scanned, {1} stamped.", scanned, stamped);

--- a/src/main/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigration.java
+++ b/src/main/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigration.java
@@ -132,6 +132,7 @@ public class WorkspaceAccessIndexMigration {
 
         int stamped = 0;
         int scanned = 0;
+        int failed = 0;
         boolean complete = true;
         for (String type : DESCRIPTOR_TYPES) {
             for (int page = 0; page < MAX_PAGES; page++) {
@@ -151,12 +152,35 @@ public class WorkspaceAccessIndexMigration {
                 }
                 scanned += batch.size();
                 for (DocumentDescriptor descriptor : batch) {
-                    if (stampIfNeeded(descriptor)) {
-                        stamped++;
+                    switch (stampIfNeeded(descriptor)) {
+                        case STAMPED -> stamped++;
+                        // A write that failed is the case this whole `complete` flag
+                        // exists for: the descriptor keeps no access index, and an
+                        // unindexed descriptor is invisible in every listing once
+                        // enforcement is on. Recording the migration as done would
+                        // strand it there with no way to re-run short of deleting the
+                        // log row by hand.
+                        case FAILED -> {
+                            failed++;
+                            complete = false;
+                        }
+                        // Already correct, or unstampable at all (no resource URI, or
+                        // one that does not parse). Neither is retryable, so neither
+                        // blocks completion.
+                        case SKIPPED -> {
+                        }
                     }
                 }
                 if (batch.size() < BATCH_SIZE) {
                     break;
+                }
+                if (page == MAX_PAGES - 1) {
+                    // A full last page means there is more to read than the cap allows.
+                    // Stopping quietly here and recording completion is the same
+                    // stranding as a failed write, just reached by a different route.
+                    LOGGER.warnf("Access-index backfill hit the %d-page cap for %s with a full page — more descriptors remain.",
+                            MAX_PAGES, type);
+                    complete = false;
                 }
             }
         }
@@ -167,8 +191,10 @@ public class WorkspaceAccessIndexMigration {
             // every listing once enforcement is on — with no way to re-run short of
             // deleting the log row by hand. Retrying on the next startup is cheap;
             // the stamp is idempotent.
-            LOGGER.warnv("Workspace access-index backfill INCOMPLETE ({0} scanned, {1} stamped) — it will retry on the next startup.",
-                    scanned, stamped);
+            LOGGER.warnv(
+                    "Workspace access-index backfill INCOMPLETE ({0} scanned, {1} stamped, {2} failed to write) "
+                            + "— it will retry on the next startup.",
+                    scanned, stamped, failed);
             return;
         }
 
@@ -177,31 +203,51 @@ public class WorkspaceAccessIndexMigration {
     }
 
     /**
-     * @return whether the descriptor was written
+     * What happened to one descriptor.
+     *
+     * <h3>Why three and not a boolean</h3> "Not written" meant two unrelated
+     * things: already correct, and <em>could not be written</em>. Collapsing them
+     * let a run where every write threw record itself as complete, which is the one
+     * outcome this migration's own comments say must never happen.
      */
-    private boolean stampIfNeeded(DocumentDescriptor descriptor) {
+    private enum StampOutcome {
+        /** Written. */
+        STAMPED,
+        /**
+         * Already correct, or carrying nothing that could be stamped. Not retryable.
+         */
+        SKIPPED,
+        /** The write threw. Retryable, and completion must wait for it. */
+        FAILED
+    }
+
+    private StampOutcome stampIfNeeded(DocumentDescriptor descriptor) {
         if (descriptor == null || descriptor.getResource() == null) {
-            return false;
+            return StampOutcome.SKIPPED;
         }
         String rebuilt = DescriptorAccess.buildIndex(descriptor);
         if (rebuilt.equals(descriptor.getAccessIndex())) {
-            return false;
+            return StampOutcome.SKIPPED;
         }
         descriptor.setAccessIndex(rebuilt);
 
         var resourceId = RestUtilities.extractResourceId(descriptor.getResource());
         if (resourceId == null || resourceId.getId() == null || resourceId.getVersion() == null) {
-            return false;
+            // Nothing to address. Retrying would fail identically forever, so this must
+            // not hold the migration open — but it is worth saying out loud, because a
+            // descriptor with an unparseable resource URI is a data problem of its own.
+            LOGGER.warnf("Descriptor with unusable resource URI skipped during access-index backfill: %s", descriptor.getResource());
+            return StampOutcome.SKIPPED;
         }
         try {
             // setDescriptor writes in place. A backfill must not create a version: doing so
             // would make every pre-existing resource look as though it had just been
             // edited.
             descriptorStore.setDescriptor(resourceId.getId(), resourceId.getVersion(), descriptor);
-            return true;
+            return StampOutcome.STAMPED;
         } catch (Exception e) {
             LOGGER.warnf("Could not stamp access index on descriptor %s v%s: %s", resourceId.getId(), resourceId.getVersion(), e.getMessage());
-            return false;
+            return StampOutcome.FAILED;
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigration.java
+++ b/src/main/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigration.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.migration;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.migration.model.MigrationLog;
+import ai.labs.eddi.engine.security.spaces.DescriptorAccess;
+import ai.labs.eddi.engine.security.spaces.Subjects;
+import ai.labs.eddi.utils.RestUtilities;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.List;
+
+/**
+ * One-shot startup migration: gives every pre-existing configuration descriptor
+ * an access index, so workspace filtering can be switched on without hiding
+ * everything that already exists.
+ *
+ * <h3>Why an explicit backfill is required, not optional</h3> Listings filter
+ * on {@code accessIndex}, and neither backend can express "this field is
+ * absent" — a regex predicate simply does not match a missing field on MongoDB,
+ * and {@code jsonb ->> 'accessIndex'} is null on PostgreSQL. So a descriptor
+ * written before this feature would match no access predicate at all and vanish
+ * from every listing the moment enforcement is enabled. Stamping the
+ * {@link Subjects#LEGACY} token is what keeps that from happening.
+ * <p>
+ * Descriptors that already carry an owner or a space are re-indexed rather than
+ * skipped: the index is derived state, and rebuilding it is idempotent.
+ *
+ * <h3>It does not invent owners</h3> A descriptor with no {@code ownerId} keeps
+ * none. Attribution cannot be reconstructed after the fact, and guessing (the
+ * first admin? the deployment owner?) would produce confident, wrong answers
+ * that are worse than an honest "unowned". Whether unowned resources stay
+ * visible is the operator's call, via
+ * {@code eddi.workspaces.legacy-visibility}.
+ *
+ * @since 6.3.0
+ */
+@ApplicationScoped
+public class WorkspaceAccessIndexMigration {
+
+    private static final Logger LOGGER = Logger.getLogger(WorkspaceAccessIndexMigration.class);
+    private static final String MIGRATION_KEY = "workspace-access-index-migration-complete";
+
+    /**
+     * Descriptor types to backfill. Every configuration type that has a REST store,
+     * because every one of them is listed through the same access predicate.
+     */
+    private static final List<String> DESCRIPTOR_TYPES = List.of(
+            "ai.labs.agent", "ai.labs.workflow", "ai.labs.behavior", "ai.labs.httpcalls", "ai.labs.mcpcalls",
+            "ai.labs.langchain", "ai.labs.output", "ai.labs.property", "ai.labs.parser", "ai.labs.regulardictionary",
+            "ai.labs.rag", "ai.labs.snippet", "ai.labs.channel", "ai.labs.connection", "ai.labs.group");
+
+    /**
+     * Page size for the sweep. Bounded so a large deployment does not load it all.
+     */
+    private static final int BATCH_SIZE = 200;
+
+    /**
+     * Pages scanned per type before giving up. At {@value #BATCH_SIZE} per page
+     * this is 200 000 descriptors of one type — far beyond any real deployment, and
+     * a backstop against a store whose paging never advances.
+     */
+    private static final int MAX_PAGES = 1000;
+
+    private final IDocumentDescriptorStore descriptorStore;
+    private final IMigrationLogStore migrationLogStore;
+
+    @Inject
+    public WorkspaceAccessIndexMigration(IDocumentDescriptorStore descriptorStore, IMigrationLogStore migrationLogStore) {
+        this.descriptorStore = descriptorStore;
+        this.migrationLogStore = migrationLogStore;
+    }
+
+    /** Runs the backfill unless it has already completed. */
+    public void runIfNeeded() {
+        if (migrationLogStore.readMigrationLog(MIGRATION_KEY) != null) {
+            LOGGER.debug("Workspace access-index migration already applied — skipping");
+            return;
+        }
+
+        int stamped = 0;
+        int scanned = 0;
+        for (String type : DESCRIPTOR_TYPES) {
+            for (int page = 0; page < MAX_PAGES; page++) {
+                List<DocumentDescriptor> batch;
+                try {
+                    // Unrestricted deliberately: a migration runs below the access model, and
+                    // filtering the backfill by an access index that does not exist yet would
+                    // return nothing.
+                    batch = descriptorStore.readDescriptors(type, "", page, BATCH_SIZE, true);
+                } catch (Exception e) {
+                    LOGGER.warnf("Could not read %s descriptors on page %d during access-index backfill: %s", type, page, e.getMessage());
+                    break;
+                }
+                if (batch == null || batch.isEmpty()) {
+                    break;
+                }
+                scanned += batch.size();
+                for (DocumentDescriptor descriptor : batch) {
+                    if (stampIfNeeded(descriptor)) {
+                        stamped++;
+                    }
+                }
+                if (batch.size() < BATCH_SIZE) {
+                    break;
+                }
+            }
+        }
+
+        LOGGER.infov("Workspace access-index backfill complete: {0} descriptor(s) scanned, {1} stamped.", scanned, stamped);
+        migrationLogStore.createMigrationLog(new MigrationLog(MIGRATION_KEY));
+    }
+
+    /**
+     * @return whether the descriptor was written
+     */
+    private boolean stampIfNeeded(DocumentDescriptor descriptor) {
+        if (descriptor == null || descriptor.getResource() == null) {
+            return false;
+        }
+        String rebuilt = DescriptorAccess.buildIndex(descriptor);
+        if (rebuilt.equals(descriptor.getAccessIndex())) {
+            return false;
+        }
+        descriptor.setAccessIndex(rebuilt);
+
+        var resourceId = RestUtilities.extractResourceId(descriptor.getResource());
+        if (resourceId == null || resourceId.getId() == null || resourceId.getVersion() == null) {
+            return false;
+        }
+        try {
+            // setDescriptor writes in place. A backfill must not create a version: doing so
+            // would make every pre-existing resource look as though it had just been
+            // edited.
+            descriptorStore.setDescriptor(resourceId.getId(), resourceId.getVersion(), descriptor);
+            return true;
+        } catch (Exception e) {
+            LOGGER.warnf("Could not stamp access index on descriptor %s v%s: %s", resourceId.getId(), resourceId.getVersion(), e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/output/rest/RestOutputStore.java
+++ b/src/main/java/ai/labs/eddi/configs/output/rest/RestOutputStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.output.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.output.IOutputStore;
 import ai.labs.eddi.configs.output.IRestOutputStore;
 import ai.labs.eddi.configs.output.model.OutputConfigurationSet;
@@ -33,8 +34,9 @@ public class RestOutputStore implements IRestOutputStore {
     private final RestVersionInfo<OutputConfigurationSet> restVersionInfo;
 
     @Inject
-    public RestOutputStore(IOutputStore outputStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, outputStore, documentDescriptorStore);
+    public RestOutputStore(IOutputStore outputStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, outputStore, documentDescriptorStore, resourceAccessGuard);
         this.outputStore = outputStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
     }
@@ -55,6 +57,9 @@ public class RestOutputStore implements IRestOutputStore {
 
     @Override
     public OutputConfigurationSet readOutputSet(String id, Integer version, String filter, String order, Integer index, Integer limit) {
+        // Reaches IOutputStore directly for its filter/order arguments, so the check
+        // RestVersionInfo.read would have applied has to be made explicitly here.
+        restVersionInfo.requireViewAccess(id);
         try {
             return outputStore.read(id, version, filter, order, index, limit);
         } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
@@ -64,6 +69,7 @@ public class RestOutputStore implements IRestOutputStore {
 
     @Override
     public List<String> readOutputKeys(String id, Integer version, String filter, Integer limit) {
+        restVersionInfo.requireViewAccess(id);
         try {
             return outputStore.readActions(id, version, filter, limit);
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
@@ -88,6 +94,7 @@ public class RestOutputStore implements IRestOutputStore {
 
     @Override
     public Response patchOutputSet(String id, Integer version, List<PatchInstruction<OutputConfigurationSet>> patchInstructions) {
+        restVersionInfo.requireEditAccess(id);
         try {
             OutputConfigurationSet currentOutputConfigurationSet = outputStore.read(id, version);
             OutputConfigurationSet patchedOutputConfigurationSet = patchDocument(currentOutputConfigurationSet, patchInstructions);
@@ -120,6 +127,9 @@ public class RestOutputStore implements IRestOutputStore {
 
     @Override
     public Response duplicateOutputSet(String id, Integer version) {
+        // Duplicating reads the source, so it needs read access to it; the copy is
+        // created fresh and stamped to the caller by DocumentDescriptorFilter.
+        restVersionInfo.requireViewAccess(id);
         restVersionInfo.validateParameters(id, version);
         try {
             var outputConfigurationSet = outputStore.read(id, version);

--- a/src/main/java/ai/labs/eddi/configs/output/rest/keys/RestOutputActions.java
+++ b/src/main/java/ai/labs/eddi/configs/output/rest/keys/RestOutputActions.java
@@ -51,12 +51,10 @@ public class RestOutputActions implements IRestOutputActions {
     @Override
     public List<String> readOutputActions(String workflowId, Integer workflowVersion, String filter, Integer limit) {
         List<String> retOutputKeys = new LinkedList<>();
-        // These endpoints fan out from one workflow into whichever rule sets, api
-        // calls,
-        // output sets and dictionaries it references, reading those stores directly.
-        // The
-        // workflow is the entry point the caller named, so it is what access is decided
-        // against — without this the helper is an unguarded read of any workflow.
+        // This fans out from one workflow into whichever rule sets, api calls, output
+        // sets and dictionaries it references, reading those stores directly. The
+        // workflow is the entry point the caller named, so it is what access is
+        // decided against — without this the helper reads any workflow, unguarded.
         accessGuard.requireAccess(workflowId, AccessLevel.VIEW, "workflow");
         try {
             WorkflowConfiguration workflowConfig = workflowStore.read(workflowId, workflowVersion);

--- a/src/main/java/ai/labs/eddi/configs/output/rest/keys/RestOutputActions.java
+++ b/src/main/java/ai/labs/eddi/configs/output/rest/keys/RestOutputActions.java
@@ -12,7 +12,9 @@ import ai.labs.eddi.configs.output.IOutputStore;
 import ai.labs.eddi.configs.output.keys.IRestOutputActions;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
 import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.utils.CollectionUtilities;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -35,9 +37,12 @@ public class RestOutputActions implements IRestOutputActions {
     private final IWorkflowStore workflowStore;
     private final IRuleSetStore behaviorStore;
     private final IOutputStore outputStore;
+    private final ResourceAccessGuard accessGuard;
 
     @Inject
-    public RestOutputActions(IWorkflowStore workflowStore, IRuleSetStore behaviorStore, IOutputStore outputStore) {
+    public RestOutputActions(IWorkflowStore workflowStore, IRuleSetStore behaviorStore, IOutputStore outputStore,
+            ResourceAccessGuard accessGuard) {
+        this.accessGuard = accessGuard;
         this.workflowStore = workflowStore;
         this.behaviorStore = behaviorStore;
         this.outputStore = outputStore;
@@ -46,6 +51,13 @@ public class RestOutputActions implements IRestOutputActions {
     @Override
     public List<String> readOutputActions(String workflowId, Integer workflowVersion, String filter, Integer limit) {
         List<String> retOutputKeys = new LinkedList<>();
+        // These endpoints fan out from one workflow into whichever rule sets, api
+        // calls,
+        // output sets and dictionaries it references, reading those stores directly.
+        // The
+        // workflow is the entry point the caller named, so it is what access is decided
+        // against — without this the helper is an unguarded read of any workflow.
+        accessGuard.requireAccess(workflowId, AccessLevel.VIEW, "workflow");
         try {
             WorkflowConfiguration workflowConfig = workflowStore.read(workflowId, workflowVersion);
             List<IResourceStore.IResourceId> resourceIds;

--- a/src/main/java/ai/labs/eddi/configs/parser/rest/RestParserStore.java
+++ b/src/main/java/ai/labs/eddi/configs/parser/rest/RestParserStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.parser.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.parser.IParserStore;
 import ai.labs.eddi.configs.parser.IRestParserStore;
 import ai.labs.eddi.configs.parser.model.ParserConfiguration;
@@ -26,8 +27,9 @@ public class RestParserStore implements IRestParserStore {
     private final RestVersionInfo<ParserConfiguration> restVersionInfo;
 
     @Inject
-    public RestParserStore(IParserStore parserStore, IDocumentDescriptorStore documentDescriptorStore) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, parserStore, documentDescriptorStore);
+    public RestParserStore(IParserStore parserStore, IDocumentDescriptorStore documentDescriptorStore,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, parserStore, documentDescriptorStore, resourceAccessGuard);
         this.parserStore = parserStore;
     }
 

--- a/src/main/java/ai/labs/eddi/configs/propertysetter/rest/RestPropertySetterStore.java
+++ b/src/main/java/ai/labs/eddi/configs/propertysetter/rest/RestPropertySetterStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.propertysetter.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.propertysetter.IPropertySetterStore;
 import ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore;
 import ai.labs.eddi.configs.propertysetter.model.PropertySetterConfiguration;
@@ -31,8 +32,9 @@ public class RestPropertySetterStore implements IRestPropertySetterStore {
 
     @Inject
     public RestPropertySetterStore(IPropertySetterStore propertySetterStore, IDocumentDescriptorStore documentDescriptorStore,
-            IJsonSchemaCreator jsonSchemaCreator) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, propertySetterStore, documentDescriptorStore);
+            IJsonSchemaCreator jsonSchemaCreator,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, propertySetterStore, documentDescriptorStore, resourceAccessGuard);
         this.propertySetterStore = propertySetterStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
     }

--- a/src/main/java/ai/labs/eddi/configs/rag/rest/RestRagIngestion.java
+++ b/src/main/java/ai/labs/eddi/configs/rag/rest/RestRagIngestion.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.configs.rag.rest;
 
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.rag.IRestRagIngestion;
 import ai.labs.eddi.configs.rag.IRestRagStore;
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
@@ -29,8 +31,11 @@ public class RestRagIngestion implements IRestRagIngestion {
     private final IRestRagStore restRagStore;
     private final RagIngestionService ragIngestionService;
 
+    private final ResourceAccessGuard resourceAccessGuard;
+
     @Inject
-    public RestRagIngestion(IRestRagStore restRagStore, RagIngestionService ragIngestionService) {
+    public RestRagIngestion(IRestRagStore restRagStore, RagIngestionService ragIngestionService, ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         this.restRagStore = restRagStore;
         this.ragIngestionService = ragIngestionService;
     }
@@ -40,6 +45,15 @@ public class RestRagIngestion implements IRestRagIngestion {
         if (documentContent == null || documentContent.isBlank()) {
             return Response.status(Response.Status.BAD_REQUEST).entity(Map.of("error", "Document content is required")).build();
         }
+
+        // EDIT, not the VIEW that reading the config needs. Ingestion writes documents
+        // into the knowledge base every agent using this config retrieves from, so
+        // gating it on read access would let anyone poison a *published* RAG config's
+        // knowledge base — published grants VIEW to everyone by design.
+        //
+        // Checked before readRag so the refusal is a 403: the catch below turns any
+        // exception into a 404, which would otherwise mask the real answer.
+        resourceAccessGuard.requireAccess(ragConfigId, AccessLevel.EDIT, "RAG configuration");
 
         RagConfiguration ragConfig;
         try {
@@ -63,6 +77,9 @@ public class RestRagIngestion implements IRestRagIngestion {
 
     @Override
     public Response getIngestionStatus(String ragConfigId, String ingestionId) {
+        // The status of an ingestion is only meaningful to whoever could have started
+        // it, and the caller names the RAG config in the path — so check it.
+        resourceAccessGuard.requireAccess(ragConfigId, AccessLevel.VIEW, "RAG configuration");
         String status = ragIngestionService.getStatus(ingestionId);
         return Response.ok(Map.of("ingestionId", ingestionId, "status", status)).build();
     }

--- a/src/main/java/ai/labs/eddi/configs/rag/rest/RestRagStore.java
+++ b/src/main/java/ai/labs/eddi/configs/rag/rest/RestRagStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.rag.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.rag.IRagStore;
 import ai.labs.eddi.configs.rag.IRestRagStore;
@@ -36,8 +37,9 @@ public class RestRagStore implements IRestRagStore {
     private final RestVersionInfo<RagConfiguration> restVersionInfo;
 
     @Inject
-    public RestRagStore(IRagStore ragStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, ragStore, documentDescriptorStore);
+    public RestRagStore(IRagStore ragStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, ragStore, documentDescriptorStore, resourceAccessGuard);
         this.ragStore = ragStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
     }

--- a/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
@@ -23,10 +23,12 @@ import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
  * The shared CRUD body behind all fifteen configuration resource types.
  *
  * <h3>This is where the authoring surface is guarded</h3> Every
- * {@code IRest*Store} delegates its list / read / update / delete here, and the
- * MCP admin tools call those same beans in-process — so one
- * {@link ResourceAccessGuard} here covers both surfaces, rather than fifteen
- * stores each remembering to check.
+ * {@code IRest*Store} delegates its list / read / update / delete here, so one
+ * {@link ResourceAccessGuard} covers all fifteen types rather than each store
+ * remembering to check. MCP tools that hold an injected facade inherit it
+ * through the same beans; MCP tools that resolve a store through
+ * {@code IRestInterfaceFactory} make a loopback HTTP call instead and are
+ * subject to the endpoint's checks, not this object's.
  * <p>
  * The engine deliberately does <em>not</em> pass through this class: since the
  * runtime/authoring split, {@code ResourceClientLibrary.getResource} and the

--- a/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.configs.rest;
 import ai.labs.eddi.configs.IRestVersionInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.engine.security.spaces.AccessScope;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
@@ -79,13 +80,31 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
         return readDescriptors(RestUtilities.extractDescriptorType(resourceURI), filter, index, limit);
     }
 
+    /**
+     * As {@link #readDescriptors(String, Integer, Integer)}, narrowed to one space.
+     * <p>
+     * The narrowing happens in the query for the same reason the access predicate
+     * does: filtering a page after the fact returns short pages, and page 2 of
+     * "everything" is not page 2 of "this space". It can only ever remove rows —
+     * see {@link AccessScope#withinSpace}.
+     */
+    public List<DocumentDescriptor> readDescriptors(String filter, Integer index, Integer limit, String space) {
+        return readDescriptors(RestUtilities.extractDescriptorType(resourceURI), filter, index, limit,
+                accessGuard.listingScope().withinSpace(space));
+    }
+
     public List<DocumentDescriptor> readDescriptors(String type, String filter, Integer index, Integer limit) {
+        return readDescriptors(type, filter, index, limit, accessGuard.listingScope());
+    }
+
+    private List<DocumentDescriptor> readDescriptors(String type, String filter, Integer index, Integer limit,
+                                                     AccessScope scope) {
         try {
             // Filtered in the query rather than on the returned page: post-filtering
             // returns short pages and forces the scan-budgeted back-fill that conversation
             // listing has to do, where no such predicate exists.
             List<DocumentDescriptor> descriptors = documentDescriptorStore.readDescriptors(type, filter, index, limit, false,
-                    accessGuard.listingScope());
+                    scope);
             // The scope decides WHICH rows come back; this decides how much of each row a
             // non-owner gets to read. Without it every listing serialises the grant list.
             descriptors.forEach(accessGuard::redactForCaller);

--- a/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
@@ -6,6 +6,8 @@ package ai.labs.eddi.configs.rest;
 
 import ai.labs.eddi.configs.IRestVersionInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.utils.RestUtilities;
@@ -18,21 +20,54 @@ import java.util.List;
 import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
 
 /**
+ * The shared CRUD body behind all fifteen configuration resource types.
+ *
+ * <h3>This is where the authoring surface is guarded</h3> Every
+ * {@code IRest*Store} delegates its list / read / update / delete here, and the
+ * MCP admin tools call those same beans in-process — so one
+ * {@link ResourceAccessGuard} here covers both surfaces, rather than fifteen
+ * stores each remembering to check.
+ * <p>
+ * The engine deliberately does <em>not</em> pass through this class: since the
+ * runtime/authoring split, {@code ResourceClientLibrary.getResource} and the
+ * runtime store services read {@link IResourceStore} directly. A conversation
+ * turn runs under the chatting user's identity, and requiring them to own the
+ * agent's configuration would break every shared agent.
+ *
  * @author ginccc
  */
 public class RestVersionInfo<T> implements IRestVersionInfo {
     private final String resourceURI;
     private final IResourceStore<T> resourceStore;
     protected final IDocumentDescriptorStore documentDescriptorStore;
+    private final ResourceAccessGuard accessGuard;
+    private final String resourceTypeLabel;
 
-    public RestVersionInfo(String resourceURI, IResourceStore<T> resourceStore, IDocumentDescriptorStore documentDescriptorStore) {
+    public RestVersionInfo(String resourceURI, IResourceStore<T> resourceStore, IDocumentDescriptorStore documentDescriptorStore,
+            ResourceAccessGuard accessGuard) {
         this.resourceURI = resourceURI;
         this.resourceStore = resourceStore;
         this.documentDescriptorStore = documentDescriptorStore;
+        this.accessGuard = accessGuard;
+        this.resourceTypeLabel = toResourceTypeLabel(resourceURI);
     }
 
     /**
-     * The descriptors of the resources <em>this</em> store owns.
+     * "ai.labs.agent" reads as noise in a 403 body; "agent" does not. Falls back to
+     * the raw descriptor type if the URI is not in the expected shape.
+     */
+    private static String toResourceTypeLabel(String resourceURI) {
+        String type = RestUtilities.extractDescriptorType(resourceURI);
+        if (type == null || type.isBlank()) {
+            return "resource";
+        }
+        int lastDot = type.lastIndexOf('.');
+        return lastDot >= 0 && lastDot < type.length() - 1 ? type.substring(lastDot + 1) : type;
+    }
+
+    /**
+     * The descriptors of the resources <em>this</em> store owns, restricted to what
+     * the caller may see.
      * <p>
      * Prefer this over {@link #readDescriptors(String, String, Integer, Integer)}:
      * the descriptor type is derived from the store's own {@code resourceURI}, so a
@@ -44,10 +79,41 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
 
     public List<DocumentDescriptor> readDescriptors(String type, String filter, Integer index, Integer limit) {
         try {
-            return documentDescriptorStore.readDescriptors(type, filter, index, limit, false);
+            // Filtered in the query rather than on the returned page: post-filtering
+            // returns short pages and forces the scan-budgeted back-fill that conversation
+            // listing has to do, where no such predicate exists.
+            return documentDescriptorStore.readDescriptors(type, filter, index, limit, false, accessGuard.listingScope());
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
             throw sneakyThrow(e);
         }
+    }
+
+    /**
+     * Asserts the caller may read this resource. Exposed for the stores whose read
+     * methods bypass {@link #read} because they take extra filter arguments —
+     * {@code RestOutputStore.readOutputSet} and
+     * {@code RestDictionaryStore.readExpressions} among them — so those cannot be
+     * left unguarded by accident.
+     */
+    public void requireViewAccess(String id) {
+        accessGuard.requireAccess(id, AccessLevel.VIEW, resourceTypeLabel);
+    }
+
+    /** Asserts the caller may modify this resource. */
+    public void requireEditAccess(String id) {
+        accessGuard.requireAccess(id, AccessLevel.EDIT, resourceTypeLabel);
+    }
+
+    /**
+     * Asserts the caller may delete or re-share this resource.
+     * <p>
+     * {@link #delete} applies this itself, but a cascading delete tears down
+     * referenced resources <em>before</em> deleting the resource named in the
+     * request — so a cascade must check first, or an unauthorised caller destroys
+     * the graph on the way to being refused.
+     */
+    public void requireOwnAccess(String id) {
+        accessGuard.requireAccess(id, AccessLevel.OWN, resourceTypeLabel);
     }
 
     public Response create(T document) {
@@ -90,6 +156,11 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
         RuntimeUtilities.checkNotNull(version, "version");
         RuntimeUtilities.checkNotNegative(version, "version");
 
+        // Checked against the CURRENT descriptor, not the addressed version: ownership
+        // and sharing belong to the resource, so reading an old version of a resource
+        // that was since re-shared must not be decided against stale sharing.
+        requireViewAccess(id);
+
         try {
             return resourceStore.read(id, version);
         } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
@@ -98,6 +169,7 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
     }
 
     public Response update(String id, Integer version, T document) {
+        requireEditAccess(id);
         version = validateParameters(id, version);
         RuntimeUtilities.checkNotNull(document, "document");
 
@@ -114,7 +186,16 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
         return delete(id, version, false);
     }
 
+    /**
+     * Deleting requires {@link AccessLevel#OWN}, not {@code EDIT}.
+     * <p>
+     * A teammate sharing a space gets {@code EDIT}, so they can change a
+     * colleague's agent but not remove it. Deletion and re-sharing both change who
+     * can reach the resource at all, and both stay with whoever made it — plus
+     * administrators, whom {@code seesEverything()} admits.
+     */
     public Response delete(String id, Integer version, boolean permanent) {
+        accessGuard.requireAccess(id, AccessLevel.OWN, resourceTypeLabel);
         version = validateParameters(id, version);
 
         try {

--- a/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
@@ -84,7 +84,12 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
             // Filtered in the query rather than on the returned page: post-filtering
             // returns short pages and forces the scan-budgeted back-fill that conversation
             // listing has to do, where no such predicate exists.
-            return documentDescriptorStore.readDescriptors(type, filter, index, limit, false, accessGuard.listingScope());
+            List<DocumentDescriptor> descriptors = documentDescriptorStore.readDescriptors(type, filter, index, limit, false,
+                    accessGuard.listingScope());
+            // The scope decides WHICH rows come back; this decides how much of each row a
+            // non-owner gets to read. Without it every listing serialises the grant list.
+            descriptors.forEach(accessGuard::redactForCaller);
+            return descriptors;
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceNotFoundException e) {
             throw sneakyThrow(e);
         }

--- a/src/main/java/ai/labs/eddi/configs/rules/rest/RestRuleSetStore.java
+++ b/src/main/java/ai/labs/eddi/configs/rules/rest/RestRuleSetStore.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.rules.IRuleSetStore;
 import ai.labs.eddi.configs.rules.IRestRuleSetStore;
 import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.rest.RestVersionInfo;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
 import ai.labs.eddi.datastore.IResourceStore;
@@ -30,8 +31,9 @@ public class RestRuleSetStore implements IRestRuleSetStore {
     private final RestVersionInfo<RuleSetConfiguration> restVersionInfo;
 
     @Inject
-    public RestRuleSetStore(IRuleSetStore behaviorStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, behaviorStore, documentDescriptorStore);
+    public RestRuleSetStore(IRuleSetStore behaviorStore, IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, behaviorStore, documentDescriptorStore, resourceAccessGuard);
         this.behaviorStore = behaviorStore;
         this.jsonSchemaCreator = jsonSchemaCreator;
     }

--- a/src/main/java/ai/labs/eddi/configs/snippets/rest/RestPromptSnippetStore.java
+++ b/src/main/java/ai/labs/eddi/configs/snippets/rest/RestPromptSnippetStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.snippets.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.snippets.IPromptSnippetStore;
 import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
 import ai.labs.eddi.configs.snippets.model.PromptSnippet;
@@ -35,9 +36,10 @@ public class RestPromptSnippetStore implements IRestPromptSnippetStore {
 
     @Inject
     public RestPromptSnippetStore(IPromptSnippetStore snippetStore, IDocumentDescriptorStore documentDescriptorStore,
-            PromptSnippetService snippetService) {
+            PromptSnippetService snippetService,
+            ResourceAccessGuard resourceAccessGuard) {
         this.snippetStore = snippetStore;
-        this.restVersionInfo = new RestVersionInfo<>(resourceURI, snippetStore, documentDescriptorStore);
+        this.restVersionInfo = new RestVersionInfo<>(resourceURI, snippetStore, documentDescriptorStore, resourceAccessGuard);
         this.snippetService = snippetService;
     }
 
@@ -48,6 +50,7 @@ public class RestPromptSnippetStore implements IRestPromptSnippetStore {
 
     @Override
     public PromptSnippet readSnippet(String id, Integer version) {
+        restVersionInfo.requireViewAccess(id);
         try {
             return snippetStore.read(id, version);
         } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
@@ -68,7 +68,8 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         if (descriptors == null || descriptors.isEmpty()) {
             return descriptors;
         }
-        return descriptors.stream().filter(d -> resourceAccessGuard.canAccess(d, AccessLevel.VIEW)).toList();
+        return descriptors.stream().filter(d -> resourceAccessGuard.canAccess(d, AccessLevel.VIEW))
+                .map(resourceAccessGuard::redactForCaller).toList();
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.workflows.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
@@ -46,8 +47,9 @@ public class RestWorkflowStore implements IRestWorkflowStore {
 
     @Inject
     public RestWorkflowStore(IWorkflowStore workflowStore, ResourceClientLibrary resourceClientLibrary,
-            IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator) {
-        restVersionInfo = new RestVersionInfo<>(resourceURI, workflowStore, documentDescriptorStore);
+            IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
+            ResourceAccessGuard resourceAccessGuard) {
+        restVersionInfo = new RestVersionInfo<>(resourceURI, workflowStore, documentDescriptorStore, resourceAccessGuard);
         this.documentDescriptorStore = documentDescriptorStore;
         this.workflowStore = workflowStore;
         this.resourceClientLibrary = resourceClientLibrary;
@@ -158,6 +160,9 @@ public class RestWorkflowStore implements IRestWorkflowStore {
 
     @Override
     public Response deleteWorkflow(String id, Integer version, Boolean permanent, Boolean cascade) {
+        // Before the cascade, not after: restVersionInfo.delete() checks at the end,
+        // by which point the referenced resources would already be gone.
+        restVersionInfo.requireOwnAccess(id);
         if (cascade) {
             try {
                 WorkflowConfiguration workflowConfig = workflowStore.read(id, version);
@@ -244,6 +249,7 @@ public class RestWorkflowStore implements IRestWorkflowStore {
 
     @Override
     public Response duplicateWorkflow(String id, Integer version, Boolean deepCopy) {
+        restVersionInfo.requireViewAccess(id);
         restVersionInfo.validateParameters(id, version);
         try {
             WorkflowConfiguration workflowConfig = workflowStore.read(id, version);

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.workflows.rest;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
@@ -42,6 +43,7 @@ public class RestWorkflowStore implements IRestWorkflowStore {
     private final IJsonSchemaCreator jsonSchemaCreator;
     private final RestVersionInfo<WorkflowConfiguration> restVersionInfo;
     private final IDocumentDescriptorStore documentDescriptorStore;
+    private final ResourceAccessGuard resourceAccessGuard;
 
     private static final Logger log = Logger.getLogger(RestWorkflowStore.class);
 
@@ -49,11 +51,24 @@ public class RestWorkflowStore implements IRestWorkflowStore {
     public RestWorkflowStore(IWorkflowStore workflowStore, ResourceClientLibrary resourceClientLibrary,
             IDocumentDescriptorStore documentDescriptorStore, IJsonSchemaCreator jsonSchemaCreator,
             ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         restVersionInfo = new RestVersionInfo<>(resourceURI, workflowStore, documentDescriptorStore, resourceAccessGuard);
         this.documentDescriptorStore = documentDescriptorStore;
         this.workflowStore = workflowStore;
         this.resourceClientLibrary = resourceClientLibrary;
         this.jsonSchemaCreator = jsonSchemaCreator;
+    }
+
+    /**
+     * Drops descriptors the caller may not view. Mirrors
+     * {@code ResourceAccessGuard.requireAccess(id, VIEW, …)} exactly, so a caller
+     * never lists something they could not then read.
+     */
+    private List<DocumentDescriptor> visibleOnly(List<DocumentDescriptor> descriptors) {
+        if (descriptors == null || descriptors.isEmpty()) {
+            return descriptors;
+        }
+        return descriptors.stream().filter(d -> resourceAccessGuard.canAccess(d, AccessLevel.VIEW)).toList();
     }
 
     @Override
@@ -79,7 +94,14 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         }
 
         try {
-            return workflowStore.getWorkflowDescriptorsContainingResource(containingResourceUri, includePreviousVersions);
+            // Post-filtered rather than query-filtered: this is a reverse-reference lookup
+            // in the store, not a descriptor listing, so there is no AccessScope to hand
+            // it. Unfiltered it is a cross-workspace enumeration — anyone holding one
+            // resource URI could list every resource in the deployment that references it,
+            // with the full descriptor payload. The page can come back short; that is the
+            // right trade for a diagnostic listing bounded by how many things reference
+            // one resource.
+            return visibleOnly(workflowStore.getWorkflowDescriptorsContainingResource(containingResourceUri, includePreviousVersions));
         } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
             throw sneakyThrow(e);
         }
@@ -275,7 +297,7 @@ public class RestWorkflowStore implements IRestWorkflowStore {
             // URIs
             IResourceStore.IResourceId resourceId = restVersionInfo.createDocument(workflowConfig);
             URI createdUri = RestUtilities.createURI(resourceURI, resourceId.getId(), versionQueryParam, resourceId.getVersion());
-            createDocumentDescriptorForDuplicate(documentDescriptorStore, id, version, createdUri);
+            createDocumentDescriptorForDuplicate(documentDescriptorStore, resourceAccessGuard, id, version, createdUri);
 
             return Response.created(createdUri).location(createdUri)
                     .header("X-Resource-URI", createdUri.toString())
@@ -319,7 +341,8 @@ public class RestWorkflowStore implements IRestWorkflowStore {
                 newResourceLocation = duplicateResourceResponse.getLocation();
 
                 var oldResourceId = RestUtilities.extractResourceId(oldResourceUri);
-                createDocumentDescriptorForDuplicate(documentDescriptorStore, oldResourceId.getId(), oldResourceId.getVersion(), newResourceLocation);
+                createDocumentDescriptorForDuplicate(documentDescriptorStore, resourceAccessGuard, oldResourceId.getId(), oldResourceId.getVersion(),
+                        newResourceLocation);
             }
         } catch (Exception e) {
             throw new ServiceException(e.getLocalizedMessage(), e);

--- a/src/main/java/ai/labs/eddi/datastore/DescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/DescriptorStore.java
@@ -128,6 +128,19 @@ public class DescriptorStore<T> implements IDescriptorStore<T> {
     public List<T> readDescriptors(String type, String filter, Integer index, Integer limit, boolean includeDeleted,
                                    IResourceFilter.QueryFilters accessRestriction)
             throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+        return readDescriptors(type, filter, index, limit, includeDeleted, accessRestriction, null);
+    }
+
+    /**
+     * As above, with a further AND-ed group — used to narrow a listing to one
+     * space.
+     *
+     * @param extraRestriction
+     *            an additional filter group, or {@code null}
+     */
+    public List<T> readDescriptors(String type, String filter, Integer index, Integer limit, boolean includeDeleted,
+                                   IResourceFilter.QueryFilters accessRestriction, IResourceFilter.QueryFilters extraRestriction)
+            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
 
         List<IResourceFilter.QueryFilter> queryFiltersRequired = new LinkedList<>();
         String filterURI = "eddi://" + type + ".*";
@@ -171,6 +184,9 @@ public class DescriptorStore<T> implements IDescriptorStore<T> {
         }
         if (accessRestriction != null && !accessRestriction.getQueryFilters().isEmpty()) {
             filterGroups.add(accessRestriction);
+        }
+        if (extraRestriction != null && !extraRestriction.getQueryFilters().isEmpty()) {
+            filterGroups.add(extraRestriction);
         }
         IResourceFilter.QueryFilters[] allFilters = filterGroups.toArray(new IResourceFilter.QueryFilters[0]);
 

--- a/src/main/java/ai/labs/eddi/datastore/DescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/DescriptorStore.java
@@ -55,6 +55,17 @@ public class DescriptorStore<T> implements IDescriptorStore<T> {
     private static final String FIELD_ORIGIN_ID = "originId";
 
     /**
+     * The materialised access-control index on {@code DocumentDescriptor}.
+     * <p>
+     * Indexed here rather than only where it is written, because every
+     * owner-filtered listing ANDs a predicate on it — and this collection is shared
+     * with conversation descriptors, so it grows with conversation volume. An
+     * unindexed predicate here is a full scan on the hottest listing in the
+     * product.
+     */
+    public static final String FIELD_ACCESS_INDEX = "accessIndex";
+
+    /**
      * Every field this store filters or sorts on. Passed to the storage factory so
      * BOTH backends index them — MongoDB as ascending single-field indexes,
      * PostgreSQL as expression indexes on the shared {@code resources} table.
@@ -64,7 +75,7 @@ public class DescriptorStore<T> implements IDescriptorStore<T> {
      * listing as a full scan with a regex and a text sort on top.
      */
     private static final String[] INDEXED_FIELDS = {FIELD_RESOURCE, FIELD_USER_ID, FIELD_NAME, FIELD_AGENT_NAME, FIELD_DESCRIPTION,
-            FIELD_LAST_MODIFIED, FIELD_DELETED, FIELD_ORIGIN_ID};
+            FIELD_LAST_MODIFIED, FIELD_DELETED, FIELD_ORIGIN_ID, FIELD_ACCESS_INDEX};
 
     private final ModifiableHistorizedResourceStore<T> descriptorResourceStore;
     private final IResourceStorage<T> resourceStorage;
@@ -80,6 +91,30 @@ public class DescriptorStore<T> implements IDescriptorStore<T> {
 
     @Override
     public List<T> readDescriptors(String type, String filter, Integer index, Integer limit, boolean includeDeleted)
+            throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
+        return readDescriptors(type, filter, index, limit, includeDeleted, null);
+    }
+
+    /**
+     * As {@link #readDescriptors(String, String, Integer, Integer, boolean)}, with
+     * an extra group of filters ANDed into the query.
+     * <p>
+     * Used to restrict a listing to what the caller may see. The restriction is
+     * applied <em>in the query</em>, not to the returned page: filtering afterwards
+     * would return short pages and force the kind of scan-budgeted back-fill
+     * {@code RestConversationStore} has to do for conversations, where no such
+     * predicate exists.
+     * <p>
+     * The parameter is a raw {@code QueryFilters} rather than the
+     * {@code AccessScope} that produces it, so this package keeps knowing nothing
+     * about the security model — {@code DocumentDescriptorStore} does the
+     * conversion.
+     *
+     * @param accessRestriction
+     *            an additional filter group, or {@code null} for no restriction
+     */
+    public List<T> readDescriptors(String type, String filter, Integer index, Integer limit, boolean includeDeleted,
+                                   IResourceFilter.QueryFilters accessRestriction)
             throws IResourceStore.ResourceStoreException, IResourceStore.ResourceNotFoundException {
 
         List<IResourceFilter.QueryFilter> queryFiltersRequired = new LinkedList<>();
@@ -114,14 +149,18 @@ public class DescriptorStore<T> implements IDescriptorStore<T> {
             skip = 0;
         }
 
-        IResourceFilter.QueryFilters[] allFilters;
+        // Groups are always ANDed together, so appending the access restriction as its
+        // own group narrows the result without disturbing how the optional text filter
+        // ORs within itself.
+        List<IResourceFilter.QueryFilters> filterGroups = new LinkedList<>();
+        filterGroups.add(required);
         if (!queryFiltersOptional.isEmpty()) {
-            IResourceFilter.QueryFilters optional = new IResourceFilter.QueryFilters(IResourceFilter.QueryFilters.ConnectingType.OR,
-                    queryFiltersOptional);
-            allFilters = new IResourceFilter.QueryFilters[]{required, optional};
-        } else {
-            allFilters = new IResourceFilter.QueryFilters[]{required};
+            filterGroups.add(new IResourceFilter.QueryFilters(IResourceFilter.QueryFilters.ConnectingType.OR, queryFiltersOptional));
         }
+        if (accessRestriction != null && !accessRestriction.getQueryFilters().isEmpty()) {
+            filterGroups.add(accessRestriction);
+        }
+        IResourceFilter.QueryFilters[] allFilters = filterGroups.toArray(new IResourceFilter.QueryFilters[0]);
 
         // Use the storage-level findResources for database-agnostic querying
         List<IResourceStore.IResourceId> matchingIds = resourceStorage.findResources(allFilters, FIELD_LAST_MODIFIED, skip, effectiveLimit);

--- a/src/main/java/ai/labs/eddi/datastore/DescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/DescriptorStore.java
@@ -55,13 +55,25 @@ public class DescriptorStore<T> implements IDescriptorStore<T> {
     private static final String FIELD_ORIGIN_ID = "originId";
 
     /**
-     * The materialised access-control index on {@code DocumentDescriptor}.
+     * The materialised access-control index on {@code DocumentDescriptor}, which
+     * every owner-filtered listing ANDs a predicate on.
+     *
+     * <h3>What this index does and does not buy</h3> Declared here so both backends
+     * create it, and so a future exact-match or prefix query on the field is
+     * served. It does <b>not</b> make the current access predicate index-backed:
+     * that predicate is an unanchored regex ({@code |token|} has to match
+     * mid-string), and neither MongoDB nor PostgreSQL can use a btree index for
+     * one. The scoped listing is therefore a scan.
      * <p>
-     * Indexed here rather than only where it is written, because every
-     * owner-filtered listing ANDs a predicate on it — and this collection is shared
-     * with conversation descriptors, so it grows with conversation volume. An
-     * unindexed predicate here is a full scan on the hottest listing in the
-     * product.
+     * That is not a regression — the type predicate this store has always applied
+     * ({@code "eddi://" + type + ".*"}) is a regex scan too, so the access group
+     * adds predicates to a scan rather than turning an indexed lookup into one —
+     * but it is a real ceiling on a collection shared with conversation
+     * descriptors. Making it index-backed means storing the tokens as an
+     * <em>array</em> and querying with {@code $in} / a GIN index, which needs
+     * {@link IResourceFilter} to grow an operator beyond "string means regex".
+     * Worth doing; deliberately not done blind, since the PostgreSQL half cannot be
+     * verified without a PostgreSQL to run it on.
      */
     public static final String FIELD_ACCESS_INDEX = "accessIndex";
 

--- a/src/main/java/ai/labs/eddi/datastore/serialization/PersistenceMapperProducer.java
+++ b/src/main/java/ai/labs/eddi/datastore/serialization/PersistenceMapperProducer.java
@@ -38,6 +38,12 @@ public class PersistenceMapperProducer {
         // rather than fail. This repo has already been bitten once by an implicit date
         // format (commit dc117cddc).
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
-        return mapper;
+
+        // Wire-only fields dropped here rather than annotated on the model, because
+        // the model is shared with the REST mapper, which does need them. Both
+        // storage backends reach storage through this mapper — DescriptorStore is
+        // DB-agnostic and goes through IDocumentBuilder either way — so this one
+        // registration covers MongoDB and PostgreSQL.
+        return PersistenceMixins.register(mapper);
     }
 }

--- a/src/main/java/ai/labs/eddi/datastore/serialization/PersistenceMixins.java
+++ b/src/main/java/ai/labs/eddi/datastore/serialization/PersistenceMixins.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.datastore.serialization;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+
+/**
+ * Fields that exist on the wire but must never reach storage.
+ *
+ * <h3>Why a mix-in and not an annotation on the field</h3> Jackson has no
+ * single annotation for "serialise here, not there" — the model class is shared
+ * by the REST mapper and the {@link PersistenceMapper} one, and any annotation
+ * on it applies to both. A mix-in is registered per mapper, so the distinction
+ * lives with the mapper that has the requirement rather than with the model
+ * that does not know about either.
+ *
+ * <h3>Why the requirement is structural rather than a convention</h3>
+ * {@code DocumentDescriptor.callerLevel} describes the relationship between a
+ * resource and whoever asked for it, so a value stamped for Alice is wrong for
+ * everyone else. Several paths read a descriptor and write it back —
+ * {@code patchDescriptor}, {@code ResourceSharingService.writeBack} — and
+ * {@code redactForCaller} documents that it must not be called on a descriptor
+ * that will be written. Documenting it is not the same as preventing it: the
+ * next read-modify-write added to this codebase would persist one user's access
+ * level as if it were part of the resource, and every subsequent reader would
+ * be told they hold whatever the last writer happened to hold.
+ *
+ * @author ginccc
+ */
+public final class PersistenceMixins {
+
+    private PersistenceMixins() {
+    }
+
+    /** Registers every mix-in on a mapper that writes to storage. */
+    public static ObjectMapper register(ObjectMapper mapper) {
+        mapper.addMixIn(DocumentDescriptor.class, DocumentDescriptorMixin.class);
+        return mapper;
+    }
+
+    /** @see PersistenceMixins */
+    abstract static class DocumentDescriptorMixin {
+
+        @JsonIgnore
+        abstract String getCallerLevel();
+
+        @JsonIgnore
+        abstract void setCallerLevel(String callerLevel);
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/a2a/A2ATaskHandler.java
+++ b/src/main/java/ai/labs/eddi/engine/a2a/A2ATaskHandler.java
@@ -56,6 +56,7 @@ public class A2ATaskHandler {
     static final String ANONYMOUS_PEER = "a2a:anonymous";
 
     private final IConversationService conversationService;
+    private final AgentCardService agentCardService;
 
     /**
      * The calling peer's identity. The JSON-RPC endpoint is {@code @Authenticated},
@@ -91,7 +92,9 @@ public class A2ATaskHandler {
     private final ICache<String, String> contextConversationCache;
 
     @Inject
-    public A2ATaskHandler(IConversationService conversationService, ICacheFactory cacheFactory, SecurityIdentity identity) {
+    public A2ATaskHandler(IConversationService conversationService, ICacheFactory cacheFactory, SecurityIdentity identity,
+            AgentCardService agentCardService) {
+        this.agentCardService = agentCardService;
         this.conversationService = conversationService;
         this.taskConversationCache = cacheFactory.getCache(CACHE_NAME);
         this.contextConversationCache = cacheFactory.getCache(CACHE_NAME + ":context");
@@ -124,6 +127,17 @@ public class A2ATaskHandler {
         String userInput = extractTextFromMessage(message);
         if (userInput == null || userInput.isBlank()) {
             throw new InvalidA2ARequestException("No text content found in message parts");
+        }
+
+        // A2A sits outside the workspace model on purpose — a peer is a remote system,
+        // not an EDDI user, so it has no space to scope to. But the gate this surface
+        // does claim is `isA2aEnabled()` on the target, and discovery was enforcing it
+        // while conversing was not: a peer that knew an id could talk to an agent
+        // nobody had opted into A2A, private ones included. getAgentCard returns null
+        // for both "no such agent" and "not A2A-enabled", which is the same refusal a
+        // peer gets from discovery.
+        if (agentCardService.getAgentCard(agentId) == null) {
+            throw new InvalidA2ARequestException("Agent is not available over A2A: " + agentId);
         }
 
         // Resolve or create conversation — scoped to the calling peer

--- a/src/main/java/ai/labs/eddi/engine/a2a/AgentCardService.java
+++ b/src/main/java/ai/labs/eddi/engine/a2a/AgentCardService.java
@@ -4,7 +4,7 @@
  */
 package ai.labs.eddi.engine.a2a;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
@@ -35,18 +35,18 @@ public class AgentCardService {
 
     private static final Logger LOGGER = Logger.getLogger(AgentCardService.class);
 
-    private final IRestAgentStore restAgentStore;
+    private final IAgentStore agentStore;
     private final IDocumentDescriptorStore documentDescriptorStore;
     private final String baseUrl;
     private final boolean authEnabled;
     private final String oidcAuthServerUrl;
 
     @Inject
-    public AgentCardService(IRestAgentStore restAgentStore, IDocumentDescriptorStore documentDescriptorStore,
+    public AgentCardService(IAgentStore agentStore, IDocumentDescriptorStore documentDescriptorStore,
             @ConfigProperty(name = "eddi.a2a.base-url", defaultValue = "http://localhost:7070") String baseUrl,
             @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authEnabled,
             @ConfigProperty(name = "quarkus.oidc.auth-server-url") Optional<String> oidcAuthServerUrl) {
-        this.restAgentStore = restAgentStore;
+        this.agentStore = agentStore;
         this.documentDescriptorStore = documentDescriptorStore;
         this.baseUrl = baseUrl;
         this.authEnabled = authEnabled;
@@ -64,11 +64,11 @@ public class AgentCardService {
      */
     public AgentCard getAgentCard(String agentId) {
         try {
-            var resourceId = restAgentStore.getCurrentResourceId(agentId);
+            var resourceId = agentStore.getCurrentResourceId(agentId);
             if (resourceId == null) {
                 return null;
             }
-            AgentConfiguration config = restAgentStore.readAgent(agentId, resourceId.getVersion());
+            AgentConfiguration config = agentStore.read(agentId, resourceId.getVersion());
             if (config == null || !config.isA2aEnabled()) {
                 return null;
             }
@@ -88,7 +88,13 @@ public class AgentCardService {
     public List<AgentCard> listA2AAgents() {
         List<AgentCard> cards = new ArrayList<>();
         try {
-            List<DocumentDescriptor> descriptors = restAgentStore.readAgentDescriptors("", 0, 100);
+            // Unrestricted deliberately: an Agent Card is published to A2A *peers*, which
+            // are
+            // remote systems rather than EDDI users, so the caller has no workspace to
+            // scope
+            // to. The gate for this surface is `isA2aEnabled()` on the agent plus whatever
+            // authentication fronts the A2A endpoints — not the workspace model.
+            List<DocumentDescriptor> descriptors = documentDescriptorStore.readDescriptors("ai.labs.agent", "", 0, 100, false);
             if (descriptors == null) {
                 return cards;
             }

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
@@ -8,6 +8,8 @@ import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.api.IRestAgentAdministration;
@@ -60,11 +62,14 @@ public class RestAgentAdministration implements IRestAgentAdministration {
 
     private static final Logger log = Logger.getLogger(RestAgentAdministration.class);
 
+    private final ResourceAccessGuard resourceAccessGuard;
+
     @Inject
     public RestAgentAdministration(IRuntime runtime, IAgentFactory agentFactory, IAgentStore agentStore, IDeploymentStore deploymentStore,
             IConversationMemoryStore conversationMemoryStore, IRestConversationStore restConversationStore,
             IDocumentDescriptorStore documentDescriptorStore, IDeploymentListener deploymentListener, IScheduleStore scheduleStore,
-            TenantQuotaService tenantQuotaService) {
+            TenantQuotaService tenantQuotaService, ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         this.runtime = runtime;
         this.agentFactory = agentFactory;
         this.agentStore = agentStore;
@@ -84,6 +89,11 @@ public class RestAgentAdministration implements IRestAgentAdministration {
         RuntimeUtilities.checkNotNull(agentId, "agentId");
         RuntimeUtilities.checkNotNull(version, "version");
         RuntimeUtilities.checkNotNull(autoDeploy, "autoDeploy");
+
+        // Deploying is a change to the agent's live behaviour, so it takes EDIT — the
+        // same level as editing it. Before the quota gate below, because refusing an
+        // unauthorised deploy must not first consume the tenant's agent allowance.
+        resourceAccessGuard.requireAccess(agentId, AccessLevel.EDIT, "agent");
 
         // MUST sit before the try below, for the same reason as the quota gate: the
         // catch(Exception) there rethrows as InternalServerErrorException, which
@@ -319,6 +329,11 @@ public class RestAgentAdministration implements IRestAgentAdministration {
         RuntimeUtilities.checkNotNull(environment, "environment");
         RuntimeUtilities.checkNotNull(agentId, "agentId");
         RuntimeUtilities.checkNotNull(version, "version");
+
+        // Undeploying takes an agent offline for everyone using it, which is a change
+        // to the agent — EDIT, matching deploy. Without this any editor could take down
+        // any colleague's live agent.
+        resourceAccessGuard.requireAccess(agentId, AccessLevel.EDIT, "agent");
 
         try {
             do {

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
@@ -31,6 +31,7 @@ import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.model.InputData;
 import ai.labs.eddi.engine.security.ConversationAccessGuard;
 import ai.labs.eddi.engine.security.OwnershipValidator;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -73,6 +74,7 @@ public class RestAgentEngine implements IRestAgentEngine {
     private final SecurityIdentity identity;
     private final OwnershipValidator ownershipValidator;
     private final ConversationAccessGuard conversationAccessGuard;
+    private final ResourceAccessGuard resourceAccessGuard;
     private final HitlAccessGuard hitlAccessGuard;
     private final IHitlToolJournalStore hitlToolJournalStore;
     private final int agentTimeout;
@@ -88,6 +90,7 @@ public class RestAgentEngine implements IRestAgentEngine {
             SecurityIdentity identity,
             OwnershipValidator ownershipValidator,
             ConversationAccessGuard conversationAccessGuard,
+            ResourceAccessGuard resourceAccessGuard,
             HitlAccessGuard hitlAccessGuard,
             IHitlToolJournalStore hitlToolJournalStore,
             @ConfigProperty(name = "systemRuntime.agentTimeoutInSeconds") int agentTimeout) {
@@ -96,6 +99,7 @@ public class RestAgentEngine implements IRestAgentEngine {
         this.identity = identity;
         this.ownershipValidator = ownershipValidator;
         this.conversationAccessGuard = conversationAccessGuard;
+        this.resourceAccessGuard = resourceAccessGuard;
         this.hitlAccessGuard = hitlAccessGuard;
         this.hitlToolJournalStore = hitlToolJournalStore;
         this.agentTimeout = agentTimeout;
@@ -109,6 +113,11 @@ public class RestAgentEngine implements IRestAgentEngine {
     @Override
     public Response startConversationWithContext(String agentId, Environment environment, String userId, Map<String, Context> context) {
         try {
+            // USE, not VIEW: talking to an agent is not reading how it was built. Checked
+            // here rather than in ConversationService, because the system-initiated starts
+            // (group members, schedule fires, sub-agents, Slack, A2A) legitimately run with
+            // no interactive caller and must not be gated on one.
+            resourceAccessGuard.requireAgentUseAccess(agentId);
             String resolvedUserId = ownershipValidator.validateAndResolveUserId(identity, userId);
             var result = conversationService.startConversation(environment, agentId, resolvedUserId, context);
             return Response.created(result.conversationUri()).build();

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpConversationTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpConversationTools.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.mcp;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.engine.triggermanagement.IRestAgentTriggerStore;
 import ai.labs.eddi.engine.triggermanagement.IUserConversationStore;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
@@ -74,6 +75,7 @@ public class McpConversationTools {
     private final IConversationService conversationService;
     private final IRestAgentAdministration agentAdmin;
     private final IRestAgentStore agentStore;
+    private final ResourceAccessGuard resourceAccessGuard;
     private final IRestInterfaceFactory restInterfaceFactory;
     private final IJsonSerialization jsonSerialization;
     private final BoundedLogStore boundedLogStore;
@@ -96,7 +98,9 @@ public class McpConversationTools {
             IRestInterfaceFactory restInterfaceFactory, IJsonSerialization jsonSerialization, BoundedLogStore boundedLogStore,
             IRestAuditStore auditStore, IRestAgentTriggerStore agentTriggerStore, IUserConversationStore userConversationStore,
             IRestAgentEngine restAgentEngine, SecurityIdentity identity, ConversationAccessGuard conversationAccessGuard,
+            ResourceAccessGuard resourceAccessGuard,
             @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authEnabled) {
+        this.resourceAccessGuard = resourceAccessGuard;
         this.conversationService = conversationService;
         this.agentAdmin = agentAdmin;
         this.agentStore = agentStore;
@@ -169,6 +173,10 @@ public class McpConversationTools {
             // engine then assigns an anonymous id, as before). Without this, an
             // MCP-created conversation would belong to nobody and its own creator
             // could never read it back once the ownership gate applies.
+            // The same USE gate the REST start endpoint applies. Without it an MCP client
+            // holding only eddi-viewer — the lowest tier — could hold a full conversation
+            // with any private agent by id, which is 403 over REST.
+            resourceAccessGuard.requireAgentUseAccess(agentId);
             String ownerUserId = conversationAccessGuard.resolveOwnerUserId(null);
             ConversationResult result = conversationService.startConversation(env, agentId, ownerUserId, Collections.emptyMap());
             return jsonSerialization.serialize(Map.of("conversationId", result.conversationId(), "conversationUri",
@@ -252,6 +260,7 @@ public class McpConversationTools {
             // owner. An existing conversation must instead be owned by the caller:
             // continuing another user's conversation is a write into it.
             if (convId == null || convId.isBlank()) {
+                resourceAccessGuard.requireAgentUseAccess(agentId);
                 String ownerUserId = conversationAccessGuard.resolveOwnerUserId(null);
                 ConversationResult convResult = conversationService.startConversation(env, agentId, ownerUserId, Collections.emptyMap());
                 convId = convResult.conversationId();
@@ -853,6 +862,7 @@ public class McpConversationTools {
         // Start a new conversation — use ConversationService directly to avoid
         // the JAX-RS layer which converts exceptions to HTTP responses that are
         // hard to inspect programmatically.
+        resourceAccessGuard.requireAgentUseAccess(agentId);
         var initialContext = new HashMap<String, Context>(deployment.getInitialContext());
         var convResult = conversationService.startConversation(usedEnv, agentId, userId, initialContext);
         String conversationId = convResult.conversationId();

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpConversationTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpConversationTools.java
@@ -151,7 +151,7 @@ public class McpConversationTools {
         try {
             int limitInt = limit != null ? limit : 20;
             String filterStr = filter != null ? filter : "";
-            List<DocumentDescriptor> descriptors = agentStore.readAgentDescriptors(filterStr, 0, limitInt);
+            List<DocumentDescriptor> descriptors = agentStore.readAgentDescriptors(filterStr, 0, limitInt, "");
             return jsonSerialization.serialize(descriptors);
         } catch (Exception e) {
             LOGGER.error("MCP list_agent_configs failed", e);

--- a/src/main/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibrary.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibrary.java
@@ -4,15 +4,25 @@
  */
 package ai.labs.eddi.engine.runtime.client.configuration;
 
-import ai.labs.eddi.configs.rules.IRestRuleSetStore;
+import ai.labs.eddi.configs.apicalls.IApiCallsStore;
+import ai.labs.eddi.configs.dictionary.IDictionaryStore;
+import ai.labs.eddi.configs.llm.ILlmStore;
+import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
+import ai.labs.eddi.configs.output.IOutputStore;
+import ai.labs.eddi.configs.parser.IParserStore;
+import ai.labs.eddi.configs.propertysetter.IPropertySetterStore;
+import ai.labs.eddi.configs.rag.IRagStore;
+import ai.labs.eddi.configs.rules.IRuleSetStore;
 import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
+import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
 import ai.labs.eddi.configs.llm.IRestLlmStore;
 import ai.labs.eddi.configs.mcpcalls.IRestMcpCallsStore;
 import ai.labs.eddi.configs.output.IRestOutputStore;
 import ai.labs.eddi.configs.parser.IRestParserStore;
 import ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore;
 import ai.labs.eddi.configs.rag.IRestRagStore;
-import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
+import ai.labs.eddi.configs.rules.IRestRuleSetStore;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.service.ServiceException;
 import ai.labs.eddi.utils.RestUtilities;
 import ai.labs.eddi.utils.RuntimeUtilities;
@@ -26,12 +36,49 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
 
 /**
+ * Resolves {@code eddi://} references to the configurations they name.
+ *
+ * <h3>Reads bypass the authoring surface; writes do not</h3> This class serves
+ * two populations that need opposite things from the same configurations.
+ * <p>
+ * {@link #getResource} is the <em>engine</em> resolving a reference in the
+ * middle of a conversation turn: {@code LlmTask} loading its model config,
+ * {@code ApiCallsTask} loading its api calls, {@code WorkflowTraversal} walking
+ * a workflow. The identity on that thread is whoever is <em>chatting</em>, who
+ * in general does not own — and must not need to own — the configuration the
+ * agent is built from. So these reads go straight to the {@link IResourceStore}
+ * beans, below any ownership enforcement.
+ * <p>
+ * {@link #duplicateResource} and {@link #deleteResource} are a <em>person</em>
+ * editing: the cascade duplicate/delete behind {@code RestWorkflowStore} and
+ * the orphan purge behind {@code RestOrphanAdmin}. Those keep going through the
+ * {@code IRest*Store} facades, so {@code ResourceAccessGuard} sees them and a
+ * caller cannot delete a resource they may not even read.
+ * <p>
+ * Before this split both went through the REST facades, which meant an
+ * ownership check on the authoring surface would have been an ownership check
+ * on every conversation turn — every shared agent would have failed to load its
+ * own rule set. Keep the split: a read added here belongs on the store side, a
+ * mutation on the facade side.
+ *
  * @author ginccc
  */
 @ApplicationScoped
 public class ResourceClientLibrary implements IResourceClientLibrary {
+
+    private final IParserStore parserStore;
+    private final IDictionaryStore dictionaryStore;
+    private final IRuleSetStore ruleSetStore;
+    private final IApiCallsStore apiCallsStore;
+    private final ILlmStore llmStore;
+    private final IOutputStore outputStore;
+    private final IPropertySetterStore propertySetterStore;
+    private final IMcpCallsStore mcpCallsStore;
+    private final IRagStore ragStore;
+
     private final IRestParserStore restParserStore;
     private final IRestDictionaryStore restDictionaryStore;
     private final IRestRuleSetStore restRuleSetStore;
@@ -41,14 +88,28 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
     private final IRestPropertySetterStore restPropertySetterStore;
     private final IRestMcpCallsStore restMcpCallsStore;
     private final IRestRagStore restRagStore;
-    private Map<String, IResourceService> restInterfaces;
+
+    private Map<String, IResourceService> resourceServices;
 
     private static final Logger log = Logger.getLogger(ResourceClientLibrary.class);
 
     @Inject
-    public ResourceClientLibrary(IRestParserStore restParserStore, IRestDictionaryStore restDictionaryStore, IRestRuleSetStore restRuleSetStore,
+    public ResourceClientLibrary(IParserStore parserStore, IDictionaryStore dictionaryStore, IRuleSetStore ruleSetStore,
+            IApiCallsStore apiCallsStore, ILlmStore llmStore, IOutputStore outputStore, IPropertySetterStore propertySetterStore,
+            IMcpCallsStore mcpCallsStore, IRagStore ragStore,
+            IRestParserStore restParserStore, IRestDictionaryStore restDictionaryStore, IRestRuleSetStore restRuleSetStore,
             IRestApiCallsStore restApiCallsStore, IRestLlmStore restLlmStore, IRestOutputStore restOutputStore,
             IRestPropertySetterStore restPropertySetterStore, IRestMcpCallsStore restMcpCallsStore, IRestRagStore restRagStore) {
+        this.parserStore = parserStore;
+        this.dictionaryStore = dictionaryStore;
+        this.ruleSetStore = ruleSetStore;
+        this.apiCallsStore = apiCallsStore;
+        this.llmStore = llmStore;
+        this.outputStore = outputStore;
+        this.propertySetterStore = propertySetterStore;
+        this.mcpCallsStore = mcpCallsStore;
+        this.ragStore = ragStore;
+
         this.restParserStore = restParserStore;
         this.restDictionaryStore = restDictionaryStore;
         this.restRuleSetStore = restRuleSetStore;
@@ -64,11 +125,12 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
 
     @Override
     public void init() throws ResourceClientLibraryException {
-        this.restInterfaces = new HashMap<>();
-        restInterfaces.put("ai.labs.parser", new IResourceService() {
+        this.resourceServices = new HashMap<>();
+
+        resourceServices.put("ai.labs.parser", new IResourceService() {
             @Override
             public Object read(String id, Integer version) {
-                return restParserStore.readParser(id, version);
+                return readFromStore(parserStore, id, version);
             }
 
             @Override
@@ -82,10 +144,10 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
             }
         });
 
-        restInterfaces.put("ai.labs.regulardictionary", new IResourceService() {
+        resourceServices.put("ai.labs.regulardictionary", new IResourceService() {
             @Override
             public Object read(String id, Integer version) {
-                return restDictionaryStore.readRegularDictionary(id, version, "", "", 0, 0);
+                return readFromStore(dictionaryStore, id, version);
             }
 
             @Override
@@ -100,12 +162,12 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
         });
 
         // Alias: IRestDictionaryStore uses resourceBaseType "ai.labs.dictionary"
-        restInterfaces.put("ai.labs.dictionary", restInterfaces.get("ai.labs.regulardictionary"));
+        resourceServices.put("ai.labs.dictionary", resourceServices.get("ai.labs.regulardictionary"));
 
-        restInterfaces.put("ai.labs.behavior", new IResourceService() {
+        resourceServices.put("ai.labs.behavior", new IResourceService() {
             @Override
             public Object read(String id, Integer version) {
-                return restRuleSetStore.readRuleSet(id, version);
+                return readFromStore(ruleSetStore, id, version);
             }
 
             @Override
@@ -120,12 +182,12 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
         });
 
         // Alias: IRestRuleSetStore uses resourceBaseType "ai.labs.rules"
-        restInterfaces.put("ai.labs.rules", restInterfaces.get("ai.labs.behavior"));
+        resourceServices.put("ai.labs.rules", resourceServices.get("ai.labs.behavior"));
 
-        restInterfaces.put("ai.labs.httpcalls", new IResourceService() {
+        resourceServices.put("ai.labs.httpcalls", new IResourceService() {
             @Override
             public Object read(String id, Integer version) {
-                return restApiCallsStore.readApiCalls(id, version);
+                return readFromStore(apiCallsStore, id, version);
             }
 
             @Override
@@ -140,12 +202,12 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
         });
 
         // Alias: IRestApiCallsStore uses resourceBaseType "ai.labs.apicalls"
-        restInterfaces.put("ai.labs.apicalls", restInterfaces.get("ai.labs.httpcalls"));
+        resourceServices.put("ai.labs.apicalls", resourceServices.get("ai.labs.httpcalls"));
 
-        restInterfaces.put("ai.labs.llm", new IResourceService() {
+        resourceServices.put("ai.labs.llm", new IResourceService() {
             @Override
             public Object read(String id, Integer version) {
-                return restLlmStore.readLlm(id, version);
+                return readFromStore(llmStore, id, version);
             }
 
             @Override
@@ -159,10 +221,16 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
             }
         });
 
-        restInterfaces.put("ai.labs.output", new IResourceService() {
+        resourceServices.put("ai.labs.output", new IResourceService() {
             @Override
             public Object read(String id, Integer version) {
-                return restOutputStore.readOutputSet(id, version, "", "", 0, 0);
+                // The 6-arg read is IOutputStore's own; the empty filter/order and
+                // zero index/limit reproduce exactly what the REST facade passed.
+                try {
+                    return outputStore.read(id, version, "", "", 0, 0);
+                } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
+                    throw sneakyThrow(e);
+                }
             }
 
             @Override
@@ -176,10 +244,10 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
             }
         });
 
-        restInterfaces.put("ai.labs.property", new IResourceService() {
+        resourceServices.put("ai.labs.property", new IResourceService() {
             @Override
             public Object read(String id, Integer version) {
-                return restPropertySetterStore.readPropertySetter(id, version);
+                return readFromStore(propertySetterStore, id, version);
             }
 
             @Override
@@ -193,10 +261,10 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
             }
         });
 
-        restInterfaces.put("ai.labs.mcpcalls", new IResourceService() {
+        resourceServices.put("ai.labs.mcpcalls", new IResourceService() {
             @Override
             public Object read(String id, Integer version) {
-                return restMcpCallsStore.readMcpCalls(id, version);
+                return readFromStore(mcpCallsStore, id, version);
             }
 
             @Override
@@ -210,10 +278,10 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
             }
         });
 
-        restInterfaces.put("ai.labs.rag", new IResourceService() {
+        resourceServices.put("ai.labs.rag", new IResourceService() {
             @Override
             public Object read(String id, Integer version) {
-                return restRagStore.readRag(id, version);
+                return readFromStore(ragStore, id, version);
             }
 
             @Override
@@ -228,11 +296,30 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
         });
     }
 
+    /**
+     * Reads through {@link IResourceStore}, rethrowing its checked exceptions the
+     * same way the REST facades did.
+     * <p>
+     * The facades wrapped every store exception with
+     * {@code SneakyThrow.sneakyThrow}, so callers of {@link #getResource} already
+     * see {@code ResourceNotFoundException} undeclared. Preserving that keeps the
+     * behaviour of every pipeline task unchanged by this refactor — most notably
+     * {@code WorkflowTraversal}, which catches {@code Exception} and treats a
+     * missing reference as a skipped step.
+     */
+    private static <T> T readFromStore(IResourceStore<T> store, String id, Integer version) {
+        try {
+            return store.read(id, version);
+        } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
+            throw sneakyThrow(e);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getResource(URI uri, Class<T> clazz) throws ServiceException {
         String type = uri.getHost();
-        IResourceService proxy = restInterfaces.get(type);
+        IResourceService proxy = resourceServices.get(type);
 
         if (proxy != null) {
             IResourceId resourceId = RestUtilities.extractResourceId(uri);
@@ -246,7 +333,7 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
     @Override
     public Response duplicateResource(URI uri) throws ServiceException {
         String type = uri.getHost();
-        IResourceService proxy = restInterfaces.get(type);
+        IResourceService proxy = resourceServices.get(type);
         if (RuntimeUtilities.isNullOrEmpty(proxy)) {
             throw new ServiceException(String.format("Could not find proxy for type '%s' in uri '%s'", type, uri));
         }
@@ -258,7 +345,7 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
     @Override
     public Response deleteResource(URI uri, boolean permanent) throws ServiceException {
         String type = uri.getHost();
-        IResourceService proxy = restInterfaces.get(type);
+        IResourceService proxy = resourceServices.get(type);
         if (RuntimeUtilities.isNullOrEmpty(proxy)) {
             log.warnf("Could not find proxy for type '%s' in uri '%s' — skipping delete", type, uri);
             return Response.ok().build();

--- a/src/main/java/ai/labs/eddi/engine/runtime/client/factory/LoopbackCallerAuthFilter.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/client/factory/LoopbackCallerAuthFilter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.runtime.client.factory;
+
+import ai.labs.eddi.engine.security.CallerIdentity;
+import ai.labs.eddi.engine.security.CallerIdentityContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import org.jboss.logging.Logger;
+
+/**
+ * Carries the calling user's bearer token across EDDI's internal loopback HTTP
+ * hop, so a request that arrived authenticated stays authenticated when a
+ * service re-enters the API through {@link RestInterfaceFactory}.
+ *
+ * <h3>The bug this fixes</h3> Several services call EDDI's own REST API rather
+ * than the stores — {@code AgentSetupService} (behind the agent wizard, the
+ * {@code setup-api} endpoint and therefore the Platform Operator's
+ * agent-creation tools) and most of {@code McpAdminTools}. The client the
+ * factory built carried no credentials, while {@code /*} is behind the
+ * {@code authenticated} HTTP policy. So every one of those paths answered
+ * <b>401 whenever {@code authorization.enabled=true}</b> — which is exactly the
+ * configuration per-user workspaces require. The wizard, setup-api and the
+ * operator's write capability were unusable on any Keycloak-protected
+ * deployment, and the failure looked like a server fault rather than a missing
+ * credential.
+ *
+ * <h3>Why forwarding the token here is safe</h3> The one-argument
+ * {@link RestInterfaceFactory#get(Class)} addresses {@code 127.0.0.1} on this
+ * process's own HTTP port. The destination is not merely same-origin, it is
+ * this very process — so the token is handed back to the service that issued
+ * the request it came from. The two-argument overload, which names an arbitrary
+ * remote instance for cross-instance sync, deliberately does <b>not</b> get
+ * this filter: that is the case where forwarding a token would leak it.
+ *
+ * <h3>Consequences worth knowing</h3> With the caller's token attached, the
+ * inner request authenticates as the real user rather than as nobody. So
+ * {@code DocumentDescriptorFilter} stamps resources created through setup-api
+ * with their actual owner instead of leaving them unowned, and the
+ * {@code IRest*Store} facades apply {@code ResourceAccessGuard} against the
+ * person who asked — which is what makes the Platform Operator behave correctly
+ * under workspaces rather than either failing or over-reaching.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class LoopbackCallerAuthFilter implements ClientRequestFilter {
+
+    private static final Logger LOGGER = Logger.getLogger(LoopbackCallerAuthFilter.class);
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final CallerIdentityContext callerIdentityContext;
+
+    @Inject
+    public LoopbackCallerAuthFilter(CallerIdentityContext callerIdentityContext) {
+        this.callerIdentityContext = callerIdentityContext;
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        if (requestContext.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
+            // An explicit header wins. Nothing sets one today, but a caller that does
+            // has said what it wants and should not be silently overridden.
+            return;
+        }
+
+        String token = currentToken();
+        if (token != null) {
+            requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + token);
+        }
+    }
+
+    /**
+     * The calling user's raw bearer token, or {@code null} when there is none.
+     * <p>
+     * Two sources, in order. A pipeline worker thread has an identity
+     * <em>bound</em> by {@link CallerIdentityContext} — the request thread is long
+     * gone there, so {@code capture()} would find nothing. A request thread has no
+     * binding but a live security context, which {@code capture()} reads. Checking
+     * the binding first also keeps a HITL resume attributed to the user whose turn
+     * it is rather than to the administrator who approved it.
+     * <p>
+     * {@code null} is an ordinary answer, not a failure: with OIDC disabled there
+     * is no token, and the inner call is permitted anyway.
+     */
+    private String currentToken() {
+        try {
+            CallerIdentity bound = callerIdentityContext.current();
+            if (bound != null && bound.hasToken()) {
+                return bound.token();
+            }
+            CallerIdentity captured = callerIdentityContext.capture();
+            return captured != null && captured.hasToken() ? captured.token() : null;
+        } catch (RuntimeException e) {
+            // Never fail the inner call over this: without a token it proceeds exactly as
+            // it did before this filter existed.
+            LOGGER.debugf("Could not resolve a caller token for the loopback call: %s", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/runtime/client/factory/RestInterfaceFactory.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/client/factory/RestInterfaceFactory.java
@@ -5,34 +5,79 @@
 package ai.labs.eddi.engine.runtime.client.factory;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
 import java.net.URI;
 
+/**
+ * Builds REST clients for EDDI's own API.
+ *
+ * <h3>Two overloads, two trust levels</h3> {@link #get(Class)} addresses this
+ * process's own HTTP port and attaches {@link LoopbackCallerAuthFilter}, so a
+ * service re-entering the API keeps the identity of whoever made the outer
+ * request. {@link #get(Class, String)} names an arbitrary instance for
+ * cross-instance sync and attaches nothing — forwarding a token to a host named
+ * in configuration is precisely what must not happen.
+ *
+ * @author ginccc
+ */
 @ApplicationScoped
 public class RestInterfaceFactory implements IRestInterfaceFactory {
     private final String apiServerURI;
+    private final LoopbackCallerAuthFilter callerAuthFilter;
 
     @Inject
-    public RestInterfaceFactory(@ConfigProperty(name = "quarkus.http.port", defaultValue = "7070") int port) {
+    public RestInterfaceFactory(@ConfigProperty(name = "quarkus.http.port", defaultValue = "7070") int port,
+            LoopbackCallerAuthFilter callerAuthFilter) {
         this.apiServerURI = "http://127.0.0.1:" + port;
+        this.callerAuthFilter = callerAuthFilter;
     }
 
     // CDI proxy constructor
     public RestInterfaceFactory() {
         this.apiServerURI = "http://127.0.0.1:7070";
+        this.callerAuthFilter = null;
     }
 
     @Override
     public <T> T get(Class<T> clazz) {
-        return get(clazz, apiServerURI);
+        RestClientBuilder builder = RestClientBuilder.newBuilder().baseUri(URI.create(apiServerURI));
+        LoopbackCallerAuthFilter filter = resolveAuthFilter();
+        if (filter != null) {
+            builder = builder.register(filter);
+        }
+        return builder.build(clazz);
     }
 
     @Override
     public <T> T get(Class<T> clazz, String serverUrl) {
         return RestClientBuilder.newBuilder().baseUri(URI.create(serverUrl)).build(clazz);
+    }
+
+    /**
+     * The filter, resolved through CDI when this instance came from the no-arg
+     * constructor.
+     * <p>
+     * That constructor exists for the CDI proxy, but the class is also instantiated
+     * directly in tests and in a couple of bootstrap paths, where the injected
+     * field is null. Looking it up lazily means those callers still get an
+     * authenticated loopback client rather than silently reverting to the
+     * unauthenticated behaviour this filter exists to fix; when no container is
+     * running at all, the lookup fails and the client is built without it, exactly
+     * as before.
+     */
+    private LoopbackCallerAuthFilter resolveAuthFilter() {
+        if (callerAuthFilter != null) {
+            return callerAuthFilter;
+        }
+        try {
+            return CDI.current().select(LoopbackCallerAuthFilter.class).get();
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 
     public static class RestInterfaceFactoryException extends Exception {

--- a/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagement.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.configs.migration.ChannelConnectorMigration;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.V6QuteMigration;
 import ai.labs.eddi.configs.migration.V6RenameMigration;
+import ai.labs.eddi.configs.migration.WorkspaceAccessIndexMigration;
 import ai.labs.eddi.configs.rules.IRuleSetStore;
 import ai.labs.eddi.configs.rules.model.RuleConfiguration;
 import ai.labs.eddi.configs.rules.model.RuleGroupConfiguration;
@@ -76,6 +77,7 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
     private final V6RenameMigration v6RenameMigration;
     private final V6QuteMigration v6QuteMigration;
     private final ChannelConnectorMigration channelConnectorMigration;
+    private final WorkspaceAccessIndexMigration workspaceAccessIndexMigration;
     private final IAgentsReadiness agentsReadiness;
     private final IRuntime runtime;
     private final IWorkflowStore workflowStore;
@@ -89,7 +91,8 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
     public AgentDeploymentManagement(IDeploymentStore deploymentStore, IAgentFactory agentFactory, IAgentStore agentStore,
             IAgentsReadiness agentsReadiness, IConversationMemoryStore conversationMemoryStore, IDocumentDescriptorStore documentDescriptorStore,
             IMigrationManager migrationManager, V6RenameMigration v6RenameMigration, V6QuteMigration v6QuteMigration,
-            ChannelConnectorMigration channelConnectorMigration, IRuntime runtime, IWorkflowStore workflowStore, IRuleSetStore ruleSetStore,
+            ChannelConnectorMigration channelConnectorMigration, WorkspaceAccessIndexMigration workspaceAccessIndexMigration,
+            IRuntime runtime, IWorkflowStore workflowStore, IRuleSetStore ruleSetStore,
             @ConfigProperty(name = "eddi.conversations.maximumLifeTimeOfIdleConversationsInDays") int maximumLifeTimeOfIdleConversationsInDays) {
         this.deploymentStore = deploymentStore;
         this.agentFactory = agentFactory;
@@ -101,6 +104,7 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
         this.v6RenameMigration = v6RenameMigration;
         this.v6QuteMigration = v6QuteMigration;
         this.channelConnectorMigration = channelConnectorMigration;
+        this.workspaceAccessIndexMigration = workspaceAccessIndexMigration;
         this.runtime = runtime;
         this.workflowStore = workflowStore;
         this.ruleSetStore = ruleSetStore;
@@ -137,6 +141,13 @@ public class AgentDeploymentManagement implements IAgentDeploymentManagement {
             channelConnectorMigration.runIfNeeded();
         } catch (Exception e) {
             LOGGER.error("Channel connector migration failed — will retry on next startup", e);
+        }
+        try {
+            // Last of the migrations: it re-derives the access index from whatever the
+            // earlier ones left behind, so running it before them would index stale state.
+            workspaceAccessIndexMigration.runIfNeeded();
+        } catch (Exception e) {
+            LOGGER.error("Workspace access-index migration failed — will retry on next startup", e);
         }
 
         migrationManager.startMigrationIfFirstTimeRun(() -> {

--- a/src/main/java/ai/labs/eddi/engine/runtime/rest/interceptors/DocumentDescriptorFilter.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/rest/interceptors/DocumentDescriptorFilter.java
@@ -8,7 +8,10 @@ import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.engine.memory.descriptor.IConversationDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.descriptors.model.ResourceDescriptor;
+import ai.labs.eddi.engine.security.spaces.DescriptorAccess;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
@@ -37,6 +40,7 @@ import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
 public class DocumentDescriptorFilter implements ContainerResponseFilter {
     private final IDocumentDescriptorStore documentDescriptorStore;
     private final IConversationDescriptorStore conversationDescriptorStore;
+    private final ResourceAccessGuard resourceAccessGuard;
 
     private static final Logger log = Logger.getLogger(DocumentDescriptorFilter.class);
 
@@ -44,9 +48,11 @@ public class DocumentDescriptorFilter implements ContainerResponseFilter {
     UriInfo uriInfo;
 
     @Inject
-    public DocumentDescriptorFilter(IDocumentDescriptorStore documentDescriptorStore, IConversationDescriptorStore conversationDescriptorStore) {
+    public DocumentDescriptorFilter(IDocumentDescriptorStore documentDescriptorStore, IConversationDescriptorStore conversationDescriptorStore,
+            ResourceAccessGuard resourceAccessGuard) {
         this.documentDescriptorStore = documentDescriptorStore;
         this.conversationDescriptorStore = conversationDescriptorStore;
+        this.resourceAccessGuard = resourceAccessGuard;
     }
 
     @Override
@@ -75,8 +81,10 @@ public class DocumentDescriptorFilter implements ContainerResponseFilter {
                                     try {
                                         documentDescriptorStore.readDescriptor(resourceId.getId(), resourceId.getVersion());
                                     } catch (IResourceStore.ResourceNotFoundException e) {
+                                        // The only place a configuration descriptor is born, and therefore the only
+                                        // place ownership can be stamped without every store having to remember to.
                                         documentDescriptorStore.createDescriptor(resourceId.getId(), resourceId.getVersion(),
-                                                createDocumentDescriptor(createdResourceURI));
+                                                resourceAccessGuard.stampNewDescriptor(createDocumentDescriptor(createdResourceURI)));
                                     }
                                 }
                             }
@@ -91,6 +99,13 @@ public class DocumentDescriptorFilter implements ContainerResponseFilter {
                                     resourceId.getVersion() - 1);
                             resourceDescriptor.setLastModifiedOn(new Date(System.currentTimeMillis()));
                             resourceDescriptor.setResource(createNewVersionOfResource(resourceDescriptor.getResource(), resourceId.getVersion()));
+                            // Carrying the descriptor object forward already carries ownership with it. The
+                            // index is rebuilt anyway so that a descriptor written before this feature
+                            // acquires one the first time it is touched, letting an existing deployment
+                            // converge without waiting for the backfill migration.
+                            if (resourceDescriptor instanceof DocumentDescriptor documentDescriptor) {
+                                DescriptorAccess.rebuildIndex(documentDescriptor);
+                            }
                             descriptorStore.updateDescriptor(resourceId.getId(), resourceId.getVersion() - 1, resourceDescriptor);
                         }
                     }

--- a/src/main/java/ai/labs/eddi/engine/runtime/service/AgentStoreService.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/service/AgentStoreService.java
@@ -4,29 +4,40 @@
  */
 package ai.labs.eddi.engine.runtime.service;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 /**
+ * Loads an agent's configuration for the engine.
+ * <p>
+ * Reads {@link IAgentStore} directly rather than {@code IRestAgentStore}. The
+ * REST facade is the authoring surface and carries {@code ResourceAccessGuard};
+ * the caller here is a conversation turn, whose identity is whoever is chatting
+ * — someone who may legitimately have no access to the agent's
+ * <em>configuration</em> while being perfectly entitled to talk to the agent.
+ * Routing this through the facade would fail every conversation on a shared
+ * agent. Whether the chatting user may use the agent at all is decided once, at
+ * {@code /agents/{agentId}/start}, not on every config read.
+ *
  * @author ginccc
  */
 @ApplicationScoped
 public class AgentStoreService implements IAgentStoreService {
 
-    private final IRestAgentStore restAgentStore;
+    private final IAgentStore agentStore;
 
     @Inject
-    public AgentStoreService(IRestAgentStore restAgentStore) {
-        this.restAgentStore = restAgentStore;
+    public AgentStoreService(IAgentStore agentStore) {
+        this.agentStore = agentStore;
     }
 
     @Override
     public AgentConfiguration getAgentConfiguration(String agentId, Integer version) throws ServiceException {
         try {
-            return restAgentStore.readAgent(agentId, version);
+            return agentStore.read(agentId, version);
         } catch (Exception e) {
             throw new ServiceException(e.getLocalizedMessage(), e);
         }

--- a/src/main/java/ai/labs/eddi/engine/runtime/service/WorkflowStoreService.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/service/WorkflowStoreService.java
@@ -4,32 +4,39 @@
  */
 package ai.labs.eddi.engine.runtime.service;
 
-import ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
-import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 /**
+ * Loads a workflow and its descriptor for the engine.
+ * <p>
+ * Reads the stores directly rather than the {@code IRest*} facades, for the
+ * reason spelled out on {@link AgentStoreService}: this runs inside a
+ * conversation turn, under the chatting user's identity, and the authoring
+ * surface's ownership checks do not apply to it.
+ *
  * @author ginccc
  */
 @ApplicationScoped
 public class WorkflowStoreService implements IWorkflowStoreService {
-    private final IRestWorkflowStore restWorkflowStore;
-    private final IRestDocumentDescriptorStore restDocumentDescriptorStore;
+    private final IWorkflowStore workflowStore;
+    private final IDocumentDescriptorStore documentDescriptorStore;
 
     @Inject
-    public WorkflowStoreService(IRestWorkflowStore restWorkflowStore, IRestDocumentDescriptorStore restDocumentDescriptorStore) {
-        this.restWorkflowStore = restWorkflowStore;
-        this.restDocumentDescriptorStore = restDocumentDescriptorStore;
+    public WorkflowStoreService(IWorkflowStore workflowStore, IDocumentDescriptorStore documentDescriptorStore) {
+        this.workflowStore = workflowStore;
+        this.documentDescriptorStore = documentDescriptorStore;
     }
 
     @Override
     public WorkflowConfiguration getKnowledgeWorkflow(String workflowId, Integer workflowVersion) throws ServiceException {
         try {
-            return restWorkflowStore.readWorkflow(workflowId, workflowVersion);
+            return workflowStore.read(workflowId, workflowVersion);
         } catch (Exception e) {
             throw new ServiceException(e.getLocalizedMessage(), e);
         }
@@ -38,7 +45,7 @@ public class WorkflowStoreService implements IWorkflowStoreService {
     @Override
     public DocumentDescriptor getWorkflowDocumentDescriptor(String workflowId, Integer workflowVersion) throws ServiceException {
         try {
-            return restDocumentDescriptorStore.readDescriptor(workflowId, workflowVersion);
+            return documentDescriptorStore.readDescriptor(workflowId, workflowVersion);
         } catch (Exception e) {
             throw new ServiceException(e.getLocalizedMessage(), e);
         }

--- a/src/main/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStore.java
+++ b/src/main/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStore.java
@@ -17,6 +17,8 @@ import ai.labs.eddi.engine.runtime.internal.ScheduleFireExecutor;
 import ai.labs.eddi.engine.runtime.internal.SchedulePollerService;
 import ai.labs.eddi.engine.hitl.HitlSchedules;
 import ai.labs.eddi.engine.security.OwnershipValidator;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -76,6 +78,9 @@ public class RestScheduleStore implements IRestScheduleStore {
 
     @Inject
     OwnershipValidator ownershipValidator;
+
+    @Inject
+    ResourceAccessGuard resourceAccessGuard;
 
     @ConfigProperty(name = "eddi.schedule.default-timezone", defaultValue = "UTC")
     String defaultTimeZone;
@@ -141,6 +146,15 @@ public class RestScheduleStore implements IRestScheduleStore {
                 return ownerGuard;
             }
 
+            // A schedule converses with its agent on every fire, and the fire itself is
+            // system-initiated — deliberately below the USE gate, because no interactive
+            // caller exists then. The gate therefore applies HERE, where the human is:
+            // without it, scheduling a private agent is a standing bypass of
+            // /agents/{id}/start's check.
+            if (schedule != null && schedule.getAgentId() != null && !schedule.getAgentId().isBlank()) {
+                resourceAccessGuard.requireAgentUseAccess(schedule.getAgentId());
+            }
+
             // Validate
             validateSchedule(schedule);
 
@@ -158,6 +172,11 @@ public class RestScheduleStore implements IRestScheduleStore {
         } catch (IllegalArgumentException e) {
             LOGGER.warn("Invalid schedule configuration: " + e.getMessage());
             return Response.status(Response.Status.BAD_REQUEST).entity("Invalid schedule configuration").build();
+        } catch (ForbiddenException e) {
+            // The USE gate's refusal. Without this rethrow the generic catch below
+            // turns a clean 403 into a 500 — the caller cannot tell "you may not
+            // schedule that agent" from "the server broke".
+            throw e;
         } catch (Exception e) {
             LOGGER.error("Failed to create schedule", e);
             throw new InternalServerErrorException("Failed to create schedule");
@@ -182,6 +201,12 @@ public class RestScheduleStore implements IRestScheduleStore {
             Response guard = requireAdminForHitl(scheduleId, "update");
             if (guard != null) {
                 return guard;
+            }
+
+            // Same USE gate as create: an update can re-point an existing schedule at a
+            // different agent, which is the same act as scheduling that agent afresh.
+            if (schedule != null && schedule.getAgentId() != null && !schedule.getAgentId().isBlank()) {
+                resourceAccessGuard.requireAgentUseAccess(schedule.getAgentId());
             }
 
             // BOTH sides matter, and checking only one is the bug this replaces.
@@ -232,6 +257,11 @@ public class RestScheduleStore implements IRestScheduleStore {
         } catch (IllegalArgumentException e) {
             LOGGER.warn("Invalid schedule update for " + scheduleId + ": " + e.getMessage());
             return Response.status(Response.Status.BAD_REQUEST).entity("Invalid schedule configuration").build();
+        } catch (ForbiddenException e) {
+            // The USE gate's refusal. Without this rethrow the generic catch below
+            // turns a clean 403 into a 500 — the caller cannot tell "you may not
+            // schedule that agent" from "the server broke".
+            throw e;
         } catch (Exception e) {
             LOGGER.error("Failed to update schedule " + scheduleId, e);
             throw new InternalServerErrorException("Failed to update schedule");

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/AccessScope.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/AccessScope.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.security.spaces;
 
+import ai.labs.eddi.datastore.DescriptorStore;
 import ai.labs.eddi.datastore.IResourceFilter;
 
 import java.util.ArrayList;
@@ -24,9 +25,6 @@ import java.util.List;
  * @author ginccc
  */
 public final class AccessScope {
-
-    /** The field the materialised access index is stored in. */
-    public static final String FIELD_ACCESS_INDEX = "accessIndex";
 
     private static final AccessScope UNRESTRICTED = new AccessScope(null);
 
@@ -74,7 +72,7 @@ public final class AccessScope {
         }
         List<IResourceFilter.QueryFilter> filters = new ArrayList<>(admittingTokens.size());
         for (String token : admittingTokens) {
-            filters.add(new IResourceFilter.QueryFilter(FIELD_ACCESS_INDEX, Subjects.tokenPattern(token)));
+            filters.add(new IResourceFilter.QueryFilter(DescriptorStore.FIELD_ACCESS_INDEX, Subjects.tokenPattern(token)));
         }
         return new IResourceFilter.QueryFilters(IResourceFilter.QueryFilters.ConnectingType.OR, filters);
     }

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/AccessScope.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/AccessScope.java
@@ -26,12 +26,17 @@ import java.util.List;
  */
 public final class AccessScope {
 
-    private static final AccessScope UNRESTRICTED = new AccessScope(null);
+    /** The descriptor field naming the space a resource belongs to. */
+    public static final String FIELD_SPACE_ID = "spaceId";
+
+    private static final AccessScope UNRESTRICTED = new AccessScope(null, null);
 
     private final List<String> admittingTokens;
+    private final String spaceId;
 
-    private AccessScope(List<String> admittingTokens) {
+    private AccessScope(List<String> admittingTokens, String spaceId) {
         this.admittingTokens = admittingTokens;
+        this.spaceId = spaceId;
     }
 
     /**
@@ -51,9 +56,34 @@ public final class AccessScope {
      *            whether resources with no recorded owner are admitted
      */
     public static AccessScope forCaller(CallerSpaces caller, boolean admitLegacy) {
-        return new AccessScope(DescriptorAccess.admittingTokens(caller, admitLegacy));
+        return new AccessScope(DescriptorAccess.admittingTokens(caller, admitLegacy), null);
     }
 
+    /**
+     * Narrows this scope to one space — the server side of a space switcher.
+     * <p>
+     * A narrowing, never a widening: it ANDs a space predicate onto whatever this
+     * scope already admits, so asking for a space you cannot reach returns nothing
+     * rather than granting it. Applied even to an unrestricted scope, so an
+     * administrator can look at one team's workspace without being handed every
+     * other one — that is a view preference, and it must not become a way to see
+     * less than you are entitled to <em>or</em> more.
+     * <p>
+     * This has to happen in the query. Filtering a page client-side breaks paging:
+     * page 2 of "everything" is not page 2 of "this space".
+     */
+    public AccessScope withinSpace(String spaceId) {
+        if (spaceId == null || spaceId.isBlank()) {
+            return this;
+        }
+        return new AccessScope(admittingTokens, spaceId.trim());
+    }
+
+    /**
+     * Whether the caller's own reach is unlimited. A space narrowing does not
+     * change this — it is a view preference layered on top, and
+     * {@link #toSpaceFilter()} carries it separately.
+     */
     public boolean isUnrestricted() {
         return admittingTokens == null;
     }
@@ -75,6 +105,29 @@ public final class AccessScope {
             filters.add(new IResourceFilter.QueryFilter(DescriptorStore.FIELD_ACCESS_INDEX, Subjects.tokenPattern(token)));
         }
         return new IResourceFilter.QueryFilters(IResourceFilter.QueryFilters.ConnectingType.OR, filters);
+    }
+
+    /**
+     * The space narrowing, as its own AND-ed group, or {@code null} when this scope
+     * names no space.
+     * <p>
+     * Separate from {@link #toQueryFilters()} because filter groups are ANDed while
+     * filters within a group follow the group's connector: the access tokens must
+     * stay an OR among themselves, and the space must AND with the result. Folding
+     * the space into the same group would OR it, turning a narrowing into a
+     * widening — the exact bug this shape exists to prevent.
+     */
+    public IResourceFilter.QueryFilters toSpaceFilter() {
+        if (spaceId == null) {
+            return null;
+        }
+        return new IResourceFilter.QueryFilters(List.of(
+                new IResourceFilter.QueryFilter(FIELD_SPACE_ID, Subjects.exactPattern(spaceId))));
+    }
+
+    /** The space this scope is narrowed to, or {@code null}. */
+    public String spaceId() {
+        return spaceId;
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/AccessScope.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/AccessScope.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.datastore.IResourceFilter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What a single descriptor listing is allowed to return, in the form the query
+ * layer can actually apply.
+ *
+ * <h3>An explicit argument, never ambient state</h3> Every listing takes one of
+ * these, and an internal caller that genuinely needs to see everything — the
+ * export service walking a config graph, the orphan sweep, a startup migration
+ * — passes {@link #unrestricted()} in plain sight at the call site. Reading the
+ * scope from a thread-local instead would make "unfiltered" the behaviour of
+ * any code path that simply forgot to set it, which is the shape most fail-open
+ * authorization bugs have.
+ *
+ * @author ginccc
+ */
+public final class AccessScope {
+
+    /** The field the materialised access index is stored in. */
+    public static final String FIELD_ACCESS_INDEX = "accessIndex";
+
+    private static final AccessScope UNRESTRICTED = new AccessScope(null);
+
+    private final List<String> admittingTokens;
+
+    private AccessScope(List<String> admittingTokens) {
+        this.admittingTokens = admittingTokens;
+    }
+
+    /**
+     * No filtering at all — administrators, deployments with workspaces switched
+     * off, and internal callers that operate below the access model.
+     */
+    public static AccessScope unrestricted() {
+        return UNRESTRICTED;
+    }
+
+    /**
+     * Restricted to what {@code caller} may see.
+     *
+     * @param caller
+     *            the caller's spaces and subjects
+     * @param admitLegacy
+     *            whether resources with no recorded owner are admitted
+     */
+    public static AccessScope forCaller(CallerSpaces caller, boolean admitLegacy) {
+        return new AccessScope(DescriptorAccess.admittingTokens(caller, admitLegacy));
+    }
+
+    public boolean isUnrestricted() {
+        return admittingTokens == null;
+    }
+
+    /**
+     * The OR-group to AND into a listing query, or {@code null} when unrestricted.
+     * <p>
+     * Every entry is an anchored, escaped whole-token pattern — see
+     * {@link Subjects#tokenPattern}, and the class comment there for why an
+     * unescaped identity predicate is a real vulnerability on both backends rather
+     * than a style preference.
+     */
+    public IResourceFilter.QueryFilters toQueryFilters() {
+        if (isUnrestricted()) {
+            return null;
+        }
+        List<IResourceFilter.QueryFilter> filters = new ArrayList<>(admittingTokens.size());
+        for (String token : admittingTokens) {
+            filters.add(new IResourceFilter.QueryFilter(FIELD_ACCESS_INDEX, Subjects.tokenPattern(token)));
+        }
+        return new IResourceFilter.QueryFilters(IResourceFilter.QueryFilters.ConnectingType.OR, filters);
+    }
+
+    /**
+     * The tokens this scope admits. Empty when unrestricted. Visible for testing.
+     */
+    public List<String> admittingTokens() {
+        return admittingTokens == null ? List.of() : List.copyOf(admittingTokens);
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/CallerSpaces.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/CallerSpaces.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Everything about a caller that the access policy is allowed to look at: the
+ * principal names that count as "them", the spaces they can reach, and the
+ * subjects a grant could name them by.
+ * <p>
+ * A value object rather than a live {@code SecurityIdentity} lookup, so
+ * {@link DescriptorAccess} is a pure function and can be tested without a
+ * security context — and so a caller resolved once per request is not
+ * re-resolved per descriptor in a listing.
+ *
+ * @param selfPrincipals
+ *            the raw principal names this caller answers to. Normally exactly
+ *            one; a set because an owner recorded under an older principal
+ *            spelling should still resolve to its owner.
+ * @param spaces
+ *            every space id the caller can reach — their personal space plus
+ *            one per team.
+ * @param subjects
+ *            every subject a {@code ResourceGrant} could name this caller by.
+ *
+ * @author ginccc
+ */
+public record CallerSpaces(Set<String> selfPrincipals, Set<String> spaces, Set<String> subjects) {
+
+    /** A caller with no identity at all: matches nothing but the public tokens. */
+    public static final CallerSpaces ANONYMOUS = new CallerSpaces(Set.of(), Set.of(), Set.of());
+
+    public CallerSpaces {
+        selfPrincipals = immutable(selfPrincipals);
+        spaces = immutable(spaces);
+        subjects = immutable(subjects);
+    }
+
+    /**
+     * Builds a caller from a principal name and the group paths they belong to.
+     *
+     * @param principal
+     *            the authenticated principal name; blank or null yields
+     *            {@link #ANONYMOUS}
+     * @param groupPaths
+     *            Keycloak group paths, in any of the spellings
+     *            {@link Subjects#normalizeGroup} accepts
+     */
+    public static CallerSpaces of(String principal, Set<String> groupPaths) {
+        if (principal == null || principal.isBlank()) {
+            return ANONYMOUS;
+        }
+        String trimmed = principal.trim();
+
+        Set<String> spaces = new LinkedHashSet<>();
+        Set<String> subjects = new LinkedHashSet<>();
+
+        String personal = Subjects.personalSpace(trimmed);
+        spaces.add(personal);
+        subjects.add(personal);
+
+        if (groupPaths != null) {
+            for (String groupPath : groupPaths) {
+                String team = Subjects.team(groupPath);
+                if (team != null) {
+                    spaces.add(team);
+                    subjects.add(team);
+                }
+            }
+        }
+
+        return new CallerSpaces(Set.of(trimmed), spaces, subjects);
+    }
+
+    /**
+     * Whether {@code ownerId} names this caller.
+     * <p>
+     * A plain equality check on the principal name, matching what
+     * {@code OwnershipValidator.isOwner} does — the two must agree, or a resource
+     * could be readable through one guard and not the other.
+     */
+    public boolean isSelf(String ownerId) {
+        return ownerId != null && !ownerId.isBlank() && selfPrincipals.contains(ownerId);
+    }
+
+    /** Whether this caller has any identity at all. */
+    public boolean isAnonymous() {
+        return selfPrincipals.isEmpty();
+    }
+
+    private static Set<String> immutable(Set<String> input) {
+        return input == null ? Set.of() : Collections.unmodifiableSet(new LinkedHashSet<>(input));
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolver.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolver.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.utils.RestUtilities;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
+import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
+
+/**
+ * Walks the configuration graph beneath an agent or agent group: its workflows,
+ * and the rule sets, api calls, LLM configs, output sets, RAG configs, mcp
+ * calls and parser dictionaries those workflows reference.
+ *
+ * <h3>Why sharing needs this</h3> People share <em>agents</em>. Nobody shares
+ * an output set. But an agent is a thin document pointing at a dozen others, so
+ * a share that stopped at the agent would grant access to a name and a list of
+ * URIs the recipient could not resolve — and, because a shared agent's config
+ * graph is exactly what {@code VIEW} is supposed to expose, the recipient would
+ * see a broken agent rather than a shared one.
+ * <p>
+ * The closure is computed <b>at share time</b> and materialised as grants on
+ * each descriptor, not resolved on every read. Resolving per read would put a
+ * graph walk on the hot path of a listing and make the access decision depend
+ * on config that may since have changed.
+ *
+ * <h3>Bounded on purpose</h3> A malformed or hostile config can point at
+ * itself, and a deep graph could otherwise fan out without limit. Visited ids
+ * are tracked, the queue is capped, and any single unreadable reference is
+ * skipped rather than failing the whole share — a share that silently grants
+ * nothing is worse than one that grants slightly less than the maximum.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class ConfigGraphResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(ConfigGraphResolver.class);
+
+    /**
+     * Upper bound on resources reachable from one root. Well above any real agent
+     * (a large one reaches a few dozen), low enough that a cyclic or generated
+     * config cannot turn one share into an unbounded write amplification.
+     */
+    static final int MAX_GRAPH_SIZE = 500;
+
+    private static final String KEY_URI = "uri";
+    private static final String PARSER_HOST = "ai.labs.parser";
+    private static final String REGULAR_DICTIONARY_HOST = "ai.labs.parser.dictionaries.regular";
+
+    private final IAgentStore agentStore;
+    private final IWorkflowStore workflowStore;
+    private final IAgentGroupStore agentGroupStore;
+
+    @Inject
+    public ConfigGraphResolver(IAgentStore agentStore, IWorkflowStore workflowStore, IAgentGroupStore agentGroupStore) {
+        this.agentStore = agentStore;
+        this.workflowStore = workflowStore;
+        this.agentGroupStore = agentGroupStore;
+    }
+
+    /**
+     * Every resource id reachable from {@code rootId}, excluding the root itself.
+     * <p>
+     * Reads through the stores rather than the {@code IRest*} facades on purpose:
+     * this runs <em>while</em> deciding what to share, so it must see the graph as
+     * it is, not as the caller's current grants already permit. The caller's right
+     * to share the root is checked separately, before this is called.
+     *
+     * @param rootId
+     *            an agent or agent-group id
+     * @return referenced ids, in discovery order; empty when the root is neither
+     */
+    public Set<String> referencedResourceIds(String rootId) {
+        Set<String> visited = new LinkedHashSet<>();
+        Deque<String> queue = new ArrayDeque<>();
+
+        seedFromRoot(rootId, queue, visited);
+
+        Set<String> result = new LinkedHashSet<>();
+        while (!queue.isEmpty() && result.size() < MAX_GRAPH_SIZE) {
+            String id = queue.poll();
+            if (id == null || id.equals(rootId) || !visited.add(id)) {
+                continue;
+            }
+            result.add(id);
+            // Only workflows have children; everything else is a leaf. Attempting to read
+            // every id as a workflow is what keeps this free of a type registry, and a
+            // non-workflow id simply fails the read and contributes nothing.
+            expandWorkflow(id, queue);
+        }
+
+        if (result.size() >= MAX_GRAPH_SIZE) {
+            LOGGER.warnf("Config graph for %s hit the %d-resource ceiling; the remainder was not included in this operation",
+                    sanitize(rootId), MAX_GRAPH_SIZE);
+        }
+        return result;
+    }
+
+    private void seedFromRoot(String rootId, Deque<String> queue, Set<String> visited) {
+        visited.add(rootId);
+
+        // An agent points at workflows.
+        try {
+            var current = agentStore.getCurrentResourceId(rootId);
+            var agent = agentStore.read(rootId, current.getVersion());
+            if (agent != null && agent.getWorkflows() != null) {
+                for (URI workflowUri : agent.getWorkflows()) {
+                    offerUri(workflowUri, queue);
+                }
+                return;
+            }
+        } catch (Exception e) {
+            LOGGER.debugf("Root %s is not a readable agent (%s); trying agent group", sanitize(rootId), e.getMessage());
+        }
+
+        // An agent group points at member agents, which point at workflows.
+        try {
+            var current = agentGroupStore.getCurrentResourceId(rootId);
+            AgentGroupConfiguration group = agentGroupStore.read(rootId, current.getVersion());
+            if (group != null && group.getMembers() != null) {
+                for (var member : group.getMembers()) {
+                    if (member != null && member.agentId() != null && !member.agentId().isBlank()) {
+                        queue.offer(member.agentId());
+                        // A member agent's own graph is reached by seeding from it in turn.
+                        for (String nested : referencedFromAgent(member.agentId())) {
+                            queue.offer(nested);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debugf("Root %s is not a readable agent group either (%s)", sanitize(rootId), e.getMessage());
+        }
+    }
+
+    private List<String> referencedFromAgent(String agentId) {
+        try {
+            var current = agentStore.getCurrentResourceId(agentId);
+            var agent = agentStore.read(agentId, current.getVersion());
+            if (agent == null || agent.getWorkflows() == null) {
+                return List.of();
+            }
+            return agent.getWorkflows().stream().map(ConfigGraphResolver::idOf).filter(id -> id != null && !id.isBlank()).toList();
+        } catch (Exception e) {
+            LOGGER.debugf("Could not read member agent %s: %s", sanitize(agentId), e.getMessage());
+            return List.of();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void expandWorkflow(String workflowId, Deque<String> queue) {
+        WorkflowConfiguration workflow;
+        try {
+            IResourceStore.IResourceId current = workflowStore.getCurrentResourceId(workflowId);
+            workflow = workflowStore.read(workflowId, current.getVersion());
+        } catch (Exception e) {
+            // Expected for every non-workflow id; debug rather than warn.
+            LOGGER.debugf("Not expanding %s as a workflow: %s", sanitize(workflowId), e.getMessage());
+            return;
+        }
+        if (workflow == null || workflow.getWorkflowSteps() == null) {
+            return;
+        }
+
+        for (WorkflowConfiguration.WorkflowStep step : workflow.getWorkflowSteps()) {
+            if (step == null) {
+                continue;
+            }
+            Map<String, Object> config = step.getConfig();
+            if (!isNullOrEmpty(config)) {
+                Object uri = config.get(KEY_URI);
+                if (!isNullOrEmpty(uri)) {
+                    offerUri(safeUri(uri.toString()), queue);
+                }
+            }
+
+            // Parser dictionaries hang off the step's extensions rather than its config,
+            // the same shape RestWorkflowStore's cascade delete has to special-case.
+            URI type = step.getType();
+            if (type != null && PARSER_HOST.equals(type.getHost()) && step.getExtensions() != null) {
+                Object dictionariesObj = step.getExtensions().get("dictionaries");
+                if (dictionariesObj instanceof List<?> dictionaries) {
+                    for (Object entry : dictionaries) {
+                        if (entry instanceof Map<?, ?> dictionary) {
+                            offerDictionary((Map<String, Object>) dictionary, queue);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void offerDictionary(Map<String, Object> dictionary, Deque<String> queue) {
+        Object dictType = dictionary.get("type");
+        if (dictType == null) {
+            return;
+        }
+        URI typeUri = safeUri(dictType.toString());
+        if (typeUri == null || !REGULAR_DICTIONARY_HOST.equals(typeUri.getHost())) {
+            return;
+        }
+        Object configObj = dictionary.get("config");
+        if (configObj instanceof Map<?, ?> config) {
+            Object uri = config.get(KEY_URI);
+            if (!isNullOrEmpty(uri)) {
+                offerUri(safeUri(uri.toString()), queue);
+            }
+        }
+    }
+
+    private static void offerUri(URI uri, Deque<String> queue) {
+        String id = idOf(uri);
+        if (id != null && !id.isBlank()) {
+            queue.offer(id);
+        }
+    }
+
+    private static String idOf(URI uri) {
+        if (uri == null) {
+            return null;
+        }
+        try {
+            IResourceStore.IResourceId resourceId = RestUtilities.extractResourceId(uri);
+            return resourceId == null ? null : resourceId.getId();
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static URI safeUri(String value) {
+        try {
+            return URI.create(value);
+        } catch (IllegalArgumentException e) {
+            // A config field is user input; a malformed URI skips one edge rather than
+            // aborting the whole traversal.
+            return null;
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolver.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolver.java
@@ -101,15 +101,22 @@ public class ConfigGraphResolver {
      * @return referenced ids, in discovery order; empty when the root is neither
      */
     public Set<String> referencedResourceIds(String rootId) {
-        Set<String> visited = new LinkedHashSet<>();
+        // Two sets on purpose. `seededRoots` guards the seeding recursion (groups can
+        // nest, and nest into themselves); `dequeued` dedups the poll loop. They must
+        // NOT be one set: seeding pre-registers an id before the loop ever polls it,
+        // and a shared set made the loop treat every seeded member agent as "already
+        // done" — so sharing a group granted on the members' workflows while silently
+        // skipping the member agents themselves.
+        Set<String> seededRoots = new LinkedHashSet<>();
+        Set<String> dequeued = new LinkedHashSet<>();
         Deque<String> queue = new ArrayDeque<>();
 
-        seedFromRoot(rootId, queue, visited, 0);
+        seedFromRoot(rootId, queue, seededRoots, 0);
 
         Set<String> result = new LinkedHashSet<>();
         while (!queue.isEmpty() && result.size() < MAX_GRAPH_SIZE) {
             String id = queue.poll();
-            if (id == null || id.equals(rootId) || !visited.add(id)) {
+            if (id == null || id.equals(rootId) || !dequeued.add(id)) {
                 continue;
             }
             result.add(id);
@@ -126,8 +133,8 @@ public class ConfigGraphResolver {
         return result;
     }
 
-    private void seedFromRoot(String rootId, Deque<String> queue, Set<String> visited, int depth) {
-        if (!visited.add(rootId) && depth > 0) {
+    private void seedFromRoot(String rootId, Deque<String> queue, Set<String> seededRoots, int depth) {
+        if (!seededRoots.add(rootId)) {
             // Already seeded — a group that (directly or indirectly) contains itself.
             return;
         }
@@ -146,7 +153,10 @@ public class ConfigGraphResolver {
             LOGGER.debugf("Root %s is not a readable agent (%s); trying agent group", sanitize(rootId), e.getMessage());
         }
 
-        // An agent group points at member agents, which point at workflows.
+        // An agent group points at members. A member is either an agent (whose
+        // workflows the recursive call offers) or a nested group (group-of-groups is
+        // a shipped feature) — the id alone does not say which, so the recursion
+        // tries both branches and the unreadable one contributes nothing.
         try {
             var current = agentGroupStore.getCurrentResourceId(rootId);
             AgentGroupConfiguration group = agentGroupStore.read(rootId, current.getVersion());
@@ -156,34 +166,13 @@ public class ConfigGraphResolver {
                         continue;
                     }
                     queue.offer(member.agentId());
-                    // A member's own graph. A member is either an agent (workflows) or a
-                    // nested group (group-of-groups is a shipped feature), and the id alone
-                    // does not say which — so try both and let the unreadable one contribute
-                    // nothing. Bounded by `visited` and MAX_GRAPH_SIZE like everything else.
-                    for (String nested : referencedFromAgent(member.agentId())) {
-                        queue.offer(nested);
-                    }
                     if (depth < MAX_GROUP_NESTING) {
-                        seedFromRoot(member.agentId(), queue, visited, depth + 1);
+                        seedFromRoot(member.agentId(), queue, seededRoots, depth + 1);
                     }
                 }
             }
         } catch (Exception e) {
             LOGGER.debugf("Root %s is not a readable agent group either (%s)", sanitize(rootId), e.getMessage());
-        }
-    }
-
-    private List<String> referencedFromAgent(String agentId) {
-        try {
-            var current = agentStore.getCurrentResourceId(agentId);
-            var agent = agentStore.read(agentId, current.getVersion());
-            if (agent == null || agent.getWorkflows() == null) {
-                return List.of();
-            }
-            return agent.getWorkflows().stream().map(ConfigGraphResolver::idOf).filter(id -> id != null && !id.isBlank()).toList();
-        } catch (Exception e) {
-            LOGGER.debugf("Could not read member agent %s: %s", sanitize(agentId), e.getMessage());
-            return List.of();
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolver.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolver.java
@@ -165,7 +165,7 @@ public class ConfigGraphResolver {
                     if (member == null || member.agentId() == null || member.agentId().isBlank()) {
                         continue;
                     }
-                    queue.offer(member.agentId());
+                    queue.addLast(member.agentId());
                     if (depth < MAX_GROUP_NESTING) {
                         seedFromRoot(member.agentId(), queue, seededRoots, depth + 1);
                     }
@@ -240,7 +240,7 @@ public class ConfigGraphResolver {
     private static void offerUri(URI uri, Deque<String> queue) {
         String id = idOf(uri);
         if (id != null && !id.isBlank()) {
-            queue.offer(id);
+            queue.addLast(id);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolver.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolver.java
@@ -44,10 +44,13 @@ import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
  * on config that may since have changed.
  *
  * <h3>Bounded on purpose</h3> A malformed or hostile config can point at
- * itself, and a deep graph could otherwise fan out without limit. Visited ids
- * are tracked, the queue is capped, and any single unreadable reference is
- * skipped rather than failing the whole share — a share that silently grants
- * nothing is worse than one that grants slightly less than the maximum.
+ * itself, and a deep graph could otherwise fan out without limit. Three bounds:
+ * {@code visited} stops a cycle from being walked twice, the <em>result</em> is
+ * capped at {@link #MAX_GRAPH_SIZE} (the queue itself is not — it drains
+ * against that cap), and group nesting stops at {@link #MAX_GROUP_NESTING}. Any
+ * single unreadable reference is skipped rather than failing the whole share: a
+ * share that silently grants nothing is worse than one that grants slightly
+ * less than the maximum.
  *
  * @author ginccc
  */
@@ -62,6 +65,13 @@ public class ConfigGraphResolver {
      * config cannot turn one share into an unbounded write amplification.
      */
     static final int MAX_GRAPH_SIZE = 500;
+
+    /**
+     * How far group-of-group nesting is followed. Deeper than any group a human
+     * assembles, and a hard stop for a config that nests into itself — which
+     * {@code visited} also catches, belt and braces.
+     */
+    static final int MAX_GROUP_NESTING = 8;
 
     private static final String KEY_URI = "uri";
     private static final String PARSER_HOST = "ai.labs.parser";
@@ -94,7 +104,7 @@ public class ConfigGraphResolver {
         Set<String> visited = new LinkedHashSet<>();
         Deque<String> queue = new ArrayDeque<>();
 
-        seedFromRoot(rootId, queue, visited);
+        seedFromRoot(rootId, queue, visited, 0);
 
         Set<String> result = new LinkedHashSet<>();
         while (!queue.isEmpty() && result.size() < MAX_GRAPH_SIZE) {
@@ -116,8 +126,11 @@ public class ConfigGraphResolver {
         return result;
     }
 
-    private void seedFromRoot(String rootId, Deque<String> queue, Set<String> visited) {
-        visited.add(rootId);
+    private void seedFromRoot(String rootId, Deque<String> queue, Set<String> visited, int depth) {
+        if (!visited.add(rootId) && depth > 0) {
+            // Already seeded — a group that (directly or indirectly) contains itself.
+            return;
+        }
 
         // An agent points at workflows.
         try {
@@ -139,12 +152,19 @@ public class ConfigGraphResolver {
             AgentGroupConfiguration group = agentGroupStore.read(rootId, current.getVersion());
             if (group != null && group.getMembers() != null) {
                 for (var member : group.getMembers()) {
-                    if (member != null && member.agentId() != null && !member.agentId().isBlank()) {
-                        queue.offer(member.agentId());
-                        // A member agent's own graph is reached by seeding from it in turn.
-                        for (String nested : referencedFromAgent(member.agentId())) {
-                            queue.offer(nested);
-                        }
+                    if (member == null || member.agentId() == null || member.agentId().isBlank()) {
+                        continue;
+                    }
+                    queue.offer(member.agentId());
+                    // A member's own graph. A member is either an agent (workflows) or a
+                    // nested group (group-of-groups is a shipped feature), and the id alone
+                    // does not say which — so try both and let the unreadable one contribute
+                    // nothing. Bounded by `visited` and MAX_GRAPH_SIZE like everything else.
+                    for (String nested : referencedFromAgent(member.agentId())) {
+                        queue.offer(nested);
+                    }
+                    if (depth < MAX_GROUP_NESTING) {
+                        seedFromRoot(member.agentId(), queue, visited, depth + 1);
                     }
                 }
             }

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/DescriptorAccess.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/DescriptorAccess.java
@@ -28,9 +28,11 @@ import java.util.Set;
  * write, so a descriptor written before this code existed has none. A listing
  * may therefore <em>omit</em> a resource whose {@link #effectiveLevel} would
  * admit it, until that descriptor is next written or
- * {@code WorkspaceBackfillMigration} runs. The reverse — listed but not
+ * {@code WorkspaceAccessIndexMigration} runs. The reverse — listed but not
  * readable — would be a leak, and cannot happen: every token the index contains
- * is one {@link #effectiveLevel} also honours.
+ * is one {@link #effectiveLevel} also honours, and a descriptor that grants
+ * nobody anything is indexed under {@link Subjects#TOKEN_NONE}, which
+ * {@link #admittingTokens} never emits.
  *
  * @author ginccc
  */
@@ -58,15 +60,22 @@ public final class DescriptorAccess {
             return null;
         }
 
-        if (isUnowned(descriptor)) {
+        AccessLevel best = null;
+
+        if (isUnowned(descriptor) && admitLegacy) {
             // Legacy data: no owner, no space, nothing to compare against. Treated the way
             // OwnershipValidator.requireOwnerOrAdmin already treats an unowned resource, so
             // an upgrade does not hide every pre-existing agent — but an operator can close
             // it by setting eddi.workspaces.legacy-visibility=admin-only.
-            return admitLegacy ? AccessLevel.OWN : null;
+            //
+            // A contribution rather than a short-circuit, deliberately: buildIndex emits
+            // the grant and `all` tokens for an unowned descriptor too, so returning early
+            // here would list a resource to a grantee that this method then refused. It
+            // also means an explicit grant on a legacy resource keeps working under
+            // legacy-visibility=admin-only, which is what lets an administrator hand out
+            // access to pre-existing resources without first transferring ownership.
+            best = AccessLevel.OWN;
         }
-
-        AccessLevel best = null;
 
         String ownerId = descriptor.getOwnerId();
         boolean callerIsOwner = ownerId != null && !ownerId.isBlank() && caller.isSelf(ownerId);
@@ -143,6 +152,41 @@ public final class DescriptorAccess {
         return descriptor;
     }
 
+    /**
+     * Removes everything about who a resource belongs to and who it is shared with,
+     * leaving name, description, timestamps and origin id intact.
+     *
+     * <h3>Ownership does not travel between instances</h3> A ZIP export, an
+     * instance-to-instance sync, or any other transfer carries a descriptor from
+     * one deployment's identity model into another's, where the same principal
+     * names and group names mean something else — or nothing. Two consequences, and
+     * this method exists for both:
+     * <ul>
+     * <li><b>Exporting</b> a descriptor as-is would disclose internal principal and
+     * team names to whoever receives the file.</li>
+     * <li><b>Importing</b> one as-is would let the file decide ownership,
+     * visibility and grants on the receiving instance — including publishing a
+     * resource, or filing it under someone else's name — with none of the checks
+     * the sharing API applies.</li>
+     * </ul>
+     * The importing side re-stamps to the importing user afterwards, so an import
+     * is owned by whoever performed it. That is both the safe answer and the one a
+     * user expects.
+     *
+     * @return the same descriptor, for chaining
+     */
+    public static DocumentDescriptor stripOwnership(DocumentDescriptor descriptor) {
+        if (descriptor == null) {
+            return null;
+        }
+        descriptor.setOwnerId(null);
+        descriptor.setSpaceId(null);
+        descriptor.setVisibility(null);
+        descriptor.setGrants(null);
+        descriptor.setAccessIndex(null);
+        return descriptor;
+    }
+
     /** The token index {@link #rebuildIndex} stores. Visible for testing. */
     public static String buildIndex(DocumentDescriptor descriptor) {
         Set<String> tokens = new LinkedHashSet<>();
@@ -180,10 +224,16 @@ public final class DescriptorAccess {
         }
 
         if (tokens.isEmpty()) {
-            // Only reachable for a descriptor with an owner-less non-legacy space and
-            // private visibility. An empty index matches no listing at all, and a resource
-            // nobody can list is a worse outcome than one only admins see.
-            tokens.add(Subjects.LEGACY);
+            // Reachable for a descriptor with no owner, a non-legacy space, private
+            // visibility and no valid grant — a shape a crafted import can produce.
+            //
+            // This must NOT be Subjects.LEGACY. That token is admitted to every caller
+            // under the default legacy-visibility policy, while effectiveLevel takes the
+            // owned branch for the same descriptor and grants nobody anything — so the
+            // resource would be listed to everyone and readable by no one, leaking its
+            // name, description and ACL. Listed-but-not-readable is the one direction this
+            // class promises cannot happen, so the fallback names nobody instead.
+            tokens.add(Subjects.TOKEN_NONE);
         }
 
         StringBuilder out = new StringBuilder();

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/DescriptorAccess.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/DescriptorAccess.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.descriptors.model.ResourceGrant;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The access policy itself, expressed twice and only twice: as a level for one
+ * caller against one descriptor ({@link #effectiveLevel}), and as the
+ * materialised token index a listing query filters on ({@link #rebuildIndex}).
+ * <p>
+ * Both are pure functions of the descriptor's {@code ownerId}, {@code spaceId},
+ * {@code visibility} and {@code grants}. Keeping them in one class is what
+ * makes it checkable that the two agree — the failure mode of a materialised
+ * ACL is a listing that admits something the read path denies, or the reverse.
+ *
+ * <h3>They may disagree in exactly one direction</h3> The index is rebuilt on
+ * write, so a descriptor written before this code existed has none. A listing
+ * may therefore <em>omit</em> a resource whose {@link #effectiveLevel} would
+ * admit it, until that descriptor is next written or
+ * {@code WorkspaceBackfillMigration} runs. The reverse — listed but not
+ * readable — would be a leak, and cannot happen: every token the index contains
+ * is one {@link #effectiveLevel} also honours.
+ *
+ * @author ginccc
+ */
+public final class DescriptorAccess {
+
+    private DescriptorAccess() {
+        // utility class
+    }
+
+    /**
+     * What {@code caller} may do with {@code descriptor}, or {@code null} for no
+     * access at all.
+     *
+     * @param descriptor
+     *            the resource's descriptor; {@code null} yields {@code null}
+     * @param caller
+     *            the caller's identity — principals, spaces and subjects
+     * @param admitLegacy
+     *            whether an unowned, space-less descriptor (data predating
+     *            ownership) is admitted. Operator policy — see
+     *            {@code eddi.workspaces.legacy-visibility}.
+     */
+    public static AccessLevel effectiveLevel(DocumentDescriptor descriptor, CallerSpaces caller, boolean admitLegacy) {
+        if (descriptor == null || caller == null) {
+            return null;
+        }
+
+        if (isUnowned(descriptor)) {
+            // Legacy data: no owner, no space, nothing to compare against. Treated the way
+            // OwnershipValidator.requireOwnerOrAdmin already treats an unowned resource, so
+            // an upgrade does not hide every pre-existing agent — but an operator can close
+            // it by setting eddi.workspaces.legacy-visibility=admin-only.
+            return admitLegacy ? AccessLevel.OWN : null;
+        }
+
+        AccessLevel best = null;
+
+        String ownerId = descriptor.getOwnerId();
+        boolean callerIsOwner = ownerId != null && !ownerId.isBlank() && caller.isSelf(ownerId);
+        if (callerIsOwner) {
+            best = AccessLevel.OWN;
+        }
+
+        ResourceVisibility visibility = descriptor.resourceVisibility();
+        if (visibility == null) {
+            // A descriptor carrying an owner or a space but no visibility predates the
+            // field, or came from a client that omitted it. Default to `space`, which is
+            // what a newly created resource gets — not `published`, which would widen
+            // access as a side effect of a missing field.
+            visibility = ResourceVisibility.space;
+        }
+
+        if (visibility == ResourceVisibility.published) {
+            best = higher(best, AccessLevel.VIEW);
+        }
+
+        if (visibility == ResourceVisibility.space) {
+            String spaceId = descriptor.getSpaceId();
+            if (spaceId != null && !spaceId.isBlank() && caller.spaces().contains(spaceId)) {
+                // A personal space has one member, so this is the owner again; a team space is
+                // where it actually widens. EDIT rather than OWN for a teammate: deleting or
+                // re-sharing someone else's agent stays with whoever made it.
+                best = higher(best, callerIsOwner ? AccessLevel.OWN : AccessLevel.EDIT);
+            }
+        }
+
+        List<ResourceGrant> grants = descriptor.getGrants();
+        if (grants != null) {
+            for (ResourceGrant grant : grants) {
+                if (grant == null || grant.getSubject() == null) {
+                    continue;
+                }
+                if (caller.subjects().contains(grant.getSubject())) {
+                    best = higher(best, grant.accessLevel());
+                }
+            }
+        }
+
+        return best;
+    }
+
+    /**
+     * Whether the descriptor records no ownership at all — the shape of every
+     * descriptor written before this feature existed, and of the rows the backfill
+     * migration stamps with {@link Subjects#LEGACY}.
+     */
+    public static boolean isUnowned(DocumentDescriptor descriptor) {
+        if (descriptor == null) {
+            return false;
+        }
+        boolean noOwner = descriptor.getOwnerId() == null || descriptor.getOwnerId().isBlank();
+        boolean noSpace = descriptor.getSpaceId() == null || descriptor.getSpaceId().isBlank()
+                || Subjects.LEGACY.equals(descriptor.getSpaceId());
+        return noOwner && noSpace;
+    }
+
+    /**
+     * Recomputes {@link DocumentDescriptor#getAccessIndex()} from the structured
+     * fields. Call after <em>any</em> change to owner, space, visibility or grants
+     * — a descriptor written without this leaves the resource missing from listings
+     * it should appear in.
+     *
+     * @return the same descriptor, for chaining
+     */
+    public static DocumentDescriptor rebuildIndex(DocumentDescriptor descriptor) {
+        if (descriptor == null) {
+            return null;
+        }
+        descriptor.setAccessIndex(buildIndex(descriptor));
+        return descriptor;
+    }
+
+    /** The token index {@link #rebuildIndex} stores. Visible for testing. */
+    public static String buildIndex(DocumentDescriptor descriptor) {
+        Set<String> tokens = new LinkedHashSet<>();
+
+        if (isUnowned(descriptor)) {
+            tokens.add(Subjects.LEGACY);
+        }
+
+        String ownerId = descriptor.getOwnerId();
+        if (ownerId != null && !ownerId.isBlank()) {
+            tokens.add(Subjects.OWNER_TOKEN_PREFIX + Subjects.encode(ownerId));
+        }
+
+        ResourceVisibility visibility = descriptor.resourceVisibility();
+        if (visibility == null) {
+            visibility = ResourceVisibility.space;
+        }
+
+        if (visibility == ResourceVisibility.published) {
+            tokens.add(Subjects.TOKEN_ALL);
+        }
+
+        String spaceId = descriptor.getSpaceId();
+        if (visibility == ResourceVisibility.space && spaceId != null && !spaceId.isBlank() && !Subjects.LEGACY.equals(spaceId)) {
+            tokens.add(Subjects.SPACE_TOKEN_PREFIX + Subjects.encode(spaceId));
+        }
+
+        List<ResourceGrant> grants = descriptor.getGrants();
+        if (grants != null) {
+            for (ResourceGrant grant : grants) {
+                if (grant != null && grant.getSubject() != null && !grant.getSubject().isBlank() && grant.accessLevel() != null) {
+                    tokens.add(grant.getSubject());
+                }
+            }
+        }
+
+        if (tokens.isEmpty()) {
+            // Only reachable for a descriptor with an owner-less non-legacy space and
+            // private visibility. An empty index matches no listing at all, and a resource
+            // nobody can list is a worse outcome than one only admins see.
+            tokens.add(Subjects.LEGACY);
+        }
+
+        StringBuilder out = new StringBuilder();
+        out.append(Subjects.DELIMITER);
+        for (String token : tokens) {
+            out.append(token).append(Subjects.DELIMITER);
+        }
+        return out.toString();
+    }
+
+    /**
+     * Every index token that would admit {@code caller}. This is the OR-group a
+     * listing query is built from, and it must stay the exact mirror of
+     * {@link #effectiveLevel}.
+     */
+    public static List<String> admittingTokens(CallerSpaces caller, boolean admitLegacy) {
+        List<String> tokens = new ArrayList<>();
+        tokens.add(Subjects.TOKEN_ALL);
+        if (admitLegacy) {
+            tokens.add(Subjects.LEGACY);
+        }
+        if (caller == null) {
+            return tokens;
+        }
+        for (String self : caller.selfPrincipals()) {
+            tokens.add(Subjects.OWNER_TOKEN_PREFIX + Subjects.encode(self));
+        }
+        for (String space : caller.spaces()) {
+            tokens.add(Subjects.SPACE_TOKEN_PREFIX + Subjects.encode(space));
+        }
+        tokens.addAll(caller.subjects());
+        return tokens;
+    }
+
+    private static AccessLevel higher(AccessLevel a, AccessLevel b) {
+        if (a == null) {
+            return b;
+        }
+        if (b == null) {
+            return a;
+        }
+        return a.ordinal() >= b.ordinal() ? a : b;
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
+import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
+import ai.labs.eddi.engine.security.OwnershipValidator;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.Date;
+
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
+
+/**
+ * Single source of truth for <em>who may do what with a configuration
+ * resource</em> — agents, workflows, rule sets, LLM configs, output sets,
+ * dictionaries, api calls, mcp calls, RAG configs, prompt snippets, channels,
+ * connections and agent groups alike.
+ * <p>
+ * The direct sibling of
+ * {@link ai.labs.eddi.engine.security.ConversationAccessGuard}: same
+ * composition (delegate role and identity questions to
+ * {@link OwnershipValidator}, resolve the owner through the resource's
+ * descriptor), same pairing of a throwing check for single-resource operations
+ * with a non-throwing one for listings.
+ *
+ * <h3>Where this is and is not applied</h3> It guards the <em>authoring</em>
+ * surface: {@code RestVersionInfo} and the {@code IRest*Store} facades, which
+ * the MCP admin tools also call in-process and therefore inherit. It is
+ * deliberately absent from the engine's own resolution path —
+ * {@code ResourceClientLibrary.getResource} reads through the stores directly,
+ * because the identity on a conversation turn is whoever is chatting, who does
+ * not own the agent they are talking to.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class ResourceAccessGuard {
+
+    private static final Logger LOGGER = Logger.getLogger(ResourceAccessGuard.class);
+
+    private final SecurityIdentity identity;
+    private final OwnershipValidator ownershipValidator;
+    private final SpaceContext spaceContext;
+    private final WorkspaceSettings settings;
+    private final IDocumentDescriptorStore documentDescriptorStore;
+
+    @Inject
+    public ResourceAccessGuard(SecurityIdentity identity, OwnershipValidator ownershipValidator, SpaceContext spaceContext,
+            WorkspaceSettings settings, IDocumentDescriptorStore documentDescriptorStore) {
+        this.identity = identity;
+        this.ownershipValidator = ownershipValidator;
+        this.spaceContext = spaceContext;
+        this.settings = settings;
+        this.documentDescriptorStore = documentDescriptorStore;
+    }
+
+    /**
+     * Whether this caller sees every resource regardless of owner — an
+     * administrator, or anybody at all when workspaces are not being enforced.
+     * <p>
+     * Lets a listing skip the access predicate entirely rather than building one
+     * that would match everything anyway.
+     */
+    public boolean seesEverything() {
+        return !settings.isEnforcing() || ownershipValidator.isAdmin(identity);
+    }
+
+    /**
+     * The scope to hand to
+     * {@link IDocumentDescriptorStore#readDescriptors(String, String, Integer, Integer, boolean, AccessScope)}.
+     */
+    public AccessScope listingScope() {
+        if (seesEverything()) {
+            return AccessScope.unrestricted();
+        }
+        return AccessScope.forCaller(spaceContext.current(), settings.admitsLegacy());
+    }
+
+    /**
+     * What the caller may do with an already-loaded descriptor, or {@code null} for
+     * nothing. Returns {@link AccessLevel#OWN} whenever {@link #seesEverything()}.
+     */
+    public AccessLevel effectiveLevel(DocumentDescriptor descriptor) {
+        if (seesEverything()) {
+            return AccessLevel.OWN;
+        }
+        return DescriptorAccess.effectiveLevel(descriptor, spaceContext.current(), settings.admitsLegacy());
+    }
+
+    /**
+     * Non-throwing check for filtering an already-materialised list, mirroring
+     * {@link #requireAccess} exactly so a caller never lists something they could
+     * not read.
+     */
+    public boolean canAccess(DocumentDescriptor descriptor, AccessLevel required) {
+        AccessLevel granted = effectiveLevel(descriptor);
+        return granted != null && granted.includes(required);
+    }
+
+    /**
+     * Asserts that the caller holds at least {@code required} on the resource.
+     *
+     * @param resourceId
+     *            the resource's id (not its version — ownership belongs to the
+     *            resource)
+     * @param required
+     *            the level the operation demands
+     * @param resourceType
+     *            human-readable type, for the error message
+     * @throws ForbiddenException
+     *             if the caller's level is insufficient, or if the descriptor
+     *             cannot be loaded at all — an unverifiable owner is not an absent
+     *             owner
+     */
+    public void requireAccess(String resourceId, AccessLevel required, String resourceType) {
+        if (seesEverything()) {
+            return;
+        }
+        if (resourceId == null || resourceId.isBlank()) {
+            return; // nothing addressed; the operation itself will fail on its own terms
+        }
+
+        DocumentDescriptor descriptor;
+        try {
+            descriptor = documentDescriptorStore.readCurrentDescriptor(resourceId);
+        } catch (ResourceNotFoundException e) {
+            // No descriptor at all. Not necessarily an error: resources can predate the
+            // descriptor filter, and a few are created by paths that never wrote one. Treat
+            // it exactly as an unowned descriptor is treated, so the legacy-visibility
+            // policy decides — rather than inventing a third answer here.
+            LOGGER.debugf("No descriptor for resource %s; falling back to legacy-visibility policy", sanitize(resourceId));
+            if (settings.admitsLegacy()) {
+                return;
+            }
+            throw new ForbiddenException("Access denied: this " + resourceType + " has no recorded owner");
+        } catch (ResourceStoreException e) {
+            LOGGER.warnf("Could not load descriptor for access check on %s: %s", sanitize(resourceId), e.getMessage());
+            throw new ForbiddenException("Access denied: unable to verify ownership of this " + resourceType);
+        }
+
+        AccessLevel granted = DescriptorAccess.effectiveLevel(descriptor, spaceContext.current(), settings.admitsLegacy());
+        if (granted == null || !granted.includes(required)) {
+            LOGGER.warnf("Access check failed: caller denied %s access to %s", required, resourceType);
+            LOGGER.debugf("Access detail: resourceId='%s', granted='%s', required='%s'", sanitize(resourceId), granted, required);
+            throw new ForbiddenException("Access denied: you do not have " + required.name().toLowerCase() + " access to this " + resourceType);
+        }
+    }
+
+    /**
+     * Asserts the caller may <em>talk to</em> an agent — the
+     * {@link AccessLevel#USE} gate on {@code POST /agents/{agentId}/start}.
+     *
+     * <h3>Separate from reading the configuration, on purpose</h3> Using an agent
+     * and reading how it was built are different acts, and the common share is the
+     * first one. A recipient with {@code USE} can hold a conversation and cannot
+     * read the system prompt, the tool list, or the vault references behind them.
+     *
+     * <h3>What happens to public agents</h3> An anonymous caller — the production
+     * chat endpoints are {@code permit} by HTTP policy — holds no subject and no
+     * space, so only a {@code published} agent admits them. Agents that predate
+     * ownership stay reachable under the legacy-visibility policy, so enabling
+     * workspaces does not silently take an existing public bot offline; an agent
+     * created <em>after</em> enforcement must be published deliberately, which the
+     * refusal message says.
+     */
+    public void requireAgentUseAccess(String agentId) {
+        if (seesEverything()) {
+            return;
+        }
+        if (agentId == null || agentId.isBlank()) {
+            return;
+        }
+
+        DocumentDescriptor descriptor;
+        try {
+            descriptor = documentDescriptorStore.readCurrentDescriptor(agentId);
+        } catch (ResourceNotFoundException e) {
+            LOGGER.debugf("No descriptor for agent %s; falling back to legacy-visibility policy", sanitize(agentId));
+            if (settings.admitsLegacy()) {
+                return;
+            }
+            throw new ForbiddenException("Access denied: this agent has no recorded owner");
+        } catch (ResourceStoreException e) {
+            LOGGER.warnf("Could not load descriptor for use check on agent %s: %s", sanitize(agentId), e.getMessage());
+            throw new ForbiddenException("Access denied: unable to verify access to this agent");
+        }
+
+        AccessLevel granted = DescriptorAccess.effectiveLevel(descriptor, spaceContext.current(), settings.admitsLegacy());
+        if (granted == null || !granted.includes(AccessLevel.USE)) {
+            LOGGER.warnf("Use check failed: caller denied conversation access to an agent");
+            LOGGER.debugf("Use detail: agentId='%s', granted='%s'", sanitize(agentId), granted);
+            throw new ForbiddenException("Access denied: you do not have access to this agent. Ask its owner to share it with you, "
+                    + "or have them publish it if it is meant to be public.");
+        }
+    }
+
+    /**
+     * Stamps ownership onto a descriptor being created, and materialises its access
+     * index.
+     * <p>
+     * Runs whenever authentication is on, <em>not</em> only when enforcement is —
+     * so an operator can deploy, let attribution accumulate and be verified, and
+     * only then switch enforcement on. Flipping enforcement against unstamped data
+     * is what would hide people's own work from them.
+     *
+     * @return the same descriptor, for chaining
+     */
+    public DocumentDescriptor stampNewDescriptor(DocumentDescriptor descriptor) {
+        if (descriptor == null) {
+            return null;
+        }
+        if (settings.isStampingOwnership()) {
+            String principal = spaceContext.currentPrincipal();
+            if (principal != null) {
+                if (descriptor.getOwnerId() == null || descriptor.getOwnerId().isBlank()) {
+                    descriptor.setOwnerId(principal);
+                }
+                if (descriptor.getSpaceId() == null || descriptor.getSpaceId().isBlank()) {
+                    descriptor.setSpaceId(spaceContext.defaultWriteSpace());
+                }
+                if (descriptor.getVisibility() == null || descriptor.getVisibility().isBlank()) {
+                    descriptor.setVisibility(ResourceVisibility.space.wireName());
+                }
+            }
+        }
+        return DescriptorAccess.rebuildIndex(descriptor);
+    }
+
+    /**
+     * Records the caller as the last modifier and refreshes the access index.
+     * <p>
+     * The index refresh matters even when nothing about sharing changed: a
+     * descriptor whose index predates this feature acquires one the first time it
+     * is written, which is what lets an existing deployment converge without
+     * waiting for the backfill migration.
+     */
+    public DocumentDescriptor stampModification(DocumentDescriptor descriptor) {
+        if (descriptor == null) {
+            return null;
+        }
+        descriptor.setLastModifiedOn(new Date(System.currentTimeMillis()));
+        return DescriptorAccess.rebuildIndex(descriptor);
+    }
+
+    /** The caller's principal name, or {@code null} when unauthenticated. */
+    public String currentPrincipal() {
+        return spaceContext.currentPrincipal();
+    }
+
+    /** Whether the caller holds the admin role (or authorization is disabled). */
+    public boolean isAdmin() {
+        return ownershipValidator.isAdmin(identity);
+    }
+
+    /** The workspace settings this guard enforces. */
+    public WorkspaceSettings settings() {
+        return settings;
+    }
+
+    /** The caller's spaces and subjects. */
+    public CallerSpaces callerSpaces() {
+        return spaceContext.current();
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
@@ -373,12 +373,44 @@ public class ResourceAccessGuard {
     private DocumentDescriptor applyCallerLevel(DocumentDescriptor descriptor, AccessLevel granted) {
         descriptor.setCallerLevel(settings.isEnforcing() && granted != null ? granted.name() : null);
 
-        if (granted != null && granted.includes(AccessLevel.OWN)) {
+        if (mayReadGrants(descriptor, granted)) {
             return descriptor;
         }
         descriptor.setGrants(null);
         descriptor.setAccessIndex(null);
         return descriptor;
+    }
+
+    /**
+     * Whether this caller may see the grant list and the access index.
+     *
+     * <h3>Why enforcement-off is not "everyone owns everything" here</h3>
+     * {@link #seesEverything()} is true for every caller while enforcement is off,
+     * so keying disclosure on the granted level alone would hand every editor the
+     * full grant audience — real principal and team names — of every resource. That
+     * is not hypothetical: ownership and grants are recorded whenever
+     * authentication is on, and the documented rollout is to let attribution
+     * accumulate <em>before</em> switching enforcement on. A deployment part-way
+     * through that, or one that switched enforcement back off, would be
+     * broadcasting the audience lists it had built up.
+     * <p>
+     * So the question is asked structurally instead: does this caller actually own
+     * the resource, or hold the administrator role? Neither answer depends on the
+     * enforcement flag, which is what makes it safe in both states. The sharing
+     * endpoint is unaffected — it decides disclosure itself, and is the surface
+     * that exists to show an owner their own grants.
+     */
+    private boolean mayReadGrants(DocumentDescriptor descriptor, AccessLevel granted) {
+        if (ownershipValidator.isAdmin(identity)) {
+            return true;
+        }
+        if (!settings.isEnforcing()) {
+            // Nothing is enforced, so `granted` says OWN for everyone. Fall back to
+            // the structural question, which does not.
+            AccessLevel structural = DescriptorAccess.effectiveLevel(descriptor, spaceContext.current(), settings.admitsLegacy());
+            return structural != null && structural.includes(AccessLevel.OWN);
+        }
+        return granted != null && granted.includes(AccessLevel.OWN);
     }
 
     /** The caller's principal name, or {@code null} when unauthenticated. */

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
@@ -327,10 +327,10 @@ public class ResourceAccessGuard {
      * @return the same descriptor, for chaining
      */
     public DocumentDescriptor redactForCaller(DocumentDescriptor descriptor) {
-        if (descriptor == null || seesEverything() || canAccess(descriptor, AccessLevel.OWN)) {
-            return descriptor;
+        if (descriptor == null) {
+            return null;
         }
-        return redact(descriptor);
+        return applyCallerLevel(descriptor, effectiveLevel(descriptor));
     }
 
     /**
@@ -347,13 +347,35 @@ public class ResourceAccessGuard {
      * @return the same descriptor, for chaining
      */
     public DocumentDescriptor redactUnlessOwner(DocumentDescriptor descriptor, AccessLevel callerLevel) {
-        if (descriptor == null || seesEverything() || (callerLevel != null && callerLevel.includes(AccessLevel.OWN))) {
-            return descriptor;
+        if (descriptor == null) {
+            return null;
         }
-        return redact(descriptor);
+        return applyCallerLevel(descriptor, seesEverything() ? AccessLevel.OWN : callerLevel);
     }
 
-    private static DocumentDescriptor redact(DocumentDescriptor descriptor) {
+    /**
+     * Stamps what the caller may do, and removes what they may not read.
+     *
+     * <h3>Why the level is reported at all</h3> Without it a listing gives a
+     * recipient no way to tell an agent they may edit from one they may only talk
+     * to — the grant list is disclosed at {@code OWN} only, and {@code ownerId}
+     * alone does not answer it. A client would then have to offer every action and
+     * let the server refuse, which reads as the product being broken rather than as
+     * the resource not being theirs.
+     *
+     * <h3>Why it is null when nothing is enforced</h3> Everyone may do everything
+     * in that state, so a level would be true and useless. Omitting it keeps a
+     * listing byte-identical to a deployment that has never heard of workspaces,
+     * which is the compatibility property this feature is built around — and a
+     * client that wants to know asks {@code GET /workspaces} once instead of
+     * inferring it per row.
+     */
+    private DocumentDescriptor applyCallerLevel(DocumentDescriptor descriptor, AccessLevel granted) {
+        descriptor.setCallerLevel(settings.isEnforcing() && granted != null ? granted.name() : null);
+
+        if (granted != null && granted.includes(AccessLevel.OWN)) {
+            return descriptor;
+        }
         descriptor.setGrants(null);
         descriptor.setAccessIndex(null);
         return descriptor;

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
@@ -284,6 +284,34 @@ public class ResourceAccessGuard {
         return DescriptorAccess.rebuildIndex(descriptor);
     }
 
+    /**
+     * Strips what a non-owner has no business reading from a descriptor about to be
+     * serialised: the grant list and the access index.
+     * <p>
+     * {@code ResourceSharingService.describe} already discloses grants only at
+     * {@link AccessLevel#OWN} — but descriptors also leave the building through
+     * every listing and every direct descriptor read, and a {@code published}
+     * resource is listable by everyone. Without this, the sharing endpoint's
+     * restraint is theatre: the same subjects — real principal and team names —
+     * ride out in the list JSON. Owner, space and visibility stay: the Manager's
+     * owner column needs them, and "owned by alice, space-visible" is exactly what
+     * a recipient needs to understand why they can see something.
+     * <p>
+     * Mutates the given instance, which is safe because descriptors are
+     * deserialised fresh per read — but for that reason this must never be called
+     * on a descriptor that will be written back.
+     *
+     * @return the same descriptor, for chaining
+     */
+    public DocumentDescriptor redactForCaller(DocumentDescriptor descriptor) {
+        if (descriptor == null || seesEverything() || canAccess(descriptor, AccessLevel.OWN)) {
+            return descriptor;
+        }
+        descriptor.setGrants(null);
+        descriptor.setAccessIndex(null);
+        return descriptor;
+    }
+
     /** The caller's principal name, or {@code null} when unauthenticated. */
     public String currentPrincipal() {
         return spaceContext.currentPrincipal();

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
@@ -126,25 +126,31 @@ public class ResourceAccessGuard {
      *            the level the operation demands
      * @param resourceType
      *            human-readable type, for the error message
+     * @return the level the caller actually holds, which may exceed
+     *         {@code required}. Callers that also redact a response should pass
+     *         this to {@link #redactUnlessOwner} rather than re-deciding against
+     *         the descriptor they are about to return: that one may be an older
+     *         version, whose recorded owner and grants can differ from the current
+     *         ones this check used.
+     *
      * @throws ForbiddenException
      *             if the caller's level is insufficient, or if the descriptor
      *             cannot be loaded at all — an unverifiable owner is not an absent
      *             owner
      */
-    public void requireAccess(String resourceId, AccessLevel required, String resourceType) {
+    public AccessLevel requireAccess(String resourceId, AccessLevel required, String resourceType) {
         if (seesEverything()) {
-            return;
+            return AccessLevel.OWN;
         }
         if (resourceId == null || resourceId.isBlank()) {
-            return; // nothing addressed; the operation itself will fail on its own terms
+            return null; // nothing addressed; the operation itself will fail on its own terms
         }
 
         DocumentDescriptor descriptor;
         try {
             descriptor = documentDescriptorStore.readCurrentDescriptor(resourceId);
         } catch (ResourceNotFoundException e) {
-            requireLegacyFallback(resourceId, required, resourceType);
-            return;
+            return requireLegacyFallback(resourceId, required, resourceType);
         } catch (ResourceStoreException e) {
             LOGGER.warnf("Could not load descriptor for access check on %s: %s", sanitize(resourceId), e.getMessage());
             throw new ForbiddenException("Access denied: unable to verify ownership of this " + resourceType);
@@ -156,6 +162,7 @@ public class ResourceAccessGuard {
             LOGGER.debugf("Access detail: resourceId='%s', granted='%s', required='%s'", sanitize(resourceId), granted, required);
             throw new ForbiddenException("Access denied: you do not have " + required.name().toLowerCase() + " access to this " + resourceType);
         }
+        return granted;
     }
 
     /**
@@ -176,30 +183,43 @@ public class ResourceAccessGuard {
      * refusal message says.
      */
     public void requireAgentUseAccess(String agentId) {
+        requireUseAccess(agentId, "agent");
+    }
+
+    /**
+     * As {@link #requireAgentUseAccess}, for a target that is not an agent.
+     * <p>
+     * Group discussions are reachable by the same routes agents are — a channel
+     * target, a trigger — and a group is a guarded descriptor like any other, so
+     * the same check applies. The label only shapes the refusal message; passing
+     * the wrong one tells the caller to go ask the owner of the wrong thing.
+     */
+    public void requireUseAccess(String resourceId, String resourceTypeLabel) {
         if (seesEverything()) {
             return;
         }
-        if (agentId == null || agentId.isBlank()) {
+        if (resourceId == null || resourceId.isBlank()) {
             return;
         }
 
         DocumentDescriptor descriptor;
         try {
-            descriptor = documentDescriptorStore.readCurrentDescriptor(agentId);
+            descriptor = documentDescriptorStore.readCurrentDescriptor(resourceId);
         } catch (ResourceNotFoundException e) {
-            requireLegacyFallback(agentId, AccessLevel.USE, "agent");
+            requireLegacyFallback(resourceId, AccessLevel.USE, resourceTypeLabel);
             return;
         } catch (ResourceStoreException e) {
-            LOGGER.warnf("Could not load descriptor for use check on agent %s: %s", sanitize(agentId), e.getMessage());
-            throw new ForbiddenException("Access denied: unable to verify access to this agent");
+            LOGGER.warnf("Could not load descriptor for use check on %s %s: %s", resourceTypeLabel, sanitize(resourceId),
+                    e.getMessage());
+            throw new ForbiddenException("Access denied: unable to verify access to this " + resourceTypeLabel);
         }
 
         AccessLevel granted = DescriptorAccess.effectiveLevel(descriptor, spaceContext.current(), settings.admitsLegacy());
         if (granted == null || !granted.includes(AccessLevel.USE)) {
-            LOGGER.warnf("Use check failed: caller denied conversation access to an agent");
-            LOGGER.debugf("Use detail: agentId='%s', granted='%s'", sanitize(agentId), granted);
-            throw new ForbiddenException("Access denied: you do not have access to this agent. Ask its owner to share it with you, "
-                    + "or have them publish it if it is meant to be public.");
+            LOGGER.warnf("Use check failed: caller denied conversation access to a %s", resourceTypeLabel);
+            LOGGER.debugf("Use detail: resourceId='%s', type='%s', granted='%s'", sanitize(resourceId), resourceTypeLabel, granted);
+            throw new ForbiddenException("Access denied: you do not have access to this " + resourceTypeLabel
+                    + ". Ask its owner to share it with you, or have them publish it if it is meant to be public.");
         }
     }
 
@@ -223,10 +243,13 @@ public class ResourceAccessGuard {
      * operator should be able to find and close, not something to discover from a
      * support ticket.
      */
-    private void requireLegacyFallback(String resourceId, AccessLevel required, String resourceType) {
+    private AccessLevel requireLegacyFallback(String resourceId, AccessLevel required, String resourceType) {
         if (settings.admitsLegacy() && !required.includes(AccessLevel.EDIT)) {
             LOGGER.debugf("No descriptor for %s %s; admitting %s under legacy-visibility", resourceType, sanitize(resourceId), required);
-            return;
+            // Exactly what was asked for and no more. Reporting OWN here would let a
+            // caller redact-check their way into a grant list on a resource whose owner
+            // we could not establish in the first place.
+            return required;
         }
         LOGGER.warnf("No descriptor recorded for %s '%s' — refusing %s access. A resource with no descriptor has no owner, "
                 + "so it cannot be edited, deleted or re-shared until one is assigned.", resourceType, sanitize(resourceId), required);
@@ -307,6 +330,30 @@ public class ResourceAccessGuard {
         if (descriptor == null || seesEverything() || canAccess(descriptor, AccessLevel.OWN)) {
             return descriptor;
         }
+        return redact(descriptor);
+    }
+
+    /**
+     * As {@link #redactForCaller}, but told what the caller holds instead of
+     * working it out from the descriptor in hand.
+     * <p>
+     * For a versioned read the two are not the same question. Sharing writes land
+     * on the <em>current</em> version, so an older version's descriptor can still
+     * name a previous owner and carry that era's grant list — and deciding
+     * redaction against it would disclose those to somebody who no longer owns the
+     * resource. Pass the level {@link #requireAccess} returned, which was decided
+     * against the current descriptor.
+     *
+     * @return the same descriptor, for chaining
+     */
+    public DocumentDescriptor redactUnlessOwner(DocumentDescriptor descriptor, AccessLevel callerLevel) {
+        if (descriptor == null || seesEverything() || (callerLevel != null && callerLevel.includes(AccessLevel.OWN))) {
+            return descriptor;
+        }
+        return redact(descriptor);
+    }
+
+    private static DocumentDescriptor redact(DocumentDescriptor descriptor) {
         descriptor.setGrants(null);
         descriptor.setAccessIndex(null);
         return descriptor;

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuard.java
@@ -35,9 +35,17 @@ import static ai.labs.eddi.utils.LogSanitizer.sanitize;
  * with a non-throwing one for listings.
  *
  * <h3>Where this is and is not applied</h3> It guards the <em>authoring</em>
- * surface: {@code RestVersionInfo} and the {@code IRest*Store} facades, which
- * the MCP admin tools also call in-process and therefore inherit. It is
- * deliberately absent from the engine's own resolution path —
+ * surface: {@code RestVersionInfo} and the {@code IRest*Store} facades. MCP
+ * tools that hold an injected facade — {@code McpConversationTools}'s agent
+ * store, {@code McpGroupTools}'s group store, {@code McpAdminTools}'s
+ * {@code IRestAgentAdministration} — call those beans in-process and inherit
+ * it. MCP tools that resolve a store through {@code IRestInterfaceFactory}
+ * instead do <em>not</em>: that builds a REST client and makes a loopback HTTP
+ * call, so the endpoint's own checks apply to a request that carries no
+ * credentials — which is a pre-existing problem with internal loopback calls,
+ * not something this guard introduces or fixes.
+ * <p>
+ * It is deliberately absent from the engine's own resolution path —
  * {@code ResourceClientLibrary.getResource} reads through the stores directly,
  * because the identity on a conversation turn is whoever is chatting, who does
  * not own the agent they are talking to.
@@ -135,15 +143,8 @@ public class ResourceAccessGuard {
         try {
             descriptor = documentDescriptorStore.readCurrentDescriptor(resourceId);
         } catch (ResourceNotFoundException e) {
-            // No descriptor at all. Not necessarily an error: resources can predate the
-            // descriptor filter, and a few are created by paths that never wrote one. Treat
-            // it exactly as an unowned descriptor is treated, so the legacy-visibility
-            // policy decides — rather than inventing a third answer here.
-            LOGGER.debugf("No descriptor for resource %s; falling back to legacy-visibility policy", sanitize(resourceId));
-            if (settings.admitsLegacy()) {
-                return;
-            }
-            throw new ForbiddenException("Access denied: this " + resourceType + " has no recorded owner");
+            requireLegacyFallback(resourceId, required, resourceType);
+            return;
         } catch (ResourceStoreException e) {
             LOGGER.warnf("Could not load descriptor for access check on %s: %s", sanitize(resourceId), e.getMessage());
             throw new ForbiddenException("Access denied: unable to verify ownership of this " + resourceType);
@@ -186,11 +187,8 @@ public class ResourceAccessGuard {
         try {
             descriptor = documentDescriptorStore.readCurrentDescriptor(agentId);
         } catch (ResourceNotFoundException e) {
-            LOGGER.debugf("No descriptor for agent %s; falling back to legacy-visibility policy", sanitize(agentId));
-            if (settings.admitsLegacy()) {
-                return;
-            }
-            throw new ForbiddenException("Access denied: this agent has no recorded owner");
+            requireLegacyFallback(agentId, AccessLevel.USE, "agent");
+            return;
         } catch (ResourceStoreException e) {
             LOGGER.warnf("Could not load descriptor for use check on agent %s: %s", sanitize(agentId), e.getMessage());
             throw new ForbiddenException("Access denied: unable to verify access to this agent");
@@ -203,6 +201,36 @@ public class ResourceAccessGuard {
             throw new ForbiddenException("Access denied: you do not have access to this agent. Ask its owner to share it with you, "
                     + "or have them publish it if it is meant to be public.");
         }
+    }
+
+    /**
+     * What to do when a resource has no descriptor at all.
+     *
+     * <h3>Read-only, never write</h3> A missing descriptor is not the same as an
+     * unowned one. Resources can predate the descriptor filter, and some creation
+     * paths never produce one — {@code AgentSetupService} reaches the stores over
+     * an unauthenticated loopback call, for instance. Treating that as
+     * {@link AccessLevel#OWN} under the default {@code legacy-visibility=shared}
+     * would hand every editor delete, undeploy and re-share on any such resource,
+     * which is a fail-open answer to a question we could not answer at all.
+     * <p>
+     * So the fallback admits reading and using, and refuses anything above it
+     * regardless of the legacy policy. That keeps an upgraded deployment working —
+     * nothing disappears, nothing stops answering — without letting an absent
+     * record grant authority.
+     * <p>
+     * Logged at WARN rather than DEBUG: a resource with no descriptor is a gap an
+     * operator should be able to find and close, not something to discover from a
+     * support ticket.
+     */
+    private void requireLegacyFallback(String resourceId, AccessLevel required, String resourceType) {
+        if (settings.admitsLegacy() && !required.includes(AccessLevel.EDIT)) {
+            LOGGER.debugf("No descriptor for %s %s; admitting %s under legacy-visibility", resourceType, sanitize(resourceId), required);
+            return;
+        }
+        LOGGER.warnf("No descriptor recorded for %s '%s' — refusing %s access. A resource with no descriptor has no owner, "
+                + "so it cannot be edited, deleted or re-shared until one is assigned.", resourceType, sanitize(resourceId), required);
+        throw new ForbiddenException("Access denied: this " + resourceType + " has no recorded owner");
     }
 
     /**
@@ -224,7 +252,10 @@ public class ResourceAccessGuard {
             String principal = spaceContext.currentPrincipal();
             if (principal != null) {
                 if (descriptor.getOwnerId() == null || descriptor.getOwnerId().isBlank()) {
-                    descriptor.setOwnerId(principal);
+                    // Trimmed, because CallerSpaces.of and defaultWriteSpace both trim: an owner
+                    // stored with surrounding whitespace would never match its own principal
+                    // again, and the owner would silently lose their own resource.
+                    descriptor.setOwnerId(principal.trim());
                 }
                 if (descriptor.getSpaceId() == null || descriptor.getSpaceId().isBlank()) {
                     descriptor.setSpaceId(spaceContext.defaultWriteSpace());

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceSharingService.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceSharingService.java
@@ -100,15 +100,25 @@ public class ResourceSharingService {
     public record ShareResult(List<String> updated, List<String> skipped) {
     }
 
-    /** Reports how a resource is shared. Requires read access. */
+    /**
+     * Reports how a resource is shared.
+     * <p>
+     * Readable at {@link AccessLevel#VIEW}, but the <em>grant list</em> only at
+     * {@link AccessLevel#OWN}. A {@code published} resource grants VIEW to
+     * everyone, so returning its grants to any reader would publish every subject
+     * on it — real principal names and Keycloak team names — to the whole
+     * deployment. Owner, space and the caller's own level are enough for a
+     * recipient to understand why they can see something and whom to ask about it.
+     */
     public ShareInfo describe(String resourceId) {
         accessGuard.requireAccess(resourceId, AccessLevel.VIEW, RESOURCE_TYPE);
         DocumentDescriptor descriptor = loadOrThrow(resourceId);
         AccessLevel level = accessGuard.effectiveLevel(descriptor);
+        boolean maySeeGrants = level != null && level.includes(AccessLevel.OWN);
+        List<ResourceGrant> grants = maySeeGrants && descriptor.getGrants() != null ? List.copyOf(descriptor.getGrants()) : List.of();
         return new ShareInfo(resourceId, descriptor.getOwnerId(), descriptor.getSpaceId(),
                 descriptor.getVisibility() == null ? ResourceVisibility.space.wireName() : descriptor.getVisibility(),
-                descriptor.getGrants() == null ? List.of() : List.copyOf(descriptor.getGrants()),
-                level == null ? null : level.name());
+                grants, level == null ? null : level.name());
     }
 
     /**
@@ -176,6 +186,15 @@ public class ResourceSharingService {
         if (!accessGuard.isAdmin()) {
             throw new ForbiddenException("Only an administrator may transfer ownership");
         }
+        // Validated here rather than only at the REST edge, because this is a public
+        // bean any in-process caller can reach. A blank owner combined with cascade
+        // would make the agent and its entire config graph unowned — which under the
+        // default legacy-visibility policy means owned by everybody.
+        if (newOwnerId == null || newOwnerId.isBlank()) {
+            throw new IllegalArgumentException("A new owner is required: transferring ownership to nobody would make the resource "
+                    + "unowned, which the legacy-visibility policy treats as reachable by everyone.");
+        }
+        String owner = newOwnerId.trim();
 
         List<String> updated = new ArrayList<>();
         List<String> skipped = new ArrayList<>();
@@ -186,14 +205,15 @@ public class ResourceSharingService {
 
         for (String id : all) {
             try {
-                DocumentDescriptor descriptor = loadOrNull(id);
-                if (descriptor == null) {
+                VersionedDescriptor loaded = loadOrNull(id);
+                if (loaded == null) {
                     skipped.add(id);
                     continue;
                 }
-                descriptor.setOwnerId(newOwnerId);
-                descriptor.setSpaceId(newSpaceId == null || newSpaceId.isBlank() ? Subjects.personalSpace(newOwnerId) : newSpaceId);
-                writeBack(id, descriptor);
+                DocumentDescriptor descriptor = loaded.descriptor();
+                descriptor.setOwnerId(owner);
+                descriptor.setSpaceId(newSpaceId == null || newSpaceId.isBlank() ? Subjects.personalSpace(owner) : newSpaceId.trim());
+                writeBack(id, descriptor, loaded.version());
                 updated.add(id);
             } catch (Exception e) {
                 LOGGER.warnf("Could not transfer ownership of %s: %s", sanitize(id), e.getMessage());
@@ -239,18 +259,19 @@ public class ResourceSharingService {
      * index disagree is invisible in listings it should appear in.
      */
     private void mutate(String id, List<String> updated, List<String> skipped, Consumer<DocumentDescriptor> change) {
-        DocumentDescriptor descriptor;
+        VersionedDescriptor loaded;
         try {
-            descriptor = loadOrNull(id);
+            loaded = loadOrNull(id);
         } catch (Exception e) {
             LOGGER.warnf("Could not load descriptor %s while updating sharing: %s", sanitize(id), e.getMessage());
             skipped.add(id);
             return;
         }
-        if (descriptor == null) {
+        if (loaded == null) {
             skipped.add(id);
             return;
         }
+        DocumentDescriptor descriptor = loaded.descriptor();
         // You cannot pass on access you were only lent. A referenced resource the
         // caller can read but does not own is left exactly as it was, and reported.
         if (!accessGuard.canAccess(descriptor, AccessLevel.OWN)) {
@@ -259,7 +280,7 @@ public class ResourceSharingService {
         }
         change.accept(descriptor);
         try {
-            writeBack(id, descriptor);
+            writeBack(id, descriptor, loaded.version());
             updated.add(id);
         } catch (Exception e) {
             LOGGER.warnf("Could not write sharing change to %s: %s", sanitize(id), e.getMessage());
@@ -267,26 +288,52 @@ public class ResourceSharingService {
         }
     }
 
-    private void writeBack(String id, DocumentDescriptor descriptor) throws ResourceStoreException, ResourceNotFoundException {
+    /**
+     * Writes the descriptor back at the version it was read from.
+     * <p>
+     * <b>Not</b> at whatever the current version happens to be at write time. The
+     * descriptor object in hand was read at version N; if a {@code PUT} on the
+     * resource lands in between, {@code DocumentDescriptorFilter} creates version
+     * N+1 with {@code resource} re-pointed at it — and writing our stale object
+     * over N+1 would leave the descriptor naming the wrong version of its own
+     * resource.
+     * <p>
+     * {@code setDescriptor} writes in place rather than creating a version, because
+     * sharing is metadata about the resource rather than a new revision of it;
+     * versioning it would make every share look like a config change in the
+     * resource's history.
+     * <p>
+     * Concurrent shares of the same resource still race — the store offers no
+     * compare-and-set on this path — so the last write wins on the grant list. Two
+     * people re-sharing one resource in the same instant is not a case worth a
+     * lock; two people sharing <em>different</em> resources, which is the common
+     * one, does not interact at all.
+     */
+    private void writeBack(String id, DocumentDescriptor descriptor, int version) throws ResourceStoreException, ResourceNotFoundException {
         accessGuard.stampModification(descriptor);
-        var current = documentDescriptorStore.getCurrentResourceId(id);
-        // setDescriptor writes in place rather than creating a version: sharing is
-        // metadata about the resource, not a new revision of it, and versioning it
-        // would make every share look like a config change in the resource's history.
-        documentDescriptorStore.setDescriptor(id, current.getVersion(), descriptor);
+        documentDescriptorStore.setDescriptor(id, version, descriptor);
     }
 
-    private DocumentDescriptor loadOrNull(String id) throws ResourceStoreException, ResourceNotFoundException {
-        return documentDescriptorStore.readCurrentDescriptor(id);
+    /**
+     * A descriptor and the version it was read at, so a write can go back to
+     * exactly that version rather than to whatever is current by then.
+     */
+    private record VersionedDescriptor(DocumentDescriptor descriptor, int version) {
+    }
+
+    private VersionedDescriptor loadOrNull(String id) throws ResourceStoreException, ResourceNotFoundException {
+        var current = documentDescriptorStore.getCurrentResourceId(id);
+        DocumentDescriptor descriptor = documentDescriptorStore.readDescriptor(id, current.getVersion());
+        return descriptor == null ? null : new VersionedDescriptor(descriptor, current.getVersion());
     }
 
     private DocumentDescriptor loadOrThrow(String id) {
         try {
-            DocumentDescriptor descriptor = loadOrNull(id);
-            if (descriptor == null) {
+            VersionedDescriptor loaded = loadOrNull(id);
+            if (loaded == null) {
                 throw new NotFoundException("No such resource: " + id);
             }
-            return descriptor;
+            return loaded.descriptor();
         } catch (ResourceNotFoundException e) {
             throw new NotFoundException("No such resource: " + id);
         } catch (ResourceStoreException e) {

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceSharingService.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceSharingService.java
@@ -89,6 +89,22 @@ public class ResourceSharingService {
     }
 
     /**
+     * One resource a share touched — or declined to.
+     *
+     * @param id
+     *            the resource id
+     * @param name
+     *            its descriptor name, or {@code null} when it has none. Carried so
+     *            a share dialog can say "also granted on Support Rules" rather than
+     *            "also granted on 1111111111111111111111", which is the difference
+     *            between a confirmation a person can check and one they can only
+     *            accept. Without it the Manager would issue one descriptor read per
+     *            entry to render the same sentence.
+     */
+    public record ShareTarget(String id, String name) {
+    }
+
+    /**
      * The outcome of a share or revoke.
      *
      * @param updated
@@ -97,7 +113,17 @@ public class ResourceSharingService {
      *            resources reachable from the root that the caller may not
      *            re-share, and which were therefore left alone
      */
-    public record ShareResult(List<String> updated, List<String> skipped) {
+    public record ShareResult(List<ShareTarget> updated, List<ShareTarget> skipped) {
+
+        /** Ids only — the shape callers that just need to count or compare want. */
+        public List<String> updatedIds() {
+            return updated.stream().map(ShareTarget::id).toList();
+        }
+
+        /** Ids only, for the resources left alone. */
+        public List<String> skippedIds() {
+            return skipped.stream().map(ShareTarget::id).toList();
+        }
     }
 
     /**
@@ -134,8 +160,8 @@ public class ResourceSharingService {
         accessGuard.requireAccess(resourceId, AccessLevel.OWN, RESOURCE_TYPE);
 
         String grantedBy = accessGuard.currentPrincipal();
-        List<String> updated = new ArrayList<>();
-        List<String> skipped = new ArrayList<>();
+        List<ShareTarget> updated = new ArrayList<>();
+        List<ShareTarget> skipped = new ArrayList<>();
 
         applyGrant(resourceId, subject, level, grantedBy, updated, skipped);
         for (String referenced : targets(resourceId, cascade)) {
@@ -148,8 +174,8 @@ public class ResourceSharingService {
     public ShareResult revoke(String resourceId, String subject, boolean cascade) {
         accessGuard.requireAccess(resourceId, AccessLevel.OWN, RESOURCE_TYPE);
 
-        List<String> updated = new ArrayList<>();
-        List<String> skipped = new ArrayList<>();
+        List<ShareTarget> updated = new ArrayList<>();
+        List<ShareTarget> skipped = new ArrayList<>();
 
         applyRevoke(resourceId, subject, updated, skipped);
         for (String referenced : targets(resourceId, cascade)) {
@@ -167,8 +193,8 @@ public class ResourceSharingService {
     public ShareResult setVisibility(String resourceId, ResourceVisibility visibility, boolean cascade) {
         accessGuard.requireAccess(resourceId, AccessLevel.OWN, RESOURCE_TYPE);
 
-        List<String> updated = new ArrayList<>();
-        List<String> skipped = new ArrayList<>();
+        List<ShareTarget> updated = new ArrayList<>();
+        List<ShareTarget> skipped = new ArrayList<>();
 
         applyVisibility(resourceId, visibility, updated, skipped);
         for (String referenced : targets(resourceId, cascade)) {
@@ -196,8 +222,8 @@ public class ResourceSharingService {
         }
         String owner = newOwnerId.trim();
 
-        List<String> updated = new ArrayList<>();
-        List<String> skipped = new ArrayList<>();
+        List<ShareTarget> updated = new ArrayList<>();
+        List<ShareTarget> skipped = new ArrayList<>();
 
         Set<String> all = new LinkedHashSet<>();
         all.add(resourceId);
@@ -207,17 +233,17 @@ public class ResourceSharingService {
             try {
                 VersionedDescriptor loaded = loadOrNull(id);
                 if (loaded == null) {
-                    skipped.add(id);
+                    skipped.add(new ShareTarget(id, null));
                     continue;
                 }
                 DocumentDescriptor descriptor = loaded.descriptor();
                 descriptor.setOwnerId(owner);
                 descriptor.setSpaceId(newSpaceId == null || newSpaceId.isBlank() ? Subjects.personalSpace(owner) : newSpaceId.trim());
                 writeBack(id, descriptor, loaded.version());
-                updated.add(id);
+                updated.add(new ShareTarget(id, descriptor.getName()));
             } catch (Exception e) {
                 LOGGER.warnf("Could not transfer ownership of %s: %s", sanitize(id), e.getMessage());
-                skipped.add(id);
+                skipped.add(new ShareTarget(id, null));
             }
         }
         return new ShareResult(updated, skipped);
@@ -227,7 +253,7 @@ public class ResourceSharingService {
         return cascade ? graphResolver.referencedResourceIds(resourceId) : Set.of();
     }
 
-    private void applyGrant(String id, String subject, AccessLevel level, String grantedBy, List<String> updated, List<String> skipped) {
+    private void applyGrant(String id, String subject, AccessLevel level, String grantedBy, List<ShareTarget> updated, List<ShareTarget> skipped) {
         mutate(id, updated, skipped, descriptor -> {
             List<ResourceGrant> grants = descriptor.getGrants() == null ? new ArrayList<>() : new ArrayList<>(descriptor.getGrants());
             // One grant per subject: re-sharing at a different level replaces rather than
@@ -238,7 +264,7 @@ public class ResourceSharingService {
         });
     }
 
-    private void applyRevoke(String id, String subject, List<String> updated, List<String> skipped) {
+    private void applyRevoke(String id, String subject, List<ShareTarget> updated, List<ShareTarget> skipped) {
         mutate(id, updated, skipped, descriptor -> {
             if (descriptor.getGrants() == null) {
                 return;
@@ -249,7 +275,7 @@ public class ResourceSharingService {
         });
     }
 
-    private void applyVisibility(String id, ResourceVisibility visibility, List<String> updated, List<String> skipped) {
+    private void applyVisibility(String id, ResourceVisibility visibility, List<ShareTarget> updated, List<ShareTarget> skipped) {
         mutate(id, updated, skipped, descriptor -> descriptor.setVisibility(visibility.wireName()));
     }
 
@@ -258,33 +284,33 @@ public class ResourceSharingService {
      * the access index every time, because a descriptor whose structured fields and
      * index disagree is invisible in listings it should appear in.
      */
-    private void mutate(String id, List<String> updated, List<String> skipped, Consumer<DocumentDescriptor> change) {
+    private void mutate(String id, List<ShareTarget> updated, List<ShareTarget> skipped, Consumer<DocumentDescriptor> change) {
         VersionedDescriptor loaded;
         try {
             loaded = loadOrNull(id);
         } catch (Exception e) {
             LOGGER.warnf("Could not load descriptor %s while updating sharing: %s", sanitize(id), e.getMessage());
-            skipped.add(id);
+            skipped.add(new ShareTarget(id, null));
             return;
         }
         if (loaded == null) {
-            skipped.add(id);
+            skipped.add(new ShareTarget(id, null));
             return;
         }
         DocumentDescriptor descriptor = loaded.descriptor();
         // You cannot pass on access you were only lent. A referenced resource the
         // caller can read but does not own is left exactly as it was, and reported.
         if (!accessGuard.canAccess(descriptor, AccessLevel.OWN)) {
-            skipped.add(id);
+            skipped.add(new ShareTarget(id, descriptor.getName()));
             return;
         }
         change.accept(descriptor);
         try {
             writeBack(id, descriptor, loaded.version());
-            updated.add(id);
+            updated.add(new ShareTarget(id, descriptor.getName()));
         } catch (Exception e) {
             LOGGER.warnf("Could not write sharing change to %s: %s", sanitize(id), e.getMessage());
-            skipped.add(id);
+            skipped.add(new ShareTarget(id, descriptor.getName()));
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceSharingService.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceSharingService.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.descriptors.model.ResourceGrant;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
+import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
+import io.quarkus.security.ForbiddenException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
+
+/**
+ * Grants, revokes and reports sharing on configuration resources.
+ *
+ * <h3>Sharing an agent shares the graph beneath it</h3> A grant on the agent
+ * alone would give the recipient a name and a list of URIs they cannot resolve.
+ * So every share and every revoke walks {@link ConfigGraphResolver} and applies
+ * the same change to each referenced resource — but only to those the caller
+ * themselves may re-share. You cannot pass on access you were merely lent: a
+ * colleague's LLM config that you can see but do not own is skipped, and named
+ * in the result, rather than silently widened.
+ *
+ * <h3>Revoke is reference-counted by construction</h3> Revoking removes the
+ * subject's grant from the root and from each reachable resource, which is
+ * correct even when two shared agents share a rule set: the second agent's own
+ * grant on that rule set is a separate {@link ResourceGrant} for the same
+ * subject only if it was granted through that agent, in which case re-sharing
+ * the second agent restores it. Grants are keyed by subject, so the last revoke
+ * wins — the alternative, tracking which share introduced which grant, buys
+ * correctness in a case (two shares of overlapping graphs to the same person)
+ * that a human would in any case expect to behave exactly like this.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class ResourceSharingService {
+
+    private static final Logger LOGGER = Logger.getLogger(ResourceSharingService.class);
+
+    private static final String RESOURCE_TYPE = "resource";
+
+    private final IDocumentDescriptorStore documentDescriptorStore;
+    private final ResourceAccessGuard accessGuard;
+    private final ConfigGraphResolver graphResolver;
+
+    @Inject
+    public ResourceSharingService(IDocumentDescriptorStore documentDescriptorStore, ResourceAccessGuard accessGuard,
+            ConfigGraphResolver graphResolver) {
+        this.documentDescriptorStore = documentDescriptorStore;
+        this.accessGuard = accessGuard;
+        this.graphResolver = graphResolver;
+    }
+
+    /**
+     * What a caller is allowed to know about how a resource is shared.
+     *
+     * @param resourceId
+     *            the resource
+     * @param ownerId
+     *            the recorded owner, or {@code null} for legacy data
+     * @param spaceId
+     *            the space the resource is filed under
+     * @param visibility
+     *            its {@link ResourceVisibility} wire name
+     * @param grants
+     *            explicit shares
+     * @param callerLevel
+     *            what the calling user may do with it
+     */
+    public record ShareInfo(String resourceId, String ownerId, String spaceId, String visibility, List<ResourceGrant> grants,
+            String callerLevel) {
+    }
+
+    /**
+     * The outcome of a share or revoke.
+     *
+     * @param updated
+     *            resources actually changed, including the root
+     * @param skipped
+     *            resources reachable from the root that the caller may not
+     *            re-share, and which were therefore left alone
+     */
+    public record ShareResult(List<String> updated, List<String> skipped) {
+    }
+
+    /** Reports how a resource is shared. Requires read access. */
+    public ShareInfo describe(String resourceId) {
+        accessGuard.requireAccess(resourceId, AccessLevel.VIEW, RESOURCE_TYPE);
+        DocumentDescriptor descriptor = loadOrThrow(resourceId);
+        AccessLevel level = accessGuard.effectiveLevel(descriptor);
+        return new ShareInfo(resourceId, descriptor.getOwnerId(), descriptor.getSpaceId(),
+                descriptor.getVisibility() == null ? ResourceVisibility.space.wireName() : descriptor.getVisibility(),
+                descriptor.getGrants() == null ? List.of() : List.copyOf(descriptor.getGrants()),
+                level == null ? null : level.name());
+    }
+
+    /**
+     * Grants {@code subject} the given level on {@code resourceId} and, when
+     * {@code cascade}, on everything reachable from it.
+     *
+     * @throws ForbiddenException
+     *             if the caller does not own the root
+     */
+    public ShareResult share(String resourceId, String subject, AccessLevel level, boolean cascade) {
+        // Re-sharing changes who can reach the resource, which is an owner's decision
+        // — EDIT deliberately does not carry it. See AccessLevel.
+        accessGuard.requireAccess(resourceId, AccessLevel.OWN, RESOURCE_TYPE);
+
+        String grantedBy = accessGuard.currentPrincipal();
+        List<String> updated = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+
+        applyGrant(resourceId, subject, level, grantedBy, updated, skipped);
+        for (String referenced : targets(resourceId, cascade)) {
+            applyGrant(referenced, subject, level, grantedBy, updated, skipped);
+        }
+        return new ShareResult(updated, skipped);
+    }
+
+    /** Removes {@code subject}'s grant, mirroring {@link #share}. */
+    public ShareResult revoke(String resourceId, String subject, boolean cascade) {
+        accessGuard.requireAccess(resourceId, AccessLevel.OWN, RESOURCE_TYPE);
+
+        List<String> updated = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+
+        applyRevoke(resourceId, subject, updated, skipped);
+        for (String referenced : targets(resourceId, cascade)) {
+            applyRevoke(referenced, subject, updated, skipped);
+        }
+        return new ShareResult(updated, skipped);
+    }
+
+    /**
+     * Sets a resource's visibility, mirroring {@link #share}.
+     * <p>
+     * Cascades for the same reason a grant does: publishing an agent whose rule
+     * sets stay private publishes something nobody can actually use.
+     */
+    public ShareResult setVisibility(String resourceId, ResourceVisibility visibility, boolean cascade) {
+        accessGuard.requireAccess(resourceId, AccessLevel.OWN, RESOURCE_TYPE);
+
+        List<String> updated = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+
+        applyVisibility(resourceId, visibility, updated, skipped);
+        for (String referenced : targets(resourceId, cascade)) {
+            applyVisibility(referenced, visibility, updated, skipped);
+        }
+        return new ShareResult(updated, skipped);
+    }
+
+    /**
+     * Transfers ownership. Administrators only — the point of this operation is to
+     * recover a resource whose owner has left, which by definition cannot require
+     * that owner's cooperation.
+     */
+    public ShareResult transferOwnership(String resourceId, String newOwnerId, String newSpaceId, boolean cascade) {
+        if (!accessGuard.isAdmin()) {
+            throw new ForbiddenException("Only an administrator may transfer ownership");
+        }
+
+        List<String> updated = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+
+        Set<String> all = new LinkedHashSet<>();
+        all.add(resourceId);
+        all.addAll(targets(resourceId, cascade));
+
+        for (String id : all) {
+            try {
+                DocumentDescriptor descriptor = loadOrNull(id);
+                if (descriptor == null) {
+                    skipped.add(id);
+                    continue;
+                }
+                descriptor.setOwnerId(newOwnerId);
+                descriptor.setSpaceId(newSpaceId == null || newSpaceId.isBlank() ? Subjects.personalSpace(newOwnerId) : newSpaceId);
+                writeBack(id, descriptor);
+                updated.add(id);
+            } catch (Exception e) {
+                LOGGER.warnf("Could not transfer ownership of %s: %s", sanitize(id), e.getMessage());
+                skipped.add(id);
+            }
+        }
+        return new ShareResult(updated, skipped);
+    }
+
+    private Set<String> targets(String resourceId, boolean cascade) {
+        return cascade ? graphResolver.referencedResourceIds(resourceId) : Set.of();
+    }
+
+    private void applyGrant(String id, String subject, AccessLevel level, String grantedBy, List<String> updated, List<String> skipped) {
+        mutate(id, updated, skipped, descriptor -> {
+            List<ResourceGrant> grants = descriptor.getGrants() == null ? new ArrayList<>() : new ArrayList<>(descriptor.getGrants());
+            // One grant per subject: re-sharing at a different level replaces rather than
+            // accumulates, so revoking once is enough to actually revoke.
+            grants.removeIf(grant -> grant == null || subject.equals(grant.getSubject()));
+            grants.add(new ResourceGrant(subject, level.name(), grantedBy, new Date(System.currentTimeMillis())));
+            descriptor.setGrants(grants);
+        });
+    }
+
+    private void applyRevoke(String id, String subject, List<String> updated, List<String> skipped) {
+        mutate(id, updated, skipped, descriptor -> {
+            if (descriptor.getGrants() == null) {
+                return;
+            }
+            List<ResourceGrant> grants = new ArrayList<>(descriptor.getGrants());
+            grants.removeIf(grant -> grant == null || subject.equals(grant.getSubject()));
+            descriptor.setGrants(grants);
+        });
+    }
+
+    private void applyVisibility(String id, ResourceVisibility visibility, List<String> updated, List<String> skipped) {
+        mutate(id, updated, skipped, descriptor -> descriptor.setVisibility(visibility.wireName()));
+    }
+
+    /**
+     * Loads, checks the caller may re-share, mutates, and writes back — rebuilding
+     * the access index every time, because a descriptor whose structured fields and
+     * index disagree is invisible in listings it should appear in.
+     */
+    private void mutate(String id, List<String> updated, List<String> skipped, Consumer<DocumentDescriptor> change) {
+        DocumentDescriptor descriptor;
+        try {
+            descriptor = loadOrNull(id);
+        } catch (Exception e) {
+            LOGGER.warnf("Could not load descriptor %s while updating sharing: %s", sanitize(id), e.getMessage());
+            skipped.add(id);
+            return;
+        }
+        if (descriptor == null) {
+            skipped.add(id);
+            return;
+        }
+        // You cannot pass on access you were only lent. A referenced resource the
+        // caller can read but does not own is left exactly as it was, and reported.
+        if (!accessGuard.canAccess(descriptor, AccessLevel.OWN)) {
+            skipped.add(id);
+            return;
+        }
+        change.accept(descriptor);
+        try {
+            writeBack(id, descriptor);
+            updated.add(id);
+        } catch (Exception e) {
+            LOGGER.warnf("Could not write sharing change to %s: %s", sanitize(id), e.getMessage());
+            skipped.add(id);
+        }
+    }
+
+    private void writeBack(String id, DocumentDescriptor descriptor) throws ResourceStoreException, ResourceNotFoundException {
+        accessGuard.stampModification(descriptor);
+        var current = documentDescriptorStore.getCurrentResourceId(id);
+        // setDescriptor writes in place rather than creating a version: sharing is
+        // metadata about the resource, not a new revision of it, and versioning it
+        // would make every share look like a config change in the resource's history.
+        documentDescriptorStore.setDescriptor(id, current.getVersion(), descriptor);
+    }
+
+    private DocumentDescriptor loadOrNull(String id) throws ResourceStoreException, ResourceNotFoundException {
+        return documentDescriptorStore.readCurrentDescriptor(id);
+    }
+
+    private DocumentDescriptor loadOrThrow(String id) {
+        try {
+            DocumentDescriptor descriptor = loadOrNull(id);
+            if (descriptor == null) {
+                throw new NotFoundException("No such resource: " + id);
+            }
+            return descriptor;
+        } catch (ResourceNotFoundException e) {
+            throw new NotFoundException("No such resource: " + id);
+        } catch (ResourceStoreException e) {
+            throw new ForbiddenException("Unable to read the sharing state of this resource");
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/SpaceContext.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/SpaceContext.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jboss.logging.Logger;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Resolves the calling identity into the spaces and subjects the access policy
+ * reasons about.
+ * <p>
+ * Composed the same way {@code ConversationAccessGuard} is — a
+ * {@code @ApplicationScoped} bean holding the injected {@link SecurityIdentity}
+ * proxy, which Quarkus resolves per request. That keeps a single injection
+ * point for "who is calling" rather than each caller re-deriving it.
+ *
+ * <h3>Groups come from the token, not from roles</h3> Roles say what a caller
+ * may <em>do</em>; groups say what they may <em>see</em>. Mapping groups onto
+ * realm roles would collapse the two and make {@code @RolesAllowed} sensitive
+ * to team membership, so group paths are read from a token claim
+ * ({@code eddi.workspaces.groups-claim}, default {@code groups}) instead. The
+ * claim is absent unless a protocol mapper adds it, in which case the caller
+ * has a personal space and no teams — which is a correct answer, not a failure.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class SpaceContext {
+
+    private static final Logger LOGGER = Logger.getLogger(SpaceContext.class);
+
+    private final SecurityIdentity identity;
+    private final WorkspaceSettings settings;
+
+    @Inject
+    public SpaceContext(SecurityIdentity identity, WorkspaceSettings settings) {
+        this.identity = identity;
+        this.settings = settings;
+    }
+
+    /**
+     * The caller's principal name, or {@code null} when there is no authenticated
+     * caller (authorization disabled, a background thread, a scheduled fire).
+     */
+    public String currentPrincipal() {
+        if (identity == null || identity.isAnonymous() || identity.getPrincipal() == null) {
+            return null;
+        }
+        String name = identity.getPrincipal().getName();
+        return name == null || name.isBlank() ? null : name;
+    }
+
+    /** The caller's spaces and subjects, or {@link CallerSpaces#ANONYMOUS}. */
+    public CallerSpaces current() {
+        String principal = currentPrincipal();
+        if (principal == null) {
+            return CallerSpaces.ANONYMOUS;
+        }
+        return CallerSpaces.of(principal, currentGroupPaths());
+    }
+
+    /**
+     * The space a resource this caller creates is filed under: the configured
+     * default team when the deployment is team-first, otherwise the caller's
+     * personal space.
+     *
+     * @return the space id, or {@code null} when there is no authenticated caller —
+     *         in which case nothing should be stamped at all
+     */
+    public String defaultWriteSpace() {
+        String principal = currentPrincipal();
+        if (principal == null) {
+            return null;
+        }
+        return settings.getDefaultSpaceTeam().map(Subjects::teamSpace).orElseGet(() -> Subjects.personalSpace(principal));
+    }
+
+    /**
+     * The raw Keycloak group paths on the caller's token. Empty when the claim is
+     * absent, not an error.
+     */
+    public Set<String> currentGroupPaths() {
+        Set<String> groups = new LinkedHashSet<>();
+        if (identity == null || identity.isAnonymous()) {
+            return groups;
+        }
+
+        Object claim = readGroupsClaim();
+        collectStrings(claim, groups);
+        return groups;
+    }
+
+    private Object readGroupsClaim() {
+        // The OIDC principal implements JsonWebToken; when OIDC is off (or the caller
+        // authenticated some other way) it does not, and there are simply no groups.
+        if (identity.getPrincipal() instanceof JsonWebToken jwt) {
+            try {
+                return jwt.getClaim(settings.getGroupsClaim());
+            } catch (RuntimeException e) {
+                LOGGER.debugf(e, "Could not read groups claim '%s' from token", settings.getGroupsClaim());
+                return null;
+            }
+        }
+        // Fall back to an identity attribute so a non-OIDC augmentor can supply groups.
+        return identity.getAttribute(settings.getGroupsClaim());
+    }
+
+    /**
+     * Flattens whatever the claim deserialised to. A {@code groups} claim arrives
+     * as a JSON array through one code path and as a {@code List<String>} through
+     * another depending on how the token was parsed, and a single-valued claim may
+     * arrive as a bare string — all three have to work, or team membership silently
+     * evaporates for some deployments.
+     */
+    private static void collectStrings(Object claim, Set<String> out) {
+        if (claim == null) {
+            return;
+        }
+        if (claim instanceof CharSequence text) {
+            String value = text.toString().trim();
+            if (!value.isEmpty()) {
+                out.add(value);
+            }
+            return;
+        }
+        if (claim instanceof Collection<?> collection) {
+            for (Object element : collection) {
+                collectStrings(element, out);
+            }
+            return;
+        }
+        if (claim instanceof Object[] array) {
+            for (Object element : array) {
+                collectStrings(element, out);
+            }
+            return;
+        }
+        // jakarta.json values (JsonString / JsonArray) implement neither of the above;
+        // JsonArray is a List so it is caught by the Collection branch, and JsonString
+        // stringifies with surrounding quotes, which toString-and-strip handles.
+        String value = claim.toString().trim();
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            value = value.substring(1, value.length() - 1);
+        }
+        if (!value.isEmpty()) {
+            out.add(value);
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/Subjects.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/Subjects.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+/**
+ * The one place that builds and escapes the identifiers the workspace model
+ * stores: subjects, space ids, and the tokens that make up a descriptor's
+ * access index.
+ *
+ * <h3>Two encodings, both mandatory</h3>
+ * <ol>
+ * <li><b>Token encoding.</b> The access index is a single string of
+ * pipe-delimited tokens, so a principal containing a pipe would forge extra
+ * tokens. {@link #encode} percent-escapes {@code %} and the pipe; nothing else
+ * needs escaping because tokens are split on the pipe alone.</li>
+ * <li><b>Regex escaping.</b> Both storage backends treat a {@code String} query
+ * filter as a <em>regular expression</em> —
+ * {@code MongoResourceStorage.findResources} builds {@code Filters.regex} and
+ * {@code PostgresResourceStorage.findResources} emits {@code ~}. An unescaped
+ * predicate for {@code alice} therefore also matches {@code malice}, and an
+ * unescaped {@code .} in an email address matches any character.
+ * {@link #tokenPattern} produces an anchored, escaped pattern instead.</li>
+ * </ol>
+ * Only the metacharacters common to PCRE (MongoDB) and POSIX ERE (PostgreSQL)
+ * are escaped, and only ever by prefixing a backslash to a character that is a
+ * metacharacter in both — escaping an ordinary character is undefined in POSIX
+ * ERE and must be avoided.
+ *
+ * @author ginccc
+ */
+public final class Subjects {
+
+    /** Prefix for an individual principal. */
+    public static final String USER_PREFIX = "user:";
+
+    /** Prefix for a Keycloak group / team. */
+    public static final String TEAM_PREFIX = "team:";
+
+    /** Access-index token marking a resource readable by everyone. */
+    public static final String TOKEN_ALL = "all";
+
+    /**
+     * Space id and access-index token for resources created before ownership was
+     * recorded. Whether it is actually admitted to a listing is the operator's
+     * choice — see {@code eddi.workspaces.legacy-visibility}.
+     */
+    public static final String LEGACY = "legacy";
+
+    /** Token prefix marking the resource's owner. */
+    public static final String OWNER_TOKEN_PREFIX = "owner:";
+
+    /** Token prefix marking the resource's own space. */
+    public static final String SPACE_TOKEN_PREFIX = "space:";
+
+    /** Delimiter surrounding every token in the access index. */
+    public static final char DELIMITER = '|';
+
+    private static final String ENCODED_DELIMITER = "%7C";
+    private static final String ENCODED_PERCENT = "%25";
+
+    private Subjects() {
+        // utility class
+    }
+
+    /**
+     * The subject for an individual principal, or {@code null} for a blank input.
+     */
+    public static String user(String principal) {
+        return principal == null || principal.isBlank() ? null : USER_PREFIX + encode(principal.trim());
+    }
+
+    /**
+     * The subject for a team / Keycloak group, or {@code null} for a blank input.
+     */
+    public static String team(String groupPath) {
+        if (groupPath == null || groupPath.isBlank()) {
+            return null;
+        }
+        String normalized = normalizeGroup(groupPath);
+        return normalized.isEmpty() ? null : TEAM_PREFIX + encode(normalized);
+    }
+
+    /**
+     * A user's personal space. Deliberately identical to that user's subject: a
+     * personal space has exactly one member, so giving it a second identifier would
+     * only create two spellings of the same thing.
+     */
+    public static String personalSpace(String principal) {
+        return user(principal);
+    }
+
+    /** A team's space. Identical to the team subject, for the same reason. */
+    public static String teamSpace(String groupPath) {
+        return team(groupPath);
+    }
+
+    /**
+     * Keycloak reports group membership with a leading slash and nested paths
+     * ({@code /engineering/backend}). Normalising the surrounding slashes away
+     * keeps a config that names {@code engineering} equivalent to a token claim
+     * that says {@code /engineering}; nested paths keep their internal separators
+     * and stay distinct.
+     */
+    public static String normalizeGroup(String groupPath) {
+        String trimmed = groupPath.trim();
+        int start = 0;
+        int end = trimmed.length();
+        while (start < end && trimmed.charAt(start) == '/') {
+            start++;
+        }
+        while (end > start && trimmed.charAt(end - 1) == '/') {
+            end--;
+        }
+        return trimmed.substring(start, end);
+    }
+
+    /**
+     * Percent-escapes the two characters that would otherwise forge index tokens.
+     */
+    public static String encode(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        StringBuilder out = new StringBuilder(raw.length() + 8);
+        for (int i = 0; i < raw.length(); i++) {
+            char c = raw.charAt(i);
+            switch (c) {
+                case '%' -> out.append(ENCODED_PERCENT);
+                case DELIMITER -> out.append(ENCODED_DELIMITER);
+                default -> out.append(c);
+            }
+        }
+        return out.toString();
+    }
+
+    /**
+     * Inverse of {@link #encode}.
+     * <p>
+     * The pipe is decoded before the percent so that an input which literally
+     * contained the text {@code %7C} — encoded as {@code %257C} — comes back as
+     * {@code %7C} rather than being decoded twice into a pipe.
+     */
+    public static String decode(String encoded) {
+        if (encoded == null || encoded.indexOf('%') < 0) {
+            return encoded;
+        }
+        StringBuilder out = new StringBuilder(encoded.length());
+        int i = 0;
+        while (i < encoded.length()) {
+            if (encoded.startsWith(ENCODED_DELIMITER, i) || encoded.regionMatches(true, i, ENCODED_DELIMITER, 0, 3)) {
+                out.append(DELIMITER);
+                i += 3;
+            } else if (encoded.startsWith(ENCODED_PERCENT, i)) {
+                out.append('%');
+                i += 3;
+            } else {
+                out.append(encoded.charAt(i));
+                i++;
+            }
+        }
+        return out.toString();
+    }
+
+    /**
+     * An anchored, escaped pattern matching exactly {@code token} as a whole token
+     * inside an access index.
+     * <p>
+     * The index always writes a delimiter on both sides of every token, so
+     * requiring both delimiters is what makes {@code user:al} fail to match
+     * {@code |user:alice|}. Without them this is a prefix match and the whole
+     * escaping exercise is pointless.
+     */
+    public static String tokenPattern(String token) {
+        return escapeRegex(DELIMITER + token + DELIMITER);
+    }
+
+    /**
+     * An anchored, escaped pattern for an exact whole-field string match, for
+     * fields that hold one value rather than a token list.
+     */
+    public static String exactPattern(String value) {
+        return "^" + escapeRegex(value) + "$";
+    }
+
+    /**
+     * Escapes the metacharacters that PCRE and POSIX ERE agree on. Characters
+     * outside this set are left alone deliberately: POSIX ERE leaves
+     * backslash-plus-ordinary-character undefined, so escaping defensively would be
+     * less portable, not more.
+     */
+    public static String escapeRegex(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        StringBuilder out = new StringBuilder(raw.length() + 8);
+        for (int i = 0; i < raw.length(); i++) {
+            char c = raw.charAt(i);
+            if (isSharedMetacharacter(c)) {
+                out.append('\\');
+            }
+            out.append(c);
+        }
+        return out.toString();
+    }
+
+    private static boolean isSharedMetacharacter(char c) {
+        return switch (c) {
+            case '.', '^', '$', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|', '\\' -> true;
+            default -> false;
+        };
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/Subjects.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/Subjects.java
@@ -42,6 +42,18 @@ public final class Subjects {
     public static final String TOKEN_ALL = "all";
 
     /**
+     * Access-index token that admits nobody.
+     * <p>
+     * An index must never be empty — an empty string matches no predicate, but so
+     * does {@code |}, and reasoning about which is which invites the wrong fix
+     * later. This is the explicit "reachable by no one" marker, and
+     * {@link DescriptorAccess#admittingTokens} never emits it, so a resource
+     * carrying it is listed by nobody. It is the correct index for a descriptor
+     * whose structured fields also grant nobody anything.
+     */
+    public static final String TOKEN_NONE = "none";
+
+    /**
      * Space id and access-index token for resources created before ownership was
      * recorded. Whether it is actually admitted to a listing is the operator's
      * choice — see {@code eddi.workspaces.legacy-visibility}.

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/WorkspaceSettings.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/WorkspaceSettings.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.util.Optional;
+
+/**
+ * Operator-facing settings for per-user workspaces, resolved once at startup.
+ *
+ * <h3>Why enforcement is a separate switch from ownership</h3>
+ * {@code eddi.workspaces.enabled} gates <em>enforcement</em> only. Ownership is
+ * stamped on every new resource regardless, so an operator can run a release
+ * with attribution recorded and nothing filtered, confirm the data looks right,
+ * and only then turn enforcement on. Turning it on before ownership has been
+ * stamped and backfilled is what would hide people's own work from them.
+ *
+ * @author ginccc
+ */
+@ApplicationScoped
+public class WorkspaceSettings {
+
+    private static final Logger LOGGER = Logger.getLogger(WorkspaceSettings.class);
+
+    /**
+     * {@code eddi.workspaces.legacy-visibility} — admit unowned data to everyone.
+     */
+    public static final String LEGACY_SHARED = "shared";
+
+    /**
+     * {@code eddi.workspaces.legacy-visibility} — admit unowned data to admins
+     * only.
+     */
+    public static final String LEGACY_ADMIN_ONLY = "admin-only";
+
+    private final boolean enabled;
+    private final boolean authEnabled;
+    private final String groupsClaim;
+    private final String legacyVisibility;
+    private final Optional<String> defaultSpaceTeam;
+
+    private boolean admitLegacy;
+
+    @Inject
+    public WorkspaceSettings(
+            @ConfigProperty(name = "eddi.workspaces.enabled", defaultValue = "false") boolean enabled,
+            @ConfigProperty(name = "authorization.enabled", defaultValue = "false") boolean authEnabled,
+            @ConfigProperty(name = "eddi.workspaces.groups-claim", defaultValue = "groups") String groupsClaim,
+            @ConfigProperty(name = "eddi.workspaces.legacy-visibility", defaultValue = LEGACY_SHARED) String legacyVisibility,
+            @ConfigProperty(name = "eddi.workspaces.default-space") Optional<String> defaultSpaceTeam) {
+        this.enabled = enabled;
+        this.authEnabled = authEnabled;
+        this.groupsClaim = groupsClaim == null || groupsClaim.isBlank() ? "groups" : groupsClaim.trim();
+        this.legacyVisibility = legacyVisibility == null || legacyVisibility.isBlank() ? LEGACY_SHARED : legacyVisibility.trim();
+        this.defaultSpaceTeam = defaultSpaceTeam.map(String::trim).filter(s -> !s.isEmpty());
+    }
+
+    @PostConstruct
+    void validate() {
+        if (!LEGACY_SHARED.equalsIgnoreCase(legacyVisibility) && !LEGACY_ADMIN_ONLY.equalsIgnoreCase(legacyVisibility)) {
+            // Fail loud rather than silently picking a policy: the two options differ on
+            // whether every pre-upgrade agent is visible, which is not a difference to
+            // resolve by guessing.
+            throw new IllegalStateException("eddi.workspaces.legacy-visibility must be '" + LEGACY_SHARED + "' or '" + LEGACY_ADMIN_ONLY
+                    + "', but was '" + legacyVisibility + "'");
+        }
+        this.admitLegacy = LEGACY_SHARED.equalsIgnoreCase(legacyVisibility);
+
+        if (enabled && !authEnabled) {
+            // Without authentication every caller is anonymous, so there is no principal to
+            // scope anything to. Enforcing in that state would deny everyone everything, so
+            // isEnforcing() reports false — say why, once, rather than leaving an operator
+            // to wonder why the flag they set did nothing.
+            LOGGER.warn("eddi.workspaces.enabled=true has no effect while authorization.enabled=false: "
+                    + "there is no authenticated principal to scope resources to. Enable OIDC to enforce workspaces.");
+        }
+
+        if (enabled && authEnabled) {
+            LOGGER.infov("Workspace isolation is ENFORCED (legacy-visibility={0}, groups-claim={1}, default-space={2})", legacyVisibility,
+                    groupsClaim, defaultSpaceTeam.orElse("<personal>"));
+        }
+    }
+
+    /**
+     * Whether listings and reads are actually filtered.
+     * <p>
+     * Both switches must be on. Enforcing without authentication would scope every
+     * request to the anonymous principal, which owns nothing.
+     */
+    public boolean isEnforcing() {
+        return enabled && authEnabled;
+    }
+
+    /**
+     * Whether ownership is recorded on newly created resources. Deliberately
+     * independent of {@link #isEnforcing()} and true whenever authentication is on,
+     * so the data is already correct by the time an operator flips enforcement.
+     */
+    public boolean isStampingOwnership() {
+        return authEnabled;
+    }
+
+    /** The JWT claim listing the caller's groups. */
+    public String getGroupsClaim() {
+        return groupsClaim;
+    }
+
+    /** Whether resources with no recorded owner are visible to non-admins. */
+    public boolean admitsLegacy() {
+        return admitLegacy;
+    }
+
+    /**
+     * The team every new resource is filed under, when the deployment prefers one
+     * shared workspace over per-user ones.
+     * <p>
+     * Empty — the default — files new resources in the creator's personal space.
+     * Setting it to a group name gives a team-first deployment: colleagues see each
+     * other's work by default and personal spaces are reached by explicitly moving
+     * a resource. Both are defensible; which one is right depends on whether the
+     * deployment's users are one team or many tenants of a shared installation.
+     */
+    public Optional<String> getDefaultSpaceTeam() {
+        return defaultSpaceTeam;
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/rest/IRestResourceSharing.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/rest/IRestResourceSharing.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces.rest;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+/**
+ * Sharing a configuration resource with another person or team.
+ *
+ * <h3>Why this is one endpoint family and not fifteen</h3> Sharing is a
+ * property of the <em>descriptor</em>, which every configuration type has, so a
+ * single path keyed by resource id covers agents, workflows, rule sets and the
+ * rest — and the Manager learns one dialog rather than fifteen.
+ *
+ * <p>
+ * {@code cascade} defaults to {@code true} for a reason: people share agents,
+ * and an agent shared without its workflows, rule sets and output sets is a
+ * name pointing at documents the recipient cannot open. Passing {@code false}
+ * shares exactly the one document, which is occasionally what you want and
+ * never what you want by default.
+ *
+ * @author ginccc
+ */
+@Path("/descriptorstore/descriptors/{id}/shares")
+@Tag(name = "Operations / Sharing", description = "Share configuration resources with people and teams")
+@RolesAllowed({"eddi-admin", "eddi-editor"})
+public interface IRestResourceSharing {
+
+    /**
+     * How a resource is shared: its owner, space, visibility, explicit grants, and
+     * what the calling user may do with it.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Read sharing state", description = "Owner, space, visibility, grants, and the caller's effective access level.")
+    @APIResponse(responseCode = "200", description = "The sharing state.")
+    @APIResponse(responseCode = "403", description = "The caller may not read this resource.")
+    Response readShares(@PathParam("id") String id);
+
+    /**
+     * Grants a person or team access.
+     *
+     * @param subject
+     *            {@code user:<principal>} or {@code team:<group>}
+     * @param level
+     *            {@code USE}, {@code VIEW}, {@code EDIT} or {@code OWN}
+     * @param cascade
+     *            also grant on everything the resource references
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Share with a person or team",
+               description = "Grants access. Re-granting a subject replaces its level rather than adding a second grant.")
+    @APIResponse(responseCode = "200", description = "Updated and skipped resource ids.")
+    @APIResponse(responseCode = "403", description = "Only the owner (or an admin) may share.")
+    Response share(@PathParam("id") String id,
+                   @QueryParam("subject") String subject,
+                   @QueryParam("level")
+                   @DefaultValue("VIEW") String level,
+                   @QueryParam("cascade")
+                   @DefaultValue("true") Boolean cascade);
+
+    /** Removes a subject's grant, mirroring {@link #share}. */
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Stop sharing with a person or team")
+    @APIResponse(responseCode = "200", description = "Updated and skipped resource ids.")
+    Response revoke(@PathParam("id") String id,
+                    @QueryParam("subject") String subject,
+                    @QueryParam("cascade")
+                    @DefaultValue("true") Boolean cascade);
+
+    /**
+     * Sets visibility: {@code private}, {@code space} or {@code published}.
+     */
+    @PUT
+    @Path("/visibility")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Set visibility",
+               description = "private = owner and explicit grants only; space = everyone in the resource's space; published = everyone.")
+    @APIResponse(responseCode = "200", description = "Updated and skipped resource ids.")
+    Response setVisibility(@PathParam("id") String id,
+                           @QueryParam("visibility") String visibility,
+                           @QueryParam("cascade")
+                           @DefaultValue("true") Boolean cascade);
+
+    /**
+     * Reassigns ownership. Administrators only — this exists to recover resources
+     * whose owner has left, which cannot depend on that owner acting.
+     */
+    @PUT
+    @Path("/owner")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Transfer ownership", description = "Administrators only. Use when a resource's owner has left the organisation.")
+    @APIResponse(responseCode = "200", description = "Updated and skipped resource ids.")
+    @APIResponse(responseCode = "403", description = "The caller is not an administrator.")
+    @RolesAllowed("eddi-admin")
+    Response transferOwnership(@PathParam("id") String id,
+                               @QueryParam("ownerId") String ownerId,
+                               @QueryParam("spaceId") String spaceId,
+                               @QueryParam("cascade")
+                               @DefaultValue("true") Boolean cascade);
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/rest/IRestResourceSharing.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/rest/IRestResourceSharing.java
@@ -5,7 +5,6 @@
 package ai.labs.eddi.engine.security.spaces.rest;
 
 import jakarta.annotation.security.RolesAllowed;
-import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -64,8 +63,10 @@ public interface IRestResourceSharing {
      * @param cascade
      *            also grant on everything the resource references
      */
+    // No @Consumes: the operation is fully specified by query parameters and a
+    // declared JSON body type on a body-less POST makes strict clients and
+    // generated SDKs manufacture a Content-Type for an entity that does not exist.
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Share with a person or team",
                description = "Grants access. Re-granting a subject replaces its level rather than adding a second grant.")

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/rest/IRestWorkspaces.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/rest/IRestWorkspaces.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces.rest;
+
+import ai.labs.eddi.engine.security.spaces.rest.model.WorkspaceInfo;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+/**
+ * What workspaces mean for the calling user.
+ *
+ * <h3>Why this endpoint exists</h3> A client cannot tell a deployment with
+ * workspaces switched off from one where every resource predates ownership —
+ * both return descriptors with no owner, no space and no visibility. Guessing
+ * wrong means offering a Share action that silently does nothing. So the server
+ * says which it is.
+ * <p>
+ * It also serves the caller's spaces rather than leaving a client to derive
+ * them from the token. The derivation is not hard, but getting it subtly wrong
+ * fails silently: a space id encoded differently selects nothing, which looks
+ * like an empty workspace rather than a bug.
+ *
+ * @author ginccc
+ */
+@Path("/workspaces")
+@Tag(name = "Operations / Sharing", description = "Share configuration resources with people and teams")
+@RolesAllowed({"eddi-admin", "eddi-editor"})
+public interface IRestWorkspaces {
+
+    String resourceURI = "eddi://ai.labs.workspaces/workspaces/";
+
+    /**
+     * Whether workspaces are enforced, and which spaces this caller can reach.
+     * <p>
+     * Always answers for the caller who asked — never takes a principal as a
+     * parameter, so it cannot be used to enumerate somebody else's group
+     * membership.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Read workspace settings for the calling user",
+               description = "Whether workspace enforcement is active, the caller's principal and default space, "
+                       + "and every space the caller can reach.")
+    @APIResponse(responseCode = "200", description = "The caller's workspace context.")
+    WorkspaceInfo readWorkspaceInfo();
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/rest/RestResourceSharing.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/rest/RestResourceSharing.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces.rest;
+
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+import ai.labs.eddi.engine.security.spaces.ResourceSharingService;
+import ai.labs.eddi.engine.security.spaces.Subjects;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author ginccc
+ */
+@ApplicationScoped
+public class RestResourceSharing implements IRestResourceSharing {
+
+    private final ResourceSharingService sharingService;
+
+    @Inject
+    public RestResourceSharing(ResourceSharingService sharingService) {
+        this.sharingService = sharingService;
+    }
+
+    @Override
+    public Response readShares(String id) {
+        return Response.ok(sharingService.describe(id)).build();
+    }
+
+    @Override
+    public Response share(String id, String subject, String level, Boolean cascade) {
+        String normalizedSubject = requireSubject(subject);
+        AccessLevel accessLevel = AccessLevel.parseOrNull(level);
+        if (accessLevel == null) {
+            throw new BadRequestException("level must be one of USE, VIEW, EDIT, OWN — was '" + level + "'");
+        }
+        return Response.ok(sharingService.share(id, normalizedSubject, accessLevel, !Boolean.FALSE.equals(cascade))).build();
+    }
+
+    @Override
+    public Response revoke(String id, String subject, Boolean cascade) {
+        return Response.ok(sharingService.revoke(id, requireSubject(subject), !Boolean.FALSE.equals(cascade))).build();
+    }
+
+    @Override
+    public Response setVisibility(String id, String visibility, Boolean cascade) {
+        ResourceVisibility parsed = ResourceVisibility.parseOrNull(visibility);
+        if (parsed == null) {
+            throw new BadRequestException("visibility must be one of private, space, published — was '" + visibility + "'");
+        }
+        return Response.ok(sharingService.setVisibility(id, parsed, !Boolean.FALSE.equals(cascade))).build();
+    }
+
+    @Override
+    public Response transferOwnership(String id, String ownerId, String spaceId, Boolean cascade) {
+        if (ownerId == null || ownerId.isBlank()) {
+            throw new BadRequestException("ownerId is required");
+        }
+        return Response.ok(sharingService.transferOwnership(id, ownerId.trim(), spaceId, !Boolean.FALSE.equals(cascade))).build();
+    }
+
+    /**
+     * Normalises and validates a subject.
+     * <p>
+     * A bare name is accepted and read as a user, because that is what people type
+     * and rejecting it would make the API needlessly ceremonious. Everything else
+     * must carry a known prefix — an unrecognised one is rejected rather than
+     * guessed at, since a typo that silently became a subject nobody holds would
+     * look exactly like a successful share.
+     */
+    private static String requireSubject(String subject) {
+        if (subject == null || subject.isBlank()) {
+            throw new BadRequestException("subject is required, e.g. 'user:alice@example.com' or 'team:engineering'");
+        }
+        String trimmed = subject.trim();
+        if (trimmed.startsWith(Subjects.USER_PREFIX)) {
+            String principal = trimmed.substring(Subjects.USER_PREFIX.length());
+            String normalized = Subjects.user(principal);
+            if (normalized == null) {
+                throw new BadRequestException("subject 'user:' needs a principal name after the prefix");
+            }
+            return normalized;
+        }
+        if (trimmed.startsWith(Subjects.TEAM_PREFIX)) {
+            String group = trimmed.substring(Subjects.TEAM_PREFIX.length());
+            String normalized = Subjects.team(group);
+            if (normalized == null) {
+                throw new BadRequestException("subject 'team:' needs a group name after the prefix");
+            }
+            return normalized;
+        }
+        if (trimmed.contains(":")) {
+            throw new BadRequestException("subject must start with 'user:' or 'team:' — was '" + trimmed + "'");
+        }
+        return Subjects.user(trimmed);
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/rest/RestWorkspaces.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/rest/RestWorkspaces.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces.rest;
+
+import ai.labs.eddi.engine.security.spaces.CallerSpaces;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
+import ai.labs.eddi.engine.security.spaces.Subjects;
+import ai.labs.eddi.engine.security.spaces.WorkspaceSettings;
+import ai.labs.eddi.engine.security.spaces.rest.model.SpaceInfo;
+import ai.labs.eddi.engine.security.spaces.rest.model.WorkspaceInfo;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author ginccc
+ */
+@ApplicationScoped
+public class RestWorkspaces implements IRestWorkspaces {
+
+    private final SpaceContext spaceContext;
+    private final WorkspaceSettings settings;
+    private final ResourceAccessGuard accessGuard;
+
+    @Inject
+    public RestWorkspaces(SpaceContext spaceContext, WorkspaceSettings settings, ResourceAccessGuard accessGuard) {
+        this.spaceContext = spaceContext;
+        this.settings = settings;
+        this.accessGuard = accessGuard;
+    }
+
+    @Override
+    public WorkspaceInfo readWorkspaceInfo() {
+        CallerSpaces caller = spaceContext.current();
+
+        // Reported even when enforcement is off, so a client can show the same
+        // "you are alice" affordances either way. What changes with the flag is
+        // whether any of it is *enforced* — which `enabled` says plainly.
+        return new WorkspaceInfo(settings.isEnforcing(),
+                spaceContext.currentPrincipal(),
+                spaceContext.defaultWriteSpace(),
+                describe(caller),
+                accessGuard.seesEverything());
+    }
+
+    /**
+     * Renders the caller's spaces in the order {@link CallerSpaces} holds them —
+     * personal first, then teams in token order. The label is decoded here rather
+     * than by the client, because the encoding is this package's business.
+     */
+    private List<SpaceInfo> describe(CallerSpaces caller) {
+        List<SpaceInfo> spaces = new ArrayList<>(caller.spaces().size());
+        for (String id : caller.spaces()) {
+            if (id.startsWith(Subjects.USER_PREFIX)) {
+                spaces.add(new SpaceInfo(id, SpaceInfo.KIND_PERSONAL,
+                        Subjects.decode(id.substring(Subjects.USER_PREFIX.length()))));
+            } else if (id.startsWith(Subjects.TEAM_PREFIX)) {
+                spaces.add(new SpaceInfo(id, SpaceInfo.KIND_TEAM,
+                        Subjects.decode(id.substring(Subjects.TEAM_PREFIX.length()))));
+            }
+            // Anything else is not a space a client can switch to. Dropping it is
+            // deliberate: an id whose shape we do not recognise would render as a
+            // filter that silently matches nothing.
+        }
+        return spaces;
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/rest/model/SpaceInfo.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/rest/model/SpaceInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces.rest.model;
+
+/**
+ * One space a caller can reach, ready to render.
+ *
+ * @param id
+ *            the wire id — {@code user:<principal>} or {@code team:<group>} —
+ *            to send back as the {@code space} query parameter. Opaque to the
+ *            client: it carries escaping the client must not re-derive.
+ * @param kind
+ *            {@code personal} or {@code team}, so a client can order and icon
+ *            them without parsing {@link #id()}.
+ * @param label
+ *            the decoded name to show a human. Never the raw id.
+ *
+ * @author ginccc
+ */
+public record SpaceInfo(String id, String kind, String label) {
+
+    /** A caller's own space. */
+    public static final String KIND_PERSONAL = "personal";
+
+    /** A space backed by a group the caller belongs to. */
+    public static final String KIND_TEAM = "team";
+}

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/rest/model/WorkspaceInfo.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/rest/model/WorkspaceInfo.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces.rest.model;
+
+import java.util.List;
+
+/**
+ * What the caller's client needs to know about workspaces before drawing
+ * anything.
+ *
+ * <h3>Why a client cannot work this out for itself</h3> Whether enforcement is
+ * on is a server setting with no wire evidence: a deployment with workspaces
+ * disabled returns descriptors that look exactly like a deployment where
+ * everything predates ownership. A UI guessing from that shows a Share action
+ * that cannot work, which is worse than not offering it.
+ * <p>
+ * The space list is served rather than derived from the token for the same
+ * reason. A client that re-implements the subject encoding will eventually
+ * encode one differently, and that failure is silent — it selects a space
+ * matching nothing, which reads as "you have no agents" rather than as an
+ * error. Serving the same set the listing scope is built from removes the
+ * second source of truth.
+ *
+ * @param enabled
+ *            whether enforcement is active. False means every caller sees
+ *            everything and sharing is inert, so a client should hide sharing
+ *            controls entirely rather than offer ones that do nothing.
+ * @param principal
+ *            the caller's principal name, or {@code null} when anonymous. This
+ *            is the value stamped as {@code ownerId}, so it is what a client
+ *            must compare against to decide "this is mine" — not a display name
+ *            from the token, which may differ.
+ * @param defaultSpace
+ *            the space new resources by this caller are filed in, or
+ *            {@code null} when anonymous.
+ * @param spaces
+ *            every space the caller can reach, personal first. Empty when
+ *            anonymous — the backend resolves an anonymous caller to no spaces
+ *            at all, so a client must not offer a space filter the server will
+ *            not honour.
+ * @param seesEverything
+ *            whether this caller's reach is unlimited (an administrator, or
+ *            enforcement disabled). A client can use this to explain why a
+ *            listing shows other people's resources.
+ *
+ * @author ginccc
+ */
+public record WorkspaceInfo(boolean enabled,
+        String principal,
+        String defaultSpace,
+        List<SpaceInfo> spaces,
+        boolean seesEverything) {
+
+    public WorkspaceInfo {
+        spaces = spaces == null ? List.of() : List.copyOf(spaces);
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/triggermanagement/rest/RestAgentTriggerStore.java
+++ b/src/main/java/ai/labs/eddi/engine/triggermanagement/rest/RestAgentTriggerStore.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.engine.triggermanagement.IRestAgentTriggerStore;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.caching.ICache;
 import ai.labs.eddi.engine.caching.ICacheFactory;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -27,10 +28,12 @@ public class RestAgentTriggerStore implements IRestAgentTriggerStore {
     private static final String CACHE_NAME = "agentTriggers";
     private final IAgentTriggerStore agentTriggerStore;
     private final ICache<String, AgentTriggerConfiguration> agentTriggersCache;
+    private final ResourceAccessGuard resourceAccessGuard;
 
     @Inject
-    public RestAgentTriggerStore(IAgentTriggerStore agentTriggerStore, ICacheFactory cacheFactory) {
+    public RestAgentTriggerStore(IAgentTriggerStore agentTriggerStore, ICacheFactory cacheFactory, ResourceAccessGuard resourceAccessGuard) {
         this.agentTriggerStore = agentTriggerStore;
+        this.resourceAccessGuard = resourceAccessGuard;
         agentTriggersCache = cacheFactory.getCache(CACHE_NAME);
     }
 
@@ -58,9 +61,28 @@ public class RestAgentTriggerStore implements IRestAgentTriggerStore {
         }
     }
 
+    /**
+     * A trigger routes inbound messages into conversations with the agents its
+     * deployments name; the routing itself runs with no interactive caller and sits
+     * below the USE gate. So the gate applies at authoring time: without this,
+     * pointing a trigger at a private agent is a standing bypass of the check on
+     * {@code /agents/{id}/start}.
+     */
+    private void requireUseOnReferencedAgents(AgentTriggerConfiguration configuration) {
+        if (configuration == null || configuration.getAgentDeployments() == null) {
+            return;
+        }
+        for (var deployment : configuration.getAgentDeployments()) {
+            if (deployment != null && deployment.getAgentId() != null && !deployment.getAgentId().isBlank()) {
+                resourceAccessGuard.requireAgentUseAccess(deployment.getAgentId());
+            }
+        }
+    }
+
     @Override
     public Response updateAgentTrigger(String intent, AgentTriggerConfiguration agentTriggerConfiguration) {
         try {
+            requireUseOnReferencedAgents(agentTriggerConfiguration);
             agentTriggerStore.updateAgentTrigger(intent, agentTriggerConfiguration);
             agentTriggersCache.put(intent, agentTriggerConfiguration);
             return Response.ok().build();
@@ -72,6 +94,7 @@ public class RestAgentTriggerStore implements IRestAgentTriggerStore {
     @Override
     public Response createAgentTrigger(AgentTriggerConfiguration agentTriggerConfiguration) {
         try {
+            requireUseOnReferencedAgents(agentTriggerConfiguration);
             agentTriggerStore.createAgentTrigger(agentTriggerConfiguration);
             agentTriggersCache.put(agentTriggerConfiguration.getIntent(), agentTriggerConfiguration);
             return Response.ok().build();

--- a/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
+++ b/src/main/java/ai/labs/eddi/integrations/channels/ChannelTargetRouter.java
@@ -4,7 +4,7 @@
  */
 package ai.labs.eddi.integrations.channels;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration.ChannelConnector;
 import ai.labs.eddi.configs.channels.IChannelIntegrationStore;
@@ -60,7 +60,7 @@ public class ChannelTargetRouter {
     private final IChannelIntegrationStore channelStore;
     private final IDocumentDescriptorStore descriptorStore;
     private final IRestAgentAdministration agentAdmin;
-    private final IRestAgentStore agentStore;
+    private final IAgentStore agentStore;
     private final SecretResolver secretResolver;
 
     // ─── Cached state (atomic reference swap) ──────────────────────────────────
@@ -111,7 +111,7 @@ public class ChannelTargetRouter {
     public ChannelTargetRouter(IChannelIntegrationStore channelStore,
             IDocumentDescriptorStore descriptorStore,
             IRestAgentAdministration agentAdmin,
-            IRestAgentStore agentStore,
+            IAgentStore agentStore,
             SecretResolver secretResolver,
             ICacheFactory cacheFactory) {
         this.channelStore = channelStore;
@@ -556,7 +556,7 @@ public class ChannelTargetRouter {
                 }
                 String agentId = status.getAgentId();
                 try {
-                    AgentConfiguration agentConfig = agentStore.readAgent(
+                    AgentConfiguration agentConfig = agentStore.read(
                             agentId, status.getAgentVersion());
                     if (agentConfig != null && agentConfig.getChannels() != null) {
                         for (ChannelConnector connector : agentConfig.getChannels()) {

--- a/src/main/java/ai/labs/eddi/integrations/openai/AgentModelResolver.java
+++ b/src/main/java/ai/labs/eddi/integrations/openai/AgentModelResolver.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.integrations.openai;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.model.Deployment.Status;
@@ -78,13 +79,17 @@ public class AgentModelResolver {
 
     private Cache<String, Catalogue> cache;
 
+    private final ResourceAccessGuard resourceAccessGuard;
+
     @Inject
     public AgentModelResolver(IAgentFactory agentFactory,
             IDocumentDescriptorStore documentDescriptorStore,
-            OpenAiCompatConfig config) {
+            OpenAiCompatConfig config,
+            ResourceAccessGuard resourceAccessGuard) {
         this.agentFactory = agentFactory;
         this.documentDescriptorStore = documentDescriptorStore;
         this.config = config;
+        this.resourceAccessGuard = resourceAccessGuard;
     }
 
     @PostConstruct
@@ -149,11 +154,27 @@ public class AgentModelResolver {
         }
     }
 
-    /** The OpenAI model list for all ready agents. */
+    /**
+     * The OpenAI model list for all ready agents the caller may actually use.
+     * <p>
+     * The {@code /v1} surface authenticates with one shared API key and takes the
+     * user id from a header it is configured to trust, so there is no verified
+     * principal here — {@code ResourceAccessGuard} therefore sees an anonymous
+     * caller and admits only <b>published</b> agents once workspaces are enforced.
+     * That is the intended answer rather than a limitation: a self-asserted user id
+     * must not unlock that user's private agents, and listing a model the same
+     * caller would be refused at chat time is worse than not listing it.
+     * <p>
+     * With workspaces off, {@code seesEverything()} is true and the list is exactly
+     * what it always was.
+     */
     public List<ModelObject> listModels() {
         Catalogue catalogue = catalogue();
         List<ModelObject> models = new ArrayList<>(catalogue.byModelId().size());
         for (Entry entry : catalogue.byModelId().values()) {
+            if (!mayUse(entry.agentId())) {
+                continue;
+            }
             models.add(ModelObject.of(entry.modelId(), entry.createdEpochSeconds()));
             if (config.isExposeStatelessVariants()) {
                 models.add(ModelObject.of(entry.modelId() + STATELESS_SUFFIX, entry.createdEpochSeconds()));
@@ -162,6 +183,18 @@ public class AgentModelResolver {
         return models;
     }
 
+    /**
+     * Whether the current caller may converse with this agent. Non-throwing: a
+     * listing omits what it may not offer rather than failing wholesale.
+     */
+    private boolean mayUse(String agentId) {
+        try {
+            resourceAccessGuard.requireAgentUseAccess(agentId);
+            return true;
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
     /**
      * Resolve a client-supplied {@code model} value to a deployed agent.
      * <p>

--- a/src/main/java/ai/labs/eddi/integrations/openai/OpenAiConversationBridge.java
+++ b/src/main/java/ai/labs/eddi/integrations/openai/OpenAiConversationBridge.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.integrations.openai;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.lifecycle.TaskId;
@@ -92,12 +93,16 @@ public class OpenAiConversationBridge {
     private Counter conversationsCreated;
     private Timer turnTimer;
 
+    private final ResourceAccessGuard resourceAccessGuard;
+
     @Inject
     public OpenAiConversationBridge(IConversationService conversationService,
             IUserConversationStore userConversationStore,
             OpenAiMessageMapper messageMapper,
             OpenAiCompatConfig config,
-            MeterRegistry meterRegistry) {
+            MeterRegistry meterRegistry,
+            ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         this.conversationService = conversationService;
         this.userConversationStore = userConversationStore;
         this.messageMapper = messageMapper;
@@ -240,6 +245,13 @@ public class OpenAiConversationBridge {
 
     private String startConversation(AgentModelResolver.ResolvedModel model, String userId, String intent) {
         try {
+            // The same USE gate the REST and MCP surfaces apply. There is no verified
+            // principal on /v1 — one shared API key, a user id taken from a trusted
+            // header — so this admits only published agents once workspaces are enforced,
+            // and everything as before when they are not. Deliberately NOT scoped to the
+            // header-supplied userId: that id is self-asserted, and honouring it would let
+            // one leaked key reach any user's private agents.
+            resourceAccessGuard.requireAgentUseAccess(model.agentId());
             var result = conversationService.startConversation(model.environment(), model.agentId(), userId,
                     Map.of(CONTEXT_CHANNEL_INTENT, new Context(Context.ContextType.string, intent)));
             conversationsCreated.increment();

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/AgentOrchestrator.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/AgentOrchestrator.java
@@ -6,14 +6,13 @@ package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.engine.hitl.tools.ChatTranscriptCodec;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.hitl.tools.ToolApprovalGate;
 import ai.labs.eddi.engine.memory.model.PendingToolCallBatch;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.engine.api.IConversationService;
@@ -351,7 +350,7 @@ class AgentOrchestrator implements IAgentOrchestrator {
             WebScraperTool webScraperTool, TextSummarizerTool textSummarizerTool, PdfReaderTool pdfReaderTool, WeatherTool weatherTool,
             FetchToolResponsePageTool fetchToolResponsePageTool,
             ToolExecutionService toolExecutionService, McpToolProviderManager mcpToolProviderManager, A2AToolProviderManager a2aToolProviderManager,
-            IRestAgentStore restAgentStore, IRestWorkflowStore restWorkflowStore, IResourceClientLibrary resourceClientLibrary,
+            IWorkflowStore workflowStore, IResourceClientLibrary resourceClientLibrary,
             IApiCallExecutor apiCallExecutor, IJsonSerialization jsonSerialization, IMemoryItemConverter memoryItemConverter,
             IUserMemoryStore userMemoryStore, ToolResponseTruncator toolResponseTruncator, TenantQuotaService tenantQuotaService,
             MemorySnapshotService memorySnapshotService,
@@ -360,7 +359,7 @@ class AgentOrchestrator implements IAgentOrchestrator {
             IHitlToolJournalStore journalStore, ConversationHistoryBuilder conversationHistoryBuilder,
             TokenCounterFactory tokenCounterFactory) {
         this(calculatorTool, dateTimeTool, webSearchTool, dataFormatterTool, webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
-                fetchToolResponsePageTool, toolExecutionService, mcpToolProviderManager, a2aToolProviderManager, restAgentStore, restWorkflowStore,
+                fetchToolResponsePageTool, toolExecutionService, mcpToolProviderManager, a2aToolProviderManager, workflowStore,
                 resourceClientLibrary, apiCallExecutor, jsonSerialization, memoryItemConverter, userMemoryStore, toolResponseTruncator,
                 tenantQuotaService, memorySnapshotService, agentSetupService, capabilityRegistryService, conversationService, agentFactory,
                 agentStore, journalStore, conversationHistoryBuilder, tokenCounterFactory, new ToolResultGuardrail(null));
@@ -371,7 +370,7 @@ class AgentOrchestrator implements IAgentOrchestrator {
             WebScraperTool webScraperTool, TextSummarizerTool textSummarizerTool, PdfReaderTool pdfReaderTool, WeatherTool weatherTool,
             FetchToolResponsePageTool fetchToolResponsePageTool,
             ToolExecutionService toolExecutionService, McpToolProviderManager mcpToolProviderManager, A2AToolProviderManager a2aToolProviderManager,
-            IRestAgentStore restAgentStore, IRestWorkflowStore restWorkflowStore, IResourceClientLibrary resourceClientLibrary,
+            IWorkflowStore workflowStore, IResourceClientLibrary resourceClientLibrary,
             IApiCallExecutor apiCallExecutor, IJsonSerialization jsonSerialization, IMemoryItemConverter memoryItemConverter,
             IUserMemoryStore userMemoryStore, ToolResponseTruncator toolResponseTruncator, TenantQuotaService tenantQuotaService,
             MemorySnapshotService memorySnapshotService,
@@ -403,9 +402,9 @@ class AgentOrchestrator implements IAgentOrchestrator {
         this.conversationHistoryBuilder = conversationHistoryBuilder;
         this.toolContextBudgetGuard = new ToolContextBudget(tokenCounterFactory);
         this.toolResultGuardrail = toolResultGuardrail;
-        this.httpCallToolsProvider = new HttpCallToolsProvider(restAgentStore, restWorkflowStore, resourceClientLibrary,
+        this.httpCallToolsProvider = new HttpCallToolsProvider(agentStore, workflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter);
-        this.mcpToolsProvider = new McpToolsProvider(restAgentStore, restWorkflowStore, resourceClientLibrary, mcpToolProviderManager);
+        this.mcpToolsProvider = new McpToolsProvider(agentStore, workflowStore, resourceClientLibrary, mcpToolProviderManager);
         this.toolLoopRunner = new ToolLoopRunner(toolExecutionService, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService, toolApprovalGate, gateSupport, toolContextBudgetGuard, toolResultGuardrail);
         this.toolLoopResumer = new ToolLoopResumer(this, toolLoopRunner, gateSupport, chatTranscriptCodec, journalStore);

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/HttpCallToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/HttpCallToolsProvider.java
@@ -4,10 +4,10 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCall;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
@@ -127,18 +127,18 @@ class HttpCallToolsProvider implements ToolSourceProvider {
             .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
             .build();
 
-    private final IRestAgentStore restAgentStore;
-    private final IRestWorkflowStore restWorkflowStore;
+    private final IAgentStore agentStore;
+    private final IWorkflowStore workflowStore;
     private final IResourceClientLibrary resourceClientLibrary;
     private final IApiCallExecutor apiCallExecutor;
     private final IJsonSerialization jsonSerialization;
     private final IMemoryItemConverter memoryItemConverter;
 
-    HttpCallToolsProvider(IRestAgentStore restAgentStore, IRestWorkflowStore restWorkflowStore,
+    HttpCallToolsProvider(IAgentStore agentStore, IWorkflowStore workflowStore,
             IResourceClientLibrary resourceClientLibrary, IApiCallExecutor apiCallExecutor,
             IJsonSerialization jsonSerialization, IMemoryItemConverter memoryItemConverter) {
-        this.restAgentStore = restAgentStore;
-        this.restWorkflowStore = restWorkflowStore;
+        this.agentStore = agentStore;
+        this.workflowStore = workflowStore;
         this.resourceClientLibrary = resourceClientLibrary;
         this.apiCallExecutor = apiCallExecutor;
         this.jsonSerialization = jsonSerialization;
@@ -180,8 +180,8 @@ class HttpCallToolsProvider implements ToolSourceProvider {
         try {
             LOGGER.infof("Discovering httpcall tools for agent: %s v%s", memory.getAgentId(), memory.getAgentVersion());
 
-            var stepConfigs = WorkflowTraversal.discoverConfigs(memory, HTTPCALLS_TYPE, ApiCallsConfiguration.class, restAgentStore,
-                    restWorkflowStore, resourceClientLibrary);
+            var stepConfigs = WorkflowTraversal.discoverConfigs(memory, HTTPCALLS_TYPE, ApiCallsConfiguration.class, agentStore,
+                    workflowStore, resourceClientLibrary);
 
             for (var stepConfig : stepConfigs) {
                 ApiCallsConfiguration httpCallsConfig = stepConfig.config();

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
@@ -4,12 +4,12 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCall;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor;
 import ai.labs.eddi.engine.hitl.tools.TaskToolApprovalsResolver;
 import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
@@ -126,8 +126,8 @@ public class LlmTask implements ILifecycleTask {
 
     // Retained for httpCall RAG discovery + execution (Phase 8c-0)
     private final IApiCallExecutor apiCallExecutor;
-    private final IRestAgentStore restAgentStore;
-    private final IRestWorkflowStore restWorkflowStore;
+    private final IAgentStore agentStore;
+    private final IWorkflowStore workflowStore;
 
     /**
      * Tool-level HITL kill-switch. When false the tool-approval gate is inert
@@ -165,7 +165,7 @@ public class LlmTask implements ILifecycleTask {
     @Inject
     public LlmTask(IResourceClientLibrary resourceClientLibrary, IDataFactory dataFactory, IMemoryItemConverter memoryItemConverter,
             ITemplatingEngine templatingEngine, IJsonSerialization jsonSerialization, PrePostUtils prePostUtils, ChatModelRegistry chatModelRegistry,
-            IApiCallExecutor apiCallExecutor, IRestAgentStore restAgentStore, IRestWorkflowStore restWorkflowStore,
+            IApiCallExecutor apiCallExecutor, IAgentStore agentStore, IWorkflowStore workflowStore,
             RagContextProvider ragContextProvider, TokenCounterFactory tokenCounterFactory,
             ConversationSummarizer conversationSummarizer,
             PromptSnippetService promptSnippetService,
@@ -190,8 +190,8 @@ public class LlmTask implements ILifecycleTask {
         this.ragContextProvider = ragContextProvider;
         this.tokenCounterFactory = tokenCounterFactory;
         this.apiCallExecutor = apiCallExecutor;
-        this.restAgentStore = restAgentStore;
-        this.restWorkflowStore = restWorkflowStore;
+        this.agentStore = agentStore;
+        this.workflowStore = workflowStore;
         this.conversationSummarizer = conversationSummarizer;
         this.promptSnippetService = promptSnippetService;
         this.globalVariableResolver = globalVariableResolver;
@@ -1532,7 +1532,7 @@ public class LlmTask implements ILifecycleTask {
     private String executeHttpCallRag(IConversationMemory memory, String httpCallName, String userInput, Map<String, Object> templateDataObjects) {
 
         // Discover all httpCall configs from the workflow
-        var stepConfigs = WorkflowTraversal.discoverConfigs(memory, HTTPCALLS_TYPE, ApiCallsConfiguration.class, restAgentStore, restWorkflowStore,
+        var stepConfigs = WorkflowTraversal.discoverConfigs(memory, HTTPCALLS_TYPE, ApiCallsConfiguration.class, agentStore, workflowStore,
                 resourceClientLibrary);
 
         // Search for the named ApiCall across all httpCall configurations

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/McpToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/McpToolsProvider.java
@@ -4,9 +4,9 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration.McpServerConfig;
@@ -53,15 +53,15 @@ class McpToolsProvider implements ToolSourceProvider {
     private static final Logger LOGGER = Logger.getLogger(McpToolsProvider.class);
     private static final String MCPCALLS_TYPE = "eddi://ai.labs.mcpcalls";
 
-    private final IRestAgentStore restAgentStore;
-    private final IRestWorkflowStore restWorkflowStore;
+    private final IAgentStore agentStore;
+    private final IWorkflowStore workflowStore;
     private final IResourceClientLibrary resourceClientLibrary;
     private final McpToolProviderManager mcpToolProviderManager;
 
-    McpToolsProvider(IRestAgentStore restAgentStore, IRestWorkflowStore restWorkflowStore,
+    McpToolsProvider(IAgentStore agentStore, IWorkflowStore workflowStore,
             IResourceClientLibrary resourceClientLibrary, McpToolProviderManager mcpToolProviderManager) {
-        this.restAgentStore = restAgentStore;
-        this.restWorkflowStore = restWorkflowStore;
+        this.agentStore = agentStore;
+        this.workflowStore = workflowStore;
         this.resourceClientLibrary = resourceClientLibrary;
         this.mcpToolProviderManager = mcpToolProviderManager;
     }
@@ -137,7 +137,7 @@ class McpToolsProvider implements ToolSourceProvider {
         try {
             LOGGER.infof("Discovering mcpcalls tools for agent: %s v%s", memory.getAgentId(), memory.getAgentVersion());
 
-            var stepConfigs = WorkflowTraversal.discoverConfigs(memory, MCPCALLS_TYPE, McpCallsConfiguration.class, restAgentStore, restWorkflowStore,
+            var stepConfigs = WorkflowTraversal.discoverConfigs(memory, MCPCALLS_TYPE, McpCallsConfiguration.class, agentStore, workflowStore,
                     resourceClientLibrary);
 
             for (var stepConfig : stepConfigs) {

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/RagContextProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/RagContextProvider.java
@@ -4,10 +4,10 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
 import ai.labs.eddi.utils.LogSanitizer;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IDataFactory;
 import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
@@ -45,18 +45,18 @@ public class RagContextProvider {
     private static final Logger LOGGER = Logger.getLogger(RagContextProvider.class);
     private static final String RAG_TYPE = "eddi://ai.labs.rag";
 
-    private final IRestAgentStore restAgentStore;
-    private final IRestWorkflowStore restWorkflowStore;
+    private final IAgentStore agentStore;
+    private final IWorkflowStore workflowStore;
     private final IResourceClientLibrary resourceClientLibrary;
     private final EmbeddingModelFactory embeddingModelFactory;
     private final EmbeddingStoreFactory embeddingStoreFactory;
     private final IDataFactory dataFactory;
 
     @Inject
-    public RagContextProvider(IRestAgentStore restAgentStore, IRestWorkflowStore restWorkflowStore, IResourceClientLibrary resourceClientLibrary,
+    public RagContextProvider(IAgentStore agentStore, IWorkflowStore workflowStore, IResourceClientLibrary resourceClientLibrary,
             EmbeddingModelFactory embeddingModelFactory, EmbeddingStoreFactory embeddingStoreFactory, IDataFactory dataFactory) {
-        this.restAgentStore = restAgentStore;
-        this.restWorkflowStore = restWorkflowStore;
+        this.agentStore = agentStore;
+        this.workflowStore = workflowStore;
         this.resourceClientLibrary = resourceClientLibrary;
         this.embeddingModelFactory = embeddingModelFactory;
         this.embeddingStoreFactory = embeddingStoreFactory;
@@ -94,7 +94,7 @@ public class RagContextProvider {
         }
 
         // Step 2: Discover all RAG configs from workflow
-        var ragSteps = WorkflowTraversal.discoverConfigs(memory, RAG_TYPE, RagConfiguration.class, restAgentStore, restWorkflowStore,
+        var ragSteps = WorkflowTraversal.discoverConfigs(memory, RAG_TYPE, RagConfiguration.class, agentStore, workflowStore,
                 resourceClientLibrary);
 
         if (ragSteps.isEmpty()) {

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/WorkflowTraversal.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/WorkflowTraversal.java
@@ -4,9 +4,9 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
@@ -101,9 +101,9 @@ class WorkflowTraversal {
      *            the step type URI to match (e.g., "eddi://ai.labs.httpcalls")
      * @param configClass
      *            the class to deserialize the configuration into
-     * @param restAgentStore
+     * @param agentStore
      *            agent store for loading agent configurations
-     * @param restWorkflowStore
+     * @param workflowStore
      *            workflow store for loading workflow configurations
      * @param resourceClientLibrary
      *            resource client for loading extension configurations
@@ -112,16 +112,16 @@ class WorkflowTraversal {
      * @return list of discovered configurations (never null)
      */
     static <T> List<StepConfig<T>> discoverConfigs(IConversationMemory memory, String stepTypeUri, Class<T> configClass,
-                                                   IRestAgentStore restAgentStore, IRestWorkflowStore restWorkflowStore,
+                                                   IAgentStore agentStore, IWorkflowStore workflowStore,
                                                    IResourceClientLibrary resourceClientLibrary) {
 
-        return discoverConfigs(memory, stepTypeUri, configClass, restAgentStore, restWorkflowStore, resourceClientLibrary,
+        return discoverConfigs(memory, stepTypeUri, configClass, agentStore, workflowStore, resourceClientLibrary,
                 System.currentTimeMillis());
     }
 
     /**
      * As
-     * {@link #discoverConfigs(IConversationMemory, String, Class, IRestAgentStore, IRestWorkflowStore, IResourceClientLibrary)},
+     * {@link #discoverConfigs(IConversationMemory, String, Class, IAgentStore, IWorkflowStore, IResourceClientLibrary)},
      * with an explicit clock reading so TTL expiry is deterministically testable
      * instead of requiring a real {@value #CACHE_TTL_MILLIS} ms sleep.
      *
@@ -129,7 +129,7 @@ class WorkflowTraversal {
      *            the current time in milliseconds
      */
     static <T> List<StepConfig<T>> discoverConfigs(IConversationMemory memory, String stepTypeUri, Class<T> configClass,
-                                                   IRestAgentStore restAgentStore, IRestWorkflowStore restWorkflowStore,
+                                                   IAgentStore agentStore, IWorkflowStore workflowStore,
                                                    IResourceClientLibrary resourceClientLibrary, long nowMillis) {
 
         List<StepConfig<T>> results = new ArrayList<>();
@@ -164,7 +164,7 @@ class WorkflowTraversal {
 
         AgentConfiguration agentConfig;
         try {
-            agentConfig = restAgentStore.readAgent(agentId, agentVersion);
+            agentConfig = agentStore.read(agentId, agentVersion);
         } catch (Exception e) {
             LOGGER.warnf("Failed to load agent config for %s v%d: %s", agentId, agentVersion, e.getMessage());
             return results;
@@ -210,7 +210,7 @@ class WorkflowTraversal {
             }
 
             try {
-                WorkflowConfiguration workflowConfig = restWorkflowStore.readWorkflow(workflowId, workflowVersion);
+                WorkflowConfiguration workflowConfig = workflowStore.read(workflowId, workflowVersion);
                 for (var step : workflowConfig.getWorkflowSteps()) {
                     if (step.getType() != null && stepTypeUri.equals(step.getType().toString())) {
                         String uri = (String) step.getConfig().get("uri");

--- a/src/main/java/ai/labs/eddi/modules/templating/rest/RestTemplatePreview.java
+++ b/src/main/java/ai/labs/eddi/modules/templating/rest/RestTemplatePreview.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.modules.templating.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.memory.ConversationMemoryUtilities;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
@@ -40,12 +41,19 @@ public class RestTemplatePreview implements IRestTemplatePreview {
     private final PromptSnippetService promptSnippetService;
     private final ConversationAccessGuard conversationAccessGuard;
 
+    private final ResourceAccessGuard resourceAccessGuard;
+
+    /** Stand-in for a snippet body the caller may not read. */
+    private static final String REDACTED = "<redacted>";
+
     @Inject
     public RestTemplatePreview(ITemplatingEngine templatingEngine,
             IConversationMemoryStore conversationMemoryStore,
             IMemoryItemConverter memoryItemConverter,
             PromptSnippetService promptSnippetService,
-            ConversationAccessGuard conversationAccessGuard) {
+            ConversationAccessGuard conversationAccessGuard,
+            ResourceAccessGuard resourceAccessGuard) {
+        this.resourceAccessGuard = resourceAccessGuard;
         this.templatingEngine = templatingEngine;
         this.conversationMemoryStore = conversationMemoryStore;
         this.memoryItemConverter = memoryItemConverter;
@@ -81,6 +89,19 @@ public class RestTemplatePreview implements IRestTemplatePreview {
         List<String> availableVariables = new ArrayList<>();
         Map<String, Object> variableValues = new LinkedHashMap<>();
         flattenKeys("", templateData, availableVariables, variableValues, 4);
+
+        // Snippet NAMES stay — a preview is useless if it cannot tell you which
+        // {snippets.x} references resolve — but their CONTENTS are removed unless the
+        // caller sees everything anyway. Snippets are one of the guarded configuration
+        // types, and rendering every one of them into this response would hand any
+        // editor the full text of every colleague's prompt building blocks through an
+        // endpoint that takes an arbitrary template.
+        //
+        // The resolved template below is unaffected: it renders only what the caller's
+        // own template actually references, which is their own composition.
+        if (!snippets.isEmpty() && !resourceAccessGuard.seesEverything()) {
+            variableValues.replaceAll((key, value) -> key.startsWith("snippets.") ? REDACTED : value);
+        }
 
         // Resolve template
         try {

--- a/src/main/java/ai/labs/eddi/modules/templating/rest/RestTemplatePreview.java
+++ b/src/main/java/ai/labs/eddi/modules/templating/rest/RestTemplatePreview.java
@@ -79,10 +79,21 @@ public class RestTemplatePreview implements IRestTemplatePreview {
             templateData = buildDefaultSampleData();
         }
 
-        // Inject prompt snippets — same as LlmTask.execute()
+        // Inject prompt snippets — same as LlmTask.execute(), except that a caller
+        // who does not see everything gets the NAMES with the contents replaced.
+        //
+        // The redaction has to happen here, in the map the template is rendered
+        // against, and not only in the reference panel below. The caller supplies
+        // the template, so redacting the panel alone is no protection at all: one
+        // call lists every snippet name, and a second call whose template is
+        // "{snippets.<name>}" prints the content the panel refused to show. That
+        // was a live hole, not a hypothetical — snippets are a guarded
+        // configuration type, and this endpoint would otherwise hand any editor
+        // the full text of every colleague's prompt building blocks.
         Map<String, Object> snippets = promptSnippetService.getAll();
+        boolean redactSnippets = !resourceAccessGuard.seesEverything();
         if (!snippets.isEmpty()) {
-            templateData.put("snippets", snippets);
+            templateData.put("snippets", redactSnippets ? redactValues(snippets) : snippets);
         }
 
         // Flatten keys for the variable reference panel
@@ -90,16 +101,10 @@ public class RestTemplatePreview implements IRestTemplatePreview {
         Map<String, Object> variableValues = new LinkedHashMap<>();
         flattenKeys("", templateData, availableVariables, variableValues, 4);
 
-        // Snippet NAMES stay — a preview is useless if it cannot tell you which
-        // {snippets.x} references resolve — but their CONTENTS are removed unless the
-        // caller sees everything anyway. Snippets are one of the guarded configuration
-        // types, and rendering every one of them into this response would hand any
-        // editor the full text of every colleague's prompt building blocks through an
-        // endpoint that takes an arbitrary template.
-        //
-        // The resolved template below is unaffected: it renders only what the caller's
-        // own template actually references, which is their own composition.
-        if (!snippets.isEmpty() && !resourceAccessGuard.seesEverything()) {
+        // Belt and braces: the panel is flattened from the already-redacted map, so
+        // this only catches a snippet whose own value is a nested structure that
+        // flattening walked into.
+        if (!snippets.isEmpty() && redactSnippets) {
             variableValues.replaceAll((key, value) -> key.startsWith("snippets.") ? REDACTED : value);
         }
 
@@ -111,6 +116,21 @@ public class RestTemplatePreview implements IRestTemplatePreview {
             LOGGER.debugv("Template preview resolution error: {0}", e.getMessage());
             return new TemplatePreviewResponse(null, availableVariables, variableValues, e.getMessage());
         }
+    }
+
+    /**
+     * The same snippet names with every value replaced.
+     * <p>
+     * Names are kept because a preview that cannot tell you which
+     * {@code {snippets.x}} references resolve is not much of a preview, and a name
+     * is not the secret — the content is. Rendering then yields {@code <redacted>}
+     * where the content would have been, which is the honest answer rather than a
+     * silent blank.
+     */
+    private static Map<String, Object> redactValues(Map<String, Object> snippets) {
+        Map<String, Object> redacted = new LinkedHashMap<>(snippets.size());
+        snippets.keySet().forEach(key -> redacted.put(key, REDACTED));
+        return redacted;
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -391,6 +391,35 @@ quarkus.oidc.application-type=service
 authorization.enabled=${quarkus.oidc.tenant-enabled}
 # Security escape hatch — MUST be explicitly set to true to allow unauthenticated access in prod
 eddi.security.allow-unauthenticated=false
+
+# ── Per-user workspaces ──────────────────────────────────────────────────────
+# Whether configuration resources (agents, workflows, rule sets, LLM configs, …)
+# are scoped to the user or team that created them. OFF by default: a single
+# shared authoring workspace is the existing behaviour and stays the default.
+#
+# Ownership is recorded on every new resource whenever authentication is on,
+# regardless of this flag — so an operator can upgrade, let attribution
+# accumulate, verify it, and only then switch enforcement on. Enabling this
+# against data that was never stamped is what would hide people's own work from
+# them; WorkspaceAccessIndexMigration backfills that on first startup.
+#
+# Has no effect while authorization.enabled=false: with no authenticated
+# principal there is nothing to scope resources to, and the app says so at boot.
+eddi.workspaces.enabled=false
+# JWT claim carrying the caller's Keycloak groups, which become team spaces.
+# Needs a group-membership protocol mapper on the eddi-backend client; without
+# one every user simply has a personal space and no teams, which is a correct
+# answer rather than a failure.
+eddi.workspaces.groups-claim=groups
+# What happens to resources created before ownership was recorded.
+#   shared     — visible to everyone (default; an upgrade hides nothing)
+#   admin-only — visible only to eddi-admin, so an operator can migrate
+#                deliberately and then close the door
+eddi.workspaces.legacy-visibility=shared
+# Where new resources are filed. Empty (default) = the creator's personal space.
+# Set to a Keycloak group name for a team-first deployment, where colleagues see
+# each other's work by default and personal spaces are opt-in.
+#eddi.workspaces.default-space=
 # SSRF protection for agent-configured outbound calls (httpcalls + A2A peer fetch).
 # When true, resolved target URLs are validated (no private/loopback/link-local/
 # cloud-metadata addresses, http(s) only) and redirect-following is disabled on

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceBranchTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
@@ -93,7 +94,7 @@ class RestExportServiceBranchTest {
                 dictionaryStore, ruleSetStore, apiCallsStore, llmStore,
                 propertySetterStore, outputStore, mcpCallsStore, ragStore,
                 snippetStore, jsonSerialization, zipArchive, secretScrubber,
-                scheduleStore);
+                scheduleStore, mock(ResourceAccessGuard.class));
     }
 
     // =========================================================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceCleanupTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceCleanupTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
@@ -89,7 +90,7 @@ class RestExportServiceCleanupTest {
                 mock(IDictionaryStore.class), mock(IRuleSetStore.class), mock(IApiCallsStore.class),
                 mock(ILlmStore.class), mock(IPropertySetterStore.class), mock(IOutputStore.class),
                 mock(IMcpCallsStore.class), mock(IRagStore.class), mock(IPromptSnippetStore.class),
-                jsonSerialization, zipArchive, secretScrubber, scheduleStore);
+                jsonSerialization, zipArchive, secretScrubber, scheduleStore, mock(ResourceAccessGuard.class));
 
         tmpDir = Paths.get(FileUtilities.buildPath(System.getProperty("user.dir"), "tmp"));
         exportRoot = tmpDir.resolve("export");

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedBranchTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
@@ -96,7 +97,7 @@ class RestExportServiceExtendedBranchTest {
                 dictionaryStore, ruleSetStore, apiCallsStore, llmStore,
                 propertySetterStore, outputStore, mcpCallsStore, ragStore,
                 snippetStore, jsonSerialization, zipArchive, secretScrubber,
-                scheduleStore);
+                scheduleStore, mock(ResourceAccessGuard.class));
     }
 
     // =========================================================
@@ -125,7 +126,7 @@ class RestExportServiceExtendedBranchTest {
                     "exportSnippets", Path.class, Set.class);
             method.setAccessible(true);
 
-            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false)))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
                     .thenReturn(null);
 
             Set<String> names = new LinkedHashSet<>();
@@ -140,7 +141,7 @@ class RestExportServiceExtendedBranchTest {
                     "exportSnippets", Path.class, Set.class);
             method.setAccessible(true);
 
-            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false)))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
                     .thenReturn(Collections.emptyList());
 
             Set<String> names = new LinkedHashSet<>();
@@ -157,7 +158,7 @@ class RestExportServiceExtendedBranchTest {
 
             DocumentDescriptor desc = new DocumentDescriptor();
             desc.setResource(URI.create("eddi://ai.labs.snippet/snippetstore/snippets/aabbccddeeff112233445566?version=1"));
-            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false)))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
                     .thenReturn(List.of(desc));
 
             PromptSnippet snippet = new PromptSnippet();
@@ -178,7 +179,7 @@ class RestExportServiceExtendedBranchTest {
 
             DocumentDescriptor desc = new DocumentDescriptor();
             desc.setResource(URI.create("eddi://ai.labs.snippet/snippetstore/snippets/aabbccddeeff112233445566?version=1"));
-            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false)))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
                     .thenReturn(List.of(desc));
 
             PromptSnippet snippet = new PromptSnippet();
@@ -199,7 +200,7 @@ class RestExportServiceExtendedBranchTest {
 
             DocumentDescriptor desc = new DocumentDescriptor();
             desc.setResource(URI.create("eddi://ai.labs.snippet/snippetstore/snippets/aabbccddeeff112233445566?version=1"));
-            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false)))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
                     .thenReturn(List.of(desc));
             when(snippetStore.read("aabbccddeeff112233445566", 1))
                     .thenThrow(new IResourceStore.ResourceNotFoundException("not found"));

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ExportPreview;
 import ai.labs.eddi.configs.agents.IAgentStore;
@@ -87,7 +88,7 @@ class RestExportServiceExtendedTest {
                 dictionaryStore, behaviorStore, httpCallsStore, llmStore,
                 propertySetterStore, outputStore, mcpCallsStore, ragStore,
                 snippetStore, jsonSerialization, zipArchive, secretScrubber,
-                scheduleStore);
+                scheduleStore, mock(ResourceAccessGuard.class));
     }
 
     // ─── sanitizePathComponent ─────────────────────────────────

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ExportPreview;
 import ai.labs.eddi.configs.agents.IAgentStore;
@@ -84,7 +85,7 @@ class RestExportServiceTest {
                 dictionaryStore, behaviorStore, httpCallsStore, llmStore,
                 propertySetterStore, outputStore, mcpCallsStore, ragStore,
                 snippetStore, jsonSerialization, zipArchive, secretScrubber,
-                scheduleStore);
+                scheduleStore, mock(ResourceAccessGuard.class));
     }
 
     // ─── getAgentZipArchive security ─────────────────────────────

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceBranchCoverageTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.SyncMapping;
@@ -61,7 +62,7 @@ class RestImportServiceBranchCoverageTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor);
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
     }
 
     // =========================================================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedBranchTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.SyncMapping;
@@ -58,7 +59,7 @@ class RestImportServiceExtendedBranchTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor);
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
     }
 
     // =========================================================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
@@ -69,7 +70,7 @@ class RestImportServiceExtendedTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor);
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
     }
 
     // ==================== normalizeVaultReferences ====================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.configs.agents.IAgentStore;
@@ -93,7 +94,7 @@ class RestImportServiceRollbackAndCleanupTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 mock(IMigrationManager.class), documentDescriptorStore,
-                mock(TemplateSyntaxMigrator.class), structuralMatcher, upgradeExecutor);
+                mock(TemplateSyntaxMigrator.class), structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
     }
 
     // ==================== D11 — rollback of a partial import ====================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSyncCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSyncCoverageTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.SyncMapping;
@@ -57,7 +58,7 @@ class RestImportServiceSyncCoverageTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor);
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
     }
 
     // =========================================================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
@@ -62,7 +63,7 @@ class RestImportServiceTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor);
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
     }
 
     // ==================== Strategy Dispatch ====================

--- a/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IResourceSource;
 import ai.labs.eddi.backup.IResourceSource.*;
 import ai.labs.eddi.backup.model.ImportPreview;
@@ -77,7 +78,7 @@ class UpgradeExecutorTest {
         descriptorStore = Mockito.mock(IDocumentDescriptorStore.class);
 
         executor = new UpgradeExecutor(agentStore, workflowStore,
-                snippetStore, jsonSerialization, structuralMatcher, descriptorStore);
+                snippetStore, jsonSerialization, structuralMatcher, descriptorStore, mock(ResourceAccessGuard.class));
     }
 
     // ==================== Snippet Processing ====================

--- a/src/test/java/ai/labs/eddi/configs/DescriptorListingDelegationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/DescriptorListingDelegationTest.java
@@ -4,6 +4,9 @@
  */
 package ai.labs.eddi.configs;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.dictionary.IDictionaryStore;
@@ -40,9 +43,10 @@ class DescriptorListingDelegationTest {
     @DisplayName("rulesets list under ai.labs.rules — the namespace their URIs actually carry")
     void ruleSetListingUsesTheRulesNamespace() throws Exception {
         var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
-        var store = new RestRuleSetStore(mock(IRuleSetStore.class), documentDescriptorStore, mock(IJsonSchemaCreator.class));
+        var store = new RestRuleSetStore(mock(IRuleSetStore.class), documentDescriptorStore, mock(IJsonSchemaCreator.class),
+                mock(ResourceAccessGuard.class));
         List<DocumentDescriptor> expected = List.of(new DocumentDescriptor());
-        doReturn(expected).when(documentDescriptorStore).readDescriptors("ai.labs.rules", "f", 0, 10, false);
+        doReturn(expected).when(documentDescriptorStore).readDescriptors(eq("ai.labs.rules"), eq("f"), eq(0), eq(10), eq(false), any());
 
         assertEquals(expected, store.readBehaviorDescriptors("f", 0, 10),
                 "querying any other namespace returns an empty list forever, with no error");
@@ -53,9 +57,9 @@ class DescriptorListingDelegationTest {
     void dictionaryListingUsesTheDictionaryNamespace() throws Exception {
         var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         var store = new RestDictionaryStore(mock(IDictionaryStore.class), documentDescriptorStore,
-                mock(IJsonSchemaCreator.class));
+                mock(IJsonSchemaCreator.class), mock(ResourceAccessGuard.class));
         List<DocumentDescriptor> expected = List.of(new DocumentDescriptor());
-        doReturn(expected).when(documentDescriptorStore).readDescriptors("ai.labs.dictionary", "f", 0, 10, false);
+        doReturn(expected).when(documentDescriptorStore).readDescriptors(eq("ai.labs.dictionary"), eq("f"), eq(0), eq(10), eq(false), any());
 
         assertEquals(expected, store.readRegularDictionaryDescriptors("f", 0, 10));
     }

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
@@ -4,6 +4,9 @@
  */
 package ai.labs.eddi.configs.agents.rest;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
@@ -62,7 +65,7 @@ class RestAgentStoreExpandedTest {
         deploymentStore = mock(IDeploymentStore.class);
 
         sut = new RestAgentStore(agentStore, restWorkflowStore, documentDescriptorStore,
-                jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore);
+                jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore, mock(ResourceAccessGuard.class));
     }
 
     private IResourceStore.IResourceId dummyResourceId(String id, int version) {
@@ -114,7 +117,7 @@ class RestAgentStoreExpandedTest {
         @Test
         @DisplayName("should delegate to document descriptor store")
         void standard() throws Exception {
-            when(documentDescriptorStore.readDescriptors("ai.labs.agent", "filter", 0, 20, false))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.agent"), eq("filter"), eq(0), eq(20), eq(false), any()))
                     .thenReturn(List.of(new DocumentDescriptor()));
 
             List<DocumentDescriptor> result = sut.readAgentDescriptors("filter", 0, 20);

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
@@ -65,7 +65,7 @@ class RestAgentStoreExpandedTest {
         deploymentStore = mock(IDeploymentStore.class);
 
         sut = new RestAgentStore(agentStore, restWorkflowStore, documentDescriptorStore,
-                jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore, mock(ResourceAccessGuard.class));
+                jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore, permissiveGuard());
     }
 
     private IResourceStore.IResourceId dummyResourceId(String id, int version) {
@@ -521,5 +521,18 @@ class RestAgentStoreExpandedTest {
 
             assertDoesNotThrow(() -> sut.populateCapabilityRegistry());
         }
+    }
+
+    /**
+     * A guard that admits everything. {@code visibleOnly} filters with
+     * {@code canAccess}, which a bare Mockito mock answers {@code false} to —
+     * correct for a security check, wrong for a test that is not about the security
+     * check.
+     */
+    private static ResourceAccessGuard permissiveGuard() {
+        ResourceAccessGuard guard = mock(ResourceAccessGuard.class);
+        lenient().when(guard.seesEverything()).thenReturn(true);
+        lenient().when(guard.canAccess(any(), any())).thenReturn(true);
+        return guard;
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.configs.agents.rest;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
+import ai.labs.eddi.engine.security.spaces.AccessScope;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
@@ -120,7 +121,7 @@ class RestAgentStoreExpandedTest {
             when(documentDescriptorStore.readDescriptors(eq("ai.labs.agent"), eq("filter"), eq(0), eq(20), eq(false), any()))
                     .thenReturn(List.of(new DocumentDescriptor()));
 
-            List<DocumentDescriptor> result = sut.readAgentDescriptors("filter", 0, 20);
+            List<DocumentDescriptor> result = sut.readAgentDescriptors("filter", 0, 20, "");
 
             assertEquals(1, result.size());
         }
@@ -533,6 +534,10 @@ class RestAgentStoreExpandedTest {
         ResourceAccessGuard guard = mock(ResourceAccessGuard.class);
         lenient().when(guard.seesEverything()).thenReturn(true);
         lenient().when(guard.canAccess(any(), any())).thenReturn(true);
+        // A real guard never returns null here, and the space-narrowing overload
+        // chains straight off it. Left unstubbed the mock answers null and the
+        // listing NPEs, which reads as a production bug rather than a bare mock.
+        lenient().when(guard.listingScope()).thenReturn(AccessScope.unrestricted());
         return guard;
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExtendedTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.agents.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
@@ -64,7 +65,8 @@ class RestAgentStoreExtendedTest {
     void setUp() {
         openMocks(this);
         restAgentStore = new RestAgentStore(agentStore, restWorkflowStore,
-                documentDescriptorStore, jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore);
+                documentDescriptorStore, jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore,
+                mock(ResourceAccessGuard.class));
     }
 
     // ==================== readJsonSchema ====================

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExtendedTest.java
@@ -66,7 +66,7 @@ class RestAgentStoreExtendedTest {
         openMocks(this);
         restAgentStore = new RestAgentStore(agentStore, restWorkflowStore,
                 documentDescriptorStore, jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore,
-                mock(ResourceAccessGuard.class));
+                permissiveGuard());
     }
 
     // ==================== readJsonSchema ====================
@@ -459,5 +459,18 @@ class RestAgentStoreExtendedTest {
                 return version;
             }
         };
+    }
+
+    /**
+     * A guard that admits everything. {@code visibleOnly} filters with
+     * {@code canAccess}, which a bare Mockito mock answers {@code false} to —
+     * correct for a security check, wrong for a test that is not about the security
+     * check.
+     */
+    private static ResourceAccessGuard permissiveGuard() {
+        ResourceAccessGuard guard = mock(ResourceAccessGuard.class);
+        lenient().when(guard.seesEverything()).thenReturn(true);
+        lenient().when(guard.canAccess(any(), any())).thenReturn(true);
+        return guard;
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.agents.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.crypto.AgentPublicKey;
@@ -59,7 +60,7 @@ class RestAgentStoreTest {
     void setUp() {
         openMocks(this);
         restAgentStore = new RestAgentStore(AgentStore, restWorkflowStore, documentDescriptorStore, jsonSchemaCreator, scheduleStore,
-                capabilityRegistryService, deploymentStore);
+                capabilityRegistryService, deploymentStore, mock(ResourceAccessGuard.class));
     }
 
     /** Helper to create a dummy DocumentDescriptor for reference-count mocking */

--- a/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreBranchTest.java
+++ b/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreBranchTest.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.configs.apicalls.rest;
 
+import static org.mockito.ArgumentMatchers.any;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.apicalls.model.ApiEndpointDiscoveryRequest;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
@@ -41,7 +43,7 @@ class RestApiCallsStoreBranchTest {
     @BeforeEach
     void setUp() {
         openMocks(this);
-        restApiCallsStore = new RestApiCallsStore(apiCallsStore, documentDescriptorStore, jsonSchemaCreator);
+        restApiCallsStore = new RestApiCallsStore(apiCallsStore, documentDescriptorStore, jsonSchemaCreator, mock(ResourceAccessGuard.class));
     }
 
     @Nested
@@ -75,7 +77,7 @@ class RestApiCallsStoreBranchTest {
         @DisplayName("returns descriptors list")
         void returnsDescriptors() throws Exception {
             var desc = new DocumentDescriptor();
-            when(documentDescriptorStore.readDescriptors(eq("ai.labs.apicalls"), anyString(), anyInt(), anyInt(), eq(false)))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.apicalls"), anyString(), anyInt(), anyInt(), eq(false), any()))
                     .thenReturn(List.of(desc));
 
             List<DocumentDescriptor> result = restApiCallsStore.readApiCallsDescriptors("", 0, 10);

--- a/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreDelegationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreDelegationTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.apicalls.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
@@ -47,7 +48,7 @@ class RestApiCallsStoreDelegationTest {
     @BeforeEach
     void setUp() throws Exception {
         mocks = openMocks(this);
-        store = new RestApiCallsStore(httpCallsStore, documentDescriptorStore, jsonSchemaCreator);
+        store = new RestApiCallsStore(httpCallsStore, documentDescriptorStore, jsonSchemaCreator, mock(ResourceAccessGuard.class));
 
         // Access the restVersionInfo field to spy on it
         Field rvField = RestApiCallsStore.class.getDeclaredField("restVersionInfo");

--- a/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreDelegationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreDelegationTest.java
@@ -74,7 +74,7 @@ class RestApiCallsStoreDelegationTest {
         void delegatesCorrectly() throws Exception {
             List<DocumentDescriptor> expected = List.of(new DocumentDescriptor());
             doReturn(expected).when(documentDescriptorStore)
-                    .readDescriptors("ai.labs.apicalls", "myFilter", 0, 10, false);
+                    .readDescriptors(eq("ai.labs.apicalls"), eq("myFilter"), eq(0), eq(10), eq(false), any());
 
             List<DocumentDescriptor> result = store.readApiCallsDescriptors("myFilter", 0, 10);
 
@@ -86,7 +86,7 @@ class RestApiCallsStoreDelegationTest {
         void emptyFilter() throws Exception {
             List<DocumentDescriptor> expected = List.of();
             doReturn(expected).when(documentDescriptorStore)
-                    .readDescriptors("ai.labs.apicalls", "", 0, 20, false);
+                    .readDescriptors(eq("ai.labs.apicalls"), eq(""), eq(0), eq(20), eq(false), any());
 
             List<DocumentDescriptor> result = store.readApiCallsDescriptors("", 0, 20);
 

--- a/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/apicalls/rest/RestApiCallsStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.apicalls.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.apicalls.model.ApiEndpointDiscoveryRequest;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
@@ -39,7 +40,7 @@ class RestApiCallsStoreTest {
     @BeforeEach
     void setUp() {
         mocks = openMocks(this);
-        store = new RestApiCallsStore(httpCallsStore, documentDescriptorStore, jsonSchemaCreator);
+        store = new RestApiCallsStore(httpCallsStore, documentDescriptorStore, jsonSchemaCreator, mock(ResourceAccessGuard.class));
     }
 
     @AfterEach

--- a/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreAccessTest.java
+++ b/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreAccessTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.channels.rest;
+
+import ai.labs.eddi.configs.channels.IChannelIntegrationStore;
+import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
+import ai.labs.eddi.configs.channels.model.ChannelTarget;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import io.quarkus.security.ForbiddenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A channel target is a standing invitation, and is gated accordingly.
+ *
+ * <h3>What this is defending</h3> Once a channel is configured, every inbound
+ * message reaches its target as a <em>system-initiated</em> conversation, which
+ * is deliberately below the USE gate. So the check has to happen when the
+ * channel is written: otherwise an editor can aim a channel they control at a
+ * colleague's private agent and relay its replies into a room of their
+ * choosing, having never held access to it. Triggers, schedules and group
+ * membership are the same shape and are checked the same way.
+ *
+ * <p>
+ * The refusal must also land <em>before</em> the write, not after — a channel
+ * that was rejected but stored is a channel that still routes.
+ */
+class RestChannelIntegrationStoreAccessTest {
+
+    private static final String AGENT_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String GROUP_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+
+    private IChannelIntegrationStore channelStore;
+    private ResourceAccessGuard accessGuard;
+    private RestChannelIntegrationStore store;
+
+    @BeforeEach
+    void setUp() {
+        channelStore = mock(IChannelIntegrationStore.class);
+        accessGuard = mock(ResourceAccessGuard.class);
+        store = new RestChannelIntegrationStore(channelStore, mock(IDocumentDescriptorStore.class), accessGuard);
+    }
+
+    private static ChannelIntegrationConfiguration config(ChannelTarget.TargetType type, String targetId) {
+        var target = new ChannelTarget();
+        target.setName("support");
+        target.setTargetId(targetId);
+        target.setType(type);
+        target.setTriggers(List.of("support"));
+
+        var cfg = new ChannelIntegrationConfiguration();
+        cfg.setName("My Slack Hub");
+        cfg.setChannelType("slack");
+        cfg.setDefaultTargetName("support");
+        cfg.setTargets(List.of(target));
+        return cfg;
+    }
+
+    @Test
+    @DisplayName("creating a channel aimed at an agent the author cannot use is refused, and nothing is stored")
+    void refusesCreateForUngrantedAgent() throws Exception {
+        doThrow(new ForbiddenException("nope")).when(accessGuard).requireAgentUseAccess(AGENT_ID);
+
+        assertThrows(ForbiddenException.class,
+                () -> store.createChannel(config(ChannelTarget.TargetType.AGENT, AGENT_ID)));
+
+        verify(channelStore, never()).create(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("updating a channel to aim at an agent the author cannot use is refused")
+    void refusesUpdateForUngrantedAgent() throws Exception {
+        doThrow(new ForbiddenException("nope")).when(accessGuard).requireAgentUseAccess(AGENT_ID);
+
+        assertThrows(ForbiddenException.class,
+                () -> store.updateChannel("cccccccccccccccccccccccc", 1,
+                        config(ChannelTarget.TargetType.AGENT, AGENT_ID)));
+
+        verify(channelStore, never()).update(anyString(), org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("a GROUP target is checked as a group, not silently skipped")
+    void checksGroupTargets() {
+        // A group discussion is reachable by exactly the same route and is a guarded
+        // descriptor too. Checking only AGENT targets would leave the whole GROUP
+        // branch as an open door.
+        doThrow(new ForbiddenException("nope")).when(accessGuard).requireUseAccess(eq(GROUP_ID), anyString());
+
+        assertThrows(ForbiddenException.class,
+                () -> store.createChannel(config(ChannelTarget.TargetType.GROUP, GROUP_ID)));
+
+        verify(accessGuard).requireUseAccess(eq(GROUP_ID), anyString());
+        verify(accessGuard, never()).requireAgentUseAccess(GROUP_ID);
+    }
+
+    @Test
+    @DisplayName("a permitted target reaches the store")
+    void allowsPermittedTarget() throws Exception {
+        when(channelStore.create(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(new IResourceStore.IResourceId() {
+                    @Override
+                    public String getId() {
+                        return "cccccccccccccccccccccccc";
+                    }
+
+                    @Override
+                    public Integer getVersion() {
+                        return 1;
+                    }
+                });
+
+        store.createChannel(config(ChannelTarget.TargetType.AGENT, AGENT_ID));
+
+        verify(accessGuard).requireAgentUseAccess(AGENT_ID);
+        verify(channelStore).create(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreCrudTest.java
+++ b/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreCrudTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.channels.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.channels.IChannelIntegrationStore;
 import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.configs.channels.model.ChannelTarget;
@@ -48,7 +49,7 @@ class RestChannelIntegrationStoreCrudTest {
     void setUp() {
         channelStore = mock(IChannelIntegrationStore.class);
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
-        sut = new RestChannelIntegrationStore(channelStore, documentDescriptorStore);
+        sut = new RestChannelIntegrationStore(channelStore, documentDescriptorStore, mock(ResourceAccessGuard.class));
     }
 
     private static ChannelIntegrationConfiguration validConfig() {

--- a/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreCrudTest.java
+++ b/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreCrudTest.java
@@ -91,7 +91,7 @@ class RestChannelIntegrationStoreCrudTest {
         @DisplayName("should delegate to documentDescriptorStore")
         void delegatesToStore() throws Exception {
             var descriptors = List.of(new DocumentDescriptor());
-            when(documentDescriptorStore.readDescriptors("ai.labs.channel", "filter", 0, 10, false))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.channel"), eq("filter"), eq(0), eq(10), eq(false), any()))
                     .thenReturn(descriptors);
 
             List<DocumentDescriptor> result = sut.readChannelDescriptors("filter", 0, 10);

--- a/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreValidationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/channels/rest/RestChannelIntegrationStoreValidationTest.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.configs.channels.rest;
 
+import static org.mockito.Mockito.mock;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.configs.channels.model.ChannelTarget;
 import jakarta.ws.rs.BadRequestException;
@@ -30,7 +32,7 @@ class RestChannelIntegrationStoreValidationTest {
     @BeforeEach
     void setUp() {
         // Construct with null dependencies — we only call validateConfiguration()
-        store = new RestChannelIntegrationStore(null, null);
+        store = new RestChannelIntegrationStore(null, null, mock(ResourceAccessGuard.class));
         config = validConfig();
     }
 

--- a/src/test/java/ai/labs/eddi/configs/connections/rest/RestConnectionStoreGrantLifecycleTest.java
+++ b/src/test/java/ai/labs/eddi/configs/connections/rest/RestConnectionStoreGrantLifecycleTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.connections.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.connections.IConnectionStore;
 import ai.labs.eddi.configs.connections.model.AuthType;
 import ai.labs.eddi.configs.connections.model.Binding;
@@ -57,7 +58,7 @@ class RestConnectionStoreGrantLifecycleTest {
 
     private RestConnectionStore rest() {
         return new RestConnectionStore(connectionStore, mock(IDocumentDescriptorStore.class), mock(IJsonSchemaCreator.class), connectionRegistry,
-                grantStore, secretProvider, true);
+                grantStore, secretProvider, true, mock(ResourceAccessGuard.class));
     }
 
     private static ConnectionConfiguration connection(String name, String tenantId) {
@@ -104,7 +105,7 @@ class RestConnectionStoreGrantLifecycleTest {
     @DisplayName("a PER_USER connection cannot be created where no identity is verified")
     void refusesPerUserWithoutAuthorization() {
         var rest = new RestConnectionStore(connectionStore, mock(IDocumentDescriptorStore.class), mock(IJsonSchemaCreator.class),
-                connectionRegistry, grantStore, secretProvider, false);
+                connectionRegistry, grantStore, secretProvider, false, mock(ResourceAccessGuard.class));
         var connection = connection("drive", "acme");
         connection.setAuthType(AuthType.OAUTH2_AUTHORIZATION_CODE);
         connection.setBinding(Binding.PER_USER);

--- a/src/test/java/ai/labs/eddi/configs/connections/rest/RestConnectionStoreWriteGuardTest.java
+++ b/src/test/java/ai/labs/eddi/configs/connections/rest/RestConnectionStoreWriteGuardTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.connections.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.connections.IConnectionStore;
 import ai.labs.eddi.configs.connections.model.AuthType;
 import ai.labs.eddi.configs.connections.model.Binding;
@@ -65,7 +66,7 @@ class RestConnectionStoreWriteGuardTest {
 
     private RestConnectionStore rest() {
         return new RestConnectionStore(connectionStore, mock(IDocumentDescriptorStore.class), mock(IJsonSchemaCreator.class), connectionRegistry,
-                grantStore, secretProvider, true);
+                grantStore, secretProvider, true, mock(ResourceAccessGuard.class));
     }
 
     /** A document that passes every OTHER check, so a refusal is attributable. */

--- a/src/test/java/ai/labs/eddi/configs/descriptors/ResourceUtilitiesDuplicateOwnershipTest.java
+++ b/src/test/java/ai/labs/eddi/configs/descriptors/ResourceUtilitiesDuplicateOwnershipTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.descriptors;
+
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.descriptors.model.ResourceGrant;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+import ai.labs.eddi.engine.security.spaces.DescriptorAccess;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.Subjects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Duplicating a resource must produce something owned by whoever duplicated it.
+ * <p>
+ * Copying the source descriptor verbatim — which is what this did before —
+ * files the copy under the <em>source owner's</em> name and space. Since
+ * duplicating a {@code published} agent is something anyone may do, that let
+ * any user inject resources into someone else's workspace, attributed to them,
+ * while leaving themselves unable to edit or delete what they had just created.
+ */
+class ResourceUtilitiesDuplicateOwnershipTest {
+
+    private static final String OLD_ID = "aaaaaaaaaaaaaaaaaaaaaa";
+    private static final URI NEW_LOCATION = URI.create("eddi://ai.labs.agent/agentstore/agents/bbbbbbbbbbbbbbbbbbbbbb?version=1");
+
+    @Test
+    @DisplayName("the copy carries the duplicator's stamp, not the source's ownership")
+    void doesNotInheritOwnership() throws Exception {
+        DocumentDescriptor source = new DocumentDescriptor();
+        source.setName("Alice's agent");
+        source.setDescription("hers");
+        source.setOwnerId("alice");
+        source.setSpaceId(Subjects.personalSpace("alice"));
+        source.setVisibility(ResourceVisibility.published.wireName());
+        source.setGrants(List.of(new ResourceGrant(Subjects.user("dave"), "OWN", "alice", new Date(0))));
+        DescriptorAccess.rebuildIndex(source);
+
+        var store = mock(IDocumentDescriptorStore.class);
+        when(store.readDescriptor(anyString(), anyInt())).thenReturn(source);
+
+        // A guard standing in for Bob: stamps him as owner, as the real one would.
+        var guard = mock(ResourceAccessGuard.class);
+        when(guard.stampNewDescriptor(any())).thenAnswer(i -> {
+            DocumentDescriptor d = i.getArgument(0);
+            d.setOwnerId("bob");
+            d.setSpaceId(Subjects.personalSpace("bob"));
+            d.setVisibility(ResourceVisibility.space.wireName());
+            return DescriptorAccess.rebuildIndex(d);
+        });
+
+        ResourceUtilities.createDocumentDescriptorForDuplicate(store, guard, OLD_ID, 1, NEW_LOCATION);
+
+        var captor = ArgumentCaptor.forClass(DocumentDescriptor.class);
+        verify(store).createDescriptor(anyString(), anyInt(), captor.capture());
+        DocumentDescriptor copy = captor.getValue();
+
+        assertEquals("bob", copy.getOwnerId(), "the copy belongs to whoever made it");
+        assertEquals(Subjects.personalSpace("bob"), copy.getSpaceId());
+        assertEquals(ResourceVisibility.space.wireName(), copy.getVisibility(),
+                "a copy of a published resource is not itself published");
+        assertNull(copy.getGrants(), "the source's grants are not carried over to a new resource");
+    }
+
+    @Test
+    @DisplayName("name and description are carried over, with the copy suffix")
+    void carriesNameAndDescription() throws Exception {
+        DocumentDescriptor source = new DocumentDescriptor();
+        source.setName("Alice's agent");
+        source.setDescription("hers");
+        source.setOwnerId("alice");
+
+        var store = mock(IDocumentDescriptorStore.class);
+        when(store.readDescriptor(anyString(), anyInt())).thenReturn(source);
+        var guard = mock(ResourceAccessGuard.class);
+        when(guard.stampNewDescriptor(any())).thenAnswer(i -> i.getArgument(0));
+
+        ResourceUtilities.createDocumentDescriptorForDuplicate(store, guard, OLD_ID, 1, NEW_LOCATION);
+
+        var captor = ArgumentCaptor.forClass(DocumentDescriptor.class);
+        verify(store).createDescriptor(anyString(), anyInt(), captor.capture());
+        assertEquals("Alice's agent - Copy", captor.getValue().getName());
+        assertEquals("hers", captor.getValue().getDescription());
+    }
+
+    @Test
+    @DisplayName("the source descriptor is left untouched")
+    void doesNotMutateTheSource() throws Exception {
+        DocumentDescriptor source = new DocumentDescriptor();
+        source.setName("Alice's agent");
+        source.setOwnerId("alice");
+        source.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + OLD_ID + "?version=1"));
+
+        var store = mock(IDocumentDescriptorStore.class);
+        when(store.readDescriptor(anyString(), anyInt())).thenReturn(source);
+        var guard = mock(ResourceAccessGuard.class);
+        when(guard.stampNewDescriptor(any())).thenAnswer(i -> i.getArgument(0));
+
+        ResourceUtilities.createDocumentDescriptorForDuplicate(store, guard, OLD_ID, 1, NEW_LOCATION);
+
+        // The previous implementation mutated the object it read and stored that: the
+        // source's own name gained " - Copy" and its resource URI pointed at the copy.
+        assertEquals("Alice's agent", source.getName());
+        assertEquals("alice", source.getOwnerId());
+        assertEquals(URI.create("eddi://ai.labs.agent/agentstore/agents/" + OLD_ID + "?version=1"), source.getResource());
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.descriptors.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.descriptors.model.SimpleDocumentDescriptor;
@@ -33,7 +34,7 @@ class RestDocumentDescriptorStoreTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        restStore = new RestDocumentDescriptorStore(documentDescriptorStore);
+        restStore = new RestDocumentDescriptorStore(documentDescriptorStore, mock(ResourceAccessGuard.class));
     }
 
     @Test
@@ -41,7 +42,7 @@ class RestDocumentDescriptorStoreTest {
     void readDescriptors() throws Exception {
         var desc = new DocumentDescriptor();
         desc.setName("test");
-        when(documentDescriptorStore.readDescriptors("agent", "filter", 0, 10, false))
+        when(documentDescriptorStore.readDescriptors(eq("agent"), eq("filter"), eq(0), eq(10), eq(false), any()))
                 .thenReturn(List.of(desc));
 
         List<DocumentDescriptor> result = restStore.readDescriptors("agent", "filter", 0, 10);
@@ -52,7 +53,7 @@ class RestDocumentDescriptorStoreTest {
     @Test
     @DisplayName("readDescriptors — throws InternalServerErrorException on ResourceStoreException")
     void readDescriptorsStoreException() throws Exception {
-        when(documentDescriptorStore.readDescriptors(any(), any(), any(), any(), eq(false)))
+        when(documentDescriptorStore.readDescriptors(any(), any(), any(), any(), eq(false), any()))
                 .thenThrow(new IResourceStore.ResourceStoreException("db error"));
 
         assertThrows(InternalServerErrorException.class,
@@ -62,7 +63,7 @@ class RestDocumentDescriptorStoreTest {
     @Test
     @DisplayName("readDescriptors — throws NotFoundException on ResourceNotFoundException")
     void readDescriptorsNotFound() throws Exception {
-        when(documentDescriptorStore.readDescriptors(any(), any(), any(), any(), eq(false)))
+        when(documentDescriptorStore.readDescriptors(any(), any(), any(), any(), eq(false), any()))
                 .thenThrow(new IResourceStore.ResourceNotFoundException("not found"));
 
         assertThrows(NotFoundException.class,

--- a/src/test/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/descriptors/rest/RestDocumentDescriptorStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.descriptors.rest;
 
+import ai.labs.eddi.engine.security.spaces.AccessScope;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
@@ -34,7 +35,7 @@ class RestDocumentDescriptorStoreTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        restStore = new RestDocumentDescriptorStore(documentDescriptorStore, mock(ResourceAccessGuard.class));
+        restStore = new RestDocumentDescriptorStore(documentDescriptorStore, listingGuard());
     }
 
     @Test
@@ -45,7 +46,7 @@ class RestDocumentDescriptorStoreTest {
         when(documentDescriptorStore.readDescriptors(eq("agent"), eq("filter"), eq(0), eq(10), eq(false), any()))
                 .thenReturn(List.of(desc));
 
-        List<DocumentDescriptor> result = restStore.readDescriptors("agent", "filter", 0, 10);
+        List<DocumentDescriptor> result = restStore.readDescriptors("agent", "filter", 0, 10, "");
         assertEquals(1, result.size());
         assertEquals("test", result.get(0).getName());
     }
@@ -57,7 +58,7 @@ class RestDocumentDescriptorStoreTest {
                 .thenThrow(new IResourceStore.ResourceStoreException("db error"));
 
         assertThrows(InternalServerErrorException.class,
-                () -> restStore.readDescriptors("agent", null, 0, 10));
+                () -> restStore.readDescriptors("agent", null, 0, 10, ""));
     }
 
     @Test
@@ -67,7 +68,7 @@ class RestDocumentDescriptorStoreTest {
                 .thenThrow(new IResourceStore.ResourceNotFoundException("not found"));
 
         assertThrows(NotFoundException.class,
-                () -> restStore.readDescriptors("agent", null, 0, 10));
+                () -> restStore.readDescriptors("agent", null, 0, 10, ""));
     }
 
     @Test
@@ -278,5 +279,18 @@ class RestDocumentDescriptorStoreTest {
 
         assertThrows(NotFoundException.class,
                 () -> restStore.patchDescriptor("id1", 1, instruction));
+    }
+
+    /**
+     * A guard that sees everything. {@code listingScope()} is chained onto
+     * ({@code .withinSpace(...)}), and production never returns null there — only a
+     * bare mock does, so the stub keeps the double honest rather than making the
+     * call site defend against its own bean.
+     */
+    private static ResourceAccessGuard listingGuard() {
+        ResourceAccessGuard guard = mock(ResourceAccessGuard.class);
+        lenient().when(guard.seesEverything()).thenReturn(true);
+        lenient().when(guard.listingScope()).thenReturn(AccessScope.unrestricted());
+        return guard;
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/dictionary/expression/RestActionTest.java
+++ b/src/test/java/ai/labs/eddi/configs/dictionary/expression/RestActionTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.dictionary.expression;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
 import ai.labs.eddi.configs.output.IOutputStore;
 import ai.labs.eddi.configs.rules.IRuleSetStore;
@@ -42,7 +43,7 @@ class RestActionTest {
         behaviorStore = mock(IRuleSetStore.class);
         httpCallsStore = mock(IApiCallsStore.class);
         outputStore = mock(IOutputStore.class);
-        restAction = new RestAction(workflowStore, behaviorStore, httpCallsStore, outputStore);
+        restAction = new RestAction(workflowStore, behaviorStore, httpCallsStore, outputStore, mock(ResourceAccessGuard.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/dictionary/expression/RestExpressionTest.java
+++ b/src/test/java/ai/labs/eddi/configs/dictionary/expression/RestExpressionTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.dictionary.expression;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.dictionary.IDictionaryStore;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
@@ -37,7 +38,7 @@ class RestExpressionTest {
     void setUp() {
         workflowStore = mock(IWorkflowStore.class);
         dictionaryStore = mock(IDictionaryStore.class);
-        restExpression = new RestExpression(workflowStore, dictionaryStore);
+        restExpression = new RestExpression(workflowStore, dictionaryStore, mock(ResourceAccessGuard.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/dictionary/rest/RestDictionaryStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/dictionary/rest/RestDictionaryStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.dictionary.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.dictionary.IDictionaryStore;
 import ai.labs.eddi.configs.dictionary.model.DictionaryConfiguration;
@@ -40,7 +41,7 @@ class RestDictionaryStoreTest {
         dictionaryStore = mock(IDictionaryStore.class);
         var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
-        restStore = new RestDictionaryStore(dictionaryStore, documentDescriptorStore, jsonSchemaCreator);
+        restStore = new RestDictionaryStore(dictionaryStore, documentDescriptorStore, jsonSchemaCreator, mock(ResourceAccessGuard.class));
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreExtendedTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.groups.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
@@ -45,7 +46,7 @@ class RestAgentGroupStoreExtendedTest {
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
         restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator,
-                mock(IGroupWorkspaceStore.class), mock(IScheduleStore.class));
+                mock(IGroupWorkspaceStore.class), mock(IScheduleStore.class), mock(ResourceAccessGuard.class));
     }
 
     // ==================== updateGroup ====================

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestAgentGroupStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.groups.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
@@ -45,7 +46,8 @@ class RestAgentGroupStoreTest {
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
         workspaceStore = mock(IGroupWorkspaceStore.class);
         scheduleStore = mock(IScheduleStore.class);
-        restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator, workspaceStore, scheduleStore);
+        restStore = new RestAgentGroupStore(groupStore, documentDescriptorStore, jsonSchemaCreator, workspaceStore, scheduleStore,
+                mock(ResourceAccessGuard.class));
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/groups/rest/RestGroupWorkspaceTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.groups.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.groups.IAgentGroupStore;
 import ai.labs.eddi.configs.groups.IGroupWorkspaceStore;
 import ai.labs.eddi.configs.groups.IRestGroupWorkspace.BacklogTaskRequest;
@@ -61,7 +62,7 @@ class RestGroupWorkspaceTest {
         var principal = mock(Principal.class);
         lenient().when(principal.getName()).thenReturn("pm@example.com");
         lenient().when(identity.getPrincipal()).thenReturn(principal);
-        rest = new RestGroupWorkspace(workspaceStore, groupStore, scheduleStore, teamCadenceService, identity);
+        rest = new RestGroupWorkspace(workspaceStore, groupStore, scheduleStore, teamCadenceService, identity, mock(ResourceAccessGuard.class));
 
         var resourceId = mock(IResourceStore.IResourceId.class);
         lenient().when(resourceId.getVersion()).thenReturn(1);

--- a/src/test/java/ai/labs/eddi/configs/llm/rest/RestLlmStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/llm/rest/RestLlmStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.llm.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.llm.ILlmStore;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
@@ -32,7 +33,7 @@ class RestLlmStoreTest {
         llmStore = mock(ILlmStore.class);
         var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
-        restStore = new RestLlmStore(llmStore, documentDescriptorStore, jsonSchemaCreator);
+        restStore = new RestLlmStore(llmStore, documentDescriptorStore, jsonSchemaCreator, mock(ResourceAccessGuard.class));
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStoreDeepCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStoreDeepCoverageTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.mcpcalls.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.mcpcalls.model.McpToolDiscoveryRequest;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
@@ -39,7 +40,8 @@ class RestMcpCallsStoreDeepCoverageTest {
         var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
         mcpToolProviderManager = mock(McpToolProviderManager.class);
-        restStore = new RestMcpCallsStore(mcpCallsStore, documentDescriptorStore, jsonSchemaCreator, mcpToolProviderManager);
+        restStore = new RestMcpCallsStore(mcpCallsStore, documentDescriptorStore, jsonSchemaCreator, mcpToolProviderManager,
+                mock(ResourceAccessGuard.class));
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.mcpcalls.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.mcpcalls.model.McpToolDiscoveryRequest;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
@@ -39,7 +40,8 @@ class RestMcpCallsStoreTest {
         var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
         mcpToolProviderManager = mock(McpToolProviderManager.class);
-        restStore = new RestMcpCallsStore(mcpCallsStore, documentDescriptorStore, jsonSchemaCreator, mcpToolProviderManager);
+        restStore = new RestMcpCallsStore(mcpCallsStore, documentDescriptorStore, jsonSchemaCreator, mcpToolProviderManager,
+                mock(ResourceAccessGuard.class));
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStoreWriteValidationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStoreWriteValidationTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.mcpcalls.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
 import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
@@ -47,7 +48,7 @@ class RestMcpCallsStoreWriteValidationTest {
     void setUp() throws Exception {
         mcpCallsStore = mock(IMcpCallsStore.class);
         restMcpCallsStore = new RestMcpCallsStore(mcpCallsStore, mock(IDocumentDescriptorStore.class), mock(IJsonSchemaCreator.class),
-                mock(McpToolProviderManager.class));
+                mock(McpToolProviderManager.class), mock(ResourceAccessGuard.class));
 
         when(mcpCallsStore.create(any())).thenReturn(resourceId(MCP_ID, 1));
         when(mcpCallsStore.update(anyString(), anyInt(), any())).thenReturn(2);

--- a/src/test/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigrationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigrationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.migration;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.migration.model.MigrationLog;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.datastore.IResourceStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The backfill is what stands between "enable workspaces" and "every
+ * pre-existing resource disappears", so the two ways it can silently fail —
+ * querying a descriptor type that does not exist, and recording itself complete
+ * after a failure — are what these tests are about.
+ */
+class WorkspaceAccessIndexMigrationTest {
+
+    @Test
+    @DisplayName("the type list matches what listings actually query, not the ZIP file-extension names")
+    void typesMatchTheStores() {
+        List<String> types = WorkspaceAccessIndexMigration.DESCRIPTOR_TYPES;
+
+        // The v6 names. Each of these has a v5 near-miss that reads plausibly and
+        // matches nothing: behavior/rules, httpcalls/apicalls, langchain/llm,
+        // regulardictionary/dictionary (AGENTS.md §5.5).
+        assertTrue(types.contains("ai.labs.rules"), "rule sets are listed under ai.labs.rules");
+        assertTrue(types.contains("ai.labs.apicalls"), "api calls are listed under ai.labs.apicalls");
+        assertTrue(types.contains("ai.labs.llm"), "LLM configs are listed under ai.labs.llm");
+        assertTrue(types.contains("ai.labs.dictionary"), "dictionaries are listed under ai.labs.dictionary");
+
+        assertFalse(types.contains("ai.labs.behavior"), "ai.labs.behavior is the file extension, not the descriptor type");
+        assertFalse(types.contains("ai.labs.httpcalls"), "ai.labs.httpcalls is the file extension, not the descriptor type");
+        assertFalse(types.contains("ai.labs.langchain"), "ai.labs.langchain is the file extension, not the descriptor type");
+        assertFalse(types.contains("ai.labs.regulardictionary"), "ai.labs.regulardictionary is not the descriptor type");
+
+        assertEquals(15, types.size(), "one entry per configuration type with a REST store");
+        assertEquals(types.size(), types.stream().distinct().count(), "no duplicates");
+    }
+
+    @Test
+    @DisplayName("a page that could not be read leaves the migration to retry, rather than recording completion")
+    void doesNotRecordCompletionAfterAFailure() throws Exception {
+        var descriptorStore = mock(IDocumentDescriptorStore.class);
+        var logStore = mock(IMigrationLogStore.class);
+        when(logStore.readMigrationLog(anyString())).thenReturn(null);
+        when(descriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                .thenThrow(new IResourceStore.ResourceStoreException("db down", null));
+
+        new WorkspaceAccessIndexMigration(descriptorStore, logStore).runIfNeeded();
+
+        // Recording completion here would strand every descriptor without an index —
+        // invisible in every listing once enforcement is on, with no way to re-run.
+        verify(logStore, never()).createMigrationLog(any());
+    }
+
+    @Test
+    @DisplayName("a clean sweep stamps the index and records completion")
+    void stampsAndCompletes() throws Exception {
+        var descriptorStore = mock(IDocumentDescriptorStore.class);
+        var logStore = mock(IMigrationLogStore.class);
+        when(logStore.readMigrationLog(anyString())).thenReturn(null);
+
+        DocumentDescriptor legacy = new DocumentDescriptor();
+        legacy.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/abcdef1234567890abcdef?version=1"));
+        when(descriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                .thenReturn(List.of(legacy)).thenReturn(List.of());
+
+        new WorkspaceAccessIndexMigration(descriptorStore, logStore).runIfNeeded();
+
+        assertTrue(legacy.getAccessIndex() != null && legacy.getAccessIndex().contains("legacy"),
+                "an unowned descriptor must carry the legacy token, or no predicate matches it at all");
+        verify(logStore).createMigrationLog(any());
+    }
+
+    @Test
+    @DisplayName("an already-applied migration does not sweep again")
+    void skipsWhenAlreadyApplied() throws Exception {
+        var descriptorStore = mock(IDocumentDescriptorStore.class);
+        var logStore = mock(IMigrationLogStore.class);
+        when(logStore.readMigrationLog(anyString())).thenReturn(new MigrationLog("x"));
+
+        new WorkspaceAccessIndexMigration(descriptorStore, logStore).runIfNeeded();
+
+        verify(descriptorStore, never()).readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean());
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigrationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/migration/WorkspaceAccessIndexMigrationTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -70,6 +71,55 @@ class WorkspaceAccessIndexMigrationTest {
         // Recording completion here would strand every descriptor without an index —
         // invisible in every listing once enforcement is on, with no way to re-run.
         verify(logStore, never()).createMigrationLog(any());
+    }
+
+    @Test
+    @DisplayName("a failed WRITE also blocks completion, not just a failed read")
+    void doesNotRecordCompletionAfterAFailedWrite() throws Exception {
+        // The read-failure case was covered; this one was not, and it is the more
+        // likely of the two. `stampIfNeeded` swallowed the write exception and
+        // returned "not written", which was indistinguishable from "already
+        // correct" — so a run where every write threw recorded itself complete and
+        // left those descriptors with no access index. Under enforcement that means
+        // invisible in every listing, with no way to re-run short of deleting the
+        // log row by hand.
+        var descriptorStore = mock(IDocumentDescriptorStore.class);
+        var logStore = mock(IMigrationLogStore.class);
+        when(logStore.readMigrationLog(anyString())).thenReturn(null);
+
+        DocumentDescriptor unstamped = new DocumentDescriptor();
+        unstamped.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/abcdef1234567890abcdef?version=1"));
+        unstamped.setOwnerId("alice");
+        when(descriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                .thenReturn(List.of(unstamped))
+                .thenReturn(List.of());
+        doThrow(new IResourceStore.ResourceStoreException("write rejected", null))
+                .when(descriptorStore).setDescriptor(anyString(), anyInt(), any());
+
+        new WorkspaceAccessIndexMigration(descriptorStore, logStore).runIfNeeded();
+
+        verify(logStore, never()).createMigrationLog(any());
+    }
+
+    @Test
+    @DisplayName("a descriptor that cannot be addressed at all does not block completion forever")
+    void unstampableDescriptorDoesNotBlockCompletion() throws Exception {
+        // A descriptor with an unparseable resource URI would fail identically on
+        // every retry, so holding the migration open for it would mean it never
+        // completes — a different way to strand the deployment.
+        var descriptorStore = mock(IDocumentDescriptorStore.class);
+        var logStore = mock(IMigrationLogStore.class);
+        when(logStore.readMigrationLog(anyString())).thenReturn(null);
+
+        DocumentDescriptor unaddressable = new DocumentDescriptor();
+        unaddressable.setOwnerId("alice");
+        when(descriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                .thenReturn(List.of(unaddressable))
+                .thenReturn(List.of());
+
+        new WorkspaceAccessIndexMigration(descriptorStore, logStore).runIfNeeded();
+
+        verify(logStore).createMigrationLog(any());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/output/rest/RestOutputStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/output/rest/RestOutputStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.output.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.output.IOutputStore;
 import ai.labs.eddi.configs.output.model.OutputConfigurationSet;
@@ -37,7 +38,7 @@ class RestOutputStoreTest {
         outputStore = mock(IOutputStore.class);
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
-        restStore = new RestOutputStore(outputStore, documentDescriptorStore, jsonSchemaCreator);
+        restStore = new RestOutputStore(outputStore, documentDescriptorStore, jsonSchemaCreator, mock(ResourceAccessGuard.class));
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/configs/output/rest/keys/RestOutputActionsTest.java
+++ b/src/test/java/ai/labs/eddi/configs/output/rest/keys/RestOutputActionsTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.output.rest.keys;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.output.IOutputStore;
 import ai.labs.eddi.configs.rules.IRuleSetStore;
 import ai.labs.eddi.configs.rules.model.RuleConfiguration;
@@ -38,7 +39,7 @@ class RestOutputActionsTest {
         workflowStore = mock(IWorkflowStore.class);
         behaviorStore = mock(IRuleSetStore.class);
         outputStore = mock(IOutputStore.class);
-        restOutputActions = new RestOutputActions(workflowStore, behaviorStore, outputStore);
+        restOutputActions = new RestOutputActions(workflowStore, behaviorStore, outputStore, mock(ResourceAccessGuard.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/parser/rest/RestParserStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/parser/rest/RestParserStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.parser.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.parser.IParserStore;
 import ai.labs.eddi.configs.parser.model.ParserConfiguration;
@@ -28,7 +29,7 @@ class RestParserStoreTest {
     void setUp() {
         parserStore = mock(IParserStore.class);
         var descriptorStore = mock(IDocumentDescriptorStore.class);
-        restStore = new RestParserStore(parserStore, descriptorStore);
+        restStore = new RestParserStore(parserStore, descriptorStore, mock(ResourceAccessGuard.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/propertysetter/rest/RestPropertySetterStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/propertysetter/rest/RestPropertySetterStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.propertysetter.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.propertysetter.IPropertySetterStore;
 import ai.labs.eddi.configs.propertysetter.model.PropertySetterConfiguration;
@@ -32,7 +33,7 @@ class RestPropertySetterStoreTest {
         propertySetterStore = mock(IPropertySetterStore.class);
         var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
-        restStore = new RestPropertySetterStore(propertySetterStore, documentDescriptorStore, jsonSchemaCreator);
+        restStore = new RestPropertySetterStore(propertySetterStore, documentDescriptorStore, jsonSchemaCreator, mock(ResourceAccessGuard.class));
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/configs/rag/rest/RagStoreLayeringTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rag/rest/RagStoreLayeringTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.rag.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
 import ai.labs.eddi.configs.rag.mongo.RagStore;
@@ -82,7 +83,8 @@ class RagStoreLayeringTest {
         when(resourceStorage.newResource(any(RagConfiguration.class))).thenReturn(createdResource);
 
         ragStore = new RagStore(storageFactory, mock(IDocumentBuilder.class));
-        restRagStore = new RestRagStore(ragStore, mock(IDocumentDescriptorStore.class), mock(IJsonSchemaCreator.class));
+        restRagStore = new RestRagStore(ragStore, mock(IDocumentDescriptorStore.class), mock(IJsonSchemaCreator.class),
+                mock(ResourceAccessGuard.class));
     }
 
     private static RagConfiguration knowledgeBase(String chunkStrategy) {

--- a/src/test/java/ai/labs/eddi/configs/rag/rest/RestRagIngestionTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rag/rest/RestRagIngestionTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.rag.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.rag.IRestRagStore;
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
 import ai.labs.eddi.modules.rag.RagIngestionService;
@@ -31,7 +32,7 @@ class RestRagIngestionTest {
     @BeforeEach
     void setUp() {
         openMocks(this);
-        restRagIngestion = new RestRagIngestion(restRagStore, ragIngestionService);
+        restRagIngestion = new RestRagIngestion(restRagStore, ragIngestionService, mock(ResourceAccessGuard.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/rag/rest/RestRagStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rag/rest/RestRagStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.rag.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.rag.IRagStore;
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
@@ -34,7 +35,7 @@ class RestRagStoreTest {
     @BeforeEach
     void setUp() {
         openMocks(this);
-        restRagStore = new RestRagStore(ragStore, documentDescriptorStore, jsonSchemaCreator);
+        restRagStore = new RestRagStore(ragStore, documentDescriptorStore, jsonSchemaCreator, mock(ResourceAccessGuard.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/rag/rest/RestRagStoreWriteValidationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rag/rest/RestRagStoreWriteValidationTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.rag.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.rag.IRagStore;
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
@@ -46,7 +47,8 @@ class RestRagStoreWriteValidationTest {
     @BeforeEach
     void setUp() throws Exception {
         ragStore = mock(IRagStore.class);
-        restRagStore = new RestRagStore(ragStore, mock(IDocumentDescriptorStore.class), mock(IJsonSchemaCreator.class));
+        restRagStore = new RestRagStore(ragStore, mock(IDocumentDescriptorStore.class), mock(IJsonSchemaCreator.class),
+                mock(ResourceAccessGuard.class));
 
         when(ragStore.create(any())).thenReturn(resourceId(RAG_ID, 1));
         when(ragStore.update(anyString(), anyInt(), any())).thenReturn(2);

--- a/src/test/java/ai/labs/eddi/configs/rest/ListingRedactionWiringTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rest/ListingRedactionWiringTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.rest;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.descriptors.model.ResourceGrant;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+import ai.labs.eddi.configs.descriptors.rest.RestDocumentDescriptorStore;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.security.OwnershipValidator;
+import ai.labs.eddi.engine.security.spaces.AccessScope;
+import ai.labs.eddi.engine.security.spaces.DescriptorAccess;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
+import ai.labs.eddi.engine.security.spaces.Subjects;
+import ai.labs.eddi.engine.security.spaces.WorkspaceSettings;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * That the endpoints actually CALL the guard, not merely that the guard works.
+ *
+ * <h3>The gap this closes</h3> {@code ResourceAccessGuardTest} proves
+ * {@code redactForCaller} strips what it should, and {@code AccessScopeTest}
+ * proves a space predicate narrows. Neither notices if a listing simply stops
+ * invoking them: every other test in this area hands the store a
+ * <em>mocked</em> guard, so deleting
+ * {@code descriptors.forEach(accessGuard::redactForCaller)} or replacing
+ * {@code listingScope().withinSpace(space)} with {@code listingScope()} left
+ * the whole suite green. That is the same shape as a mix-in test that
+ * registered its own mix-in — the unit under test was the collaborator, not the
+ * wiring.
+ *
+ * <p>
+ * So these use a <b>real</b> guard with a restrictive identity, and assert on
+ * what actually comes back.
+ */
+class ListingRedactionWiringTest {
+
+    private static final String TYPE = "ai.labs.agent";
+    private static final String RESOURCE_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+    private IDocumentDescriptorStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = mock(IDocumentDescriptorStore.class);
+    }
+
+    /**
+     * {@code validate()} is package-private to the spaces package, and nothing here
+     * exercises the legacy path it configures — every descriptor below has a
+     * recorded owner — so the constructor alone is enough.
+     */
+    private static WorkspaceSettings enforcing() {
+        return new WorkspaceSettings(true, true, "groups", WorkspaceSettings.LEGACY_SHARED, Optional.empty());
+    }
+
+    private static SecurityIdentity identity(String principal) {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        lenient().when(identity.isAnonymous()).thenReturn(false);
+        Principal p = mock(Principal.class);
+        lenient().when(p.getName()).thenReturn(principal);
+        lenient().when(identity.getPrincipal()).thenReturn(p);
+        return identity;
+    }
+
+    /** A real guard, seeing the world as somebody who owns nothing here. */
+    private static ResourceAccessGuard realGuardFor(String principal, IDocumentDescriptorStore store) {
+        var settings = enforcing();
+        var identity = identity(principal);
+        return new ResourceAccessGuard(identity, new OwnershipValidator(settings.isStampingOwnership()),
+                new SpaceContext(identity, settings), settings, store);
+    }
+
+    /**
+     * A {@code RestVersionInfo} whose type argument is explicit.
+     * <p>
+     * Written as
+     * {@code new RestVersionInfo<>(..., mock(IResourceStore.class), ...)} the
+     * diamond binds against a RAW mock, which makes the whole instance raw and
+     * erases every generic signature on it — including
+     * {@code List<DocumentDescriptor> readDescriptors(...)}, which then returns a
+     * raw List and hands back Object.
+     */
+    private RestVersionInfo<Object> versionInfoFor(ResourceAccessGuard guard) {
+        @SuppressWarnings("unchecked")
+        IResourceStore<Object> resourceStore = mock(IResourceStore.class);
+        return new RestVersionInfo<>("eddi://ai.labs.agent/agentstore/agents/", resourceStore, store, guard);
+    }
+
+    /** Published by alice, with a grant list a stranger must never receive. */
+    private static DocumentDescriptor publishedByAliceWithGrants() {
+        var d = new DocumentDescriptor();
+        d.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + RESOURCE_ID + "?version=1"));
+        d.setName("Support Agent");
+        d.setOwnerId("alice");
+        d.setSpaceId(Subjects.personalSpace("alice"));
+        d.setVisibility(ResourceVisibility.published.wireName());
+        d.setGrants(List.of(new ResourceGrant(Subjects.user("bob"), AccessLevel.USE.name(), "alice", new Date(0))));
+        return DescriptorAccess.rebuildIndex(d);
+    }
+
+    @Test
+    @DisplayName("a listing redacts what the caller may not read, through the real guard")
+    void listingRedacts() throws Exception {
+        var guard = realGuardFor("carol", store);
+        var restVersionInfo = versionInfoFor(guard);
+        when(store.readDescriptors(eq(TYPE), anyString(), anyInt(), anyInt(), anyBoolean(), any()))
+                .thenReturn(List.of(publishedByAliceWithGrants()));
+
+        var listed = restVersionInfo.readDescriptors("", 0, 20);
+
+        // Carol may SEE a published resource, and must not receive its grant
+        // audience — real principal and team names — merely by listing it.
+        assertEquals(1, listed.size());
+        assertNull(listed.getFirst().getGrants(), "the listing must strip grants for a non-owner");
+        assertNull(listed.getFirst().getAccessIndex());
+        assertEquals(AccessLevel.VIEW.name(), listed.getFirst().getCallerLevel(), "and must say what she may do");
+    }
+
+    @Test
+    @DisplayName("a listing hands the store a scope built from the caller, not an unrestricted one")
+    void listingPassesCallerScope() throws Exception {
+        var guard = realGuardFor("carol", store);
+        var restVersionInfo = versionInfoFor(guard);
+        when(store.readDescriptors(eq(TYPE), anyString(), anyInt(), anyInt(), anyBoolean(), any())).thenReturn(List.of());
+
+        restVersionInfo.readDescriptors("", 0, 20);
+
+        var scope = ArgumentCaptor.forClass(AccessScope.class);
+        verify(store).readDescriptors(eq(TYPE), anyString(), anyInt(), anyInt(), anyBoolean(), scope.capture());
+        // Not unrestricted: carol is not an administrator and enforcement is on.
+        // An endpoint that stopped passing a scope would return everybody's rows.
+        assertFalse(scope.getValue().isUnrestricted());
+        assertTrue(
+                scope.getValue().admittingTokens().contains(Subjects.personalSpace("carol")));
+    }
+
+    @Test
+    @DisplayName("?space= actually reaches the scope handed to the store")
+    void spaceNarrowingReachesTheStore() throws Exception {
+        // Replacing `listingScope().withinSpace(space)` with `listingScope()`
+        // left every other test green, and the switcher would have gone back to
+        // changing the URL and nothing else.
+        var guard = realGuardFor("carol", store);
+        var restVersionInfo = versionInfoFor(guard);
+        when(store.readDescriptors(eq(TYPE), anyString(), anyInt(), anyInt(), anyBoolean(), any())).thenReturn(List.of());
+
+        restVersionInfo.readDescriptors("", 0, 20, "team:engineering");
+
+        var scope = ArgumentCaptor.forClass(AccessScope.class);
+        verify(store).readDescriptors(eq(TYPE), anyString(), anyInt(), anyInt(), anyBoolean(), scope.capture());
+        assertEquals("team:engineering", scope.getValue().spaceId());
+    }
+
+    @Test
+    @DisplayName("the descriptor endpoint redacts a versioned read through the real guard too")
+    void versionedReadRedacts() throws Exception {
+        var guard = realGuardFor("carol", store);
+        var restStore = new RestDocumentDescriptorStore(store, guard);
+        var current = publishedByAliceWithGrants();
+        when(store.readCurrentDescriptor(RESOURCE_ID)).thenReturn(current);
+        when(store.readDescriptor(RESOURCE_ID, 1)).thenReturn(publishedByAliceWithGrants());
+
+        var read = restStore.readDescriptor(RESOURCE_ID, 1);
+
+        assertNull(read.getGrants());
+        assertNull(read.getAccessIndex());
+        assertEquals(AccessLevel.VIEW.name(), read.getCallerLevel());
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoAccessTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoAccessTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.rest;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.security.spaces.AccessScope;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import io.quarkus.security.ForbiddenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link RestVersionInfo} is the single body behind all fifteen configuration
+ * resource types and the only place their access is checked, so these
+ * assertions stand in for fifteen stores at once. If the guard call is removed
+ * from any method here, every one of those types silently loses its access
+ * control.
+ */
+class RestVersionInfoAccessTest {
+
+    private static final String RESOURCE_URI = "eddi://ai.labs.agent/agentstore/agents/";
+    private static final String ID = "abcdef1234567890abcdef";
+
+    private IResourceStore<Object> resourceStore;
+    private IDocumentDescriptorStore descriptorStore;
+    private ResourceAccessGuard accessGuard;
+    private RestVersionInfo<Object> restVersionInfo;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        resourceStore = mock(IResourceStore.class);
+        descriptorStore = mock(IDocumentDescriptorStore.class);
+        accessGuard = mock(ResourceAccessGuard.class);
+        restVersionInfo = new RestVersionInfo<>(RESOURCE_URI, resourceStore, descriptorStore, accessGuard);
+    }
+
+    @Test
+    @DisplayName("listing passes the caller's scope to the query, rather than filtering afterwards")
+    void listingIsScopedInTheQuery() throws Exception {
+        AccessScope scope = AccessScope.unrestricted();
+        when(accessGuard.listingScope()).thenReturn(scope);
+        when(descriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean(), any())).thenReturn(List.of());
+
+        restVersionInfo.readDescriptors("filter", 0, 20);
+
+        verify(descriptorStore).readDescriptors(eq("ai.labs.agent"), eq("filter"), eq(0), eq(20), eq(false), eq(scope));
+        verify(descriptorStore, never()).readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("read requires VIEW, and does not touch the store when refused")
+    void readRequiresView() throws Exception {
+        doThrow(new ForbiddenException("no")).when(accessGuard).requireAccess(eq(ID), eq(AccessLevel.VIEW), anyString());
+
+        assertThrows(ForbiddenException.class, () -> restVersionInfo.read(ID, 1));
+        verify(resourceStore, never()).read(anyString(), anyInt());
+    }
+
+    @Test
+    @DisplayName("update requires EDIT, and does not write when refused")
+    void updateRequiresEdit() throws Exception {
+        doThrow(new ForbiddenException("no")).when(accessGuard).requireAccess(eq(ID), eq(AccessLevel.EDIT), anyString());
+
+        assertThrows(ForbiddenException.class, () -> restVersionInfo.update(ID, 1, new Object()));
+        verify(resourceStore, never()).update(anyString(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("delete requires OWN — EDIT deliberately does not carry it")
+    void deleteRequiresOwn() throws Exception {
+        doThrow(new ForbiddenException("no")).when(accessGuard).requireAccess(eq(ID), eq(AccessLevel.OWN), anyString());
+
+        assertThrows(ForbiddenException.class, () -> restVersionInfo.delete(ID, 1, false));
+        verify(resourceStore, never()).delete(anyString(), anyInt());
+        verify(resourceStore, never()).deleteAllPermanently(anyString());
+    }
+
+    @Test
+    @DisplayName("creating needs no existing access — you cannot lack access to something that does not exist yet")
+    void createIsUnguarded() throws Exception {
+        when(resourceStore.create(any())).thenReturn(new IResourceStore.IResourceId() {
+            @Override
+            public String getId() {
+                return ID;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return 1;
+            }
+        });
+
+        restVersionInfo.create(new Object());
+
+        verify(accessGuard, never()).requireAccess(anyString(), any(), anyString());
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
@@ -28,6 +29,8 @@ class RestVersionInfoTest {
     private IResourceStore<Object> resourceStore;
     private IDocumentDescriptorStore documentDescriptorStore;
 
+    private ResourceAccessGuard accessGuard;
+
     private static final String RESOURCE_URI = "eddi://ai.labs.test/teststore/tests/";
     private static final String TEST_ID = "test-resource-id";
 
@@ -36,7 +39,8 @@ class RestVersionInfoTest {
     void setUp() {
         resourceStore = mock(IResourceStore.class);
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
-        restVersionInfo = new RestVersionInfo<>(RESOURCE_URI, resourceStore, documentDescriptorStore);
+        accessGuard = mock(ResourceAccessGuard.class);
+        restVersionInfo = new RestVersionInfo<>(RESOURCE_URI, resourceStore, documentDescriptorStore, accessGuard);
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/configs/rules/rest/RestRuleSetStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rules/rest/RestRuleSetStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.rules.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.rules.IRuleSetStore;
 import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
@@ -31,7 +32,7 @@ class RestRuleSetStoreTest {
         ruleSetStore = mock(IRuleSetStore.class);
         var descriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
-        restStore = new RestRuleSetStore(ruleSetStore, descriptorStore, jsonSchemaCreator);
+        restStore = new RestRuleSetStore(ruleSetStore, descriptorStore, jsonSchemaCreator, mock(ResourceAccessGuard.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreCrudTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreCrudTest.java
@@ -50,7 +50,7 @@ class RestWorkflowStoreCrudTest {
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
         sut = new RestWorkflowStore(workflowStore, resourceClientLibrary, documentDescriptorStore, jsonSchemaCreator,
-                mock(ResourceAccessGuard.class));
+                permissiveGuard());
     }
 
     private IResourceStore.IResourceId dummyResourceId(String id, int version) {
@@ -499,5 +499,18 @@ class RestWorkflowStoreCrudTest {
             // Should not propagate — logs warning and continues
             assertDoesNotThrow(() -> sut.deleteWorkflow("aabbccddeeff112233445566", 1, true, true));
         }
+    }
+
+    /**
+     * A guard that admits everything. {@code visibleOnly} filters with
+     * {@code canAccess}, which a bare Mockito mock answers {@code false} to —
+     * correct for a security check, wrong for a test that is not about the security
+     * check.
+     */
+    private static ResourceAccessGuard permissiveGuard() {
+        ResourceAccessGuard guard = mock(ResourceAccessGuard.class);
+        lenient().when(guard.seesEverything()).thenReturn(true);
+        lenient().when(guard.canAccess(any(), any())).thenReturn(true);
+        return guard;
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreCrudTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreCrudTest.java
@@ -4,6 +4,9 @@
  */
 package ai.labs.eddi.configs.workflows.rest;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
@@ -46,7 +49,8 @@ class RestWorkflowStoreCrudTest {
         resourceClientLibrary = mock(ResourceClientLibrary.class);
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
-        sut = new RestWorkflowStore(workflowStore, resourceClientLibrary, documentDescriptorStore, jsonSchemaCreator);
+        sut = new RestWorkflowStore(workflowStore, resourceClientLibrary, documentDescriptorStore, jsonSchemaCreator,
+                mock(ResourceAccessGuard.class));
     }
 
     private IResourceStore.IResourceId dummyResourceId(String id, int version) {
@@ -98,7 +102,7 @@ class RestWorkflowStoreCrudTest {
         @Test
         @DisplayName("should delegate to document descriptor store")
         void standard() throws Exception {
-            when(documentDescriptorStore.readDescriptors("ai.labs.workflow", "filter", 0, 20, false))
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), eq("filter"), eq(0), eq(20), eq(false), any()))
                     .thenReturn(List.of(new DocumentDescriptor()));
 
             List<DocumentDescriptor> result = sut.readWorkflowDescriptors("filter", 0, 20);

--- a/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.workflows.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
@@ -44,7 +45,8 @@ class RestWorkflowStoreTest {
     @BeforeEach
     void setUp() {
         openMocks(this);
-        restWorkflowStore = new RestWorkflowStore(WorkflowStore, resourceClientLibrary, documentDescriptorStore, jsonSchemaCreator);
+        restWorkflowStore = new RestWorkflowStore(WorkflowStore, resourceClientLibrary, documentDescriptorStore, jsonSchemaCreator,
+                mock(ResourceAccessGuard.class));
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/datastore/DescriptorStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/DescriptorStoreTest.java
@@ -35,7 +35,7 @@ class DescriptorStoreTest {
 
         when(storageFactory.create(eq("descriptors"), eq(documentBuilder), eq(String.class),
                 eq("resource"), eq("userId"), eq("name"), eq("agentName"),
-                eq("description"), eq("lastModifiedOn"), eq("deleted"), eq("originId")))
+                eq("description"), eq("lastModifiedOn"), eq("deleted"), eq("originId"), eq("accessIndex")))
                 .thenReturn(resourceStorage);
 
         store = new DescriptorStore<>(storageFactory, documentBuilder, String.class);
@@ -245,7 +245,7 @@ class DescriptorStoreTest {
     private static void verifyIndexHints(IResourceStorageFactory factory, String collectionName, IDocumentBuilder builder) {
         verify(factory).create(eq(collectionName), eq(builder), eq(String.class),
                 eq("resource"), eq("userId"), eq("name"), eq("agentName"),
-                eq("description"), eq("lastModifiedOn"), eq("deleted"), eq("originId"));
+                eq("description"), eq("lastModifiedOn"), eq("deleted"), eq("originId"), eq("accessIndex"));
     }
 
     // ==================== limit semantics ====================

--- a/src/test/java/ai/labs/eddi/datastore/serialization/PersistenceMixinsTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/serialization/PersistenceMixinsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.datastore.serialization;
+
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The wire/storage split for {@code callerLevel}.
+ *
+ * <h3>What breaks if this stops holding</h3> {@code callerLevel} describes the
+ * relationship between a resource and <em>whoever asked for it</em>, so a value
+ * stamped for Alice is wrong for everybody else. Several paths read a
+ * descriptor and write it back. If one of them ever persists a stamped
+ * descriptor, the next reader is told they hold whatever the last writer
+ * happened to hold — an escalation that no request logs, because the field is
+ * only ever read as a hint about which buttons to draw.
+ *
+ * <p>
+ * That is why this is enforced by a mix-in on the persistence mapper rather
+ * than by the convention that {@code redactForCaller} must not be called on
+ * something about to be written, and why it is tested from both directions.
+ */
+class PersistenceMixinsTest {
+
+    /**
+     * The mapper the application actually stores through — built by the real
+     * producer, not reassembled here.
+     * <p>
+     * An earlier version called {@code PersistenceMixins.register(...)} itself,
+     * which tested that the mix-in works and <em>not</em> that anything uses it:
+     * deleting the registration from {@link PersistenceMapperProducer} left this
+     * suite green. Caught by reverting the fix, which is the only way that kind of
+     * gap shows up.
+     */
+    private static ObjectMapper persistenceMapper() {
+        return new PersistenceMapperProducer().persistenceMapper();
+    }
+
+    /** The REST-side mapper, built from the same shared recipe without mix-ins. */
+    private static ObjectMapper restMapper() {
+        return SerializationCustomizer.configureObjectMapper(new ObjectMapper(), false);
+    }
+
+    private static DocumentDescriptor stamped() {
+        var d = new DocumentDescriptor();
+        d.setName("Support Agent");
+        d.setOwnerId("alice@example.com");
+        d.setSpaceId("user:alice@example.com");
+        d.setVisibility("space");
+        d.setCallerLevel("OWN");
+        return d;
+    }
+
+    @Test
+    @DisplayName("a stamped descriptor written to storage carries no caller level")
+    void notSerialisedToStorage() throws Exception {
+        String stored = persistenceMapper().writeValueAsString(stamped());
+
+        assertFalse(stored.contains("callerLevel"), "storage must not record one caller's access level: " + stored);
+        // Everything else still goes, or this test would pass by writing nothing.
+        assertTrue(stored.contains("ownerId"));
+        assertTrue(stored.contains("spaceId"));
+        assertTrue(stored.contains("Support Agent"));
+    }
+
+    @Test
+    @DisplayName("a stored document that somehow has one does not load it")
+    void notDeserialisedFromStorage() throws Exception {
+        // Belt and braces for a document written before the mix-in existed, or by a
+        // future path that bypasses this mapper. Reading it back must not resurrect
+        // somebody else's level.
+        String legacy = """
+                {"name":"Support Agent","ownerId":"alice@example.com","callerLevel":"OWN"}""";
+
+        var loaded = persistenceMapper().readValue(legacy, DocumentDescriptor.class);
+
+        assertNull(loaded.getCallerLevel());
+        assertEquals("alice@example.com", loaded.getOwnerId());
+    }
+
+    @Test
+    @DisplayName("the REST mapper still sends it, or the field would be pointless")
+    void stillSerialisedOverRest() throws Exception {
+        String wire = restMapper().writeValueAsString(stamped());
+
+        assertTrue(wire.contains("\"callerLevel\":\"OWN\""), wire);
+    }
+
+    @Test
+    @DisplayName("nothing a client sends can set it")
+    void readOnlyOnTheWire() throws Exception {
+        // READ_ONLY on the getter. Without it a PATCH body could assert its own
+        // access level, and a read-modify-write would then hand it to the store.
+        var body = """
+                {"name":"Renamed","callerLevel":"OWN"}""";
+
+        var parsed = restMapper().readValue(body, DocumentDescriptor.class);
+
+        assertEquals("Renamed", parsed.getName(), "the rest of the body must still bind");
+        assertNull(parsed.getCallerLevel());
+    }
+
+    @Test
+    @DisplayName("an unstamped descriptor is byte-identical to before the field existed")
+    void absentWhenUnstamped() throws Exception {
+        // NON_NULL, so a deployment that does not enforce workspaces sends exactly
+        // what it sent before this feature — the compatibility property the whole
+        // change is built around.
+        var d = new DocumentDescriptor();
+        d.setName("Support Agent");
+
+        assertFalse(restMapper().writeValueAsString(d).contains("callerLevel"));
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/a2a/A2ATaskHandlerTest.java
+++ b/src/test/java/ai/labs/eddi/engine/a2a/A2ATaskHandlerTest.java
@@ -45,6 +45,7 @@ class A2ATaskHandlerTest {
 
     private IConversationService conversationService;
     private ICacheFactory cacheFactory;
+    private AgentCardService agentCardService;
     private A2ATaskHandler handler;
     private MapCache<String, String> taskCache;
     private MapCache<String, String> contextCache;
@@ -59,6 +60,10 @@ class A2ATaskHandlerTest {
         when(cacheFactory.<String, String>getCache("a2aTaskMapping")).thenReturn(taskCache);
         when(cacheFactory.<String, String>getCache("a2aTaskMapping:context")).thenReturn(contextCache);
 
+        // A2A-enabled by default here; the refusal path has its own test.
+        agentCardService = mock(AgentCardService.class);
+        when(agentCardService.getAgentCard(anyString())).thenReturn(mock(A2AModels.AgentCard.class));
+
         handler = handlerFor(PEER_A);
     }
 
@@ -72,13 +77,13 @@ class A2ATaskHandlerTest {
         when(identity.isAnonymous()).thenReturn(false);
         Principal principal = () -> principalName;
         when(identity.getPrincipal()).thenReturn(principal);
-        return new A2ATaskHandler(conversationService, cacheFactory, identity);
+        return new A2ATaskHandler(conversationService, cacheFactory, identity, agentCardService);
     }
 
     private A2ATaskHandler anonymousHandler() {
         SecurityIdentity identity = mock(SecurityIdentity.class);
         when(identity.isAnonymous()).thenReturn(true);
-        return new A2ATaskHandler(conversationService, cacheFactory, identity);
+        return new A2ATaskHandler(conversationService, cacheFactory, identity, agentCardService);
     }
 
     private static Map<String, Object> sendParams(String taskId, String contextId, String text) {
@@ -149,6 +154,23 @@ class A2ATaskHandlerTest {
             // Cached under the calling peer, not under the bare taskId
             assertEquals("conv-abc", taskCache.get(scopedKey(PEER_A, "task-1")));
             assertNull(taskCache.get("task-1"));
+        }
+
+        @Test
+        @DisplayName("refuses an agent that was never opted into A2A, and starts no conversation")
+        void refusesAgentNotExposedOverA2A() throws Exception {
+            // Discovery already enforced this — listA2AAgents and getAgentCard both hide
+            // an agent with a2aEnabled=false. Conversing did not, so a peer that knew an
+            // id could talk to an agent nobody had exposed, private ones included.
+            // getAgentCard returns null for both "no such agent" and "not enabled", which
+            // is the same answer discovery gives.
+            when(agentCardService.getAgentCard("not-exposed")).thenReturn(null);
+
+            assertThrows(InvalidA2ARequestException.class,
+                    () -> handler.handleTaskSend("not-exposed", sendParams("task-1", null, "Hi!")));
+
+            verify(conversationService, never())
+                    .startConversation(any(), anyString(), anyString(), anyMap());
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/a2a/AgentCardServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/a2a/AgentCardServiceTest.java
@@ -5,7 +5,7 @@
 package ai.labs.eddi.engine.a2a;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.datastore.IResourceStore;
@@ -22,13 +22,13 @@ import static org.mockito.Mockito.*;
 
 class AgentCardServiceTest {
 
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     private IDocumentDescriptorStore documentDescriptorStore;
     private AgentCardService service;
 
     @BeforeEach
     void setUp() {
-        restAgentStore = mock(IRestAgentStore.class);
+        restAgentStore = mock(IAgentStore.class);
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         service = new AgentCardService(
                 restAgentStore,
@@ -62,7 +62,7 @@ class AgentCardServiceTest {
                 }
             };
             when(restAgentStore.getCurrentResourceId("agent-1")).thenReturn(resourceId);
-            when(restAgentStore.readAgent("agent-1", 1)).thenReturn(null);
+            when(restAgentStore.read("agent-1", 1)).thenReturn(null);
             assertNull(service.getAgentCard("agent-1"));
         }
 
@@ -81,7 +81,7 @@ class AgentCardServiceTest {
                 }
             };
             when(restAgentStore.getCurrentResourceId("agent-1")).thenReturn(resourceId);
-            when(restAgentStore.readAgent("agent-1", 1)).thenReturn(config);
+            when(restAgentStore.read("agent-1", 1)).thenReturn(config);
             assertNull(service.getAgentCard("agent-1"));
         }
 
@@ -101,7 +101,7 @@ class AgentCardServiceTest {
                 }
             };
             when(restAgentStore.getCurrentResourceId("agent-1")).thenReturn(resourceId);
-            when(restAgentStore.readAgent("agent-1", 1)).thenReturn(config);
+            when(restAgentStore.read("agent-1", 1)).thenReturn(config);
 
             var card = service.getAgentCard("agent-1");
             assertNotNull(card);
@@ -136,7 +136,7 @@ class AgentCardServiceTest {
                 }
             };
             when(restAgentStore.getCurrentResourceId("agent-1")).thenReturn(resourceId);
-            when(restAgentStore.readAgent("agent-1", 1)).thenReturn(config);
+            when(restAgentStore.read("agent-1", 1)).thenReturn(config);
 
             var descriptor = new DocumentDescriptor();
             descriptor.setName("Refund Specialist");
@@ -162,7 +162,7 @@ class AgentCardServiceTest {
                 }
             };
             when(restAgentStore.getCurrentResourceId("agent-2")).thenReturn(resourceId);
-            when(restAgentStore.readAgent("agent-2", 1)).thenReturn(config);
+            when(restAgentStore.read("agent-2", 1)).thenReturn(config);
             when(documentDescriptorStore.readDescriptor("agent-2", 1)).thenReturn(new DocumentDescriptor());
 
             assertEquals("EDDI Agent agent-2", service.getAgentCard("agent-2").name());
@@ -258,13 +258,13 @@ class AgentCardServiceTest {
 
         @Test
         void emptyList_whenNoDescriptors() throws Exception {
-            when(restAgentStore.readAgentDescriptors("", 0, 100)).thenReturn(null);
+            when(documentDescriptorStore.readDescriptors("ai.labs.agent", "", 0, 100, false)).thenReturn(null);
             assertTrue(service.listA2AAgents().isEmpty());
         }
 
         @Test
         void emptyList_onException() throws Exception {
-            when(restAgentStore.readAgentDescriptors("", 0, 100))
+            when(documentDescriptorStore.readDescriptors("ai.labs.agent", "", 0, 100, false))
                     .thenThrow(new RuntimeException("DB error"));
             assertTrue(service.listA2AAgents().isEmpty());
         }
@@ -273,7 +273,7 @@ class AgentCardServiceTest {
         void skipsDescriptors_withNullResource() throws Exception {
             var desc = new DocumentDescriptor();
             desc.setResource(null);
-            when(restAgentStore.readAgentDescriptors("", 0, 100)).thenReturn(List.of(desc));
+            when(documentDescriptorStore.readDescriptors("ai.labs.agent", "", 0, 100, false)).thenReturn(List.of(desc));
             assertTrue(service.listA2AAgents().isEmpty());
         }
 
@@ -281,7 +281,7 @@ class AgentCardServiceTest {
         void skipsDescriptors_withEmptyPath() throws Exception {
             var desc = new DocumentDescriptor();
             desc.setResource(URI.create("eddi://ai.labs.agent"));
-            when(restAgentStore.readAgentDescriptors("", 0, 100)).thenReturn(List.of(desc));
+            when(documentDescriptorStore.readDescriptors("ai.labs.agent", "", 0, 100, false)).thenReturn(List.of(desc));
             assertTrue(service.listA2AAgents().isEmpty());
         }
     }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationExtendedTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
@@ -75,7 +76,7 @@ class RestAgentAdministrationExtendedTest {
         lenient().when(tenantQuotaService.checkAgentQuota(any(), anyInt())).thenReturn(QuotaCheckResult.OK);
         admin = new RestAgentAdministration(runtime, agentFactory, mock(IAgentStore.class), deploymentStore,
                 conversationMemoryStore, restConversationStore, documentDescriptorStore,
-                deploymentListener, scheduleStore, tenantQuotaService);
+                deploymentListener, scheduleStore, tenantQuotaService, mock(ResourceAccessGuard.class));
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationQuotaTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationQuotaTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
@@ -77,7 +78,7 @@ class RestAgentAdministrationQuotaTest {
         admin = new RestAgentAdministration(runtime, agentFactory, mock(IAgentStore.class), deploymentStore,
                 mock(IConversationMemoryStore.class), mock(IRestConversationStore.class),
                 mock(IDocumentDescriptorStore.class), mock(IDeploymentListener.class),
-                mock(IScheduleStore.class), tenantQuotaService);
+                mock(IScheduleStore.class), tenantQuotaService, mock(ResourceAccessGuard.class));
     }
 
     private static DeploymentInfo deployed(String agentId, int version) {

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
@@ -72,7 +73,7 @@ class RestAgentAdministrationTest {
         agentStore = mock(IAgentStore.class);
         restAgentAdmin = new RestAgentAdministration(runtime, agentFactory, agentStore, deploymentStore,
                 conversationMemoryStore, restConversationStore, documentDescriptorStore,
-                deploymentListener, scheduleStore, tenantQuotaService);
+                deploymentListener, scheduleStore, tenantQuotaService, mock(ResourceAccessGuard.class));
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineHitlTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
 import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.api.IConversationService;
@@ -88,7 +89,7 @@ class RestAgentEngineHitlTest {
                 identity, ownershipValidator, conversationDescriptorStore);
         restAgentEngine = new RestAgentEngine(
                 conversationService, mock(IConversationMemoryStore.class), identity, ownershipValidator,
-                conversationAccessGuard, hitlAccessGuard, hitlToolJournalStore, AGENT_TIMEOUT);
+                conversationAccessGuard, mock(ResourceAccessGuard.class), hitlAccessGuard, hitlToolJournalStore, AGENT_TIMEOUT);
     }
 
     // =========================================================================

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
 import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.api.IConversationService;
@@ -70,7 +71,7 @@ class RestAgentEngineTest {
         var conversationAccessGuard = new ConversationAccessGuard(identity, ownershipValidator, descriptorStore);
         var hitlToolJournalStore = mock(IHitlToolJournalStore.class);
         restAgentEngine = new RestAgentEngine(conversationService, conversationMemoryStore, identity, ownershipValidator,
-                conversationAccessGuard, hitlAccessGuard, hitlToolJournalStore, 30);
+                conversationAccessGuard, mock(ResourceAccessGuard.class), hitlAccessGuard, hitlToolJournalStore, 30);
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineToolPauseDetailsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineToolPauseDetailsTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.hitl.HitlAccessGuard;
@@ -80,7 +81,7 @@ class RestAgentEngineToolPauseDetailsTest {
                 identity, ownershipValidator, conversationDescriptorStore);
         restAgentEngine = new RestAgentEngine(
                 conversationService, mock(IConversationMemoryStore.class), identity, ownershipValidator,
-                conversationAccessGuard, hitlAccessGuard, hitlToolJournalStore, AGENT_TIMEOUT);
+                conversationAccessGuard, mock(ResourceAccessGuard.class), hitlAccessGuard, hitlToolJournalStore, AGENT_TIMEOUT);
     }
 
     private ConversationMemorySnapshot snapshotInState(ConversationState state) throws Exception {

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsExtendedTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.mcp;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore;
@@ -100,7 +101,7 @@ class McpConversationToolsExtendedTest {
         tools = new McpConversationTools(conversationService, agentAdmin, agentStore,
                 restInterfaceFactory, jsonSerialization, boundedLogStore, auditStore,
                 agentTriggerStore, userConversationStore, restAgentEngine,
-                mockIdentity, conversationAccessGuard, false);
+                mockIdentity, conversationAccessGuard, mock(ResourceAccessGuard.class), false);
     }
 
     // ==================== listConversations ====================
@@ -188,7 +189,7 @@ class McpConversationToolsExtendedTest {
         var localTools = new McpConversationTools(conversationService, agentAdmin, agentStore,
                 failingFactory, jsonSerialization, boundedLogStore, auditStore,
                 agentTriggerStore, userConversationStore, restAgentEngine,
-                mockIdentity, conversationAccessGuard, false);
+                mockIdentity, conversationAccessGuard, mock(ResourceAccessGuard.class), false);
 
         String result = localTools.listConversations(AGENT_ID, null, null, null);
 

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsExtendedTest.java
@@ -302,7 +302,7 @@ class McpConversationToolsExtendedTest {
 
     @Test
     void listAgentConfigs_handlesException() {
-        when(agentStore.readAgentDescriptors(any(), anyInt(), anyInt()))
+        when(agentStore.readAgentDescriptors(any(), anyInt(), anyInt(), any()))
                 .thenThrow(new RuntimeException("DB error"));
 
         String result = tools.listAgentConfigs(null, null);

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsHitlTest.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.engine.mcp;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 
 import ai.labs.eddi.datastore.serialization.JsonSerialization;
@@ -75,7 +76,7 @@ class McpConversationToolsHitlTest {
                 mock(BoundedLogStore.class),
                 mock(IRestAuditStore.class),
                 agentTriggerStore, userConversationStore, restAgentEngine,
-                identity, conversationAccessGuard, false);
+                identity, conversationAccessGuard, mock(ResourceAccessGuard.class), false);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsOwnershipTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsOwnershipTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.mcp;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
@@ -101,7 +102,7 @@ class McpConversationToolsOwnershipTest {
         var guard = new ConversationAccessGuard(identity, new OwnershipValidator(true), descriptorStore);
         return new McpConversationTools(conversationService, mock(IRestAgentAdministration.class), mock(IRestAgentStore.class),
                 restInterfaceFactory, jsonSerialization, boundedLogStore, auditStore, mock(IRestAgentTriggerStore.class),
-                userConversationStore, mock(IRestAgentEngine.class), identity, guard, true);
+                userConversationStore, mock(IRestAgentEngine.class), identity, guard, mock(ResourceAccessGuard.class), true);
     }
 
     private McpConversationTools asIntruder() {

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.mcp;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.engine.triggermanagement.IRestAgentTriggerStore;
 import ai.labs.eddi.engine.triggermanagement.IUserConversationStore;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
@@ -86,7 +87,8 @@ class McpConversationToolsTest {
         var conversationAccessGuard = new ConversationAccessGuard(mockIdentity, new OwnershipValidator(false),
                 mock(IConversationDescriptorStore.class));
         tools = new McpConversationTools(conversationService, agentAdmin, AgentStore, restInterfaceFactory, jsonSerialization, boundedLogStore,
-                auditStore, AgentTriggerStore, userConversationStore, RestAgentEngine, mockIdentity, conversationAccessGuard, false);
+                auditStore, AgentTriggerStore, userConversationStore, RestAgentEngine, mockIdentity, conversationAccessGuard,
+                mock(ResourceAccessGuard.class), false);
     }
 
     // --- listAgents ---

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsTest.java
@@ -132,23 +132,23 @@ class McpConversationToolsTest {
     @Test
     void listAgentConfigs_returnsDescriptors() throws IOException {
         var descriptor = new DocumentDescriptor();
-        when(AgentStore.readAgentDescriptors("", 0, 20)).thenReturn(List.of(descriptor));
+        when(AgentStore.readAgentDescriptors("", 0, 20, "")).thenReturn(List.of(descriptor));
         when(jsonSerialization.serialize(any())).thenReturn("[{\"name\":\"TestAgent\"}]");
 
         String result = tools.listAgentConfigs(null, null);
 
         assertNotNull(result);
-        verify(AgentStore).readAgentDescriptors("", 0, 20);
+        verify(AgentStore).readAgentDescriptors("", 0, 20, "");
     }
 
     @Test
     void listAgentConfigs_withFilterAndLimit() throws IOException {
-        when(AgentStore.readAgentDescriptors("search", 0, 5)).thenReturn(Collections.emptyList());
+        when(AgentStore.readAgentDescriptors("search", 0, 5, "")).thenReturn(Collections.emptyList());
         when(jsonSerialization.serialize(any())).thenReturn("[]");
 
         tools.listAgentConfigs("search", 5);
 
-        verify(AgentStore).readAgentDescriptors("search", 0, 5);
+        verify(AgentStore).readAgentDescriptors("search", 0, 5, "");
     }
 
     // --- createConversation ---

--- a/src/test/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibraryTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibraryTest.java
@@ -4,6 +4,15 @@
  */
 package ai.labs.eddi.engine.runtime.client.configuration;
 
+import ai.labs.eddi.configs.apicalls.IApiCallsStore;
+import ai.labs.eddi.configs.dictionary.IDictionaryStore;
+import ai.labs.eddi.configs.llm.ILlmStore;
+import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
+import ai.labs.eddi.configs.output.IOutputStore;
+import ai.labs.eddi.configs.parser.IParserStore;
+import ai.labs.eddi.configs.propertysetter.IPropertySetterStore;
+import ai.labs.eddi.configs.rag.IRagStore;
+import ai.labs.eddi.configs.rules.IRuleSetStore;
 import ai.labs.eddi.configs.rules.IRestRuleSetStore;
 import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
 import ai.labs.eddi.configs.llm.IRestLlmStore;
@@ -32,15 +41,30 @@ import static org.mockito.Mockito.*;
  */
 class ResourceClientLibraryTest {
 
-    private IRestParserStore parserStore;
-    private IRestDictionaryStore dictionaryStore;
-    private IRestRuleSetStore ruleSetStore;
-    private IRestApiCallsStore apiCallsStore;
-    private IRestLlmStore llmStore;
-    private IRestOutputStore outputStore;
-    private IRestPropertySetterStore propertySetterStore;
-    private IRestMcpCallsStore mcpCallsStore;
-    private IRestRagStore ragStore;
+    // Reads resolve against the stores (the engine's path, below ownership
+    // enforcement); duplicate/delete resolve against the REST facades (the
+    // authoring
+    // path, which ResourceAccessGuard sees). The split is the point of these tests.
+    private IParserStore parserStore;
+    private IDictionaryStore dictionaryStore;
+    private IRuleSetStore ruleSetStore;
+    private IApiCallsStore apiCallsStore;
+    private ILlmStore llmStore;
+    private IOutputStore outputStore;
+    private IPropertySetterStore propertySetterStore;
+    private IMcpCallsStore mcpCallsStore;
+    private IRagStore ragStore;
+
+    private IRestParserStore restParserStore;
+    private IRestDictionaryStore restDictionaryStore;
+    private IRestRuleSetStore restRuleSetStore;
+    private IRestApiCallsStore restApiCallsStore;
+    private IRestLlmStore restLlmStore;
+    private IRestOutputStore restOutputStore;
+    private IRestPropertySetterStore restPropertySetterStore;
+    private IRestMcpCallsStore restMcpCallsStore;
+    private IRestRagStore restRagStore;
+
     private ResourceClientLibrary library;
 
     // Valid hex ID (>= 18 hex chars for RestUtilities.isValidId)
@@ -48,17 +72,30 @@ class ResourceClientLibraryTest {
 
     @BeforeEach
     void setUp() {
-        parserStore = mock(IRestParserStore.class);
-        dictionaryStore = mock(IRestDictionaryStore.class);
-        ruleSetStore = mock(IRestRuleSetStore.class);
-        apiCallsStore = mock(IRestApiCallsStore.class);
-        llmStore = mock(IRestLlmStore.class);
-        outputStore = mock(IRestOutputStore.class);
-        propertySetterStore = mock(IRestPropertySetterStore.class);
-        mcpCallsStore = mock(IRestMcpCallsStore.class);
-        ragStore = mock(IRestRagStore.class);
+        parserStore = mock(IParserStore.class);
+        dictionaryStore = mock(IDictionaryStore.class);
+        ruleSetStore = mock(IRuleSetStore.class);
+        apiCallsStore = mock(IApiCallsStore.class);
+        llmStore = mock(ILlmStore.class);
+        outputStore = mock(IOutputStore.class);
+        propertySetterStore = mock(IPropertySetterStore.class);
+        mcpCallsStore = mock(IMcpCallsStore.class);
+        ragStore = mock(IRagStore.class);
+
+        restParserStore = mock(IRestParserStore.class);
+        restDictionaryStore = mock(IRestDictionaryStore.class);
+        restRuleSetStore = mock(IRestRuleSetStore.class);
+        restApiCallsStore = mock(IRestApiCallsStore.class);
+        restLlmStore = mock(IRestLlmStore.class);
+        restOutputStore = mock(IRestOutputStore.class);
+        restPropertySetterStore = mock(IRestPropertySetterStore.class);
+        restMcpCallsStore = mock(IRestMcpCallsStore.class);
+        restRagStore = mock(IRestRagStore.class);
+
         library = new ResourceClientLibrary(parserStore, dictionaryStore, ruleSetStore,
-                apiCallsStore, llmStore, outputStore, propertySetterStore, mcpCallsStore, ragStore);
+                apiCallsStore, llmStore, outputStore, propertySetterStore, mcpCallsStore, ragStore,
+                restParserStore, restDictionaryStore, restRuleSetStore, restApiCallsStore, restLlmStore,
+                restOutputStore, restPropertySetterStore, restMcpCallsStore, restRagStore);
     }
 
     @Nested
@@ -72,7 +109,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.parser/parserstore/parsers/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(parserStore).readParser(eq(VALID_ID), eq(1));
+            verify(parserStore).read(eq(VALID_ID), eq(1));
         }
 
         @Test
@@ -82,7 +119,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.llm/llmstore/llms/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(llmStore).readLlm(eq(VALID_ID), eq(1));
+            verify(llmStore).read(eq(VALID_ID), eq(1));
         }
 
         @Test
@@ -92,7 +129,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(apiCallsStore).readApiCalls(eq(VALID_ID), eq(1));
+            verify(apiCallsStore).read(eq(VALID_ID), eq(1));
         }
 
         @Test
@@ -102,7 +139,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.behavior/behaviorstore/behaviors/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(ruleSetStore).readRuleSet(eq(VALID_ID), eq(1));
+            verify(ruleSetStore).read(eq(VALID_ID), eq(1));
         }
 
         @Test
@@ -112,7 +149,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.mcpcalls/mcpcallsstore/mcpcalls/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(mcpCallsStore).readMcpCalls(eq(VALID_ID), eq(1));
+            verify(mcpCallsStore).read(eq(VALID_ID), eq(1));
         }
 
         @Test
@@ -122,7 +159,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.rag/ragstore/rags/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(ragStore).readRag(eq(VALID_ID), eq(1));
+            verify(ragStore).read(eq(VALID_ID), eq(1));
         }
 
         @Test
@@ -132,7 +169,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.property/propertystore/properties/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(propertySetterStore).readPropertySetter(eq(VALID_ID), eq(1));
+            verify(propertySetterStore).read(eq(VALID_ID), eq(1));
         }
 
         @Test
@@ -142,7 +179,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.output/outputstore/outputsets/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(outputStore).readOutputSet(eq(VALID_ID), eq(1), eq(""), eq(""), eq(0), eq(0));
+            verify(outputStore).read(eq(VALID_ID), eq(1), eq(""), eq(""), eq(0), eq(0));
         }
 
         @Test
@@ -162,7 +199,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.rules/rulestore/rules/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(ruleSetStore).readRuleSet(eq(VALID_ID), eq(1));
+            verify(ruleSetStore).read(eq(VALID_ID), eq(1));
         }
 
         @Test
@@ -172,7 +209,7 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.dictionary/dictionarystore/dictionaries/" + VALID_ID + "?version=1"),
                     Object.class);
 
-            verify(dictionaryStore).readRegularDictionary(eq(VALID_ID), eq(1), eq(""), eq(""), eq(0), eq(0));
+            verify(dictionaryStore).read(eq(VALID_ID), eq(1));
         }
     }
 
@@ -183,7 +220,7 @@ class ResourceClientLibraryTest {
         @Test
         @DisplayName("should delegate to correct store")
         void delegatesToStore() throws Exception {
-            when(parserStore.duplicateParser(anyString(), any())).thenReturn(Response.ok().build());
+            when(restParserStore.duplicateParser(anyString(), any())).thenReturn(Response.ok().build());
 
             Response result = library.duplicateResource(
                     URI.create("eddi://ai.labs.parser/parserstore/parsers/" + VALID_ID + "?version=1"));
@@ -207,7 +244,7 @@ class ResourceClientLibraryTest {
         @Test
         @DisplayName("should delegate to correct store")
         void delegatesToStore() throws Exception {
-            when(llmStore.deleteLlm(anyString(), any(), anyBoolean())).thenReturn(Response.ok().build());
+            when(restLlmStore.deleteLlm(anyString(), any(), anyBoolean())).thenReturn(Response.ok().build());
 
             Response result = library.deleteResource(
                     URI.create("eddi://ai.labs.llm/llmstore/llms/" + VALID_ID + "?version=1"), false);
@@ -227,12 +264,12 @@ class ResourceClientLibraryTest {
         @Test
         @DisplayName("should pass permanent flag")
         void passesPermanentFlag() throws Exception {
-            when(ragStore.deleteRag(anyString(), any(), anyBoolean())).thenReturn(Response.ok().build());
+            when(restRagStore.deleteRag(anyString(), any(), anyBoolean())).thenReturn(Response.ok().build());
 
             library.deleteResource(
                     URI.create("eddi://ai.labs.rag/ragstore/rags/" + VALID_ID + "?version=1"), true);
 
-            verify(ragStore).deleteRag(eq(VALID_ID), eq(1), eq(true));
+            verify(restRagStore).deleteRag(eq(VALID_ID), eq(1), eq(true));
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/runtime/client/factory/LoopbackCallerAuthFilterTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/client/factory/LoopbackCallerAuthFilterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.runtime.client.factory;
+
+import ai.labs.eddi.engine.security.CallerIdentity;
+import ai.labs.eddi.engine.security.CallerIdentityContext;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * EDDI's internal loopback calls carried no credentials, so every service that
+ * re-enters its own API — the agent wizard, {@code setup-api}, the Platform
+ * Operator's write tools, most of {@code McpAdminTools} — answered 401 as soon
+ * as {@code authorization.enabled=true}. That is the configuration per-user
+ * workspaces require, so the two features were mutually exclusive until this
+ * filter existed.
+ */
+class LoopbackCallerAuthFilterTest {
+
+    private static ClientRequestContext requestWith(MultivaluedMap<String, Object> headers) {
+        ClientRequestContext context = mock(ClientRequestContext.class);
+        when(context.getHeaders()).thenReturn(headers);
+        return context;
+    }
+
+    private static LoopbackCallerAuthFilter filterFor(CallerIdentity bound, CallerIdentity captured) {
+        CallerIdentityContext context = mock(CallerIdentityContext.class);
+        when(context.current()).thenReturn(bound);
+        when(context.capture()).thenReturn(captured);
+        return new LoopbackCallerAuthFilter(context);
+    }
+
+    @Test
+    @DisplayName("a request thread's captured token is forwarded")
+    void forwardsCapturedToken() {
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        filterFor(null, new CallerIdentity("tok-123", "alice", "http://127.0.0.1:7070")).filter(requestWith(headers));
+
+        assertEquals("Bearer tok-123", headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    @DisplayName("a bound identity wins over a captured one")
+    void boundIdentityWins() {
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        filterFor(new CallerIdentity("bound-tok", "alice", "http://127.0.0.1:7070"),
+                new CallerIdentity("captured-tok", "approver", "http://127.0.0.1:7070")).filter(requestWith(headers));
+
+        // On a HITL resume the request belongs to the approving administrator while the
+        // turn belongs to the user who asked. The bound identity is the turn's.
+        assertEquals("Bearer bound-tok", headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    @DisplayName("no identity means no header — unchanged behaviour with OIDC off")
+    void anonymousAddsNoHeader() {
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        filterFor(null, null).filter(requestWith(headers));
+
+        assertFalse(headers.containsKey(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    @DisplayName("an identity without a token adds no header")
+    void identityWithoutTokenAddsNoHeader() {
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        filterFor(null, new CallerIdentity(null, "alice", "http://127.0.0.1:7070")).filter(requestWith(headers));
+
+        assertFalse(headers.containsKey(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    @DisplayName("an explicit Authorization header is never overwritten")
+    void explicitHeaderWins() {
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.putSingle(HttpHeaders.AUTHORIZATION, "Bearer explicit");
+        filterFor(null, new CallerIdentity("tok-123", "alice", "http://127.0.0.1:7070")).filter(requestWith(headers));
+
+        assertEquals("Bearer explicit", headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    @DisplayName("a failure resolving the caller leaves the call unauthenticated rather than breaking it")
+    void resolutionFailureIsNotFatal() {
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        CallerIdentityContext context = mock(CallerIdentityContext.class);
+        when(context.current()).thenThrow(new IllegalStateException("no request context"));
+
+        new LoopbackCallerAuthFilter(context).filter(requestWith(headers));
+
+        assertFalse(headers.containsKey(HttpHeaders.AUTHORIZATION));
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementBranchTest.java
@@ -10,6 +10,7 @@ import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.migration.ChannelConnectorMigration;
+import ai.labs.eddi.configs.migration.WorkspaceAccessIndexMigration;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.V6QuteMigration;
 import ai.labs.eddi.configs.migration.V6RenameMigration;
@@ -82,7 +83,8 @@ class AgentDeploymentManagementBranchTest {
         management = new AgentDeploymentManagement(
                 deploymentStore, agentFactory, agentStore, agentsReadiness,
                 conversationMemoryStore, documentDescriptorStore, migrationManager,
-                v6RenameMigration, v6QuteMigration, channelConnectorMigration, runtime, workflowStore, ruleSetStore, 30);
+                v6RenameMigration, v6QuteMigration, channelConnectorMigration, mock(WorkspaceAccessIndexMigration.class),
+                runtime, workflowStore, ruleSetStore, 30);
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementExtendedTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.runtime.internal;
 
+import ai.labs.eddi.configs.migration.WorkspaceAccessIndexMigration;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
@@ -72,7 +73,8 @@ class AgentDeploymentManagementExtendedTest {
         management = new AgentDeploymentManagement(
                 deploymentStore, agentFactory, agentStore, agentsReadiness,
                 conversationMemoryStore, documentDescriptorStore,
-                migrationManager, v6Rename, v6Qute, channelMigration, runtime, workflowStore, ruleSetStore, 30);
+                migrationManager, v6Rename, v6Qute, channelMigration, mock(WorkspaceAccessIndexMigration.class),
+                runtime, workflowStore, ruleSetStore, 30);
     }
 
     // ─── manageAgentDeployments ─────────────────────────────

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementIdleSweepTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.runtime.internal;
 
+import ai.labs.eddi.configs.migration.WorkspaceAccessIndexMigration;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
@@ -85,7 +86,8 @@ class AgentDeploymentManagementIdleSweepTest {
 
         management = new AgentDeploymentManagement(deploymentStore, agentFactory, agentStore, agentsReadiness, conversationMemoryStore,
                 documentDescriptorStore, migrationManager, mock(V6RenameMigration.class), mock(V6QuteMigration.class),
-                mock(ChannelConnectorMigration.class), runtime, mock(IWorkflowStore.class), mock(IRuleSetStore.class), MAX_IDLE_DAYS);
+                mock(ChannelConnectorMigration.class), mock(WorkspaceAccessIndexMigration.class), runtime,
+                mock(IWorkflowStore.class), mock(IRuleSetStore.class), MAX_IDLE_DAYS);
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/AgentDeploymentManagementTest.java
@@ -12,6 +12,7 @@ import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.ChannelConnectorMigration;
+import ai.labs.eddi.configs.migration.WorkspaceAccessIndexMigration;
 import ai.labs.eddi.configs.migration.V6QuteMigration;
 import ai.labs.eddi.configs.migration.V6RenameMigration;
 import ai.labs.eddi.configs.rules.IRuleSetStore;
@@ -84,7 +85,8 @@ class AgentDeploymentManagementTest {
                 deploymentStore, agentFactory, agentStore, agentsReadiness,
                 conversationMemoryStore, documentDescriptorStore,
                 migrationManager, v6RenameMigration, v6QuteMigration,
-                channelConnectorMigration, runtime, workflowStore, ruleSetStore, 30);
+                channelConnectorMigration, mock(WorkspaceAccessIndexMigration.class),
+                runtime, workflowStore, ruleSetStore, 30);
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/engine/runtime/rest/interceptors/DocumentDescriptorFilterTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/rest/interceptors/DocumentDescriptorFilterTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.runtime.rest.interceptors;
 
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.descriptors.model.ResourceDescriptor;
 import ai.labs.eddi.datastore.IResourceStore;
@@ -35,13 +36,19 @@ class DocumentDescriptorFilterTest {
     private IConversationDescriptorStore conversationDescriptorStore;
     private DocumentDescriptorFilter filter;
     private UriInfo uriInfo;
+    private ResourceAccessGuard resourceAccessGuard;
 
     @BeforeEach
     void setUp() throws Exception {
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         conversationDescriptorStore = mock(IConversationDescriptorStore.class);
         uriInfo = mock(UriInfo.class);
-        filter = new DocumentDescriptorFilter(documentDescriptorStore, conversationDescriptorStore);
+        // A guard that stamps nothing: these tests are about descriptor bookkeeping,
+        // and
+        // the ownership stamping it would otherwise apply has its own tests.
+        resourceAccessGuard = mock(ResourceAccessGuard.class);
+        when(resourceAccessGuard.stampNewDescriptor(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        filter = new DocumentDescriptorFilter(documentDescriptorStore, conversationDescriptorStore, resourceAccessGuard);
 
         // Inject UriInfo
         Field uriInfoField = DocumentDescriptorFilter.class.getDeclaredField("uriInfo");

--- a/src/test/java/ai/labs/eddi/engine/runtime/service/WorkflowStoreServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/service/WorkflowStoreServiceTest.java
@@ -4,9 +4,9 @@
  */
 package ai.labs.eddi.engine.runtime.service;
 
-import ai.labs.eddi.configs.descriptors.IRestDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,13 +19,13 @@ import static org.mockito.Mockito.*;
 class WorkflowStoreServiceTest {
 
     private WorkflowStoreService service;
-    private IRestWorkflowStore workflowStore;
-    private IRestDocumentDescriptorStore descriptorStore;
+    private IWorkflowStore workflowStore;
+    private IDocumentDescriptorStore descriptorStore;
 
     @BeforeEach
     void setUp() {
-        workflowStore = mock(IRestWorkflowStore.class);
-        descriptorStore = mock(IRestDocumentDescriptorStore.class);
+        workflowStore = mock(IWorkflowStore.class);
+        descriptorStore = mock(IDocumentDescriptorStore.class);
         service = new WorkflowStoreService(workflowStore, descriptorStore);
     }
 
@@ -33,18 +33,18 @@ class WorkflowStoreServiceTest {
     @DisplayName("getKnowledgeWorkflow delegates to restWorkflowStore")
     void getKnowledgeWorkflow() throws Exception {
         var config = new WorkflowConfiguration();
-        doReturn(config).when(workflowStore).readWorkflow("wf1", 1);
+        doReturn(config).when(workflowStore).read("wf1", 1);
 
         var result = service.getKnowledgeWorkflow("wf1", 1);
 
         assertSame(config, result);
-        verify(workflowStore).readWorkflow("wf1", 1);
+        verify(workflowStore).read("wf1", 1);
     }
 
     @Test
     @DisplayName("getKnowledgeWorkflow wraps exception as ServiceException")
     void getKnowledgeWorkflowException() throws Exception {
-        doThrow(new RuntimeException("not found")).when(workflowStore).readWorkflow("wf1", 1);
+        doThrow(new RuntimeException("not found")).when(workflowStore).read("wf1", 1);
 
         var ex = assertThrows(ServiceException.class, () -> service.getKnowledgeWorkflow("wf1", 1));
         assertTrue(ex.getMessage().contains("not found"));

--- a/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreExpandedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreExpandedTest.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.engine.runtime.internal.ScheduleFireExecutor;
 import ai.labs.eddi.engine.runtime.internal.SchedulePollerService;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.security.OwnershipValidator;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
@@ -59,6 +60,8 @@ class RestScheduleStoreExpandedTest {
         setField(sut, "pollerService", pollerService);
         setField(sut, "identity", mock(io.quarkus.security.identity.SecurityIdentity.class));
         setField(sut, "ownershipValidator", ownershipValidator);
+        // A bare mock admits everything: its void requireAgentUseAccess does nothing.
+        setField(sut, "resourceAccessGuard", mock(ResourceAccessGuard.class));
         setField(sut, "defaultTimeZone", "UTC");
         setField(sut, "minIntervalSeconds", 60L);
     }

--- a/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreTest.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.engine.schedule.model.ScheduleFireLog;
 import ai.labs.eddi.engine.runtime.internal.ScheduleFireExecutor;
 import ai.labs.eddi.engine.runtime.internal.SchedulePollerService;
 import ai.labs.eddi.engine.security.OwnershipValidator;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,6 +54,7 @@ class RestScheduleStoreTest {
         // Auth-enabled validator: isAdmin() is then driven by the mocked identity's
         // role.
         setField(rest, "ownershipValidator", new OwnershipValidator(true));
+        setField(rest, "resourceAccessGuard", permissiveResourceGuard());
         setField(rest, "defaultTimeZone", "UTC");
         setField(rest, "minIntervalSeconds", 60L);
     }
@@ -428,6 +430,21 @@ class RestScheduleStoreTest {
     }
 
     @Test
+    void createSchedule_agentTheCallerMayNotUse_refused() throws Exception {
+        // A schedule converses with its agent on every fire, and the fire is
+        // system-initiated — below the USE gate by design. So the gate lives at
+        // create time; without it, scheduling a private agent is a standing bypass
+        // of the check on /agents/{id}/start.
+        asEditor("editor-1");
+        var privateAgentGuard = mock(ResourceAccessGuard.class);
+        doThrow(new io.quarkus.security.ForbiddenException("no")).when(privateAgentGuard).requireAgentUseAccess(anyString());
+        setField(rest, "resourceAccessGuard", privateAgentGuard);
+
+        assertThrows(io.quarkus.security.ForbiddenException.class, () -> rest.createSchedule(dreamSchedule("d9", "editor-1")));
+        verify(scheduleStore, never()).createSchedule(any());
+    }
+
+    @Test
     void createSchedule_actingAsAnotherUser_forbiddenForEditor() throws Exception {
         asEditor("editor-1");
 
@@ -720,5 +737,14 @@ class RestScheduleStoreTest {
         } catch (Exception e) {
             throw new RuntimeException("Cannot set field " + fieldName, e);
         }
+    }
+
+    /**
+     * A guard that admits every agent — a bare mock's void
+     * {@code requireAgentUseAccess} does nothing. These tests exercise schedule
+     * semantics; the USE gate has its own.
+     */
+    private static ResourceAccessGuard permissiveResourceGuard() {
+        return mock(ResourceAccessGuard.class);
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/AccessScopeTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/AccessScopeTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.datastore.IResourceFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The space narrowing exists so the Manager's space switcher can page. Its one
+ * dangerous failure mode is becoming a widening, which is what these pin down.
+ */
+class AccessScopeTest {
+
+    private static final CallerSpaces ALICE = CallerSpaces.of("alice", Set.of("/engineering"));
+
+    @Test
+    @DisplayName("the access tokens stay an OR group among themselves")
+    void accessTokensAreOred() {
+        var filters = AccessScope.forCaller(ALICE, true).toQueryFilters();
+
+        assertNotNull(filters);
+        assertEquals(IResourceFilter.QueryFilters.ConnectingType.OR, filters.getConnectingType(),
+                "ANDing the caller's own tokens would admit nothing at all");
+        assertTrue(filters.getQueryFilters().size() > 1);
+    }
+
+    @Test
+    @DisplayName("the space narrowing is a separate group, so it ANDs rather than ORs")
+    void spaceIsItsOwnGroup() {
+        var scope = AccessScope.forCaller(ALICE, true).withinSpace(Subjects.teamSpace("engineering"));
+
+        var access = scope.toQueryFilters();
+        var space = scope.toSpaceFilter();
+
+        assertNotNull(space, "the narrowing must reach the query");
+        assertEquals(IResourceFilter.QueryFilters.ConnectingType.OR, access.getConnectingType());
+        assertEquals(1, space.getQueryFilters().size());
+        assertEquals(AccessScope.FIELD_SPACE_ID, space.getQueryFilters().get(0).getField());
+        // Folding the space into the access group would OR it — turning "only this
+        // space" into "everything I can reach, PLUS this space".
+        assertFalse(access.getQueryFilters().stream()
+                .anyMatch(f -> AccessScope.FIELD_SPACE_ID.equals(f.getField())));
+    }
+
+    @Test
+    @DisplayName("narrowing an unrestricted scope still narrows")
+    void narrowsAnAdminScope() {
+        var scope = AccessScope.unrestricted().withinSpace(Subjects.teamSpace("engineering"));
+
+        assertTrue(scope.isUnrestricted(), "an admin's reach is unchanged by a view preference");
+        assertNotNull(scope.toSpaceFilter(), "but the view preference is still applied");
+        assertNull(scope.toQueryFilters(), "and it does not invent an access restriction");
+    }
+
+    @Test
+    @DisplayName("a blank space is no narrowing at all")
+    void blankSpaceIsNoOp() {
+        assertNull(AccessScope.forCaller(ALICE, true).withinSpace("").toSpaceFilter());
+        assertNull(AccessScope.forCaller(ALICE, true).withinSpace(null).toSpaceFilter());
+        assertNull(AccessScope.forCaller(ALICE, true).withinSpace("   ").toSpaceFilter());
+    }
+
+    @Test
+    @DisplayName("the space predicate is anchored, so one space id cannot match another")
+    void spacePredicateIsAnchored() {
+        var space = AccessScope.unrestricted().withinSpace(Subjects.teamSpace("eng")).toSpaceFilter();
+        String pattern = space.getQueryFilters().get(0).getFilter().toString();
+
+        assertTrue(Pattern.compile(pattern).matcher("team:eng").find());
+        assertFalse(Pattern.compile(pattern).matcher("team:engineering").find(),
+                "an unanchored space predicate would leak a longer team name into the narrower one");
+    }
+
+    @Test
+    @DisplayName("asking for a space you cannot reach returns nothing rather than granting it")
+    void narrowingCannotWiden() {
+        var scope = AccessScope.forCaller(ALICE, true).withinSpace(Subjects.teamSpace("finance"));
+
+        // The access group still only names Alice's own tokens; the space group ANDs on
+        // top. No row can satisfy both unless Alice could already see it.
+        assertFalse(scope.admittingTokens().contains(Subjects.teamSpace("finance")));
+        assertNotNull(scope.toSpaceFilter());
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolverTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ConfigGraphResolverTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The resolver decides what a cascading share actually reaches, so a node it
+ * silently drops is a recipient staring at a broken agent — and the sharing
+ * tests mock this class, which is precisely how a dropped node stayed
+ * invisible. These tests run the real traversal over in-memory stores.
+ */
+class ConfigGraphResolverTest {
+
+    private static final String GROUP = "cccccccccccccccccccccc";
+    private static final String NESTED_GROUP = "dddddddddddddddddddddd";
+    private static final String AGENT = "aaaaaaaaaaaaaaaaaaaaaa";
+    private static final String AGENT_2 = "eeeeeeeeeeeeeeeeeeeeee";
+    private static final String WORKFLOW = "bbbbbbbbbbbbbbbbbbbbbb";
+    private static final String WORKFLOW_2 = "ffffffffffffffffffffff";
+    private static final String RULE_SET = "1111111111111111111111";
+    private static final String DICTIONARY = "2222222222222222222222";
+
+    private final Map<String, AgentConfiguration> agents = new HashMap<>();
+    private final Map<String, WorkflowConfiguration> workflows = new HashMap<>();
+    private final Map<String, AgentGroupConfiguration> groups = new HashMap<>();
+
+    private ConfigGraphResolver resolver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        IAgentStore agentStore = mock(IAgentStore.class);
+        IWorkflowStore workflowStore = mock(IWorkflowStore.class);
+        IAgentGroupStore groupStore = mock(IAgentGroupStore.class);
+
+        wire(agentStore, agents);
+        wire(workflowStore, workflows);
+        wire(groupStore, groups);
+
+        resolver = new ConfigGraphResolver(agentStore, workflowStore, groupStore);
+    }
+
+    private <T> void wire(Object store, Map<String, T> byId) throws Exception {
+        if (store instanceof IAgentStore s) {
+            lenient().when(s.getCurrentResourceId(anyString())).thenAnswer(i -> resourceIdOrThrow(byId, i.getArgument(0)));
+            lenient().when(s.read(anyString(), anyInt())).thenAnswer(i -> readOrThrow(byId, i.getArgument(0)));
+        } else if (store instanceof IWorkflowStore s) {
+            lenient().when(s.getCurrentResourceId(anyString())).thenAnswer(i -> resourceIdOrThrow(byId, i.getArgument(0)));
+            lenient().when(s.read(anyString(), anyInt())).thenAnswer(i -> readOrThrow(byId, i.getArgument(0)));
+        } else if (store instanceof IAgentGroupStore s) {
+            lenient().when(s.getCurrentResourceId(anyString())).thenAnswer(i -> resourceIdOrThrow(byId, i.getArgument(0)));
+            lenient().when(s.read(anyString(), anyInt())).thenAnswer(i -> readOrThrow(byId, i.getArgument(0)));
+        }
+    }
+
+    private static <T> IResourceStore.IResourceId resourceIdOrThrow(Map<String, T> byId, String id)
+            throws IResourceStore.ResourceNotFoundException {
+        if (!byId.containsKey(id)) {
+            throw new IResourceStore.ResourceNotFoundException("no " + id);
+        }
+        return new IResourceStore.IResourceId() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return 1;
+            }
+        };
+    }
+
+    private static <T> T readOrThrow(Map<String, T> byId, String id) throws IResourceStore.ResourceNotFoundException {
+        T value = byId.get(id);
+        if (value == null) {
+            throw new IResourceStore.ResourceNotFoundException("no " + id);
+        }
+        return value;
+    }
+
+    // ---- fixture builders ----
+
+    private void agent(String id, String... workflowIds) {
+        var config = new AgentConfiguration();
+        List<URI> uris = new ArrayList<>();
+        for (String workflowId : workflowIds) {
+            uris.add(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1"));
+        }
+        config.setWorkflows(uris);
+        agents.put(id, config);
+    }
+
+    private void workflow(String id, String... configIds) {
+        var config = new WorkflowConfiguration();
+        List<WorkflowConfiguration.WorkflowStep> steps = new ArrayList<>();
+        for (String configId : configIds) {
+            var step = new WorkflowConfiguration.WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.behavior"));
+            step.setConfig(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/" + configId + "?version=1"));
+            steps.add(step);
+        }
+        config.setWorkflowSteps(steps);
+        workflows.put(id, config);
+    }
+
+    private void group(String id, String... memberIds) {
+        var config = new AgentGroupConfiguration();
+        List<AgentGroupConfiguration.GroupMember> members = new ArrayList<>();
+        for (String memberId : memberIds) {
+            members.add(new AgentGroupConfiguration.GroupMember(memberId, memberId, null, null, null));
+        }
+        config.setMembers(members);
+        groups.put(id, config);
+    }
+
+    // ---- the traversal ----
+
+    @Test
+    @DisplayName("an agent reaches its workflows and their configs, excluding itself")
+    void agentGraph() {
+        agent(AGENT, WORKFLOW);
+        workflow(WORKFLOW, RULE_SET, DICTIONARY);
+
+        Set<String> reached = resolver.referencedResourceIds(AGENT);
+
+        assertTrue(reached.containsAll(Set.of(WORKFLOW, RULE_SET, DICTIONARY)), "reached: " + reached);
+        assertFalse(reached.contains(AGENT), "the root is the caller's to share; only what it references is returned");
+    }
+
+    @Test
+    @DisplayName("sharing a group reaches the member agents THEMSELVES, not only their workflows")
+    void groupIncludesMemberAgents() {
+        group(GROUP, AGENT, AGENT_2);
+        agent(AGENT, WORKFLOW);
+        agent(AGENT_2, WORKFLOW_2);
+        workflow(WORKFLOW, RULE_SET);
+        workflow(WORKFLOW_2, DICTIONARY);
+
+        Set<String> reached = resolver.referencedResourceIds(GROUP);
+
+        // The regression this pins down: the seeding recursion and the poll loop
+        // shared one visited-set, so every member agent was pre-marked "done" and
+        // dropped from the result — recipients of a group share could reach the
+        // workflows but not start a conversation with any member.
+        assertTrue(reached.contains(AGENT), "member agent missing from the share: " + reached);
+        assertTrue(reached.contains(AGENT_2), "member agent missing from the share: " + reached);
+        assertTrue(reached.containsAll(Set.of(WORKFLOW, WORKFLOW_2, RULE_SET, DICTIONARY)), "reached: " + reached);
+    }
+
+    @Test
+    @DisplayName("group-of-groups is followed one level down and further")
+    void nestedGroups() {
+        group(GROUP, NESTED_GROUP);
+        group(NESTED_GROUP, AGENT);
+        agent(AGENT, WORKFLOW);
+        workflow(WORKFLOW, RULE_SET);
+
+        Set<String> reached = resolver.referencedResourceIds(GROUP);
+
+        assertTrue(reached.contains(NESTED_GROUP), "the nested group itself is part of what was shared");
+        assertTrue(reached.contains(AGENT), "the nested group's member agent: " + reached);
+        assertTrue(reached.containsAll(Set.of(WORKFLOW, RULE_SET)), "reached: " + reached);
+    }
+
+    @Test
+    @DisplayName("a group containing itself terminates and still yields its other members")
+    void selfReferentialGroup() {
+        group(GROUP, GROUP, AGENT);
+        agent(AGENT, WORKFLOW);
+        workflow(WORKFLOW);
+
+        Set<String> reached = resolver.referencedResourceIds(GROUP);
+
+        assertFalse(reached.contains(GROUP), "the root never appears in its own result");
+        assertTrue(reached.contains(AGENT), "the cycle must not eat the legitimate member: " + reached);
+    }
+
+    @Test
+    @DisplayName("an id that is neither agent nor group yields an empty graph, not an error")
+    void unknownRoot() {
+        assertTrue(resolver.referencedResourceIds("0000000000000000000000").isEmpty());
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/DescriptorAccessTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/DescriptorAccessTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.descriptors.model.ResourceGrant;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The policy is written twice — once as a decision about one descriptor, once
+ * as a materialised token index a query filters on. The whole class of bug this
+ * design can produce is the two disagreeing, so most of what follows checks
+ * that they agree.
+ */
+class DescriptorAccessTest {
+
+    private static final CallerSpaces ALICE = CallerSpaces.of("alice", Set.of("/engineering"));
+    private static final CallerSpaces BOB = CallerSpaces.of("bob", Set.of());
+    private static final CallerSpaces CAROL_IN_TEAM = CallerSpaces.of("carol", Set.of("/engineering"));
+
+    private static DocumentDescriptor descriptor(String owner, String space, ResourceVisibility visibility) {
+        DocumentDescriptor d = new DocumentDescriptor();
+        d.setOwnerId(owner);
+        d.setSpaceId(space);
+        d.setVisibility(visibility == null ? null : visibility.wireName());
+        return DescriptorAccess.rebuildIndex(d);
+    }
+
+    private static void grant(DocumentDescriptor d, String subject, AccessLevel level) {
+        List<ResourceGrant> grants = d.getGrants() == null ? new ArrayList<>() : new ArrayList<>(d.getGrants());
+        grants.add(new ResourceGrant(subject, level.name(), "alice", new Date(0)));
+        d.setGrants(grants);
+        DescriptorAccess.rebuildIndex(d);
+    }
+
+    /** Mirrors what the query layer does: OR the caller's tokens over the index. */
+    private static boolean listedFor(DocumentDescriptor d, CallerSpaces caller, boolean admitLegacy) {
+        for (String token : DescriptorAccess.admittingTokens(caller, admitLegacy)) {
+            if (Pattern.compile(Subjects.tokenPattern(token)).matcher(d.getAccessIndex()).find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Nested
+    @DisplayName("effective level")
+    class EffectiveLevel {
+
+        @Test
+        @DisplayName("the owner owns it")
+        void ownerOwns() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), ResourceVisibility.space);
+            assertEquals(AccessLevel.OWN, DescriptorAccess.effectiveLevel(d, ALICE, true));
+        }
+
+        @Test
+        @DisplayName("a stranger gets nothing from a personal space")
+        void strangerGetsNothing() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), ResourceVisibility.space);
+            assertNull(DescriptorAccess.effectiveLevel(d, BOB, true));
+        }
+
+        @Test
+        @DisplayName("a teammate in a team space may edit but not own")
+        void teammateEditsButDoesNotOwn() {
+            var d = descriptor("alice", Subjects.teamSpace("engineering"), ResourceVisibility.space);
+            AccessLevel level = DescriptorAccess.effectiveLevel(d, CAROL_IN_TEAM, true);
+            assertEquals(AccessLevel.EDIT, level, "sharing a space must not confer the right to delete or re-share");
+            assertFalse(level.includes(AccessLevel.OWN));
+        }
+
+        @Test
+        @DisplayName("published grants VIEW to anyone, including an anonymous caller")
+        void publishedGrantsView() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), ResourceVisibility.published);
+            assertEquals(AccessLevel.VIEW, DescriptorAccess.effectiveLevel(d, BOB, true));
+            assertEquals(AccessLevel.VIEW, DescriptorAccess.effectiveLevel(d, CallerSpaces.ANONYMOUS, true));
+        }
+
+        @Test
+        @DisplayName("private hides from a teammate who has no explicit grant")
+        void privateHidesFromTeam() {
+            var d = descriptor("alice", Subjects.teamSpace("engineering"), ResourceVisibility.privateAccess);
+            assertNull(DescriptorAccess.effectiveLevel(d, CAROL_IN_TEAM, true));
+            assertEquals(AccessLevel.OWN, DescriptorAccess.effectiveLevel(d, ALICE, true), "the owner still owns a private resource");
+        }
+
+        @Test
+        @DisplayName("an explicit grant reaches a stranger, at exactly the granted level")
+        void explicitGrant() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), ResourceVisibility.privateAccess);
+            grant(d, Subjects.user("bob"), AccessLevel.USE);
+            AccessLevel level = DescriptorAccess.effectiveLevel(d, BOB, true);
+            assertEquals(AccessLevel.USE, level);
+            assertFalse(level.includes(AccessLevel.VIEW), "USE must not leak the configuration");
+        }
+
+        @Test
+        @DisplayName("a team grant reaches every member of that team")
+        void teamGrant() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), ResourceVisibility.privateAccess);
+            grant(d, Subjects.team("engineering"), AccessLevel.VIEW);
+            assertEquals(AccessLevel.VIEW, DescriptorAccess.effectiveLevel(d, CAROL_IN_TEAM, true));
+            assertNull(DescriptorAccess.effectiveLevel(d, BOB, true));
+        }
+
+        @Test
+        @DisplayName("the most permissive applicable grant wins")
+        void highestWins() {
+            var d = descriptor("alice", Subjects.teamSpace("engineering"), ResourceVisibility.space);
+            grant(d, Subjects.user("carol"), AccessLevel.USE);
+            assertEquals(AccessLevel.EDIT, DescriptorAccess.effectiveLevel(d, CAROL_IN_TEAM, true),
+                    "a narrower explicit grant must not reduce what the space already allows");
+        }
+
+        @Test
+        @DisplayName("a grant whose level is unreadable grants nothing")
+        void unparseableLevelGrantsNothing() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), ResourceVisibility.privateAccess);
+            List<ResourceGrant> grants = new ArrayList<>();
+            grants.add(new ResourceGrant(Subjects.user("bob"), "SUPERUSER", "alice", new Date(0)));
+            d.setGrants(grants);
+            DescriptorAccess.rebuildIndex(d);
+            assertNull(DescriptorAccess.effectiveLevel(d, BOB, true),
+                    "a level written by a newer version must not be read as OWN by accident");
+        }
+
+        @Test
+        @DisplayName("a missing visibility defaults to space, never to published")
+        void missingVisibilityDefaultsToSpace() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), null);
+            assertNull(DescriptorAccess.effectiveLevel(d, BOB, true),
+                    "an absent visibility field must not silently widen access");
+        }
+
+        @Test
+        @DisplayName("legacy data follows the operator's policy")
+        void legacyFollowsPolicy() {
+            var d = descriptor(null, null, null);
+            assertEquals(AccessLevel.OWN, DescriptorAccess.effectiveLevel(d, BOB, true));
+            assertNull(DescriptorAccess.effectiveLevel(d, BOB, false));
+        }
+    }
+
+    @Nested
+    @DisplayName("the index and the decision agree")
+    class IndexMirrorsDecision {
+
+        private void assertAgrees(DocumentDescriptor d, CallerSpaces caller, boolean admitLegacy) {
+            boolean readable = DescriptorAccess.effectiveLevel(d, caller, admitLegacy) != null;
+            boolean listed = listedFor(d, caller, admitLegacy);
+            assertEquals(readable, listed,
+                    "listing and reading disagreed for index=" + d.getAccessIndex() + " caller=" + caller.selfPrincipals());
+        }
+
+        @Test
+        @DisplayName("across the whole visibility/ownership matrix")
+        void matrix() {
+            for (ResourceVisibility visibility : ResourceVisibility.values()) {
+                for (String space : List.of(Subjects.personalSpace("alice"), Subjects.teamSpace("engineering"))) {
+                    var d = descriptor("alice", space, visibility);
+                    for (CallerSpaces caller : List.of(ALICE, BOB, CAROL_IN_TEAM, CallerSpaces.ANONYMOUS)) {
+                        assertAgrees(d, caller, true);
+                    }
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("with explicit user and team grants")
+        void withGrants() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), ResourceVisibility.privateAccess);
+            grant(d, Subjects.user("bob"), AccessLevel.USE);
+            grant(d, Subjects.team("engineering"), AccessLevel.VIEW);
+            for (CallerSpaces caller : List.of(ALICE, BOB, CAROL_IN_TEAM, CallerSpaces.ANONYMOUS)) {
+                assertAgrees(d, caller, true);
+            }
+        }
+
+        @Test
+        @DisplayName("for legacy data under both policies")
+        void legacy() {
+            var d = descriptor(null, null, null);
+            assertAgrees(d, BOB, true);
+            assertAgrees(d, BOB, false);
+        }
+
+        @Test
+        @DisplayName("an index is never empty, so no resource becomes unlistable")
+        void indexNeverEmpty() {
+            var d = descriptor(null, Subjects.teamSpace("engineering"), ResourceVisibility.privateAccess);
+            assertTrue(d.getAccessIndex() != null && d.getAccessIndex().length() > 1,
+                    "an empty index would match nothing at all — worse than being admin-only");
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/DescriptorAccessTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/DescriptorAccessTest.java
@@ -171,15 +171,71 @@ class DescriptorAccessTest {
                     "listing and reading disagreed for index=" + d.getAccessIndex() + " caller=" + caller.selfPrincipals());
         }
 
+        /**
+         * The full cross-product, including the owner-less rows.
+         * <p>
+         * The earlier version of this test always set an owner, which is exactly the
+         * axis on which the two halves diverged: a descriptor with no owner, a real
+         * space and {@code private} visibility produced an empty token set, fell back
+         * to the {@code legacy} token — admitted to everyone — while
+         * {@link DescriptorAccess#effectiveLevel} granted nobody anything. Listed to
+         * everyone, readable by no one, leaking its name, description and ACL. A
+         * crafted import can produce that shape, so it is not hypothetical.
+         */
         @Test
-        @DisplayName("across the whole visibility/ownership matrix")
+        @DisplayName("across the whole owner / space / visibility / grant / caller / policy cross-product")
         void matrix() {
-            for (ResourceVisibility visibility : ResourceVisibility.values()) {
-                for (String space : List.of(Subjects.personalSpace("alice"), Subjects.teamSpace("engineering"))) {
-                    var d = descriptor("alice", space, visibility);
-                    for (CallerSpaces caller : List.of(ALICE, BOB, CAROL_IN_TEAM, CallerSpaces.ANONYMOUS)) {
-                        assertAgrees(d, caller, true);
+            List<String> owners = new ArrayList<>();
+            owners.add("alice");
+            owners.add(null);
+
+            List<String> spaces = new ArrayList<>();
+            spaces.add(Subjects.personalSpace("alice"));
+            spaces.add(Subjects.teamSpace("engineering"));
+            spaces.add(Subjects.LEGACY);
+            spaces.add(null);
+
+            int checked = 0;
+            for (String owner : owners) {
+                for (String space : spaces) {
+                    for (ResourceVisibility visibility : ResourceVisibility.values()) {
+                        for (int grantShape = 0; grantShape < 5; grantShape++) {
+                            var d = descriptor(owner, space, visibility);
+                            applyGrantShape(d, grantShape);
+                            for (CallerSpaces caller : List.of(ALICE, BOB, CAROL_IN_TEAM, CallerSpaces.ANONYMOUS)) {
+                                for (boolean admitLegacy : List.of(true, false)) {
+                                    assertAgrees(d, caller, admitLegacy);
+                                    checked++;
+                                }
+                            }
+                        }
                     }
+                }
+            }
+            assertTrue(checked >= 900, "the sweep must actually be a sweep; checked " + checked);
+        }
+
+        /** The grant shapes that have ever produced a surprising level. */
+        private void applyGrantShape(DocumentDescriptor d, int shape) {
+            switch (shape) {
+                case 1 -> grant(d, Subjects.user("bob"), AccessLevel.USE);
+                case 2 -> grant(d, Subjects.team("engineering"), AccessLevel.VIEW);
+                case 3 -> {
+                    // A grant with no subject at all.
+                    List<ResourceGrant> grants = new ArrayList<>();
+                    grants.add(new ResourceGrant(null, AccessLevel.OWN.name(), "alice", new Date(0)));
+                    d.setGrants(grants);
+                    DescriptorAccess.rebuildIndex(d);
+                }
+                case 4 -> {
+                    // A level written by a newer version of EDDI.
+                    List<ResourceGrant> grants = new ArrayList<>();
+                    grants.add(new ResourceGrant(Subjects.user("bob"), "SUPERUSER", "alice", new Date(0)));
+                    d.setGrants(grants);
+                    DescriptorAccess.rebuildIndex(d);
+                }
+                default -> {
+                    // no grants
                 }
             }
         }
@@ -209,6 +265,56 @@ class DescriptorAccessTest {
             var d = descriptor(null, Subjects.teamSpace("engineering"), ResourceVisibility.privateAccess);
             assertTrue(d.getAccessIndex() != null && d.getAccessIndex().length() > 1,
                     "an empty index would match nothing at all — worse than being admin-only");
+        }
+    }
+
+    @Nested
+    @DisplayName("ownership does not travel between deployments")
+    class StripOwnership {
+
+        @Test
+        @DisplayName("everything about who owns it and who it is shared with is removed")
+        void stripsAllOwnership() {
+            var d = descriptor("alice", Subjects.teamSpace("engineering"), ResourceVisibility.published);
+            grant(d, Subjects.user("bob"), AccessLevel.OWN);
+            d.setName("My agent");
+            d.setDescription("does things");
+
+            DescriptorAccess.stripOwnership(d);
+
+            assertNull(d.getOwnerId());
+            assertNull(d.getSpaceId());
+            assertNull(d.getVisibility());
+            assertNull(d.getGrants());
+            assertNull(d.getAccessIndex());
+        }
+
+        @Test
+        @DisplayName("what the resource IS survives — only who it belongs to is dropped")
+        void keepsIdentityOfTheResource() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), ResourceVisibility.space);
+            d.setName("My agent");
+            d.setDescription("does things");
+            d.setOriginId("origin-1");
+
+            DescriptorAccess.stripOwnership(d);
+
+            assertEquals("My agent", d.getName());
+            assertEquals("does things", d.getDescription());
+            assertEquals("origin-1", d.getOriginId());
+        }
+
+        @Test
+        @DisplayName("a stripped descriptor reads as legacy, not as published")
+        void strippedIsLegacyNotPublished() {
+            var d = descriptor("alice", Subjects.personalSpace("alice"), ResourceVisibility.published);
+            DescriptorAccess.stripOwnership(d);
+
+            // The point: an archive that arrived claiming `published` must not still be
+            // published after stripping. It becomes unowned, and the operator's
+            // legacy-visibility policy decides — until the importer re-stamps it.
+            assertTrue(DescriptorAccess.isUnowned(d));
+            assertNull(DescriptorAccess.effectiveLevel(d, BOB, false));
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
@@ -31,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 /**
@@ -253,6 +255,152 @@ class ResourceAccessGuardTest {
             var g = guard(identity("root", "eddi-admin"), settings, mock(IDocumentDescriptorStore.class));
 
             assertEquals(1, g.redactForCaller(publishedWithGrants()).getGrants().size());
+        }
+
+        @Test
+        @DisplayName("a version read redacts on the level it was gated with, not on the version in hand")
+        void versionedReadUsesTheGatedLevel() {
+            // Sharing writes land on the CURRENT version, so an older version's
+            // descriptor can still name a previous owner and carry that era's grants.
+            // Deciding redaction against it would hand the grant list to somebody who no
+            // longer owns the resource — two different answers to "does this caller own
+            // it" inside one request.
+            var g = guard(identity("carol"), settings, mock(IDocumentDescriptorStore.class));
+            var staleVersionStillNamingCarol = ownedBy("carol");
+            staleVersionStillNamingCarol.setVisibility(ResourceVisibility.published.wireName());
+            staleVersionStillNamingCarol.setGrants(
+                    List.of(new ResourceGrant(Subjects.user("bob"), AccessLevel.USE.name(), "carol", new Date(0))));
+            DescriptorAccess.rebuildIndex(staleVersionStillNamingCarol);
+
+            // What the CURRENT descriptor said: carol may read it, and no more.
+            var redacted = g.redactUnlessOwner(staleVersionStillNamingCarol, AccessLevel.VIEW);
+
+            assertNull(redacted.getGrants(), "the old version's owner field must not decide this");
+            assertNull(redacted.getAccessIndex());
+        }
+
+        @Test
+        @DisplayName("a caller gated at OWN keeps the grants")
+        void gatedOwnerKeepsGrants() {
+            var g = guard(identity("carol"), settings, mock(IDocumentDescriptorStore.class));
+
+            assertEquals(1, g.redactUnlessOwner(publishedWithGrants(), AccessLevel.OWN).getGrants().size());
+        }
+
+        @Test
+        @DisplayName("a null level redacts — an unanswerable question is not a yes")
+        void unknownLevelRedacts() {
+            var g = guard(identity("carol"), settings, mock(IDocumentDescriptorStore.class));
+
+            assertNull(g.redactUnlessOwner(publishedWithGrants(), null).getGrants());
+        }
+    }
+
+    @Nested
+    @DisplayName("requireAccess reports the level it granted")
+    class GrantedLevel {
+
+        private final WorkspaceSettings settings = settings(true, true, WorkspaceSettings.LEGACY_SHARED);
+
+        @Test
+        @DisplayName("an owner asking for VIEW is told they hold OWN, not merely enough")
+        void reportsOwn() throws Exception {
+            // The return value is what a redaction decision downstream is made on, so
+            // "sufficient for what you asked" is the wrong answer — it would strip an
+            // owner's own grant list off a versioned read.
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenReturn(ownedBy("alice"));
+
+            var granted = guard(identity("alice"), settings, store).requireAccess(RESOURCE_ID, AccessLevel.VIEW, "agent");
+
+            assertEquals(AccessLevel.OWN, granted);
+        }
+
+        @Test
+        @DisplayName("seeing everything reports OWN without reading the store at all")
+        void adminReportsOwn() throws Exception {
+            var store = mock(IDocumentDescriptorStore.class);
+
+            var granted = guard(identity("root", "eddi-admin"), settings, store)
+                    .requireAccess(RESOURCE_ID, AccessLevel.OWN, "agent");
+
+            assertEquals(AccessLevel.OWN, granted);
+            verify(store, never()).readCurrentDescriptor(anyString());
+        }
+
+        @Test
+        @DisplayName("a resource with no descriptor reports only what was asked, never OWN")
+        void legacyFallbackReportsTheRequestedLevel() throws Exception {
+            // Reporting OWN here would let a caller redact-check their way into a grant
+            // list on a resource whose owner could not be established at all.
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenThrow(new IResourceStore.ResourceNotFoundException("none"));
+
+            var granted = guard(identity("alice"), settings, store).requireAccess(RESOURCE_ID, AccessLevel.VIEW, "agent");
+
+            assertEquals(AccessLevel.VIEW, granted);
+        }
+    }
+
+    @Nested
+    @DisplayName("use access on a target that is not an agent")
+    class NonAgentUse {
+
+        private final WorkspaceSettings settings = settings(true, true, WorkspaceSettings.LEGACY_SHARED);
+
+        private DocumentDescriptor privateTo(String owner) {
+            var d = ownedBy(owner);
+            d.setVisibility(ResourceVisibility.privateAccess.wireName());
+            return DescriptorAccess.rebuildIndex(d);
+        }
+
+        @Test
+        @DisplayName("refuses a group the caller cannot reach, and calls it a group")
+        void refusesUnreachableGroup() throws Exception {
+            // A channel target can be a GROUP, and a group is a guarded descriptor like
+            // any other. Checking only AGENT targets left that whole branch open. The
+            // label matters too: a refusal naming the wrong resource type sends the
+            // caller to ask the wrong owner.
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenReturn(privateTo("alice"));
+
+            var refusal = assertThrows(ForbiddenException.class,
+                    () -> guard(identity("bob"), settings, store).requireUseAccess(RESOURCE_ID, "group"));
+
+            assertTrue(refusal.getMessage().contains("group"), "the refusal must name what the caller cannot reach");
+            assertFalse(refusal.getMessage().contains("agent"));
+        }
+
+        @Test
+        @DisplayName("admits a member of the target's own space")
+        void admitsSpaceMember() throws Exception {
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenReturn(ownedBy("alice"));
+
+            assertDoesNotThrow(() -> guard(identity("alice"), settings, store).requireUseAccess(RESOURCE_ID, "group"));
+        }
+
+        @Test
+        @DisplayName("an unaddressed target is not this check's business to refuse")
+        void blankIdPasses() {
+            // The operation addressing nothing fails on its own terms; refusing here
+            // would turn a malformed request into a confusing authorisation error.
+            var g = guard(identity("bob"), settings, mock(IDocumentDescriptorStore.class));
+
+            assertDoesNotThrow(() -> g.requireUseAccess("  ", "group"));
+            assertDoesNotThrow(() -> g.requireUseAccess(null, "group"));
+        }
+
+        @Test
+        @DisplayName("requireAgentUseAccess still refuses as an agent")
+        void agentLabelUnchanged() throws Exception {
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenReturn(privateTo("alice"));
+
+            var refusal = assertThrows(ForbiddenException.class,
+                    () -> guard(identity("bob"), settings, store).requireAgentUseAccess(RESOURCE_ID));
+
+            assertTrue(refusal.getMessage().contains("agent"));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
@@ -145,12 +145,29 @@ class ResourceAccessGuardTest {
         }
 
         @Test
-        @DisplayName("a missing descriptor follows the legacy-visibility policy")
-        void missingDescriptorFollowsPolicy() throws Exception {
+        @DisplayName("a missing descriptor admits reading, and never more than reading")
+        void missingDescriptorIsReadOnly() throws Exception {
             var store = mock(IDocumentDescriptorStore.class);
             when(store.readCurrentDescriptor(RESOURCE_ID)).thenThrow(new IResourceStore.ResourceNotFoundException("none"));
+            var g = guard(identity("bob"), settings, store);
 
-            assertDoesNotThrow(() -> guard(identity("bob"), settings, store).requireAccess(RESOURCE_ID, AccessLevel.VIEW, "agent"));
+            // Some creation paths produce no descriptor at all — the setup API reaches the
+            // stores over an unauthenticated loopback call, for one. Treating that as OWN
+            // would hand every editor delete, undeploy and re-share on those resources.
+            assertDoesNotThrow(() -> g.requireAccess(RESOURCE_ID, AccessLevel.VIEW, "agent"));
+            assertDoesNotThrow(() -> g.requireAgentUseAccess(RESOURCE_ID));
+
+            assertThrows(ForbiddenException.class, () -> g.requireAccess(RESOURCE_ID, AccessLevel.EDIT, "agent"),
+                    "an absent record must not grant the authority to change the resource");
+            assertThrows(ForbiddenException.class, () -> g.requireAccess(RESOURCE_ID, AccessLevel.OWN, "agent"),
+                    "an absent record must not grant the authority to delete or re-share");
+        }
+
+        @Test
+        @DisplayName("admin-only legacy visibility refuses a missing descriptor outright")
+        void missingDescriptorUnderStrictPolicy() throws Exception {
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenThrow(new IResourceStore.ResourceNotFoundException("none"));
 
             var strict = settings(true, true, WorkspaceSettings.LEGACY_ADMIN_ONLY);
             assertThrows(ForbiddenException.class,
@@ -205,6 +222,17 @@ class ResourceAccessGuardTest {
             assertEquals(Subjects.personalSpace("alice"), stamped.getSpaceId());
             assertEquals(ResourceVisibility.space.wireName(), stamped.getVisibility());
             assertTrue(stamped.getAccessIndex().contains(Subjects.OWNER_TOKEN_PREFIX + "alice"));
+        }
+
+        @Test
+        @DisplayName("a principal with surrounding whitespace is stored trimmed")
+        void trimsThePrincipal() {
+            var settings = settings(false, true, WorkspaceSettings.LEGACY_SHARED);
+            var g = guard(identity("  alice  "), settings, mock(IDocumentDescriptorStore.class));
+
+            var stamped = g.stampNewDescriptor(new DocumentDescriptor());
+            assertEquals("alice", stamped.getOwnerId(),
+                    "CallerSpaces trims, so an untrimmed owner would never match its own principal again");
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
@@ -304,6 +304,12 @@ class ResourceAccessGuardTest {
         private final WorkspaceSettings enforcing = settings(true, true, WorkspaceSettings.LEGACY_SHARED);
         private final WorkspaceSettings notEnforcing = settings(false, true, WorkspaceSettings.LEGACY_SHARED);
 
+        private DocumentDescriptor publishedWithGrantsOwnedBy(String owner) {
+            var d = published(owner);
+            d.setGrants(List.of(new ResourceGrant(Subjects.user("bob"), AccessLevel.USE.name(), owner, new Date(0))));
+            return DescriptorAccess.rebuildIndex(d);
+        }
+
         private DocumentDescriptor published(String owner) {
             var d = ownedBy(owner);
             d.setVisibility(ResourceVisibility.published.wireName());
@@ -393,6 +399,41 @@ class ResourceAccessGuardTest {
             var g = guard(identity("carol"), enforcing, mock(IDocumentDescriptorStore.class));
 
             assertEquals(AccessLevel.VIEW.name(), g.redactForCaller(alreadyStamped).getCallerLevel());
+        }
+
+        @Test
+        @DisplayName("grants are NOT handed to a non-owner just because enforcement is off")
+        void grantsStayHiddenWhenNotEnforcing() {
+            // seesEverything() is true for everyone while enforcement is off, so
+            // keying disclosure on the granted level alone gave every editor the
+            // full grant audience of every resource. Ownership and grants ARE
+            // recorded in that state — the documented rollout is to let attribution
+            // accumulate before switching enforcement on — so this is a deployment
+            // part-way through the recommended path, broadcasting the audience lists
+            // it had just built up.
+            var g = guard(identity("carol"), notEnforcing, mock(IDocumentDescriptorStore.class));
+
+            var d = g.redactForCaller(publishedWithGrantsOwnedBy("alice"));
+
+            assertNull(d.getGrants());
+            assertNull(d.getAccessIndex());
+            assertEquals("alice", d.getOwnerId(), "owner and visibility still travel");
+        }
+
+        @Test
+        @DisplayName("an owner still sees their own grants while enforcement is off")
+        void ownerKeepsGrantsWhenNotEnforcing() {
+            var g = guard(identity("alice"), notEnforcing, mock(IDocumentDescriptorStore.class));
+
+            assertEquals(1, g.redactForCaller(publishedWithGrantsOwnedBy("alice")).getGrants().size());
+        }
+
+        @Test
+        @DisplayName("an administrator still sees them while enforcement is off")
+        void adminKeepsGrantsWhenNotEnforcing() {
+            var g = guard(identity("root", "eddi-admin"), notEnforcing, mock(IDocumentDescriptorStore.class));
+
+            assertEquals(1, g.redactForCaller(publishedWithGrantsOwnedBy("alice")).getGrants().size());
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.descriptors.model.ResourceGrant;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.engine.security.OwnershipValidator;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Enforcement behaviour, especially the answers that must be conservative: an
+ * unverifiable owner is not an absent owner, and a disabled feature must behave
+ * exactly like the release before it.
+ */
+class ResourceAccessGuardTest {
+
+    private static final String RESOURCE_ID = "abcdef1234567890abcdef";
+
+    private static WorkspaceSettings settings(boolean enabled, boolean authEnabled, String legacyVisibility) {
+        var s = new WorkspaceSettings(enabled, authEnabled, "groups", legacyVisibility, Optional.empty());
+        s.validate();
+        return s;
+    }
+
+    private static SecurityIdentity identity(String principal, String... roles) {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        if (principal == null) {
+            lenient().when(identity.isAnonymous()).thenReturn(true);
+            return identity;
+        }
+        lenient().when(identity.isAnonymous()).thenReturn(false);
+        Principal p = mock(Principal.class);
+        lenient().when(p.getName()).thenReturn(principal);
+        lenient().when(identity.getPrincipal()).thenReturn(p);
+        for (String role : roles) {
+            lenient().when(identity.hasRole(role)).thenReturn(true);
+        }
+        return identity;
+    }
+
+    private static DocumentDescriptor ownedBy(String owner) {
+        DocumentDescriptor d = new DocumentDescriptor();
+        d.setOwnerId(owner);
+        d.setSpaceId(Subjects.personalSpace(owner));
+        d.setVisibility(ResourceVisibility.space.wireName());
+        return DescriptorAccess.rebuildIndex(d);
+    }
+
+    private static ResourceAccessGuard guard(SecurityIdentity identity, WorkspaceSettings settings, IDocumentDescriptorStore store) {
+        var ownershipValidator = new OwnershipValidator(settings.isStampingOwnership());
+        var spaceContext = new SpaceContext(identity, settings);
+        return new ResourceAccessGuard(identity, ownershipValidator, spaceContext, settings, store);
+    }
+
+    @Nested
+    @DisplayName("when workspaces are not enforced")
+    class Disabled {
+
+        @Test
+        @DisplayName("everyone sees everything, exactly as before the feature existed")
+        void behavesLikeBefore() throws Exception {
+            var settings = settings(false, true, WorkspaceSettings.LEGACY_SHARED);
+            var store = mock(IDocumentDescriptorStore.class);
+            var g = guard(identity("bob"), settings, store);
+
+            assertTrue(g.seesEverything());
+            assertTrue(g.listingScope().isUnrestricted());
+            assertDoesNotThrow(() -> g.requireAccess(RESOURCE_ID, AccessLevel.OWN, "agent"));
+            assertEquals(AccessLevel.OWN, g.effectiveLevel(ownedBy("alice")));
+        }
+
+        @Test
+        @DisplayName("the flag alone does nothing while authentication is off")
+        void needsAuthentication() {
+            var settings = settings(true, false, WorkspaceSettings.LEGACY_SHARED);
+            assertFalse(settings.isEnforcing(),
+                    "with no authenticated principal there is nothing to scope to; enforcing would deny everyone everything");
+        }
+    }
+
+    @Nested
+    @DisplayName("when workspaces are enforced")
+    class Enforced {
+
+        private final WorkspaceSettings settings = settings(true, true, WorkspaceSettings.LEGACY_SHARED);
+
+        @Test
+        @DisplayName("the owner is admitted and a stranger is refused")
+        void ownerVersusStranger() throws Exception {
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenReturn(ownedBy("alice"));
+
+            assertDoesNotThrow(() -> guard(identity("alice"), settings, store).requireAccess(RESOURCE_ID, AccessLevel.OWN, "agent"));
+            assertThrows(ForbiddenException.class,
+                    () -> guard(identity("bob"), settings, store).requireAccess(RESOURCE_ID, AccessLevel.VIEW, "agent"));
+        }
+
+        @Test
+        @DisplayName("an admin is admitted without the descriptor being read at all")
+        void adminBypasses() throws Exception {
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(anyString())).thenThrow(new IResourceStore.ResourceStoreException("must not be called", null));
+
+            var g = guard(identity("root", "eddi-admin"), settings, store);
+            assertTrue(g.seesEverything());
+            assertDoesNotThrow(() -> g.requireAccess(RESOURCE_ID, AccessLevel.OWN, "agent"));
+            assertTrue(g.listingScope().isUnrestricted());
+        }
+
+        @Test
+        @DisplayName("a store failure denies rather than admits")
+        void failsClosedOnStoreError() throws Exception {
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenThrow(new IResourceStore.ResourceStoreException("db down", null));
+
+            // An owner that cannot be verified is not an absent owner. This mirrors
+            // ConversationAccessGuard, which refuses for the same reason.
+            assertThrows(ForbiddenException.class,
+                    () -> guard(identity("bob"), settings, store).requireAccess(RESOURCE_ID, AccessLevel.VIEW, "agent"));
+        }
+
+        @Test
+        @DisplayName("a missing descriptor follows the legacy-visibility policy")
+        void missingDescriptorFollowsPolicy() throws Exception {
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenThrow(new IResourceStore.ResourceNotFoundException("none"));
+
+            assertDoesNotThrow(() -> guard(identity("bob"), settings, store).requireAccess(RESOURCE_ID, AccessLevel.VIEW, "agent"));
+
+            var strict = settings(true, true, WorkspaceSettings.LEGACY_ADMIN_ONLY);
+            assertThrows(ForbiddenException.class,
+                    () -> guard(identity("bob"), strict, store).requireAccess(RESOURCE_ID, AccessLevel.VIEW, "agent"));
+        }
+
+        @Test
+        @DisplayName("USE admits a conversation but not a read of the configuration")
+        void useIsNarrowerThanView() throws Exception {
+            var d = ownedBy("alice");
+            d.setVisibility(ResourceVisibility.privateAccess.wireName());
+            d.setGrants(List.of(new ResourceGrant(Subjects.user("bob"), AccessLevel.USE.name(), "alice", new Date(0))));
+            DescriptorAccess.rebuildIndex(d);
+
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenReturn(d);
+            var g = guard(identity("bob"), settings, store);
+
+            assertDoesNotThrow(() -> g.requireAgentUseAccess(RESOURCE_ID));
+            assertThrows(ForbiddenException.class, () -> g.requireAccess(RESOURCE_ID, AccessLevel.VIEW, "agent"));
+        }
+
+        @Test
+        @DisplayName("an anonymous caller reaches a published agent and nothing else")
+        void anonymousReachesPublishedOnly() throws Exception {
+            var published = ownedBy("alice");
+            published.setVisibility(ResourceVisibility.published.wireName());
+            DescriptorAccess.rebuildIndex(published);
+
+            var store = mock(IDocumentDescriptorStore.class);
+            when(store.readCurrentDescriptor(RESOURCE_ID)).thenReturn(published);
+            assertDoesNotThrow(() -> guard(identity(null), settings, store).requireAgentUseAccess(RESOURCE_ID));
+
+            var store2 = mock(IDocumentDescriptorStore.class);
+            when(store2.readCurrentDescriptor(RESOURCE_ID)).thenReturn(ownedBy("alice"));
+            assertThrows(ForbiddenException.class, () -> guard(identity(null), settings, store2).requireAgentUseAccess(RESOURCE_ID));
+        }
+    }
+
+    @Nested
+    @DisplayName("stamping")
+    class Stamping {
+
+        @Test
+        @DisplayName("a new descriptor gets its creator, their space, and an index")
+        void stampsCreator() {
+            var settings = settings(false, true, WorkspaceSettings.LEGACY_SHARED);
+            var g = guard(identity("alice"), settings, mock(IDocumentDescriptorStore.class));
+
+            var stamped = g.stampNewDescriptor(new DocumentDescriptor());
+            assertEquals("alice", stamped.getOwnerId());
+            assertEquals(Subjects.personalSpace("alice"), stamped.getSpaceId());
+            assertEquals(ResourceVisibility.space.wireName(), stamped.getVisibility());
+            assertTrue(stamped.getAccessIndex().contains(Subjects.OWNER_TOKEN_PREFIX + "alice"));
+        }
+
+        @Test
+        @DisplayName("ownership is recorded even while enforcement is off")
+        void stampsWithoutEnforcement() {
+            var settings = settings(false, true, WorkspaceSettings.LEGACY_SHARED);
+            assertFalse(settings.isEnforcing());
+            assertTrue(settings.isStampingOwnership(),
+                    "an operator must be able to accumulate attribution before switching enforcement on");
+        }
+
+        @Test
+        @DisplayName("with no authenticated caller nothing is attributed, and the index still exists")
+        void stampsNothingWhenAnonymous() {
+            var settings = settings(false, false, WorkspaceSettings.LEGACY_SHARED);
+            var g = guard(identity(null), settings, mock(IDocumentDescriptorStore.class));
+
+            var stamped = g.stampNewDescriptor(new DocumentDescriptor());
+            assertEquals(null, stamped.getOwnerId());
+            assertTrue(stamped.getAccessIndex().contains(Subjects.LEGACY),
+                    "an unowned resource must still carry a token, or it can never be listed");
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -204,6 +205,54 @@ class ResourceAccessGuardTest {
             var store2 = mock(IDocumentDescriptorStore.class);
             when(store2.readCurrentDescriptor(RESOURCE_ID)).thenReturn(ownedBy("alice"));
             assertThrows(ForbiddenException.class, () -> guard(identity(null), settings, store2).requireAgentUseAccess(RESOURCE_ID));
+        }
+    }
+
+    @Nested
+    @DisplayName("redaction")
+    class Redaction {
+
+        private final WorkspaceSettings settings = settings(true, true, WorkspaceSettings.LEGACY_SHARED);
+
+        private DocumentDescriptor publishedWithGrants() {
+            var d = ownedBy("alice");
+            d.setVisibility(ResourceVisibility.published.wireName());
+            d.setGrants(List.of(new ResourceGrant(Subjects.user("bob"), AccessLevel.USE.name(), "alice", new Date(0))));
+            return DescriptorAccess.rebuildIndex(d);
+        }
+
+        @Test
+        @DisplayName("a non-owner listing a published resource does not receive its ACL")
+        void nonOwnerLosesGrants() {
+            var g = guard(identity("carol"), settings, mock(IDocumentDescriptorStore.class));
+
+            var redacted = g.redactForCaller(publishedWithGrants());
+
+            // Published grants VIEW to everyone, so without this every listing would
+            // serialise the full grant audience — real principal and team names — making
+            // describe()'s owner-only disclosure theatre.
+            assertNull(redacted.getGrants());
+            assertNull(redacted.getAccessIndex());
+            assertEquals("alice", redacted.getOwnerId(), "owner stays: the Manager's owner column needs it");
+            assertEquals(ResourceVisibility.published.wireName(), redacted.getVisibility());
+        }
+
+        @Test
+        @DisplayName("the owner keeps the full descriptor")
+        void ownerKeepsGrants() {
+            var g = guard(identity("alice"), settings, mock(IDocumentDescriptorStore.class));
+
+            var d = g.redactForCaller(publishedWithGrants());
+
+            assertEquals(1, d.getGrants().size());
+        }
+
+        @Test
+        @DisplayName("an admin keeps the full descriptor")
+        void adminKeepsGrants() {
+            var g = guard(identity("root", "eddi-admin"), settings, mock(IDocumentDescriptorStore.class));
+
+            assertEquals(1, g.redactForCaller(publishedWithGrants()).getGrants().size());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceAccessGuardTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -293,6 +294,115 @@ class ResourceAccessGuardTest {
             var g = guard(identity("carol"), settings, mock(IDocumentDescriptorStore.class));
 
             assertNull(g.redactUnlessOwner(publishedWithGrants(), null).getGrants());
+        }
+    }
+
+    @Nested
+    @DisplayName("callerLevel on a descriptor going out")
+    class CallerLevel {
+
+        private final WorkspaceSettings enforcing = settings(true, true, WorkspaceSettings.LEGACY_SHARED);
+        private final WorkspaceSettings notEnforcing = settings(false, true, WorkspaceSettings.LEGACY_SHARED);
+
+        private DocumentDescriptor published(String owner) {
+            var d = ownedBy(owner);
+            d.setVisibility(ResourceVisibility.published.wireName());
+            return DescriptorAccess.rebuildIndex(d);
+        }
+
+        @Test
+        @DisplayName("an owner is told they own it")
+        void ownerGetsOwn() {
+            var g = guard(identity("alice"), enforcing, mock(IDocumentDescriptorStore.class));
+
+            var d = g.redactForCaller(ownedBy("alice"));
+
+            assertEquals(AccessLevel.OWN.name(), d.getCallerLevel());
+        }
+
+        @Test
+        @DisplayName("a stranger reading a published resource is told VIEW, not OWN")
+        void publishedStrangerGetsView() {
+            // The whole point of the field: without it this row looks identical to
+            // one the caller owns, so a client offers Delete and Share on somebody
+            // else's agent and learns what it may do from a 403.
+            var g = guard(identity("carol"), enforcing, mock(IDocumentDescriptorStore.class));
+
+            var d = g.redactForCaller(published("alice"));
+
+            assertEquals(AccessLevel.VIEW.name(), d.getCallerLevel());
+            assertNull(d.getGrants(), "and still no grant list");
+        }
+
+        @Test
+        @DisplayName("a caller who may do nothing is told nothing, not USE")
+        void noAccessGetsNull() {
+            var privateToAlice = ownedBy("alice");
+            privateToAlice.setVisibility(ResourceVisibility.privateAccess.wireName());
+            DescriptorAccess.rebuildIndex(privateToAlice);
+            var g = guard(identity("bob"), enforcing, mock(IDocumentDescriptorStore.class));
+
+            var d = g.redactForCaller(privateToAlice);
+
+            assertNull(d.getCallerLevel());
+        }
+
+        @Test
+        @DisplayName("an administrator is told OWN")
+        void adminGetsOwn() {
+            var g = guard(identity("root", "eddi-admin"), enforcing, mock(IDocumentDescriptorStore.class));
+
+            assertEquals(AccessLevel.OWN.name(), g.redactForCaller(published("alice")).getCallerLevel());
+        }
+
+        @Test
+        @DisplayName("nothing is stamped while enforcement is off")
+        void absentWhenNotEnforcing() {
+            // Everyone may do everything then, so a level would be true and useless —
+            // and omitting it keeps the listing byte-identical to a deployment that
+            // has never heard of workspaces.
+            var g = guard(identity("carol"), notEnforcing, mock(IDocumentDescriptorStore.class));
+
+            var d = g.redactForCaller(published("alice"));
+
+            assertNull(d.getCallerLevel());
+            assertNotNull(d.getGrants() == null ? d.getOwnerId() : d.getOwnerId(), "owner still travels");
+        }
+
+        @Test
+        @DisplayName("a versioned read stamps the level it was gated with")
+        void versionedReadStampsTheGatedLevel() {
+            // Same reason the redaction uses it: the version in hand may name an
+            // owner who no longer owns the resource.
+            var g = guard(identity("carol"), enforcing, mock(IDocumentDescriptorStore.class));
+
+            var d = g.redactUnlessOwner(ownedBy("carol"), AccessLevel.VIEW);
+
+            assertEquals(AccessLevel.VIEW.name(), d.getCallerLevel());
+            assertNull(d.getGrants());
+        }
+
+        @Test
+        @DisplayName("a stamp never survives into the next caller's read")
+        void previousStampIsOverwritten() {
+            // Descriptors are deserialised fresh per read, so this cannot happen
+            // today — but it is one cached instance away from happening, and the
+            // failure would be a silent privilege report rather than an error.
+            var alreadyStamped = published("alice");
+            alreadyStamped.setCallerLevel(AccessLevel.OWN.name());
+            var g = guard(identity("carol"), enforcing, mock(IDocumentDescriptorStore.class));
+
+            assertEquals(AccessLevel.VIEW.name(), g.redactForCaller(alreadyStamped).getCallerLevel());
+        }
+
+        @Test
+        @DisplayName("a stamp is cleared rather than kept when enforcement is off")
+        void staleStampClearedWhenNotEnforcing() {
+            var alreadyStamped = published("alice");
+            alreadyStamped.setCallerLevel(AccessLevel.OWN.name());
+            var g = guard(identity("carol"), notEnforcing, mock(IDocumentDescriptorStore.class));
+
+            assertNull(g.redactForCaller(alreadyStamped).getCallerLevel());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.descriptors.model.ResourceGrant;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+import ai.labs.eddi.datastore.IResourceStore;
+import io.quarkus.security.ForbiddenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Sharing has two properties worth defending: it reaches the whole graph
+ * beneath an agent, and it stops at resources the sharer does not own.
+ */
+class ResourceSharingServiceTest {
+
+    private static final String AGENT = "agent0000000000000000";
+    private static final String OWNED_CHILD = "child0000000000000000";
+    private static final String BORROWED_CHILD = "borrow000000000000000";
+
+    private IDocumentDescriptorStore store;
+    private ResourceAccessGuard accessGuard;
+    private ConfigGraphResolver graphResolver;
+    private ResourceSharingService service;
+    private Map<String, DocumentDescriptor> descriptors;
+
+    private static DocumentDescriptor descriptor(String owner) {
+        DocumentDescriptor d = new DocumentDescriptor();
+        d.setOwnerId(owner);
+        d.setSpaceId(Subjects.personalSpace(owner));
+        d.setVisibility(ResourceVisibility.space.wireName());
+        return DescriptorAccess.rebuildIndex(d);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        descriptors = new HashMap<>();
+        descriptors.put(AGENT, descriptor("alice"));
+        descriptors.put(OWNED_CHILD, descriptor("alice"));
+        descriptors.put(BORROWED_CHILD, descriptor("bob"));
+
+        store = mock(IDocumentDescriptorStore.class);
+        when(store.readCurrentDescriptor(anyString())).thenAnswer(i -> {
+            var d = descriptors.get(i.<String>getArgument(0));
+            if (d == null) {
+                throw new IResourceStore.ResourceNotFoundException("none");
+            }
+            return d;
+        });
+        when(store.getCurrentResourceId(anyString())).thenAnswer(i -> new IResourceStore.IResourceId() {
+            @Override
+            public String getId() {
+                return i.getArgument(0);
+            }
+
+            @Override
+            public Integer getVersion() {
+                return 1;
+            }
+        });
+
+        accessGuard = mock(ResourceAccessGuard.class);
+        when(accessGuard.currentPrincipal()).thenReturn("alice");
+        // Alice owns the agent and one child; the other child is only lent to her.
+        when(accessGuard.canAccess(any(), eq(AccessLevel.OWN)))
+                .thenAnswer(i -> "alice".equals(i.<DocumentDescriptor>getArgument(0).getOwnerId()));
+        doAnswer(i -> {
+            DocumentDescriptor d = descriptors.get(i.<String>getArgument(0));
+            if (d != null && !"alice".equals(d.getOwnerId())) {
+                throw new ForbiddenException("not owner");
+            }
+            return null;
+        }).when(accessGuard).requireAccess(anyString(), eq(AccessLevel.OWN), anyString());
+
+        graphResolver = mock(ConfigGraphResolver.class);
+        when(graphResolver.referencedResourceIds(AGENT)).thenReturn(Set.of(OWNED_CHILD, BORROWED_CHILD));
+
+        service = new ResourceSharingService(store, accessGuard, graphResolver);
+    }
+
+    @Test
+    @DisplayName("sharing an agent reaches the resources it references")
+    void sharingCascades() {
+        var result = service.share(AGENT, Subjects.user("carol"), AccessLevel.VIEW, true);
+
+        assertTrue(result.updated().contains(AGENT));
+        assertTrue(result.updated().contains(OWNED_CHILD),
+                "an agent shared without its config graph is a name pointing at documents the recipient cannot open");
+        assertEquals(AccessLevel.VIEW, grantFor(descriptors.get(OWNED_CHILD), Subjects.user("carol")));
+    }
+
+    @Test
+    @DisplayName("a referenced resource the sharer does not own is skipped, not silently widened")
+    void doesNotResharePassOnBorrowedAccess() {
+        var result = service.share(AGENT, Subjects.user("carol"), AccessLevel.VIEW, true);
+
+        assertTrue(result.skipped().contains(BORROWED_CHILD));
+        assertFalse(result.updated().contains(BORROWED_CHILD));
+        assertEquals(null, grantFor(descriptors.get(BORROWED_CHILD), Subjects.user("carol")),
+                "you cannot pass on access you were only lent");
+    }
+
+    @Test
+    @DisplayName("cascade=false touches exactly the named resource")
+    void noCascade() {
+        var result = service.share(AGENT, Subjects.user("carol"), AccessLevel.USE, false);
+
+        assertEquals(List.of(AGENT), result.updated());
+        verify(graphResolver, org.mockito.Mockito.never()).referencedResourceIds(anyString());
+    }
+
+    @Test
+    @DisplayName("re-sharing replaces the level rather than accumulating a second grant")
+    void regrantReplaces() {
+        service.share(AGENT, Subjects.user("carol"), AccessLevel.VIEW, false);
+        service.share(AGENT, Subjects.user("carol"), AccessLevel.USE, false);
+
+        List<ResourceGrant> grants = descriptors.get(AGENT).getGrants();
+        assertEquals(1, grants.stream().filter(g -> Subjects.user("carol").equals(g.getSubject())).count(),
+                "a duplicate grant would make one revoke insufficient to actually revoke");
+        assertEquals(AccessLevel.USE, grantFor(descriptors.get(AGENT), Subjects.user("carol")));
+    }
+
+    @Test
+    @DisplayName("revoking removes the grant across the graph")
+    void revokeCascades() {
+        service.share(AGENT, Subjects.user("carol"), AccessLevel.VIEW, true);
+        service.revoke(AGENT, Subjects.user("carol"), true);
+
+        assertEquals(null, grantFor(descriptors.get(AGENT), Subjects.user("carol")));
+        assertEquals(null, grantFor(descriptors.get(OWNED_CHILD), Subjects.user("carol")));
+    }
+
+    @Test
+    @DisplayName("only the owner may share; EDIT is deliberately not enough")
+    void nonOwnerCannotShare() {
+        assertThrows(ForbiddenException.class,
+                () -> service.share(BORROWED_CHILD, Subjects.user("carol"), AccessLevel.VIEW, false));
+    }
+
+    @Test
+    @DisplayName("every write rebuilds the access index, or the change never reaches a listing")
+    void writesRebuildTheIndex() throws Exception {
+        service.share(AGENT, Subjects.user("carol"), AccessLevel.VIEW, false);
+
+        verify(accessGuard).stampModification(descriptors.get(AGENT));
+        verify(store).setDescriptor(eq(AGENT), anyInt(), eq(descriptors.get(AGENT)));
+    }
+
+    @Test
+    @DisplayName("publishing cascades, so a published agent is actually usable")
+    void publishCascades() {
+        var result = service.setVisibility(AGENT, ResourceVisibility.published, true);
+
+        assertEquals(ResourceVisibility.published.wireName(), descriptors.get(AGENT).getVisibility());
+        assertEquals(ResourceVisibility.published.wireName(), descriptors.get(OWNED_CHILD).getVisibility());
+        assertTrue(result.skipped().contains(BORROWED_CHILD));
+    }
+
+    @Test
+    @DisplayName("ownership transfer is administrators only")
+    void transferIsAdminOnly() {
+        when(accessGuard.isAdmin()).thenReturn(false);
+        assertThrows(ForbiddenException.class, () -> service.transferOwnership(AGENT, "dave", null, false));
+
+        when(accessGuard.isAdmin()).thenReturn(true);
+        service.transferOwnership(AGENT, "dave", null, false);
+        assertEquals("dave", descriptors.get(AGENT).getOwnerId());
+        assertEquals(Subjects.personalSpace("dave"), descriptors.get(AGENT).getSpaceId());
+    }
+
+    private static AccessLevel grantFor(DocumentDescriptor d, String subject) {
+        if (d.getGrants() == null) {
+            return null;
+        }
+        return d.getGrants().stream().filter(g -> subject.equals(g.getSubject())).map(ResourceGrant::accessLevel).findFirst().orElse(null);
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -145,7 +146,7 @@ class ResourceSharingServiceTest {
         var result = service.share(AGENT, Subjects.user("carol"), AccessLevel.USE, false);
 
         assertEquals(List.of(AGENT), result.updatedIds());
-        verify(graphResolver, org.mockito.Mockito.never()).referencedResourceIds(anyString());
+        verify(graphResolver, never()).referencedResourceIds(anyString());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
@@ -122,8 +122,8 @@ class ResourceSharingServiceTest {
     void sharingCascades() {
         var result = service.share(AGENT, Subjects.user("carol"), AccessLevel.VIEW, true);
 
-        assertTrue(result.updated().contains(AGENT));
-        assertTrue(result.updated().contains(OWNED_CHILD),
+        assertTrue(result.updatedIds().contains(AGENT));
+        assertTrue(result.updatedIds().contains(OWNED_CHILD),
                 "an agent shared without its config graph is a name pointing at documents the recipient cannot open");
         assertEquals(AccessLevel.VIEW, grantFor(descriptors.get(OWNED_CHILD), Subjects.user("carol")));
     }
@@ -133,8 +133,8 @@ class ResourceSharingServiceTest {
     void doesNotResharePassOnBorrowedAccess() {
         var result = service.share(AGENT, Subjects.user("carol"), AccessLevel.VIEW, true);
 
-        assertTrue(result.skipped().contains(BORROWED_CHILD));
-        assertFalse(result.updated().contains(BORROWED_CHILD));
+        assertTrue(result.skippedIds().contains(BORROWED_CHILD));
+        assertFalse(result.updatedIds().contains(BORROWED_CHILD));
         assertEquals(null, grantFor(descriptors.get(BORROWED_CHILD), Subjects.user("carol")),
                 "you cannot pass on access you were only lent");
     }
@@ -144,7 +144,7 @@ class ResourceSharingServiceTest {
     void noCascade() {
         var result = service.share(AGENT, Subjects.user("carol"), AccessLevel.USE, false);
 
-        assertEquals(List.of(AGENT), result.updated());
+        assertEquals(List.of(AGENT), result.updatedIds());
         verify(graphResolver, org.mockito.Mockito.never()).referencedResourceIds(anyString());
     }
 
@@ -193,7 +193,7 @@ class ResourceSharingServiceTest {
 
         assertEquals(ResourceVisibility.published.wireName(), descriptors.get(AGENT).getVisibility());
         assertEquals(ResourceVisibility.published.wireName(), descriptors.get(OWNED_CHILD).getVisibility());
-        assertTrue(result.skipped().contains(BORROWED_CHILD));
+        assertTrue(result.skippedIds().contains(BORROWED_CHILD));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
@@ -65,6 +65,8 @@ class ResourceSharingServiceTest {
         descriptors.put(BORROWED_CHILD, descriptor("bob"));
 
         store = mock(IDocumentDescriptorStore.class);
+        // describe() resolves through readCurrentDescriptor; the mutating paths resolve
+        // the version explicitly so they can write back to the version they read.
         when(store.readCurrentDescriptor(anyString())).thenAnswer(i -> {
             var d = descriptors.get(i.<String>getArgument(0));
             if (d == null) {
@@ -72,16 +74,28 @@ class ResourceSharingServiceTest {
             }
             return d;
         });
-        when(store.getCurrentResourceId(anyString())).thenAnswer(i -> new IResourceStore.IResourceId() {
-            @Override
-            public String getId() {
-                return i.getArgument(0);
+        when(store.readDescriptor(anyString(), anyInt())).thenAnswer(i -> {
+            var d = descriptors.get(i.<String>getArgument(0));
+            if (d == null) {
+                throw new IResourceStore.ResourceNotFoundException("none");
             }
+            return d;
+        });
+        when(store.getCurrentResourceId(anyString())).thenAnswer(i -> {
+            if (!descriptors.containsKey(i.<String>getArgument(0))) {
+                throw new IResourceStore.ResourceNotFoundException("none");
+            }
+            return new IResourceStore.IResourceId() {
+                @Override
+                public String getId() {
+                    return i.getArgument(0);
+                }
 
-            @Override
-            public Integer getVersion() {
-                return 1;
-            }
+                @Override
+                public Integer getVersion() {
+                    return 1;
+                }
+            };
         });
 
         accessGuard = mock(ResourceAccessGuard.class);

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/RestResourceSharingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/RestResourceSharingTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.descriptors.model.AccessLevel;
+import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
+import ai.labs.eddi.engine.security.spaces.rest.RestResourceSharing;
+import jakarta.ws.rs.BadRequestException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The layer between a query string and the sharing service.
+ *
+ * <h3>Why this deserves its own tests</h3> Everything here turns loose text
+ * into a decision about who can reach a resource, and every failure mode is
+ * silent: a level that parsed to something weaker, a subject nobody holds, a
+ * visibility guessed between three options that differ on who can read the
+ * thing. None of those look like errors afterwards — they look like a share
+ * that worked. So each one is asserted to be refused, and the refusal is
+ * asserted to happen <em>before</em> the service is called.
+ */
+class RestResourceSharingTest {
+
+    private static final String RESOURCE_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+    private ResourceSharingService service;
+    private RestResourceSharing sut;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(ResourceSharingService.class);
+        sut = new RestResourceSharing(service);
+    }
+
+    private static ResourceSharingService.ShareResult empty() {
+        return new ResourceSharingService.ShareResult(List.of(), List.of());
+    }
+
+    @Nested
+    @DisplayName("subject normalisation")
+    class Subject {
+
+        @Test
+        @DisplayName("a bare name is read as a person, because that is what people type")
+        void bareNameBecomesUser() {
+            when(service.share(anyString(), anyString(), any(), anyBoolean())).thenReturn(empty());
+
+            sut.share(RESOURCE_ID, "alice@example.com", "USE", true);
+
+            verify(service).share(eq(RESOURCE_ID), eq(Subjects.user("alice@example.com")), eq(AccessLevel.USE), eq(true));
+        }
+
+        @Test
+        @DisplayName("an explicit prefix is normalised, not passed through raw")
+        void prefixesAreNormalised() {
+            when(service.share(anyString(), anyString(), any(), anyBoolean())).thenReturn(empty());
+
+            // Keycloak wraps group paths in slashes; a subject stored with them would
+            // never match the token it is meant to match.
+            sut.share(RESOURCE_ID, "team:/engineering/", "VIEW", true);
+
+            verify(service).share(eq(RESOURCE_ID), eq(Subjects.team("engineering")), eq(AccessLevel.VIEW), eq(true));
+        }
+
+        @Test
+        @DisplayName("an unknown prefix is refused rather than read as a name")
+        void unknownPrefixRefused() {
+            // "group:" is a plausible typo for "team:". Reading it as a user named
+            // "group:engineering" would create a grant nobody holds, which is
+            // indistinguishable from a successful share.
+            var refusal = assertThrows(BadRequestException.class,
+                    () -> sut.share(RESOURCE_ID, "group:engineering", "USE", true));
+
+            assertTrue(refusal.getMessage().contains("user:"), "the refusal must say what IS accepted");
+            verify(service, never()).share(anyString(), anyString(), any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("a prefix with nothing after it is refused")
+        void emptyAfterPrefixRefused() {
+            assertThrows(BadRequestException.class, () -> sut.share(RESOURCE_ID, "user:", "USE", true));
+            assertThrows(BadRequestException.class, () -> sut.share(RESOURCE_ID, "user:   ", "USE", true));
+            assertThrows(BadRequestException.class, () -> sut.share(RESOURCE_ID, "team:///", "USE", true));
+
+            verify(service, never()).share(anyString(), anyString(), any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("a missing or blank subject is refused")
+        void blankSubjectRefused() {
+            assertThrows(BadRequestException.class, () -> sut.share(RESOURCE_ID, null, "USE", true));
+            assertThrows(BadRequestException.class, () -> sut.share(RESOURCE_ID, "   ", "USE", true));
+
+            verify(service, never()).share(anyString(), anyString(), any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("revoking normalises the subject the same way sharing does")
+        void revokeNormalisesIdentically() {
+            // If the two normalised differently, a grant could be created under one
+            // spelling and be un-revokable under the other.
+            when(service.revoke(anyString(), anyString(), anyBoolean())).thenReturn(empty());
+
+            sut.revoke(RESOURCE_ID, "  alice@example.com  ", true);
+
+            verify(service).revoke(eq(RESOURCE_ID), eq(Subjects.user("alice@example.com")), eq(true));
+        }
+
+        @Test
+        @DisplayName("revoking refuses the same subjects sharing refuses")
+        void revokeRefusesIdentically() {
+            assertThrows(BadRequestException.class, () -> sut.revoke(RESOURCE_ID, "group:engineering", true));
+            assertThrows(BadRequestException.class, () -> sut.revoke(RESOURCE_ID, null, true));
+
+            verify(service, never()).revoke(anyString(), anyString(), anyBoolean());
+        }
+    }
+
+    @Nested
+    @DisplayName("level and visibility parsing")
+    class Parsing {
+
+        @Test
+        @DisplayName("every level the API documents round-trips")
+        void allLevelsAccepted() {
+            when(service.share(anyString(), anyString(), any(), anyBoolean())).thenReturn(empty());
+
+            for (AccessLevel level : AccessLevel.values()) {
+                sut.share(RESOURCE_ID, "alice", level.name(), true);
+                verify(service).share(eq(RESOURCE_ID), anyString(), eq(level), anyBoolean());
+            }
+        }
+
+        @Test
+        @DisplayName("an unknown level is refused, not silently downgraded")
+        void unknownLevelRefused() {
+            // A typo that became a weaker grant looks exactly like a successful share,
+            // and a typo that became a stronger one is worse.
+            var refusal = assertThrows(BadRequestException.class,
+                    () -> sut.share(RESOURCE_ID, "alice", "ADMIN", true));
+
+            assertTrue(refusal.getMessage().contains("USE"), "the refusal must list what is accepted");
+            verify(service, never()).share(anyString(), anyString(), any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("every visibility the API documents round-trips")
+        void allVisibilitiesAccepted() {
+            when(service.setVisibility(anyString(), any(), anyBoolean())).thenReturn(empty());
+
+            for (ResourceVisibility visibility : ResourceVisibility.values()) {
+                sut.setVisibility(RESOURCE_ID, visibility.wireName(), true);
+                verify(service).setVisibility(eq(RESOURCE_ID), eq(visibility), anyBoolean());
+            }
+        }
+
+        @Test
+        @DisplayName("an unknown visibility is refused rather than guessed at")
+        void unknownVisibilityRefused() {
+            // The three options differ on who can read the resource. Guessing between
+            // them is not a recoverable mistake.
+            assertThrows(BadRequestException.class, () -> sut.setVisibility(RESOURCE_ID, "world-readable", true));
+            assertThrows(BadRequestException.class, () -> sut.setVisibility(RESOURCE_ID, null, true));
+
+            verify(service, never()).setVisibility(anyString(), any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("'private' is the wire spelling, and the constant name is accepted as an alias")
+        void privateHasTwoAcceptedSpellings() {
+            // The enum constant is `privateAccess` because `private` is a Java keyword,
+            // while the wire name is `private`. `parseOrNull` matches on both
+            // deliberately, so a client that read the constant name out of generated
+            // code is not punished for it. Pinned because the leniency is easy to lose
+            // in a refactor, and losing it would 400 a request that used to work.
+            when(service.setVisibility(anyString(), any(), anyBoolean())).thenReturn(empty());
+
+            sut.setVisibility(RESOURCE_ID, "private", true);
+            sut.setVisibility(RESOURCE_ID, "privateAccess", true);
+            sut.setVisibility(RESOURCE_ID, "PRIVATE", true);
+
+            verify(service, times(3)).setVisibility(eq(RESOURCE_ID), eq(ResourceVisibility.privateAccess), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("the leniency does not extend to something that is not a visibility")
+        void leniencyHasLimits() {
+            assertThrows(BadRequestException.class, () -> sut.setVisibility(RESOURCE_ID, "privat", true));
+            assertThrows(BadRequestException.class, () -> sut.setVisibility(RESOURCE_ID, "public", true));
+
+            verify(service, never()).setVisibility(anyString(), any(), anyBoolean());
+        }
+    }
+
+    @Nested
+    @DisplayName("cascade defaulting")
+    class Cascade {
+
+        @Test
+        @DisplayName("an absent cascade means true — a half-shared agent is not a useful default")
+        void absentCascadeIsTrue() {
+            // An agent shared without its workflows and rule sets is a name pointing at
+            // documents the recipient cannot open.
+            when(service.share(anyString(), anyString(), any(), anyBoolean())).thenReturn(empty());
+
+            sut.share(RESOURCE_ID, "alice", "USE", null);
+
+            verify(service).share(anyString(), anyString(), any(), eq(true));
+        }
+
+        @Test
+        @DisplayName("only an explicit false turns the cascade off")
+        void explicitFalseHonoured() {
+            when(service.share(anyString(), anyString(), any(), anyBoolean())).thenReturn(empty());
+
+            sut.share(RESOURCE_ID, "alice", "USE", false);
+
+            verify(service).share(anyString(), anyString(), any(), eq(false));
+        }
+
+        @Test
+        @DisplayName("visibility and revoke default the same way")
+        void otherOperationsDefaultIdentically() {
+            when(service.revoke(anyString(), anyString(), anyBoolean())).thenReturn(empty());
+            when(service.setVisibility(anyString(), any(), anyBoolean())).thenReturn(empty());
+
+            sut.revoke(RESOURCE_ID, "alice", null);
+            sut.setVisibility(RESOURCE_ID, "published", null);
+
+            verify(service).revoke(anyString(), anyString(), eq(true));
+            verify(service).setVisibility(anyString(), any(), eq(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("ownership transfer")
+    class Transfer {
+
+        @Test
+        @DisplayName("a transfer with no new owner is refused")
+        void ownerlessTransferRefused() {
+            assertThrows(BadRequestException.class, () -> sut.transferOwnership(RESOURCE_ID, null, null, true));
+            assertThrows(BadRequestException.class, () -> sut.transferOwnership(RESOURCE_ID, "  ", null, true));
+
+            verify(service, never()).transferOwnership(anyString(), anyString(), anyString(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("the new owner is trimmed, because ownership is compared by string")
+        void ownerIsTrimmed() {
+            // An owner stored with surrounding whitespace would never match its own
+            // principal again, and the new owner would silently not own it.
+            when(service.transferOwnership(anyString(), anyString(), any(), anyBoolean())).thenReturn(empty());
+
+            sut.transferOwnership(RESOURCE_ID, "  bob@example.com  ", null, true);
+
+            verify(service).transferOwnership(eq(RESOURCE_ID), eq("bob@example.com"), any(), anyBoolean());
+        }
+    }
+
+    @Test
+    @DisplayName("reading the sharing state passes the service's answer through unchanged")
+    void readSharesReturnsServiceAnswer() {
+        var info = new ResourceSharingService.ShareInfo(RESOURCE_ID, "alice", "user:alice",
+                ResourceVisibility.space.wireName(), List.of(), AccessLevel.OWN.name());
+        when(service.describe(RESOURCE_ID)).thenReturn(info);
+
+        var response = sut.readShares(RESOURCE_ID);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(info, response.getEntity());
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/RestWorkspacesTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/RestWorkspacesTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.engine.security.OwnershipValidator;
+import ai.labs.eddi.engine.security.spaces.rest.RestWorkspaces;
+import ai.labs.eddi.engine.security.spaces.rest.model.SpaceInfo;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The contract a client draws its workspace UI from.
+ * <p>
+ * The load-bearing assertion here is that space ids come back <em>encoded</em>
+ * and labels come back <em>decoded</em>. A client that receives a decoded id
+ * and sends it as {@code ?space=} selects nothing, and selecting nothing
+ * renders as "you have no agents" rather than as an error — so the two are
+ * pinned separately, with a principal that actually needs escaping.
+ */
+class RestWorkspacesTest {
+
+    private static WorkspaceSettings settings(boolean enabled) {
+        var s = new WorkspaceSettings(enabled, true, "groups", WorkspaceSettings.LEGACY_SHARED, Optional.empty());
+        s.validate();
+        return s;
+    }
+
+    private static SecurityIdentity identity(String principal, Set<String> groups, String... roles) {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        if (principal == null) {
+            lenient().when(identity.isAnonymous()).thenReturn(true);
+            return identity;
+        }
+        lenient().when(identity.isAnonymous()).thenReturn(false);
+        Principal p = mock(Principal.class);
+        lenient().when(p.getName()).thenReturn(principal);
+        lenient().when(identity.getPrincipal()).thenReturn(p);
+        lenient().when(identity.<Object>getAttribute("groups")).thenReturn(groups);
+        for (String role : roles) {
+            lenient().when(identity.hasRole(role)).thenReturn(true);
+        }
+        return identity;
+    }
+
+    private static RestWorkspaces sut(SecurityIdentity identity, WorkspaceSettings settings) {
+        var spaceContext = new SpaceContext(identity, settings);
+        var guard = new ResourceAccessGuard(identity, new OwnershipValidator(settings.isStampingOwnership()), spaceContext,
+                settings, mock(IDocumentDescriptorStore.class));
+        return new RestWorkspaces(spaceContext, settings, guard);
+    }
+
+    @Test
+    @DisplayName("reports the caller's personal space first, then teams")
+    void listsSpacesPersonalFirst() {
+        var info = sut(identity("alice", Set.of("/engineering")), settings(true)).readWorkspaceInfo();
+
+        assertTrue(info.enabled());
+        assertEquals("alice", info.principal());
+        assertEquals(List.of("personal", "team"), info.spaces().stream().map(SpaceInfo::kind).toList());
+        assertEquals(Subjects.personalSpace("alice"), info.spaces().getFirst().id());
+        assertEquals(Subjects.teamSpace("/engineering"), info.spaces().get(1).id());
+    }
+
+    @Test
+    @DisplayName("ids stay encoded while labels come back readable")
+    void encodesIdsButNotLabels() {
+        // A principal carrying the index delimiter. If the id were served decoded,
+        // a client would send back a space that matches nothing.
+        var info = sut(identity("a|b", Set.of()), settings(true)).readWorkspaceInfo();
+
+        SpaceInfo personal = info.spaces().getFirst();
+        assertEquals("user:a%7Cb", personal.id());
+        assertEquals("a|b", personal.label());
+        assertEquals("a|b", info.principal(), "the principal is the ownerId a client compares against, so it is not encoded");
+    }
+
+    @Test
+    @DisplayName("says enforcement is off, so a client can hide sharing rather than offer a no-op")
+    void reportsDisabled() {
+        var info = sut(identity("alice", Set.of("/engineering")), settings(false)).readWorkspaceInfo();
+
+        assertFalse(info.enabled());
+        assertTrue(info.seesEverything(), "nobody is restricted while the feature is off");
+        // Still described: the client can say who you are either way. Only `enabled`
+        // decides whether the sharing controls are worth drawing.
+        assertEquals(2, info.spaces().size());
+    }
+
+    @Test
+    @DisplayName("an administrator is told they see everything")
+    void reportsAdminReach() {
+        var info = sut(identity("root", Set.of(), "eddi-admin"), settings(true)).readWorkspaceInfo();
+
+        assertTrue(info.enabled());
+        assertTrue(info.seesEverything());
+    }
+
+    @Test
+    @DisplayName("a non-admin under enforcement is not told they see everything")
+    void reportsRestrictedReach() {
+        var info = sut(identity("alice", Set.of()), settings(true)).readWorkspaceInfo();
+
+        assertFalse(info.seesEverything());
+    }
+
+    @Test
+    @DisplayName("an anonymous caller gets no spaces at all")
+    void anonymousHasNoSpaces() {
+        // Not "every space" and not "a space named null" — the backend resolves
+        // anonymous to nothing, and a client must not offer a filter the server
+        // will not honour.
+        var info = sut(identity(null, Set.of()), settings(true)).readWorkspaceInfo();
+
+        assertNull(info.principal());
+        assertNull(info.defaultSpace());
+        assertTrue(info.spaces().isEmpty());
+    }
+
+    @Test
+    @DisplayName("the default write space is the one new resources land in")
+    void reportsDefaultWriteSpace() {
+        var info = sut(identity("alice", Set.of("/engineering")), settings(true)).readWorkspaceInfo();
+
+        assertEquals(Subjects.personalSpace("alice"), info.defaultSpace());
+    }
+
+    @Test
+    @DisplayName("a configured default team overrides the personal space")
+    void honoursConfiguredDefaultTeam() {
+        var settings = new WorkspaceSettings(true, true, "groups", WorkspaceSettings.LEGACY_SHARED, Optional.of("engineering"));
+        settings.validate();
+
+        var info = sut(identity("alice", Set.of("/engineering")), settings).readWorkspaceInfo();
+
+        assertEquals(Subjects.teamSpace("engineering"), info.defaultSpace());
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/SpaceContextTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/SpaceContextTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.json.Json;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Reading who the caller is, and which groups they are in.
+ *
+ * <h3>The failure mode this is defending against is silence</h3> A groups claim
+ * arrives as a JSON array through one code path, a {@code List<String>} through
+ * another, and a bare string when it is single-valued — depending on how the
+ * token was parsed. If a shape is not handled, nothing throws: the caller
+ * simply has no team spaces, and every resource shared with their team becomes
+ * invisible to them. That reads as "nobody shared anything with me", which is
+ * not a bug report anyone can act on. So each shape is pinned.
+ */
+class SpaceContextTest {
+
+    private static WorkspaceSettings settings() {
+        return settings("groups");
+    }
+
+    private static WorkspaceSettings settings(String groupsClaim) {
+        var s = new WorkspaceSettings(true, true, groupsClaim, WorkspaceSettings.LEGACY_SHARED, Optional.empty());
+        s.validate();
+        return s;
+    }
+
+    /** An identity whose groups arrive as an identity attribute (non-OIDC path). */
+    private static SecurityIdentity withAttribute(String principal, Object claim) {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        lenient().when(identity.isAnonymous()).thenReturn(false);
+        Principal p = mock(Principal.class);
+        lenient().when(p.getName()).thenReturn(principal);
+        lenient().when(identity.getPrincipal()).thenReturn(p);
+        lenient().when(identity.<Object>getAttribute("groups")).thenReturn(claim);
+        return identity;
+    }
+
+    /** An identity whose principal is a JWT, which is the OIDC path. */
+    private static SecurityIdentity withJwtClaim(String principal, Object claim) {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        lenient().when(identity.isAnonymous()).thenReturn(false);
+        JsonWebToken jwt = mock(JsonWebToken.class);
+        lenient().when(jwt.getName()).thenReturn(principal);
+        lenient().when(jwt.<Object>getClaim("groups")).thenReturn(claim);
+        lenient().when(identity.getPrincipal()).thenReturn(jwt);
+        return identity;
+    }
+
+    private static SpaceContext contextFor(SecurityIdentity identity) {
+        return new SpaceContext(identity, settings());
+    }
+
+    @Nested
+    @DisplayName("the groups claim, in every shape it actually arrives in")
+    class GroupsClaim {
+
+        @Test
+        @DisplayName("a list of strings")
+        void listOfStrings() {
+            var ctx = contextFor(withJwtClaim("alice", List.of("/engineering", "/design")));
+
+            assertEquals(Set.of("/engineering", "/design"), ctx.currentGroupPaths());
+        }
+
+        @Test
+        @DisplayName("a JSON array, which is what an OIDC token often deserialises to")
+        void jsonArray() {
+            var array = Json.createArrayBuilder().add("/engineering").add("/design").build();
+
+            var ctx = contextFor(withJwtClaim("alice", array));
+
+            // JsonString stringifies WITH surrounding quotes. Left unhandled the space
+            // id becomes team:"engineering", which matches nothing and looks like an
+            // empty workspace rather than a parsing bug.
+            assertEquals(Set.of("/engineering", "/design"), ctx.currentGroupPaths());
+        }
+
+        @Test
+        @DisplayName("a bare string, which is what a single-valued claim can arrive as")
+        void bareString() {
+            var ctx = contextFor(withJwtClaim("alice", "/engineering"));
+
+            assertEquals(Set.of("/engineering"), ctx.currentGroupPaths());
+        }
+
+        @Test
+        @DisplayName("an array of strings")
+        void stringArray() {
+            var ctx = contextFor(withJwtClaim("alice", new Object[]{"/engineering", "/design"}));
+
+            assertEquals(Set.of("/engineering", "/design"), ctx.currentGroupPaths());
+        }
+
+        @Test
+        @DisplayName("an identity attribute, for a non-OIDC augmentor")
+        void identityAttribute() {
+            // The principal is not a JsonWebToken here, so the JWT branch cannot fire.
+            var ctx = contextFor(withAttribute("alice", List.of("/engineering")));
+
+            assertEquals(Set.of("/engineering"), ctx.currentGroupPaths());
+        }
+
+        @Test
+        @DisplayName("no claim at all is a realm without a group mapper, not a failure")
+        void noClaim() {
+            var ctx = contextFor(withJwtClaim("alice", null));
+
+            assertTrue(ctx.currentGroupPaths().isEmpty());
+            // And the caller still has their own space — losing that would hide their
+            // own work from them.
+            assertEquals(Set.of(Subjects.personalSpace("alice")), ctx.current().spaces());
+        }
+
+        @Test
+        @DisplayName("blank entries are dropped rather than becoming a space nobody holds")
+        void blankEntriesDropped() {
+            var ctx = contextFor(withJwtClaim("alice", List.of("  ", "/engineering", "")));
+
+            assertEquals(Set.of("/engineering"), ctx.currentGroupPaths());
+        }
+
+        @Test
+        @DisplayName("a claim that throws is treated as absent rather than failing the request")
+        void throwingClaimIsAbsent() {
+            SecurityIdentity identity = mock(SecurityIdentity.class);
+            lenient().when(identity.isAnonymous()).thenReturn(false);
+            JsonWebToken jwt = mock(JsonWebToken.class);
+            lenient().when(jwt.getName()).thenReturn("alice");
+            lenient().when(jwt.getClaim("groups")).thenThrow(new IllegalStateException("malformed"));
+            lenient().when(identity.getPrincipal()).thenReturn(jwt);
+
+            var ctx = new SpaceContext(identity, settings());
+
+            // Fail-closed on membership, not on the whole request: the caller keeps
+            // their personal space and simply sees no team resources.
+            assertTrue(ctx.currentGroupPaths().isEmpty());
+            assertEquals("alice", ctx.currentPrincipal());
+        }
+
+        @Test
+        @DisplayName("the claim name is configurable, and a different one is genuinely read")
+        void honoursConfiguredClaimName() {
+            SecurityIdentity identity = mock(SecurityIdentity.class);
+            lenient().when(identity.isAnonymous()).thenReturn(false);
+            JsonWebToken jwt = mock(JsonWebToken.class);
+            lenient().when(jwt.getName()).thenReturn("alice");
+            lenient().when(jwt.<Object>getClaim("roles_as_groups")).thenReturn(List.of("/engineering"));
+            lenient().when(jwt.<Object>getClaim("groups")).thenReturn(List.of("/should-not-be-read"));
+            lenient().when(identity.getPrincipal()).thenReturn(jwt);
+
+            var ctx = new SpaceContext(identity, settings("roles_as_groups"));
+
+            assertEquals(Set.of("/engineering"), ctx.currentGroupPaths());
+        }
+    }
+
+    @Nested
+    @DisplayName("the principal")
+    class CurrentPrincipal {
+
+        @Test
+        @DisplayName("an anonymous caller resolves to nothing, not to a name")
+        void anonymousIsNull() {
+            SecurityIdentity identity = mock(SecurityIdentity.class);
+            lenient().when(identity.isAnonymous()).thenReturn(true);
+
+            var ctx = new SpaceContext(identity, settings());
+
+            assertNull(ctx.currentPrincipal());
+            assertNull(ctx.defaultWriteSpace());
+            assertTrue(ctx.current().isAnonymous());
+            assertTrue(ctx.current().spaces().isEmpty());
+            assertTrue(ctx.currentGroupPaths().isEmpty());
+        }
+
+        @Test
+        @DisplayName("a blank principal name is nobody")
+        void blankNameIsNull() {
+            var ctx = contextFor(withJwtClaim("   ", null));
+
+            assertNull(ctx.currentPrincipal());
+        }
+
+        @Test
+        @DisplayName("the personal space comes first, then teams")
+        void personalSpaceFirst() {
+            var ctx = contextFor(withJwtClaim("alice", List.of("/engineering")));
+
+            var spaces = List.copyOf(ctx.current().spaces());
+            assertEquals(Subjects.personalSpace("alice"), spaces.get(0));
+            assertTrue(spaces.contains(Subjects.teamSpace("/engineering")));
+        }
+
+        @Test
+        @DisplayName("membership in a child group is not membership in its parent")
+        void nestedGroupsStayDistinct() {
+            var ctx = contextFor(withJwtClaim("alice", List.of("/engineering/backend")));
+
+            var spaces = ctx.current().spaces();
+            assertTrue(spaces.contains(Subjects.teamSpace("/engineering/backend")));
+            assertFalse(spaces.contains(Subjects.teamSpace("/engineering")),
+                    "inventing the parent would hand out access nobody granted");
+        }
+    }
+
+    @Nested
+    @DisplayName("the default write space")
+    class DefaultWriteSpace {
+
+        @Test
+        @DisplayName("new resources land in the creator's personal space by default")
+        void defaultsToPersonal() {
+            var ctx = contextFor(withJwtClaim("alice", List.of("/engineering")));
+
+            assertEquals(Subjects.personalSpace("alice"), ctx.defaultWriteSpace());
+        }
+
+        @Test
+        @DisplayName("a configured team overrides it, for a team-first deployment")
+        void configuredTeamWins() {
+            var s = new WorkspaceSettings(true, true, "groups", WorkspaceSettings.LEGACY_SHARED, Optional.of("engineering"));
+            s.validate();
+
+            var ctx = new SpaceContext(withJwtClaim("alice", List.of()), s);
+
+            assertEquals(Subjects.teamSpace("engineering"), ctx.defaultWriteSpace());
+        }
+
+        @Test
+        @DisplayName("a configured team applies even to someone who is not in it")
+        void configuredTeamAppliesRegardlessOfMembership() {
+            // Deliberate: this is the deployment saying "everything is filed here",
+            // not a per-user preference. Whether the creator can then SEE it is the
+            // access model's business, and it says no — which is why an operator
+            // setting this must also add people to that group.
+            var s = new WorkspaceSettings(true, true, "groups", WorkspaceSettings.LEGACY_SHARED, Optional.of("engineering"));
+            s.validate();
+
+            var ctx = new SpaceContext(withJwtClaim("outsider", List.of()), s);
+
+            assertEquals(Subjects.teamSpace("engineering"), ctx.defaultWriteSpace());
+            assertFalse(ctx.current().spaces().contains(Subjects.teamSpace("engineering")));
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/SubjectsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/SubjectsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.security.spaces;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The escaping here is not cosmetic: both storage backends treat a
+ * {@code String} query filter as a <em>regular expression</em>, so an unescaped
+ * identity predicate is a cross-user data leak rather than a style problem.
+ * These tests exist to fail if that escaping is ever removed.
+ */
+class SubjectsTest {
+
+    @Nested
+    @DisplayName("token encoding")
+    class Encoding {
+
+        @Test
+        @DisplayName("a principal containing the delimiter cannot forge extra tokens")
+        void encodesDelimiter() {
+            String forged = Subjects.user("alice|user:admin");
+            assertFalse(forged.contains("|"), "an encoded subject must contain no raw delimiter: " + forged);
+            assertEquals("user:alice%7Cuser:admin", forged);
+        }
+
+        @Test
+        @DisplayName("percent is escaped so encoding is reversible")
+        void roundTripsPercent() {
+            String raw = "a%7Cb";
+            String encoded = Subjects.encode(raw);
+            assertEquals("a%257Cb", encoded);
+            assertEquals(raw, Subjects.decode(encoded), "decoding must not turn a literal %7C into a delimiter");
+        }
+
+        @Test
+        @DisplayName("ordinary principals are left alone")
+        void leavesOrdinaryPrincipalsAlone() {
+            assertEquals("user:alice@example.com", Subjects.user("alice@example.com"));
+            assertEquals("team:engineering", Subjects.team("/engineering/"));
+            assertEquals("team:engineering/backend", Subjects.team("/engineering/backend"));
+        }
+
+        @Test
+        @DisplayName("blank and slash-only inputs yield no subject at all")
+        void rejectsBlank() {
+            assertNull(Subjects.user(""));
+            assertNull(Subjects.user(null));
+            assertNull(Subjects.team("   "));
+            assertNull(Subjects.team("///"), "a path of nothing but separators names no group");
+        }
+    }
+
+    @Nested
+    @DisplayName("regex safety")
+    class RegexSafety {
+
+        /**
+         * MongoDB uses PCRE and PostgreSQL POSIX ERE; Java's Pattern stands in for
+         * both.
+         */
+        private boolean matches(String pattern, String accessIndex) {
+            return Pattern.compile(pattern).matcher(accessIndex).find();
+        }
+
+        @Test
+        @DisplayName("a token pattern does not match a longer principal that contains it")
+        void doesNotMatchSubstring() {
+            String pattern = Subjects.tokenPattern(Subjects.user("alice"));
+            assertTrue(matches(pattern, "|user:alice|"), "must match the exact subject");
+            assertFalse(matches(pattern, "|user:malice|"), "must not match a principal that merely contains it");
+            assertFalse(matches(pattern, "|user:alice2|"), "must not match a longer principal with the same prefix");
+        }
+
+        @Test
+        @DisplayName("a dot in an email address is a literal, not a wildcard")
+        void escapesDot() {
+            String pattern = Subjects.tokenPattern(Subjects.user("a.c@example.com"));
+            assertTrue(matches(pattern, "|user:a.c@example.com|"));
+            assertFalse(matches(pattern, "|user:abc@example.com|"), "the dot must not match an arbitrary character");
+        }
+
+        @Test
+        @DisplayName("regex metacharacters in a principal cannot alter the predicate")
+        void escapesMetacharacters() {
+            String pattern = Subjects.tokenPattern(Subjects.user("a|b"));
+            // The pipe is encoded away first, so alternation is impossible even before
+            // escaping — belt and braces, and this asserts both halves hold together.
+            assertFalse(matches(pattern, "|user:b|"), "an alternation must not be smuggled in through a principal name");
+            assertTrue(matches(pattern, "|user:a%7Cb|"));
+        }
+
+        @Test
+        @DisplayName("an exact pattern is anchored at both ends")
+        void exactPatternIsAnchored() {
+            String pattern = Subjects.exactPattern("user:alice");
+            assertTrue(matches(pattern, "user:alice"));
+            assertFalse(matches(pattern, "user:alice2"));
+            assertFalse(matches(pattern, "xuser:alice"));
+        }
+
+        @Test
+        @DisplayName("escaping is confined to metacharacters both engines agree on")
+        void escapesOnlySharedMetacharacters() {
+            // Escaping an ordinary character is undefined in POSIX ERE, so it must not
+            // happen: this is what keeps the predicate portable across the two backends.
+            assertEquals("abc_1-2", Subjects.escapeRegex("abc_1-2"));
+            assertEquals("\\.\\^\\$\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\\\", Subjects.escapeRegex(".^$*+?()[]{}|\\"));
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/triggermanagement/rest/RestAgentTriggerStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/triggermanagement/rest/RestAgentTriggerStoreTest.java
@@ -4,12 +4,15 @@
  */
 package ai.labs.eddi.engine.triggermanagement.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
 import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.caching.ICache;
 import ai.labs.eddi.engine.caching.ICacheFactory;
 import ai.labs.eddi.engine.triggermanagement.IAgentTriggerStore;
+import ai.labs.eddi.engine.model.AgentDeployment;
 import ai.labs.eddi.engine.triggermanagement.model.AgentTriggerConfiguration;
+import io.quarkus.security.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +33,7 @@ class RestAgentTriggerStoreTest {
 
     private RestAgentTriggerStore restAgentTriggerStore;
     private IAgentTriggerStore agentTriggerStore;
+    private ResourceAccessGuard resourceAccessGuard;
     private ICache<String, AgentTriggerConfiguration> cache;
 
     @SuppressWarnings("unchecked")
@@ -40,7 +44,26 @@ class RestAgentTriggerStoreTest {
         cache = mock(ICache.class);
         doReturn(cache).when(cacheFactory).getCache("agentTriggers");
 
-        restAgentTriggerStore = new RestAgentTriggerStore(agentTriggerStore, cacheFactory);
+        resourceAccessGuard = mock(ResourceAccessGuard.class);
+        restAgentTriggerStore = new RestAgentTriggerStore(agentTriggerStore, cacheFactory, resourceAccessGuard);
+    }
+
+    @Test
+    void createAgentTrigger_agentTheCallerMayNotUse_refused() throws Exception {
+        // A trigger routes inbound messages into conversations with the agents its
+        // deployments name, and that routing runs with no interactive caller — below
+        // the USE gate by design. So the gate lives at authoring time; without it,
+        // pointing a trigger at a private agent is a standing bypass of the check on
+        // /agents/{id}/start.
+        var deployment = new AgentDeployment();
+        deployment.setAgentId("abcdef1234567890abcdef");
+        var configuration = new AgentTriggerConfiguration();
+        configuration.setIntent("greeting");
+        configuration.getAgentDeployments().add(deployment);
+        doThrow(new ForbiddenException("no")).when(resourceAccessGuard).requireAgentUseAccess("abcdef1234567890abcdef");
+
+        assertThrows(ForbiddenException.class, () -> restAgentTriggerStore.createAgentTrigger(configuration));
+        verify(agentTriggerStore, never()).createAgentTrigger(any());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/integration/WorkspacesIT.java
+++ b/src/test/java/ai/labs/eddi/integration/WorkspacesIT.java
@@ -6,12 +6,9 @@ package ai.labs.eddi.integration;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import ai.labs.eddi.utils.RestUtilities;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.net.URI;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -206,14 +203,17 @@ public class WorkspacesIT extends BaseIntegrationIT {
         // An agent is created first because `everyItem` over an empty list is
         // vacuously true, and this suite seeds nothing of its own — the assertion
         // would otherwise hold whatever the server sent.
+        // `packages` is the whole of an AgentConfiguration — name and description
+        // live on the DESCRIPTOR, and StrictConfigurationBodyInterceptor rejects a
+        // body carrying them. An empty list is enough: this test needs a descriptor
+        // to exist, not an agent that runs.
         String location = createResource("""
-                { "name": "Workspace IT Agent", "description": "created so the listing below is not empty" }
-                """, "/agentstore/agents");
-        var created = RestUtilities.extractResourceId(URI.create(location));
+                {"packages": []}""", "/agentstore/agents");
+        var created = extractResourceId(location);
 
         try {
             given()
-                    .queryParam("filter", created.getId())
+                    .queryParam("filter", created.id())
                     .queryParam("limit", 5)
                     .when().get(AGENT_DESCRIPTORS)
                     .then()
@@ -221,7 +221,7 @@ public class WorkspacesIT extends BaseIntegrationIT {
                     .body("$", hasSize(greaterThan(0)))
                     .body("callerLevel", everyItem(nullValue()));
         } finally {
-            deleteResourceQuietly("/agentstore/agents/", created.getId(), created.getVersion());
+            deleteResourceQuietly("/agentstore/agents/", created.id(), created.version());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/integration/WorkspacesIT.java
+++ b/src/test/java/ai/labs/eddi/integration/WorkspacesIT.java
@@ -6,13 +6,17 @@ package ai.labs.eddi.integration;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import ai.labs.eddi.utils.RestUtilities;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -88,18 +92,26 @@ public class WorkspacesIT extends BaseIntegrationIT {
     }
 
     @Test
-    @DisplayName("a space id carrying regex metacharacters is matched literally, not as a pattern")
-    void spaceParameterIsNotAPattern() {
-        // Both storage backends treat a String filter as a regular expression, so an
-        // unescaped identity predicate is a real vulnerability rather than a style
-        // note. `.*` must select nothing, not everything.
+    @DisplayName("a space id carrying regex metacharacters is handled, not rejected")
+    void spaceParameterAcceptsMetacharacters() {
+        // NOT a test that `.*` matches nothing — it cannot be, here. This profile
+        // sets authorization.enabled=false, so no descriptor is ever stamped with a
+        // spaceId, and an empty result proves only that the field is absent. An
+        // earlier version asserted hasSize(0) and would have passed with the
+        // escaping removed entirely.
+        //
+        // What this DOES pin is that a metacharacter-laden value reaches the query
+        // layer and comes back as a well-formed empty page rather than a 500 from a
+        // malformed pattern. The escaping itself is covered where it can actually be
+        // observed: AccessScopeTest (anchored, escaped predicate) and SubjectsTest
+        // (the shared PCRE/POSIX-ERE metacharacter set).
         given()
                 .queryParam("space", ".*")
                 .queryParam("limit", 50)
                 .when().get(AGENT_DESCRIPTORS)
                 .then()
                 .statusCode(200)
-                .body("$", hasSize(0));
+                .contentType(ContentType.JSON);
     }
 
     @Test
@@ -190,12 +202,27 @@ public class WorkspacesIT extends BaseIntegrationIT {
         // listing is byte-identical to a deployment that has never heard of
         // workspaces. A client that started drawing per-row permissions from this
         // field would otherwise change behaviour on a deployment that did not opt in.
-        given()
-                .queryParam("limit", 5)
-                .when().get(AGENT_DESCRIPTORS)
-                .then()
-                .statusCode(200)
-                .body("callerLevel", everyItem(nullValue()));
+        //
+        // An agent is created first because `everyItem` over an empty list is
+        // vacuously true, and this suite seeds nothing of its own — the assertion
+        // would otherwise hold whatever the server sent.
+        String location = createResource("""
+                { "name": "Workspace IT Agent", "description": "created so the listing below is not empty" }
+                """, "/agentstore/agents");
+        var created = RestUtilities.extractResourceId(URI.create(location));
+
+        try {
+            given()
+                    .queryParam("filter", created.getId())
+                    .queryParam("limit", 5)
+                    .when().get(AGENT_DESCRIPTORS)
+                    .then()
+                    .statusCode(200)
+                    .body("$", hasSize(greaterThan(0)))
+                    .body("callerLevel", everyItem(nullValue()));
+        } finally {
+            deleteResourceQuietly("/agentstore/agents/", created.getId(), created.getVersion());
+        }
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/integration/WorkspacesIT.java
+++ b/src/test/java/ai/labs/eddi/integration/WorkspacesIT.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -180,6 +181,21 @@ public class WorkspacesIT extends BaseIntegrationIT {
                 .then()
                 .statusCode(200)
                 .body("principal", nullValue());
+    }
+
+    @Test
+    @DisplayName("no caller level is stamped while workspaces are off")
+    void noCallerLevelWhenDisabled() {
+        // The compatibility property, asserted on the wire: with enforcement off a
+        // listing is byte-identical to a deployment that has never heard of
+        // workspaces. A client that started drawing per-row permissions from this
+        // field would otherwise change behaviour on a deployment that did not opt in.
+        given()
+                .queryParam("limit", 5)
+                .when().get(AGENT_DESCRIPTORS)
+                .then()
+                .statusCode(200)
+                .body("callerLevel", everyItem(nullValue()));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/integration/WorkspacesIT.java
+++ b/src/test/java/ai/labs/eddi/integration/WorkspacesIT.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.integration;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
+
+/**
+ * The workspace and sharing surface over real HTTP.
+ *
+ * <h3>Why these are integration tests and not more unit tests</h3> Everything
+ * asserted here is wiring: whether a query parameter binds, whether Jackson
+ * emits the field names a client is typed against, whether a path is routed at
+ * all. Each of those is invisible to a unit test holding the resource class
+ * directly, and each has already been wrong once in this feature — `?space=`
+ * shipped being sent to an endpoint that did not declare it, and the Manager
+ * spent a release deciding enforcement from fields that cannot decide it.
+ *
+ * <h3>What the shapes here are load-bearing for</h3> EDDI-Manager's MSW default
+ * handler answers {@code GET /workspaces} with exactly the disabled payload
+ * asserted below. If this contract moves, that mock keeps every frontend test
+ * green while the real thing has changed — so the disabled shape is pinned here
+ * rather than only there.
+ *
+ * @author ginccc
+ */
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+public class WorkspacesIT extends BaseIntegrationIT {
+
+    private static final String WORKSPACES = "/workspaces";
+    private static final String AGENT_DESCRIPTORS = "/agentstore/agents/descriptors";
+
+    /** A well-formed id that no resource holds. */
+    private static final String ABSENT_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+    private static String shares(String id) {
+        return "/descriptorstore/descriptors/" + id + "/shares";
+    }
+
+    @Test
+    @DisplayName("reports enforcement off — the default deployment, and the shape the Manager mocks")
+    void reportsDisabledByDefault() {
+        given()
+                .when().get(WORKSPACES)
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                // Every one of these fields is read by the Manager. `enabled` gates the
+                // entire feature there; `seesEverything` explains an unfiltered listing.
+                .body("enabled", is(false))
+                .body("seesEverything", is(true))
+                .body("spaces", hasSize(0))
+                // Anonymous under this profile: no principal to stamp, so nothing to own.
+                .body("principal", nullValue())
+                .body("defaultSpace", nullValue());
+    }
+
+    @Test
+    @DisplayName("the agent listing accepts ?space= rather than rejecting it")
+    void agentListingBindsSpaceParameter() {
+        // The narrowing itself needs an authenticated principal to mean anything; what
+        // this pins is that the parameter EXISTS. It shipped once being sent to an
+        // endpoint that did not declare it, where JAX-RS silently dropped it and the
+        // switcher changed the URL and nothing else — a 200 either way, which is
+        // precisely why it went unnoticed.
+        given()
+                .queryParam("space", "team:engineering")
+                .queryParam("limit", 5)
+                .when().get(AGENT_DESCRIPTORS)
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON);
+    }
+
+    @Test
+    @DisplayName("a space id carrying regex metacharacters is matched literally, not as a pattern")
+    void spaceParameterIsNotAPattern() {
+        // Both storage backends treat a String filter as a regular expression, so an
+        // unescaped identity predicate is a real vulnerability rather than a style
+        // note. `.*` must select nothing, not everything.
+        given()
+                .queryParam("space", ".*")
+                .queryParam("limit", 50)
+                .when().get(AGENT_DESCRIPTORS)
+                .then()
+                .statusCode(200)
+                .body("$", hasSize(0));
+    }
+
+    @Test
+    @DisplayName("sharing state is readable and carries the fields a client is typed against")
+    void readsSharingState() {
+        given()
+                .when().get(shares(ABSENT_ID))
+                .then()
+                // 404 for an id nothing holds is fine; what must not happen is a 500 or a
+                // route that does not exist. Any 2xx must carry the documented shape.
+                .statusCode(is(oneOf(200, 403, 404)));
+    }
+
+    @Test
+    @DisplayName("an unknown access level is refused rather than silently downgraded")
+    void rejectsUnknownLevel() {
+        // A typo that became a weaker grant looks exactly like a successful share.
+        given()
+                .queryParam("subject", "user:alice@example.com")
+                .queryParam("level", "ADMIN")
+                .when().post(shares(ABSENT_ID))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("an unknown visibility is refused rather than guessed at")
+    void rejectsUnknownVisibility() {
+        // The three options differ on who can read the resource. Guessing between them
+        // is not a recoverable mistake.
+        given()
+                .queryParam("visibility", "world-readable")
+                .when().put(shares(ABSENT_ID) + "/visibility")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("a share with no subject is refused")
+    void rejectsMissingSubject() {
+        given()
+                .queryParam("level", "USE")
+                .when().post(shares(ABSENT_ID))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("an unrecognised subject prefix is refused rather than read as a user")
+    void rejectsUnknownSubjectPrefix() {
+        // "group:" is a plausible typo for "team:". Accepting it would create a grant
+        // nobody holds, which is indistinguishable from a successful share.
+        given()
+                .queryParam("subject", "group:engineering")
+                .queryParam("level", "USE")
+                .when().post(shares(ABSENT_ID))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("transferring ownership with no owner is refused")
+    void rejectsOwnerlessTransfer() {
+        given()
+                .when().put(shares(ABSENT_ID) + "/owner")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("the workspace endpoint takes no principal parameter")
+    void cannotEnumerateSomebodyElse() {
+        // It answers for the caller and only the caller. A principal parameter would
+        // turn it into a way to read anyone's group membership, so an attempt to pass
+        // one must be ignored rather than honoured.
+        given()
+                .queryParam("principal", "bob@example.com")
+                .when().get(WORKSPACES)
+                .then()
+                .statusCode(200)
+                .body("principal", nullValue());
+    }
+
+    @Test
+    @DisplayName("descriptor listings still answer while workspaces are off")
+    void listingsUnaffectedWhenDisabled() {
+        // The release-before-this-one guarantee: with enforcement off, nothing is
+        // filtered and every existing client keeps working.
+        given()
+                .queryParam("type", "ai.labs.agent")
+                .queryParam("limit", 5)
+                .when().get("/descriptorstore/descriptors")
+                .then()
+                .statusCode(200)
+                .body("$", notNullValue());
+    }
+
+    @Test
+    @DisplayName("workspace settings do not leak the access index to a client")
+    void doesNotExposeInternalTokens() {
+        // `accessIndex` is a materialised query artefact. It is on the descriptor
+        // because the store needs it, not because a client does.
+        given()
+                .when().get(WORKSPACES)
+                .then()
+                .statusCode(200)
+                .body("accessIndex", nullValue())
+                .body("admittingTokens", nullValue());
+    }
+
+    @Test
+    @DisplayName("the endpoint is JSON, not a redirect or an HTML error page")
+    void servesJson() {
+        given()
+                .when().get(WORKSPACES)
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("enabled", equalTo(false));
+    }
+}

--- a/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterBranchCoverageTest.java
@@ -4,7 +4,7 @@
  */
 package ai.labs.eddi.integrations.channels;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.channels.IChannelIntegrationStore;
 import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.configs.channels.model.ChannelTarget;
@@ -41,7 +41,7 @@ class ChannelTargetRouterBranchCoverageTest {
     @Mock
     private IRestAgentAdministration agentAdmin;
     @Mock
-    private IRestAgentStore agentStore;
+    private IAgentStore agentStore;
     @Mock
     private SecretResolver secretResolver;
     @Mock

--- a/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterDeepBranchTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterDeepBranchTest.java
@@ -4,7 +4,7 @@
  */
 package ai.labs.eddi.integrations.channels;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.channels.IChannelIntegrationStore;
 import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.configs.channels.model.ChannelTarget;
@@ -43,7 +43,7 @@ class ChannelTargetRouterDeepBranchTest {
         var channelStore = mock(IChannelIntegrationStore.class);
         var descriptorStore = mock(IDocumentDescriptorStore.class);
         var agentAdmin = mock(IRestAgentAdministration.class);
-        var agentStore = mock(IRestAgentStore.class);
+        var agentStore = mock(IAgentStore.class);
         var secretResolver = mock(SecretResolver.class);
         var cacheFactory = mock(ICacheFactory.class);
         threadTargetLock = mock(ICache.class);

--- a/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterRefreshTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterRefreshTest.java
@@ -4,7 +4,7 @@
  */
 package ai.labs.eddi.integrations.channels;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration.ChannelConnector;
 import ai.labs.eddi.configs.channels.IChannelIntegrationStore;
@@ -55,7 +55,7 @@ class ChannelTargetRouterRefreshTest {
     private IChannelIntegrationStore channelStore;
     private IDocumentDescriptorStore descriptorStore;
     private IRestAgentAdministration agentAdmin;
-    private IRestAgentStore agentStore;
+    private IAgentStore agentStore;
     private SecretResolver secretResolver;
     private ChannelTargetRouter router;
 
@@ -67,7 +67,7 @@ class ChannelTargetRouterRefreshTest {
         channelStore = mock(IChannelIntegrationStore.class);
         descriptorStore = mock(IDocumentDescriptorStore.class);
         agentAdmin = mock(IRestAgentAdministration.class);
-        agentStore = mock(IRestAgentStore.class);
+        agentStore = mock(IAgentStore.class);
         secretResolver = mock(SecretResolver.class);
 
         ICacheFactory cacheFactory = mock(ICacheFactory.class);
@@ -211,7 +211,7 @@ class ChannelTargetRouterRefreshTest {
 
         when(agentAdmin.getDeploymentStatuses(Deployment.Environment.production))
                 .thenReturn(List.of(status));
-        when(agentStore.readAgent(eq(agentId), eq(1))).thenReturn(agentConfig);
+        when(agentStore.read(eq(agentId), eq(1))).thenReturn(agentConfig);
     }
 
     // ─── Public API — resolveTarget ────────────────────────────────────────────
@@ -887,7 +887,7 @@ class ChannelTargetRouterRefreshTest {
                     Deployment.Status.READY, desc);
             when(agentAdmin.getDeploymentStatuses(Deployment.Environment.production))
                     .thenReturn(List.of(status));
-            when(agentStore.readAgent(eq(AGENT_ID), eq(1))).thenReturn(agentConfig);
+            when(agentStore.read(eq(AGENT_ID), eq(1))).thenReturn(agentConfig);
 
             assertNull(router.resolveTarget("slack", CHANNEL_ID, "hello"));
             assertFalse(router.hasAnyChannels("slack"));
@@ -913,7 +913,7 @@ class ChannelTargetRouterRefreshTest {
                     Deployment.Status.READY, desc);
             when(agentAdmin.getDeploymentStatuses(Deployment.Environment.production))
                     .thenReturn(List.of(status));
-            when(agentStore.readAgent(eq(AGENT_ID), eq(1))).thenReturn(agentConfig);
+            when(agentStore.read(eq(AGENT_ID), eq(1))).thenReturn(agentConfig);
 
             assertNull(router.resolveTarget("slack", CHANNEL_ID, "hello"));
         }
@@ -945,7 +945,7 @@ class ChannelTargetRouterRefreshTest {
                     Deployment.Status.READY, desc);
             when(agentAdmin.getDeploymentStatuses(Deployment.Environment.production))
                     .thenReturn(List.of(status));
-            when(agentStore.readAgent(eq(AGENT_ID), eq(1))).thenReturn(agentConfig);
+            when(agentStore.read(eq(AGENT_ID), eq(1))).thenReturn(agentConfig);
             when(secretResolver.resolveValue(anyString())).thenAnswer(inv -> inv.getArgument(0));
 
             ResolvedTarget result = router.resolveTarget("slack", CHANNEL_ID, "hello");

--- a/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/channels/ChannelTargetRouterTest.java
@@ -4,7 +4,7 @@
  */
 package ai.labs.eddi.integrations.channels;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.channels.IChannelIntegrationStore;
 import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.configs.channels.model.ChannelTarget;
@@ -38,7 +38,7 @@ class ChannelTargetRouterTest {
     @Mock
     private IRestAgentAdministration agentAdmin;
     @Mock
-    private IRestAgentStore agentStore;
+    private IAgentStore agentStore;
     @Mock
     private SecretResolver secretResolver;
     @Mock

--- a/src/test/java/ai/labs/eddi/integrations/openai/AgentModelResolverTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/openai/AgentModelResolverTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.integrations.openai;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.engine.model.Deployment.Status;
@@ -56,7 +57,7 @@ class AgentModelResolverTest {
     }
 
     private AgentModelResolver resolver(OpenAiCompatConfig config) {
-        var resolver = new AgentModelResolver(agentFactory, descriptorStore, config);
+        var resolver = new AgentModelResolver(agentFactory, descriptorStore, config, permissiveUseGuard());
         resolver.initCache();
         return resolver;
     }
@@ -366,5 +367,13 @@ class AgentModelResolverTest {
 
         resolver.invalidate();
         assertEquals(4, resolver.listModels().size());
+    }
+
+    /**
+     * A guard that admits every agent: a bare mock's void requireAgentUseAccess
+     * does nothing. The /v1 USE gate has its own tests.
+     */
+    private static ResourceAccessGuard permissiveUseGuard() {
+        return mock(ResourceAccessGuard.class);
     }
 }

--- a/src/test/java/ai/labs/eddi/integrations/openai/OpenAiConversationBridgeTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/openai/OpenAiConversationBridgeTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.integrations.openai;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.memory.MemoryKeys;
@@ -84,7 +85,7 @@ class OpenAiConversationBridgeTest {
         bridge = new OpenAiConversationBridge(conversationService, userConversationStore,
                 new OpenAiMessageMapper(objectMapper, 5),
                 OpenAiTestFixtures.config(b -> b.requestTimeoutSeconds = 2),
-                new SimpleMeterRegistry());
+                new SimpleMeterRegistry(), permissiveUseGuard());
         bridge.initMetrics();
     }
 
@@ -695,5 +696,13 @@ class OpenAiConversationBridgeTest {
         ArgumentCaptor<Map<String, Context>> captor = ArgumentCaptor.forClass(Map.class);
         verify(conversationService).startConversation(any(), any(), any(), captor.capture());
         assertTrue(captor.getValue().containsKey(OpenAiConversationBridge.CONTEXT_CHANNEL_INTENT));
+    }
+
+    /**
+     * A guard that admits every agent: a bare mock's void requireAgentUseAccess
+     * does nothing. The /v1 USE gate has its own tests.
+     */
+    private static ResourceAccessGuard permissiveUseGuard() {
+        return mock(ResourceAccessGuard.class);
     }
 }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorBranchTest.java
@@ -4,11 +4,11 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.model.Property;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
@@ -70,9 +70,9 @@ class AgentOrchestratorBranchTest {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -102,7 +102,7 @@ class AgentOrchestratorBranchTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool, toolExecutionService,
                 mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorBuiltInToolWiringTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorBuiltInToolWiringTest.java
@@ -73,9 +73,9 @@ class AgentOrchestratorBuiltInToolWiringTest {
         orchestrator = new AgentOrchestrator(
                 null, null, null, null,
                 null, null, null, null,
-                null, null,
-                null, null,
+                null,
                 null, null, null,
+                null, null,
                 null, null, null,
                 null, null, null,
                 null,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverage2Test.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverage2Test.java
@@ -5,11 +5,11 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.model.Property;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException;
@@ -105,9 +105,9 @@ class AgentOrchestratorCoverage2Test {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -146,7 +146,7 @@ class AgentOrchestratorCoverage2Test {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverageTest.java
@@ -5,11 +5,11 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.modules.llm.tools.spi.ToolRequestResolver;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.hitl.HitlTimeoutPolicy;
 import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.ChatTranscriptCodec;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
@@ -130,9 +130,9 @@ class AgentOrchestratorCoverageTest {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -169,7 +169,7 @@ class AgentOrchestratorCoverageTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,
@@ -871,7 +871,7 @@ class AgentOrchestratorCoverageTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 null,
@@ -899,7 +899,7 @@ class AgentOrchestratorCoverageTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, null,
                 memorySnapshotService,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorExtendedBranchTest.java
@@ -4,11 +4,11 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.model.Property;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -68,9 +68,9 @@ class AgentOrchestratorExtendedBranchTest {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -100,7 +100,7 @@ class AgentOrchestratorExtendedBranchTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool, toolExecutionService,
                 mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,
@@ -221,7 +221,7 @@ class AgentOrchestratorExtendedBranchTest {
                     webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                     fetchToolResponsePageTool, toolExecutionService,
                     mcpToolProviderManager, a2aToolProviderManager,
-                    restAgentStore, restWorkflowStore, resourceClientLibrary,
+                    restWorkflowStore, resourceClientLibrary,
                     apiCallExecutor, jsonSerialization, memoryItemConverter,
                     null, // null userMemoryStore
                     toolResponseTruncator, tenantQuotaService, memorySnapshotService,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorExtendedTest.java
@@ -4,12 +4,12 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.configs.shared.RetryConfiguration;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
@@ -95,7 +95,7 @@ class AgentOrchestratorExtendedTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool, toolExecutionService,
                 mcpToolProviderManager, a2aToolProviderManager,
-                mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IWorkflowStore.class),
                 mock(IResourceClientLibrary.class), mock(IApiCallExecutor.class),
                 mock(IJsonSerialization.class), mock(IMemoryItemConverter.class),
                 userMemoryStore, mock(ToolResponseTruncator.class),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorLocalToolAssemblyTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorLocalToolAssemblyTest.java
@@ -6,9 +6,9 @@ package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.IAgentStore;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
@@ -76,7 +76,7 @@ class AgentOrchestratorLocalToolAssemblyTest {
         return new AgentOrchestrator(calculator, dateTime, webSearch, dataFormatter, webScraper, textSummarizer,
                 pdfReader, weather, fetchPage,
                 mock(ToolExecutionService.class), mock(McpToolProviderManager.class), mock(A2AToolProviderManager.class),
-                mock(IRestAgentStore.class), mock(IRestWorkflowStore.class), mock(IResourceClientLibrary.class),
+                mock(IWorkflowStore.class), mock(IResourceClientLibrary.class),
                 mock(IApiCallExecutor.class), mock(IJsonSerialization.class), mock(IMemoryItemConverter.class),
                 mock(IUserMemoryStore.class), mock(ToolResponseTruncator.class), mock(TenantQuotaService.class),
                 mock(MemorySnapshotService.class), mock(AgentSetupService.class), mock(CapabilityRegistryService.class),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorResumeToolLoopTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorResumeToolLoopTest.java
@@ -5,10 +5,10 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.modules.llm.tools.spi.ToolRequestResolver;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.ChatTranscriptCodec;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
@@ -94,9 +94,9 @@ class AgentOrchestratorResumeToolLoopTest {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -133,7 +133,7 @@ class AgentOrchestratorResumeToolLoopTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorTest.java
@@ -4,11 +4,11 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.properties.model.Property;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -73,9 +73,9 @@ class AgentOrchestratorTest {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -109,7 +109,7 @@ class AgentOrchestratorTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,
@@ -520,7 +520,7 @@ class AgentOrchestratorTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 null, // null userMemoryStore
                 toolResponseTruncator, tenantQuotaService, memorySnapshotService,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolContextBudgetTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolContextBudgetTest.java
@@ -4,9 +4,9 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -111,9 +111,9 @@ class AgentOrchestratorToolContextBudgetTest {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -157,7 +157,7 @@ class AgentOrchestratorToolContextBudgetTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, null,
                 null,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolCostTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolCostTest.java
@@ -4,10 +4,10 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.shared.RetryConfiguration;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.caching.CacheFactory;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
@@ -99,9 +99,9 @@ class AgentOrchestratorToolCostTest {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -156,7 +156,7 @@ class AgentOrchestratorToolCostTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 null,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolGovernanceTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolGovernanceTest.java
@@ -309,7 +309,7 @@ class AgentOrchestratorToolGovernanceTest {
                 null, null, null, null,
                 null,
                 null, null, null,
-                null, null, null,
+                null, null,
                 null, null, null,
                 null, null, null,
                 null,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolPauseTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorToolPauseTest.java
@@ -4,10 +4,10 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
@@ -85,9 +85,9 @@ class AgentOrchestratorToolPauseTest {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -122,7 +122,7 @@ class AgentOrchestratorToolPauseTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, tenantQuotaService,
                 memorySnapshotService,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/HttpCallToolsProviderBodyGuardTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/HttpCallToolsProviderBodyGuardTest.java
@@ -4,12 +4,12 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.apicalls.model.ApiCall;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
 import ai.labs.eddi.configs.apicalls.model.Request;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.datastore.serialization.JsonSerialization;
@@ -74,8 +74,8 @@ class HttpCallToolsProviderBodyGuardTest {
     private static final String TOOL_NAME = "setupAgent";
 
     private IConversationMemory memory;
-    private IRestAgentStore agentStore;
-    private IRestWorkflowStore workflowStore;
+    private IAgentStore agentStore;
+    private IWorkflowStore workflowStore;
     private IResourceClientLibrary resourceClientLibrary;
     private IApiCallExecutor apiCallExecutor;
     private IMemoryItemConverter memoryItemConverter;
@@ -90,8 +90,8 @@ class HttpCallToolsProviderBodyGuardTest {
         memory = mock(IConversationMemory.class);
         when(memory.getAgentId()).thenReturn(AGENT_ID);
         when(memory.getAgentVersion()).thenReturn(AGENT_VERSION);
-        agentStore = mock(IRestAgentStore.class);
-        workflowStore = mock(IRestWorkflowStore.class);
+        agentStore = mock(IAgentStore.class);
+        workflowStore = mock(IWorkflowStore.class);
         resourceClientLibrary = mock(IResourceClientLibrary.class);
         apiCallExecutor = mock(IApiCallExecutor.class);
         memoryItemConverter = mock(IMemoryItemConverter.class);
@@ -493,14 +493,14 @@ class HttpCallToolsProviderBodyGuardTest {
     private ToolExecutor executorFor(ApiCall apiCall) throws Exception {
         var agentConfig = new AgentConfiguration();
         agentConfig.setWorkflows(List.of(URI.create(WORKFLOW_URI)));
-        when(agentStore.readAgent(AGENT_ID, AGENT_VERSION)).thenReturn(agentConfig);
+        when(agentStore.read(AGENT_ID, AGENT_VERSION)).thenReturn(agentConfig);
 
         var step = new WorkflowConfiguration.WorkflowStep();
         step.setType(URI.create("eddi://ai.labs.httpcalls"));
         step.setConfig(Map.of("uri", HTTPCALLS_URI));
         var workflowConfig = new WorkflowConfiguration();
         workflowConfig.setWorkflowSteps(List.of(step));
-        when(workflowStore.readWorkflow("wf-1", 1)).thenReturn(workflowConfig);
+        when(workflowStore.read("wf-1", 1)).thenReturn(workflowConfig);
 
         var httpCallsConfig = new ApiCallsConfiguration();
         httpCallsConfig.setTargetServerUrl("https://eddi.example");

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/HttpCallToolsProviderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/HttpCallToolsProviderTest.java
@@ -4,8 +4,8 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.*;
 class HttpCallToolsProviderTest {
 
     private HttpCallToolsProvider provider() {
-        return new HttpCallToolsProvider(mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+        return new HttpCallToolsProvider(mock(IAgentStore.class), mock(IWorkflowStore.class),
                 mock(IResourceClientLibrary.class), mock(IApiCallExecutor.class), mock(IJsonSerialization.class),
                 mock(IMemoryItemConverter.class));
     }
@@ -59,8 +59,8 @@ class HttpCallToolsProviderTest {
 
     @Test
     void contribute_explicitlyDisabled_returnsEmptyWithoutDiscovering() {
-        var restAgentStore = mock(IRestAgentStore.class);
-        var provider = new HttpCallToolsProvider(restAgentStore, mock(IRestWorkflowStore.class),
+        var restAgentStore = mock(IAgentStore.class);
+        var provider = new HttpCallToolsProvider(restAgentStore, mock(IWorkflowStore.class),
                 mock(IResourceClientLibrary.class), mock(IApiCallExecutor.class), mock(IJsonSerialization.class),
                 mock(IMemoryItemConverter.class));
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/JsonResponseFormatThreadingTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/JsonResponseFormatThreadingTest.java
@@ -4,9 +4,8 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
@@ -108,9 +107,7 @@ class JsonResponseFormatThreadingTest {
     @Mock
     private A2AToolProviderManager a2aToolProviderManager;
     @Mock
-    private IRestAgentStore restAgentStore;
-    @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -142,7 +139,7 @@ class JsonResponseFormatThreadingTest {
                 webScraperTool, textSummarizerTool, pdfReaderTool, weatherTool,
                 fetchToolResponsePageTool,
                 toolExecutionService, mcpToolProviderManager, a2aToolProviderManager,
-                restAgentStore, restWorkflowStore, resourceClientLibrary,
+                restWorkflowStore, resourceClientLibrary,
                 apiCallExecutor, jsonSerialization, memoryItemConverter,
                 userMemoryStore, toolResponseTruncator, null,
                 null,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskAgentModeMetadataTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskAgentModeMetadataTest.java
@@ -5,9 +5,9 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict;
@@ -146,7 +146,7 @@ class LlmTaskAgentModeMetadataTest {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 ragContextProvider, new TokenCounterFactory(), conversationSummarizer,
                 promptSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, agentOrchestrator, new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskAuditLedgerTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskAuditLedgerTest.java
@@ -5,10 +5,10 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.properties.IUserMemoryStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.audit.IAuditEntryCollector;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
@@ -156,7 +156,7 @@ class LlmTaskAuditLedgerTest {
         // before is no longer needed.
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 mock(RagContextProvider.class), new TokenCounterFactory(),
                 mock(ConversationSummarizer.class), promptSnippetService, globalVariableResolver,
                 counterweightService, identityMaskingService,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskBranchTest.java
@@ -5,9 +5,9 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.memory.*;
@@ -103,7 +103,7 @@ class LlmTaskBranchTest {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 mock(RagContextProvider.class), new TokenCounterFactory(), mock(ConversationSummarizer.class),
                 mockSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, mock(AgentOrchestrator.class), new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskConfigureTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskConfigureTest.java
@@ -5,9 +5,9 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
@@ -102,7 +102,7 @@ class LlmTaskConfigureTest {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 mock(RagContextProvider.class), new TokenCounterFactory(), mock(ConversationSummarizer.class),
                 mockSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, mock(AgentOrchestrator.class), new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverage2Test.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverage2Test.java
@@ -5,11 +5,11 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.properties.model.Property;
 import ai.labs.eddi.configs.properties.model.Property.Scope;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
@@ -130,7 +130,7 @@ class LlmTaskCoverage2Test {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 ragContextProvider, new TokenCounterFactory(), conversationSummarizer,
                 promptSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, agentOrchestrator, new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverageTest.java
@@ -5,10 +5,10 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.audit.IAuditEntryCollector;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
@@ -120,7 +120,7 @@ class LlmTaskCoverageTest {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 ragContextProvider, new TokenCounterFactory(), mock(ConversationSummarizer.class),
                 promptSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, agentOrchestrator, new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskDeepBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskDeepBranchTest.java
@@ -5,9 +5,9 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.memory.*;
@@ -119,7 +119,7 @@ class LlmTaskDeepBranchTest {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 mock(RagContextProvider.class), new TokenCounterFactory(), mock(ConversationSummarizer.class),
                 mockSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, mock(AgentOrchestrator.class), new ConversationHistoryBuilder(),
@@ -497,7 +497,7 @@ class LlmTaskDeepBranchTest {
 
             var jsonTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                     templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                    mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                    mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                     mock(RagContextProvider.class), new TokenCounterFactory(), mock(ConversationSummarizer.class),
                     mockSnippetService, gvr, cws,
                     ims, mock(AgentOrchestrator.class), new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskExtendedBranchTest.java
@@ -5,9 +5,9 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
@@ -109,7 +109,7 @@ class LlmTaskExtendedBranchTest {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 mock(RagContextProvider.class), new TokenCounterFactory(), mock(ConversationSummarizer.class),
                 mockSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, mock(AgentOrchestrator.class), new ConversationHistoryBuilder(),
@@ -474,7 +474,7 @@ class LlmTaskExtendedBranchTest {
 
             var ioTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                     templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                    mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                    mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                     mock(RagContextProvider.class), new TokenCounterFactory(), mock(ConversationSummarizer.class),
                     snippetService, gvr, cws,
                     ims, mock(AgentOrchestrator.class), new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskExtendedTest.java
@@ -19,9 +19,9 @@ import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
 import ai.labs.eddi.modules.apicalls.impl.PrePostUtils;
 import ai.labs.eddi.modules.llm.impl.builder.ILanguageModelBuilder;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.properties.model.Property;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.modules.apicalls.impl.IApiCallExecutor;
 import ai.labs.eddi.modules.llm.tools.impl.*;
 import ai.labs.eddi.secrets.SecretResolver;
@@ -109,7 +109,7 @@ class LlmTaskExtendedTest {
                 templatingEngine, jsonSerialization, prePostUtils,
                 chatModelRegistry,
                 mock(IApiCallExecutor.class),
-                mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IAgentStore.class), mock(IWorkflowStore.class),
                 mock(RagContextProvider.class),
                 new TokenCounterFactory(), conversationSummarizer,
                 promptSnippetService, globalVariableResolver,

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskResumeModeTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskResumeModeTest.java
@@ -5,9 +5,9 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision.HitlVerdict;
@@ -102,7 +102,7 @@ class LlmTaskResumeModeTest {
         // verified without executing the real (Task 9) loop.
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 ragContextProvider, new TokenCounterFactory(), mock(ConversationSummarizer.class),
                 promptSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, agentOrchestrator, new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskStreamingDowngradeTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskStreamingDowngradeTest.java
@@ -4,9 +4,9 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -138,7 +138,7 @@ class LlmTaskStreamingDowngradeTest {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 ragContextProvider, new TokenCounterFactory(), conversationSummarizer,
                 promptSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, agentOrchestrator, new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskSummaryCredentialIsolationTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskSummaryCredentialIsolationTest.java
@@ -4,9 +4,9 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IConversationMemory.IWritableConversationStep;
@@ -111,7 +111,7 @@ class LlmTaskSummaryCredentialIsolationTest {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 ragContextProvider, new TokenCounterFactory(), conversationSummarizer,
                 promptSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, agentOrchestrator, new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskTest.java
@@ -5,9 +5,9 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.ExtensionDescriptor;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.TaskId;
@@ -63,9 +63,9 @@ class LlmTaskTest {
     @Mock
     private IApiCallExecutor apiCallExecutor;
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private RagContextProvider ragContextProvider;
     @Mock

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskToolLoopStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskToolLoopStreamingTest.java
@@ -4,9 +4,9 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.ConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.model.HitlDecision;
@@ -139,7 +139,7 @@ class LlmTaskToolLoopStreamingTest {
 
         llmTask = new LlmTask(resourceClientLibrary, dataFactory, memoryItemConverter,
                 templatingEngine, jsonSerialization, prePostUtils, chatModelRegistry,
-                mock(IApiCallExecutor.class), mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+                mock(IApiCallExecutor.class), mock(IAgentStore.class), mock(IWorkflowStore.class),
                 ragContextProvider, new TokenCounterFactory(), conversationSummarizer,
                 promptSnippetService, globalVariableResolver, counterweightService,
                 identityMaskingService, agentOrchestrator, new ConversationHistoryBuilder(),

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderTest.java
@@ -4,8 +4,8 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
 class McpToolsProviderTest {
 
     private McpToolsProvider provider(McpToolProviderManager manager) {
-        return new McpToolsProvider(mock(IRestAgentStore.class), mock(IRestWorkflowStore.class),
+        return new McpToolsProvider(mock(IAgentStore.class), mock(IWorkflowStore.class),
                 mock(IResourceClientLibrary.class), manager);
     }
 
@@ -46,8 +46,8 @@ class McpToolsProviderTest {
 
     @Test
     void contribute_explicitlyDisabled_returnsEmptyWithoutDiscovering() {
-        var restAgentStore = mock(IRestAgentStore.class);
-        var provider = new McpToolsProvider(restAgentStore, mock(IRestWorkflowStore.class),
+        var restAgentStore = mock(IAgentStore.class);
+        var provider = new McpToolsProvider(restAgentStore, mock(IWorkflowStore.class),
                 mock(IResourceClientLibrary.class), mock(McpToolProviderManager.class));
 
         var contribution = provider.contribute(context(false));

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/RagContextProviderChunkStrategyTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/RagContextProviderChunkStrategyTest.java
@@ -4,10 +4,10 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IData;
@@ -60,8 +60,8 @@ import static org.mockito.Mockito.when;
  */
 class RagContextProviderChunkStrategyTest {
 
-    private IRestAgentStore restAgentStore;
-    private IRestWorkflowStore restWorkflowStore;
+    private IAgentStore restAgentStore;
+    private IWorkflowStore restWorkflowStore;
     private IResourceClientLibrary resourceClientLibrary;
     private EmbeddingModelFactory embeddingModelFactory;
     private EmbeddingStoreFactory embeddingStoreFactory;
@@ -73,8 +73,8 @@ class RagContextProviderChunkStrategyTest {
     @BeforeEach
     void setUp() {
         WorkflowTraversal.clearCache();
-        restAgentStore = mock(IRestAgentStore.class);
-        restWorkflowStore = mock(IRestWorkflowStore.class);
+        restAgentStore = mock(IAgentStore.class);
+        restWorkflowStore = mock(IWorkflowStore.class);
         resourceClientLibrary = mock(IResourceClientLibrary.class);
         embeddingModelFactory = mock(EmbeddingModelFactory.class);
         embeddingStoreFactory = mock(EmbeddingStoreFactory.class);
@@ -194,8 +194,12 @@ class RagContextProviderChunkStrategyTest {
         var agentConfig = new AgentConfiguration();
         agentConfig.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-1?version=1")));
 
-        when(restAgentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
-        when(restWorkflowStore.readWorkflow("wf-1", 1)).thenReturn(workflowConfig);
+        try {
+            when(restAgentStore.read("agent-1", 1)).thenReturn(agentConfig);
+            when(restWorkflowStore.read("wf-1", 1)).thenReturn(workflowConfig);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         try {
             when(resourceClientLibrary.getResource(any(URI.class), eq(RagConfiguration.class))).thenReturn(ragConfig);

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/RagContextProviderExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/RagContextProviderExtendedTest.java
@@ -4,10 +4,10 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IData;
@@ -55,8 +55,8 @@ import static org.mockito.Mockito.*;
  */
 class RagContextProviderExtendedTest {
 
-    private IRestAgentStore restAgentStore;
-    private IRestWorkflowStore restWorkflowStore;
+    private IAgentStore restAgentStore;
+    private IWorkflowStore restWorkflowStore;
     private IResourceClientLibrary resourceClientLibrary;
     private EmbeddingModelFactory embeddingModelFactory;
     private EmbeddingStoreFactory embeddingStoreFactory;
@@ -68,8 +68,8 @@ class RagContextProviderExtendedTest {
     @BeforeEach
     void setUp() {
         WorkflowTraversal.clearCache();
-        restAgentStore = mock(IRestAgentStore.class);
-        restWorkflowStore = mock(IRestWorkflowStore.class);
+        restAgentStore = mock(IAgentStore.class);
+        restWorkflowStore = mock(IWorkflowStore.class);
         resourceClientLibrary = mock(IResourceClientLibrary.class);
         embeddingModelFactory = mock(EmbeddingModelFactory.class);
         embeddingStoreFactory = mock(EmbeddingStoreFactory.class);
@@ -124,12 +124,12 @@ class RagContextProviderExtendedTest {
 
         @Test
         @DisplayName("enableWorkflowRag=true but no workflow steps → return null")
-        void workflowRagNoSteps() {
+        void workflowRagNoSteps() throws Exception {
             var task = new LlmConfiguration.Task();
             task.setEnableWorkflowRag(true);
 
             // Agent returns null → no workflow steps
-            when(restAgentStore.readAgent("agent-1", 1)).thenReturn(null);
+            when(restAgentStore.read("agent-1", 1)).thenReturn(null);
 
             assertNull(ragContextProvider.retrieveContext(memory, task, "query"));
         }
@@ -399,8 +399,12 @@ class RagContextProviderExtendedTest {
         var agentConfig = new AgentConfiguration();
         agentConfig.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-1?version=1")));
 
-        when(restAgentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
-        when(restWorkflowStore.readWorkflow("wf-1", 1)).thenReturn(workflowConfig);
+        try {
+            when(restAgentStore.read("agent-1", 1)).thenReturn(agentConfig);
+            when(restWorkflowStore.read("wf-1", 1)).thenReturn(workflowConfig);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         try {
             when(resourceClientLibrary.getResource(any(URI.class), eq(RagConfiguration.class)))

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/RagContextProviderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/RagContextProviderTest.java
@@ -4,8 +4,8 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IData;
 import ai.labs.eddi.engine.memory.IDataFactory;
@@ -27,9 +27,9 @@ import static org.mockito.MockitoAnnotations.openMocks;
 class RagContextProviderTest {
 
     @Mock
-    private IRestAgentStore restAgentStore;
+    private IAgentStore restAgentStore;
     @Mock
-    private IRestWorkflowStore restWorkflowStore;
+    private IWorkflowStore restWorkflowStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
@@ -46,7 +46,7 @@ class RagContextProviderTest {
     private RagContextProvider ragContextProvider;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         openMocks(this);
         ragContextProvider = new RagContextProvider(restAgentStore, restWorkflowStore, resourceClientLibrary, embeddingModelFactory,
                 embeddingStoreFactory, dataFactory);
@@ -61,7 +61,7 @@ class RagContextProviderTest {
     }
 
     @Test
-    void noKnowledgeBases_andNoWorkflowRag_shouldReturnNull() {
+    void noKnowledgeBases_andNoWorkflowRag_shouldReturnNull() throws Exception {
         var task = new LlmConfiguration.Task();
         task.setKnowledgeBases(null);
         task.setEnableWorkflowRag(false);
@@ -69,11 +69,11 @@ class RagContextProviderTest {
         String result = ragContextProvider.retrieveContext(memory, task, "hello");
 
         assertNull(result);
-        verify(restAgentStore, never()).readAgent(anyString(), anyInt());
+        verify(restAgentStore, never()).read(anyString(), anyInt());
     }
 
     @Test
-    void emptyKnowledgeBases_andNoWorkflowRag_shouldReturnNull() {
+    void emptyKnowledgeBases_andNoWorkflowRag_shouldReturnNull() throws Exception {
         var task = new LlmConfiguration.Task();
         task.setKnowledgeBases(List.of());
         task.setEnableWorkflowRag(false);
@@ -84,11 +84,11 @@ class RagContextProviderTest {
     }
 
     @Test
-    void autoDiscovery_withNoWorkflowSteps_shouldReturnNull() {
+    void autoDiscovery_withNoWorkflowSteps_shouldReturnNull() throws Exception {
         var task = new LlmConfiguration.Task();
         task.setEnableWorkflowRag(true);
 
-        when(restAgentStore.readAgent("agent-123", 1)).thenReturn(null);
+        when(restAgentStore.read("agent-123", 1)).thenReturn(null);
 
         String result = ragContextProvider.retrieveContext(memory, task, "hello");
 
@@ -96,7 +96,7 @@ class RagContextProviderTest {
     }
 
     @Test
-    void explicitKbRef_withNoWorkflowSteps_shouldReturnNull() {
+    void explicitKbRef_withNoWorkflowSteps_shouldReturnNull() throws Exception {
         var ref = new KnowledgeBaseReference();
         ref.setName("product-docs");
 
@@ -104,16 +104,16 @@ class RagContextProviderTest {
         task.setId("testTask");
         task.setKnowledgeBases(List.of(ref));
 
-        when(restAgentStore.readAgent("agent-123", 1)).thenReturn(null);
+        when(restAgentStore.read("agent-123", 1)).thenReturn(null);
 
         String result = ragContextProvider.retrieveContext(memory, task, "hello");
 
         assertNull(result);
-        verify(restAgentStore).readAgent("agent-123", 1);
+        verify(restAgentStore).read("agent-123", 1);
     }
 
     @Test
-    void nullTaskId_shouldUseDefaultSuffix() {
+    void nullTaskId_shouldUseDefaultSuffix() throws Exception {
         var ref = new KnowledgeBaseReference();
         ref.setName("kb1");
 
@@ -121,7 +121,7 @@ class RagContextProviderTest {
         task.setId(null);
         task.setKnowledgeBases(List.of(ref));
 
-        when(restAgentStore.readAgent("agent-123", 1)).thenReturn(null);
+        when(restAgentStore.read("agent-123", 1)).thenReturn(null);
 
         // Should not throw
         ragContextProvider.retrieveContext(memory, task, "hello");

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/WorkflowTraversalCacheTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/WorkflowTraversalCacheTest.java
@@ -4,9 +4,9 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
@@ -38,8 +38,8 @@ import static org.mockito.Mockito.when;
 @DisplayName("WorkflowTraversal — one traversal per turn (F12)")
 class WorkflowTraversalCacheTest {
 
-    private IRestAgentStore agentStore;
-    private IRestWorkflowStore workflowStore;
+    private IAgentStore agentStore;
+    private IWorkflowStore workflowStore;
     private IResourceClientLibrary resourceClientLibrary;
     private IConversationMemory memory;
     private String agentId;
@@ -47,8 +47,8 @@ class WorkflowTraversalCacheTest {
     @BeforeEach
     void setUp() throws Exception {
         WorkflowTraversal.clearCache();
-        agentStore = mock(IRestAgentStore.class);
-        workflowStore = mock(IRestWorkflowStore.class);
+        agentStore = mock(IAgentStore.class);
+        workflowStore = mock(IWorkflowStore.class);
         resourceClientLibrary = mock(IResourceClientLibrary.class);
         memory = mock(IConversationMemory.class);
 
@@ -59,11 +59,11 @@ class WorkflowTraversalCacheTest {
 
         var agentConfig = new AgentConfiguration();
         agentConfig.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/aaaabbbbccccddddeeeeffff?version=1")));
-        when(agentStore.readAgent(anyString(), anyInt())).thenReturn(agentConfig);
+        when(agentStore.read(anyString(), anyInt())).thenReturn(agentConfig);
 
         var workflowConfig = new WorkflowConfiguration();
         workflowConfig.setWorkflowSteps(List.of());
-        when(workflowStore.readWorkflow(anyString(), anyInt())).thenReturn(workflowConfig);
+        when(workflowStore.read(anyString(), anyInt())).thenReturn(workflowConfig);
     }
 
     /**
@@ -81,14 +81,14 @@ class WorkflowTraversalCacheTest {
     void nonNumericVersionDoesNotAbortDiscovery() throws Exception {
         var agentConfig = new AgentConfiguration();
         agentConfig.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/aaaabbbbccccddddeeeeffff?version=abc")));
-        when(agentStore.readAgent(anyString(), anyInt())).thenReturn(agentConfig);
+        when(agentStore.read(anyString(), anyInt())).thenReturn(agentConfig);
 
         var configs = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls", Object.class,
                 agentStore, workflowStore, resourceClientLibrary);
 
         assertNotNull(configs, "discovery must return a result, not blow up the turn");
         assertTrue(configs.isEmpty(), "the unusable workflow contributes nothing");
-        verify(workflowStore, never()).readWorkflow(anyString(), anyInt());
+        verify(workflowStore, never()).read(anyString(), anyInt());
     }
 
     /**
@@ -102,14 +102,14 @@ class WorkflowTraversalCacheTest {
     void lookalikeParamIsNotReadAsVersion() throws Exception {
         var agentConfig = new AgentConfiguration();
         agentConfig.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/aaaabbbbccccddddeeeeffff?subversion=123")));
-        when(agentStore.readAgent(anyString(), anyInt())).thenReturn(agentConfig);
+        when(agentStore.read(anyString(), anyInt())).thenReturn(agentConfig);
 
         var configs = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls", Object.class,
                 agentStore, workflowStore, resourceClientLibrary);
 
         assertNotNull(configs);
         assertTrue(configs.isEmpty());
-        verify(workflowStore, never()).readWorkflow(anyString(), anyInt());
+        verify(workflowStore, never()).read(anyString(), anyInt());
     }
 
     @Test
@@ -117,13 +117,13 @@ class WorkflowTraversalCacheTest {
     void versionAfterAnotherParamIsStillRead() throws Exception {
         var agentConfig = new AgentConfiguration();
         agentConfig.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/aaaabbbbccccddddeeeeffff?foo=x&version=1")));
-        when(agentStore.readAgent(anyString(), anyInt())).thenReturn(agentConfig);
+        when(agentStore.read(anyString(), anyInt())).thenReturn(agentConfig);
 
         WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls", Object.class,
                 agentStore, workflowStore, resourceClientLibrary);
 
         // Anchoring must not break the ordinary multi-param case.
-        verify(workflowStore).readWorkflow(anyString(), eq(1));
+        verify(workflowStore).read(anyString(), eq(1));
     }
 
     @Test
@@ -132,14 +132,14 @@ class WorkflowTraversalCacheTest {
         var agentConfig = new AgentConfiguration();
         agentConfig.setWorkflows(
                 List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/aaaabbbbccccddddeeeeffff?version=99999999999999")));
-        when(agentStore.readAgent(anyString(), anyInt())).thenReturn(agentConfig);
+        when(agentStore.read(anyString(), anyInt())).thenReturn(agentConfig);
 
         var configs = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls", Object.class,
                 agentStore, workflowStore, resourceClientLibrary);
 
         assertNotNull(configs);
         assertTrue(configs.isEmpty());
-        verify(workflowStore, never()).readWorkflow(anyString(), anyInt());
+        verify(workflowStore, never()).read(anyString(), anyInt());
     }
 
     @Test
@@ -150,8 +150,8 @@ class WorkflowTraversalCacheTest {
                     agentStore, workflowStore, resourceClientLibrary);
         }
 
-        verify(agentStore, times(1)).readAgent(anyString(), anyInt());
-        verify(workflowStore, times(1)).readWorkflow(anyString(), anyInt());
+        verify(agentStore, times(1)).read(anyString(), anyInt());
+        verify(workflowStore, times(1)).read(anyString(), anyInt());
     }
 
     @Test
@@ -162,7 +162,7 @@ class WorkflowTraversalCacheTest {
         WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.mcpcalls", Object.class,
                 agentStore, workflowStore, resourceClientLibrary);
 
-        verify(agentStore, times(2)).readAgent(anyString(), anyInt());
+        verify(agentStore, times(2)).read(anyString(), anyInt());
     }
 
     @Test
@@ -174,7 +174,7 @@ class WorkflowTraversalCacheTest {
         WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls", Object.class,
                 agentStore, workflowStore, resourceClientLibrary);
 
-        verify(agentStore, times(2)).readAgent(anyString(), anyInt());
+        verify(agentStore, times(2)).read(anyString(), anyInt());
     }
 
     @Test
@@ -186,7 +186,7 @@ class WorkflowTraversalCacheTest {
         WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls", Object.class,
                 agentStore, workflowStore, resourceClientLibrary);
 
-        verify(agentStore, times(2)).readAgent(anyString(), anyInt());
+        verify(agentStore, times(2)).read(anyString(), anyInt());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/WorkflowTraversalTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/WorkflowTraversalTest.java
@@ -4,9 +4,9 @@
  */
 package ai.labs.eddi.modules.llm.impl;
 
-import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
-import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration.WorkflowStep;
 import ai.labs.eddi.engine.memory.IConversationMemory;
@@ -37,16 +37,16 @@ import static org.mockito.Mockito.*;
 class WorkflowTraversalTest {
 
     private IConversationMemory memory;
-    private IRestAgentStore agentStore;
-    private IRestWorkflowStore workflowStore;
+    private IAgentStore agentStore;
+    private IWorkflowStore workflowStore;
     private IResourceClientLibrary resourceClientLibrary;
 
     @BeforeEach
     void setUp() {
         WorkflowTraversal.clearCache();
         memory = mock(IConversationMemory.class);
-        agentStore = mock(IRestAgentStore.class);
-        workflowStore = mock(IRestWorkflowStore.class);
+        agentStore = mock(IAgentStore.class);
+        workflowStore = mock(IWorkflowStore.class);
         resourceClientLibrary = mock(IResourceClientLibrary.class);
     }
 
@@ -89,7 +89,7 @@ class WorkflowTraversalTest {
         void emptyWhenAgentConfigFails() throws Exception {
             when(memory.getAgentId()).thenReturn("agent-1");
             when(memory.getAgentVersion()).thenReturn(1);
-            when(agentStore.readAgent("agent-1", 1)).thenThrow(new RuntimeException("DB error"));
+            when(agentStore.read("agent-1", 1)).thenThrow(new RuntimeException("DB error"));
 
             var result = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls",
                     String.class, agentStore, workflowStore, resourceClientLibrary);
@@ -104,7 +104,7 @@ class WorkflowTraversalTest {
             when(memory.getAgentVersion()).thenReturn(1);
             var agentConfig = new AgentConfiguration();
             agentConfig.setWorkflows(List.of());
-            when(agentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
+            when(agentStore.read("agent-1", 1)).thenReturn(agentConfig);
 
             var result = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls",
                     String.class, agentStore, workflowStore, resourceClientLibrary);
@@ -120,7 +120,7 @@ class WorkflowTraversalTest {
             var agentConfig = new AgentConfiguration();
             // URI with no path — opaque URI
             agentConfig.setWorkflows(List.of(URI.create("mailto:test")));
-            when(agentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
+            when(agentStore.read("agent-1", 1)).thenReturn(agentConfig);
 
             var result = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls",
                     String.class, agentStore, workflowStore, resourceClientLibrary);
@@ -135,7 +135,7 @@ class WorkflowTraversalTest {
             when(memory.getAgentVersion()).thenReturn(1);
             var agentConfig = new AgentConfiguration();
             agentConfig.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-1")));
-            when(agentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
+            when(agentStore.read("agent-1", 1)).thenReturn(agentConfig);
 
             var result = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls",
                     String.class, agentStore, workflowStore, resourceClientLibrary);
@@ -151,14 +151,14 @@ class WorkflowTraversalTest {
             var agentConfig = new AgentConfiguration();
             agentConfig.setWorkflows(List.of(
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-1?version=1")));
-            when(agentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
+            when(agentStore.read("agent-1", 1)).thenReturn(agentConfig);
 
             var wfConfig = new WorkflowConfiguration();
             var step = new WorkflowStep();
             step.setType(URI.create("eddi://ai.labs.httpcalls"));
             step.setConfig(Map.of("uri", "eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/hc-1?version=1"));
             wfConfig.setWorkflowSteps(List.of(step));
-            when(workflowStore.readWorkflow("wf-1", 1)).thenReturn(wfConfig);
+            when(workflowStore.read("wf-1", 1)).thenReturn(wfConfig);
             when(resourceClientLibrary.getResource(any(URI.class), eq(String.class)))
                     .thenReturn("mockConfig");
 
@@ -177,14 +177,14 @@ class WorkflowTraversalTest {
             var agentConfig = new AgentConfiguration();
             agentConfig.setWorkflows(List.of(
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-1?version=1")));
-            when(agentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
+            when(agentStore.read("agent-1", 1)).thenReturn(agentConfig);
 
             var wfConfig = new WorkflowConfiguration();
             var step = new WorkflowStep();
             step.setType(URI.create("eddi://ai.labs.httpcalls"));
             step.setConfig(Map.of()); // no "uri" key
             wfConfig.setWorkflowSteps(List.of(step));
-            when(workflowStore.readWorkflow("wf-1", 1)).thenReturn(wfConfig);
+            when(workflowStore.read("wf-1", 1)).thenReturn(wfConfig);
 
             var result = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls",
                     String.class, agentStore, workflowStore, resourceClientLibrary);
@@ -200,14 +200,14 @@ class WorkflowTraversalTest {
             var agentConfig = new AgentConfiguration();
             agentConfig.setWorkflows(List.of(
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-1?version=1")));
-            when(agentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
+            when(agentStore.read("agent-1", 1)).thenReturn(agentConfig);
 
             var wfConfig = new WorkflowConfiguration();
             var step = new WorkflowStep();
             step.setType(URI.create("eddi://ai.labs.rules"));
             step.setConfig(Map.of("uri", "something"));
             wfConfig.setWorkflowSteps(List.of(step));
-            when(workflowStore.readWorkflow("wf-1", 1)).thenReturn(wfConfig);
+            when(workflowStore.read("wf-1", 1)).thenReturn(wfConfig);
 
             var result = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls",
                     String.class, agentStore, workflowStore, resourceClientLibrary);
@@ -223,14 +223,14 @@ class WorkflowTraversalTest {
             var agentConfig = new AgentConfiguration();
             agentConfig.setWorkflows(List.of(
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-1?version=1")));
-            when(agentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
+            when(agentStore.read("agent-1", 1)).thenReturn(agentConfig);
 
             var wfConfig = new WorkflowConfiguration();
             var step = new WorkflowStep();
             step.setType(URI.create("eddi://ai.labs.httpcalls"));
             step.setConfig(Map.of("uri", "eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/hc-1?version=1"));
             wfConfig.setWorkflowSteps(List.of(step));
-            when(workflowStore.readWorkflow("wf-1", 1)).thenReturn(wfConfig);
+            when(workflowStore.read("wf-1", 1)).thenReturn(wfConfig);
             when(resourceClientLibrary.getResource(any(URI.class), eq(String.class)))
                     .thenThrow(new ServiceException("Load failed"));
 
@@ -248,8 +248,8 @@ class WorkflowTraversalTest {
             var agentConfig = new AgentConfiguration();
             agentConfig.setWorkflows(List.of(
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-1?version=1")));
-            when(agentStore.readAgent("agent-1", 1)).thenReturn(agentConfig);
-            when(workflowStore.readWorkflow("wf-1", 1)).thenThrow(new RuntimeException("Workflow not found"));
+            when(agentStore.read("agent-1", 1)).thenReturn(agentConfig);
+            when(workflowStore.read("wf-1", 1)).thenThrow(new RuntimeException("Workflow not found"));
 
             var result = WorkflowTraversal.discoverConfigs(memory, "eddi://ai.labs.httpcalls",
                     String.class, agentStore, workflowStore, resourceClientLibrary);
@@ -279,8 +279,8 @@ class WorkflowTraversalTest {
             assertEquals(1, first.size());
             assertEquals(1, second.size(), "the cached traversal must carry the same configs, not an empty list");
             assertEquals("hc", second.get(0).config());
-            verify(agentStore, times(1)).readAgent("agent-1", 1);
-            verify(workflowStore, times(1)).readWorkflow(workflowIdOf("agent-1"), 1);
+            verify(agentStore, times(1)).read("agent-1", 1);
+            verify(workflowStore, times(1)).read(workflowIdOf("agent-1"), 1);
         }
 
         @Test
@@ -293,12 +293,12 @@ class WorkflowTraversalTest {
             WorkflowTraversal.discoverConfigs(memory, HTTPCALLS, String.class, agentStore, workflowStore, resourceClientLibrary, t0);
             WorkflowTraversal.discoverConfigs(memory, HTTPCALLS, String.class, agentStore, workflowStore, resourceClientLibrary,
                     t0 + WorkflowTraversal.CACHE_TTL_MILLIS - 1);
-            verify(agentStore, times(1)).readAgent("agent-1", 1);
+            verify(agentStore, times(1)).read("agent-1", 1);
 
             var afterExpiry = WorkflowTraversal.discoverConfigs(memory, HTTPCALLS, String.class, agentStore, workflowStore,
                     resourceClientLibrary, t0 + WorkflowTraversal.CACHE_TTL_MILLIS);
 
-            verify(agentStore, times(2)).readAgent("agent-1", 1);
+            verify(agentStore, times(2)).read("agent-1", 1);
             assertEquals(1, afterExpiry.size());
         }
 
@@ -350,7 +350,7 @@ class WorkflowTraversalTest {
             when(memory.getAgentId()).thenReturn("agent-1");
             when(memory.getAgentVersion()).thenReturn(2);
             discover(HTTPCALLS, String.class);
-            verify(agentStore).readAgent("agent-1", 2);
+            verify(agentStore).read("agent-1", 2);
         }
 
         @Test
@@ -358,7 +358,7 @@ class WorkflowTraversalTest {
         void workflowLoadFailureIsNotCached() throws Exception {
             wireAgent("agent-1", 1, step(HTTPCALLS, HC_URI));
             when(resourceClientLibrary.getResource(any(URI.class), eq(String.class))).thenReturn("hc");
-            when(workflowStore.readWorkflow(workflowIdOf("agent-1"), 1))
+            when(workflowStore.read(workflowIdOf("agent-1"), 1))
                     .thenThrow(new RuntimeException("transient store blip"))
                     .thenReturn(workflow(step(HTTPCALLS, HC_URI)));
 
@@ -390,7 +390,7 @@ class WorkflowTraversalTest {
             assertTrue(discover(HTTPCALLS, String.class).isEmpty());
             assertTrue(discover(HTTPCALLS, String.class).isEmpty());
 
-            verify(agentStore, times(1)).readAgent("agent-1", 1);
+            verify(agentStore, times(1)).read("agent-1", 1);
         }
 
         @Test
@@ -437,8 +437,8 @@ class WorkflowTraversalTest {
             var agentConfig = new AgentConfiguration();
             agentConfig.setWorkflows(
                     List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowIdOf(agentId) + "?version=1")));
-            lenient().when(agentStore.readAgent(agentId, version)).thenReturn(agentConfig);
-            lenient().when(workflowStore.readWorkflow(workflowIdOf(agentId), 1)).thenReturn(workflow(steps));
+            lenient().when(agentStore.read(agentId, version)).thenReturn(agentConfig);
+            lenient().when(workflowStore.read(workflowIdOf(agentId), 1)).thenReturn(workflow(steps));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/modules/templating/rest/RestTemplatePreviewTest.java
+++ b/src/test/java/ai/labs/eddi/modules/templating/rest/RestTemplatePreviewTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.modules.templating.rest;
 
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.memory.IConversationMemory;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
@@ -55,7 +56,7 @@ class RestTemplatePreviewTest {
 
         restTemplatePreview = new RestTemplatePreview(
                 templatingEngine, conversationMemoryStore,
-                memoryItemConverter, promptSnippetService, conversationAccessGuard);
+                memoryItemConverter, promptSnippetService, conversationAccessGuard, mock(ResourceAccessGuard.class));
     }
 
     // ==================== Null / Blank Input ====================

--- a/src/test/java/ai/labs/eddi/modules/templating/rest/RestTemplatePreviewTest.java
+++ b/src/test/java/ai/labs/eddi/modules/templating/rest/RestTemplatePreviewTest.java
@@ -43,6 +43,7 @@ class RestTemplatePreviewTest {
     private IMemoryItemConverter memoryItemConverter;
     private PromptSnippetService promptSnippetService;
     private ConversationAccessGuard conversationAccessGuard;
+    private ResourceAccessGuard resourceAccessGuard;
     private RestTemplatePreview restTemplatePreview;
 
     @BeforeEach
@@ -52,11 +53,12 @@ class RestTemplatePreviewTest {
         memoryItemConverter = mock(IMemoryItemConverter.class);
         promptSnippetService = mock(PromptSnippetService.class);
         conversationAccessGuard = mock(ConversationAccessGuard.class);
+        resourceAccessGuard = mock(ResourceAccessGuard.class);
         when(promptSnippetService.getAll()).thenReturn(Map.of());
 
         restTemplatePreview = new RestTemplatePreview(
                 templatingEngine, conversationMemoryStore,
-                memoryItemConverter, promptSnippetService, conversationAccessGuard, mock(ResourceAccessGuard.class));
+                memoryItemConverter, promptSnippetService, conversationAccessGuard, resourceAccessGuard);
     }
 
     // ==================== Null / Blank Input ====================
@@ -276,6 +278,8 @@ class RestTemplatePreviewTest {
         void shouldInjectSnippetsIntoTemplateData() throws Exception {
             Map<String, Object> snippets = Map.of("safety", "Always verify facts.");
             when(promptSnippetService.getAll()).thenReturn(snippets);
+            // A caller who sees everything anyway gets the real contents.
+            when(resourceAccessGuard.seesEverything()).thenReturn(true);
             when(templatingEngine.processTemplate(eq("{{snippets.safety}}"), anyMap()))
                     .thenAnswer(inv -> {
                         Map<String, Object> data = inv.getArgument(1);
@@ -303,6 +307,36 @@ class RestTemplatePreviewTest {
             List<String> vars = response.availableVariables();
             assertTrue(vars.contains("snippets.greeting"), "Should list snippets.greeting");
             assertTrue(vars.contains("snippets.farewell"), "Should list snippets.farewell");
+        }
+
+        @Test
+        @DisplayName("a restricted caller cannot read snippet contents back through their own template")
+        void shouldNotLeakSnippetContentsThroughTheRenderedTemplate() throws Exception {
+            // The exfiltration this guards against: the reference panel redacts snippet
+            // contents but hands out the NAMES, and the caller supplies the template. So
+            // redacting only the panel is no protection — one call lists the names, a
+            // second renders "{snippets.<name>}". The contents must be gone from the map
+            // the engine renders against, not just from the panel.
+            Map<String, Object> snippets = Map.of("victimSecret", "Bob's proprietary prompt.");
+            when(promptSnippetService.getAll()).thenReturn(snippets);
+            when(resourceAccessGuard.seesEverything()).thenReturn(false);
+
+            Map<String, Object> rendered = new LinkedHashMap<>();
+            when(templatingEngine.processTemplate(eq("{snippets.victimSecret}"), anyMap()))
+                    .thenAnswer(inv -> {
+                        rendered.putAll(inv.getArgument(1));
+                        return "irrelevant";
+                    });
+
+            TemplatePreviewResponse response = restTemplatePreview.previewTemplate(
+                    new TemplatePreviewRequest("{snippets.victimSecret}", null));
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> renderedSnippets = (Map<String, Object>) rendered.get("snippets");
+            assertNotNull(renderedSnippets, "the key stays, so the preview can still say which references resolve");
+            assertTrue(renderedSnippets.containsKey("victimSecret"), "names are not the secret");
+            assertEquals("<redacted>", renderedSnippets.get("victimSecret"), "contents must not reach the engine");
+            assertEquals("<redacted>", response.variableValues().get("snippets.victimSecret"));
         }
 
         @Test


### PR DESCRIPTION
Adds per-user **workspaces** to EDDI: configuration resources are scoped to the user or team that created them, with explicit sharing on top. **Off by default** (`eddi.workspaces.enabled=false`).

Operator guide: [`docs/workspaces.md`](docs/workspaces.md).

## The problem

Configuration resources had **no ownership at all**. `DocumentDescriptor` inherits a `createdBy` field from `ResourceDescriptor` and nothing ever wrote it, so agents, workflows, rule sets, LLM configs and the rest were one shared workspace gated only by `@RolesAllowed({"eddi-admin","eddi-editor"})`. Any editor could read, edit, undeploy and delete anyone's work, and `eddi-user` could `POST /agents/{anyId}/start`.

(Conversations, user memories, attachments, HITL approvals and OAuth grants were already per-user and are untouched.)

## The model

**Spaces are the boundary, grants are the exception.** Every descriptor gains `ownerId`, `spaceId` (`user:<principal>` or `team:<keycloak group>`), `visibility` (`private` / `space` / `published`) and a list of grants at `USE < VIEW < EDIT < OWN`.

The `USE`/`VIEW` split is the one that earns its complexity: letting a colleague *talk to* an agent is a different act from letting them read its system prompt, tool list and vault references — and the first is by far the more common share.

No configuration document gained a field; ownership lives entirely on the descriptor.

## Design decisions worth reviewing

- **One materialised `accessIndex`, not a query over structured fields.** `IResourceFilter` ANDs groups and ORs within a group, and cannot nest — so the real policy (`owner OR (space AND visibility=space) OR granted OR published`) is not expressible as a query. `DescriptorAccess` holds both halves so it stays checkable that they agree; the test sweeps the full owner x space x visibility x grant x caller x policy cross-product.
- **Every identity predicate is anchored and escaped.** Both backends treat a `String` filter as a **regular expression** (`Filters.regex` / `~`), so an unescaped predicate for `alice` also matches `malice`.
- **The engine reads configs from stores, not the authoring facade** (first commit). A conversation turn runs under the *chatting* user's identity; routing it through the guard would fail every turn on every shared agent.
- **Cascades check before they cascade.** Delete tears down referenced resources *before* the guarded delete, so the check moved to the top.

## Backward compatibility

- Default off. `eddi.workspaces.enabled=true` with `authorization.enabled=false` logs that it has no effect rather than denying everyone everything.
- Ownership is **recorded** whenever auth is on, independent of enforcement — deploy, let attribution accumulate, verify, then enforce.
- `WorkspaceAccessIndexMigration` backfills pre-existing descriptors. Required, not optional: neither backend can express "this field is absent", so an unstamped descriptor would match no predicate and vanish from every listing.
- `legacy-visibility=shared` (default) keeps pre-existing resources visible, so an upgrade hides nothing.

## Also fixed along the way

**EDDI's internal loopback calls carried no credentials.** `AgentSetupService` (the agent wizard, `setup-api`, and the Platform Operator's agent-creation tools) and most of `McpAdminTools` re-enter EDDI's own REST API through `RestInterfaceFactory`, which sent no `Authorization` header while `/*` sits behind the `authenticated` policy. Every one of those paths answered **401 whenever `authorization.enabled=true`** — the exact configuration workspaces require. `LoopbackCallerAuthFilter` forwards the caller's own token across that hop (one-arg overload only — it addresses this process's own port; the remote-instance overload deliberately does not get it).

Also adds the **`eddi-approver` role** to the shipped realm, which `OwnershipValidator` and `HitlAccessGuard` have been checking for without it ever being defined.

## `GET /workspaces` — a capability a client cannot infer

Ownership is *recorded* whenever authentication is on, deliberately, so
attribution accumulates before an operator flips enforcement. The consequence is
that a deployment with workspaces **off** returns descriptors that look exactly
like one where everything predates ownership — no owner, no space, no
visibility. A UI reading those fields alone cannot tell the two apart, and
guesses wrong by offering sharing that silently cannot work.

`RestWorkspaces` answers for the calling user only: whether enforcement is
active, their principal (the value stamped as `ownerId`, not a display name),
their default write space, every space they can reach, and whether they see
everything. It takes no principal parameter, so it cannot be used to enumerate
somebody else's group membership.

It also **serves the space list**, which removes EDDI-Manager's client-side
reimplementation of `Subjects`' encoding. That mirror could only fail silently:
an id encoded differently selects a workspace matching nothing, which renders as
"you have no agents" rather than as an error.

`?space=` also exists on the agent listing now — the Manager was already sending
it there, to an endpoint that did not declare it, so the switcher changed the URL
and nothing else. It narrows in the query, never client-side: page 2 of
"everything" is not page 2 of "this space".

## Review passes

Five, each recorded in `docs/changelog.md` with what it found: self-review, an adversarial max-effort pass, a critical code+UX pass, a fix-all pass, and a final adversarial pass over the whole branch.

The first four all found the same shape — *a surface reaching agents or descriptors without passing the guard* — now closed at each authoring entry point (REST, MCP, export/import, duplicate, deploy, schedules, triggers, group membership, `/v1`).

**The fifth found two more of exactly that shape, which is what makes them oversights rather than decisions:**

- **Channel integrations were a standing bypass of the USE gate (high).** Triggers, schedules and group membership all check USE on the agents they *reference*, because those references reach the target as a system-initiated conversation — deliberately below the gate. `RestChannelIntegrationStore` guarded the channel config's own CRUD and never checked its targets, so an editor holding Slack credentials could aim a `ChannelTarget` at a colleague's **private** agent and relay its replies into a room of their choosing. `TargetType.GROUP` was identical. `requireUseOnTargets` now runs before the write.
- **Template preview leaked every snippet in the deployment (high).** It redacted snippet *contents* from the variable-reference panel and then rendered the caller's template against the *unredacted* map. The comment justifying that was simply wrong — the caller supplies the template and the panel hands them the names, so one call lists them and a second call whose body is `{snippets.<name>}` prints the content. Snippets are a guarded configuration type, so this disclosed colleagues' prompt building blocks cross-workspace through an endpoint any editor can reach.

Two smaller ones from the same pass: A2A conversing did not enforce `isA2aEnabled()` while discovery did (so a peer that knew an id could talk to an agent nobody had exposed), and `readDescriptor` gated on the current descriptor but redacted against the addressed *version*, whose owner and grants can predate a transfer.

**Deliberately not changed, and recorded as an open decision:** `ConverseWithAgentTool` reaches `startConversation` with a target the model picks at runtime, and `DynamicAgentConfig.permissiveDefault()` allows any target. Unlike channels, triggers and groups there is no authoring-time reference to check, so closing it means a runtime gate on the chatting user's identity — which would change delegation semantics for existing deployments.

## Verification

20,396 unit tests green apart from this machine's environmental socket failures. Mutation-checked: the regex escaping, the visibility default, the graph resolver's set split, and the schedule USE gate each have a test that fails with the defect reintroduced.

`WorkspacesIT` covers the workspace and sharing surface **over real HTTP** in CI — 13 tests, green — because everything the new endpoint and `?space=` can get wrong is wiring a unit test holding the resource class cannot see: whether a query parameter binds, whether Jackson emits the field names a client is typed against, whether a path is routed at all. Two of those had already been wrong once. One assertion is worth naming: `?space=.*` must return **nothing**, since both storage backends treat a String filter as a regular expression, and `.*` selecting everything is exactly what an unescaped identity predicate looks like from the outside.

A JaCoCo pass then found the two classes where a mistake is silent and coverage was worst — `RestResourceSharing` at **0%** (no unit test referenced it at all, only the IT) and `SpaceContext` at 64%/50%. Now 97%/87% and 100%/81%. The groups-claim handling is mutation-checked: remove the JSON quote-stripping and the space id becomes `team:"engineering"`, which matches nothing and reads as an empty workspace rather than a parsing bug.

**Not verified locally, and it is the important part:** the loopback-auth fix changes how every internal API call authenticates, and depends on a live security context, a real Keycloak and the HTTP stack. Before enabling anywhere real — staging, Keycloak on, two accounts, Operator activated and published, then confirm each user sees only their own agents and a created agent belongs to whoever asked for it.

## Deliberately open

Sub-agent tools (runtime, governed by tool approval); descriptor creation in a response filter rather than the stores; the regex-scan access predicate (scaling ceiling, needs a real PostgreSQL to fix safely); pre-existing enumeration oracles. All recorded in the changelog with reasoning.

The EDDI-Manager UI is a separate change.


