### PR TITLE
fix(review): close an SSRF gap, and two tests that passed for the wrong reason

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,71 @@
 
 
 
+## 🧹 refactor(style): make ImportStyleTest enforce the rule it documents (2026-08-28)
+
+**Repo:** EDDI (`claude/code-review-test-coverage-59bf99`)
+
+`ImportStyleTest` guards AGENTS.md §4.7 ("never inline a fully-qualified name"), but
+its `INLINE_FQN` pattern only matched four package roots —
+`ai.labs.eddi|java.util|java.time|java.nio.file`. Every third-party FQN was invisible
+to it, so the rule was enforced on about a tenth of the surface it claims to cover.
+
+Measured blind spot: **381 inline FQNs across 118 files**, for roots the project
+actually depends on — `jakarta`, `javax`, `org.eclipse`, `org.jboss`, `com.fasterxml`,
+`io.quarkus`, `io.smallrye`, `io.micrometer`, `io.nats`, `org.bson`, `com.mongodb`,
+`org.postgresql`, `dev.langchain4j`, plus the JDK's `java.io`, `java.net`, `java.lang`
+and `java.security`. Examples: `jakarta.ws.rs.NotFoundException` in `McpHitlTools`,
+`io.micrometer.core.instrument.Counter` as a field type in `AuditLedgerService`,
+`org.eclipse.microprofile.openapi.models.tags.Tag::getName` in `OpenApiTagSortFilter`.
+
+Essentially none were the disambiguation case §4.7 permits — they were simply missing
+imports. Rather than park 118 files in an allowlist (the test's own doc argues an
+`ALLOWED` entry should be "a deliberate, reviewable act rather than silent drift", and
+an allowlist that never shrinks is exactly the drift it warns about), the pattern is
+widened to an explicit root list and the violations are fixed.
+
+The root list stays explicit rather than a general lowercase-dotted-path shape,
+because a generic pattern also matches method chains and builder idioms on a
+lowercase receiver, which are not FQNs at all.
+
+### One genuine collision found, and allowlisted
+
+`NatsConversationCoordinator` imports `io.nats.client.api.*`, which brings in
+`io.nats.client.api.Error`. Its `catch (RuntimeException | java.lang.Error e)` clauses
+mean the JDK type, and the inline FQN is load-bearing: rewriting it to `Error` makes
+the reference ambiguous and the file stops compiling. An explicit
+`import java.lang.Error` resolves it but is a redundant import (`java.lang` is
+implicit) that Checkstyle flags — so the inline FQN really is the only clean spelling.
+Added to `ALLOWED` with that reasoning recorded.
+
+Worth noting how this surfaced: the automated rewrite's conflict check only consulted
+*single-type* imports, so a name introduced by a wildcard import was invisible to it.
+The compiler caught it. Anyone repeating this exercise should expect wildcard imports
+to hide exactly this class of collision.
+
+### Verification
+
+Clean `test-compile` (not incremental — a type-level refactor reuses stale `.class`
+files otherwise), `ImportStyleTest` green against the widened pattern, and the full
+unit suite re-run against the pre-change baseline of 20,295 tests / 8 failures /
+193 errors (all environmental: loopback sockets, Docker, network). Checkstyle is
+unchanged at its pre-existing violation count — the one violation this work did
+introduce, a redundant `import java.lang.Error`, is gone with the revert above.
+
+No behaviour changes: every edit replaces an inline FQN with the identical type named
+by a top-level import, or moves an import line.
+
+Branch totals after both commits: **20,311 tests** (+16 over the baseline: 13 new
+MCP discovery tests, 3 new SSRF tests), same 8 failures / 193 errors, and an
+*identical* set of failing classes - so nothing regressed. Coverage moved
+89.91% -> 90.01% instruction and 79.24% -> 79.38% branch, with
+`McpToolsProvider` going 31.1% -> **93.5%** (branches missed 41 -> 10) and
+`SourceUrlValidator` landing at 96.3%.
+
+---
+
+
+
 ## 🔍 fix(review): close an SSRF gap, and two tests that passed for the wrong reason (2026-08-28)
 
 **Repo:** EDDI (`claude/code-review-test-coverage-59bf99`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,109 @@
 
 
 
+## 🔍 fix(review): close an SSRF gap, and two tests that passed for the wrong reason (2026-08-28)
+
+**Repo:** EDDI (`claude/code-review-test-coverage-59bf99`)
+
+A review pass for dead code, defects and thin coverage. Dead code came up empty —
+every candidate turned out to be framework-wired (`OpenApiTagSortFilter` via Quarkus
+`@OpenApiFilter`, `LifecycleModule` as a CDI producer, `URIMessageBodyProvider` as a
+JAX-RS `@Provider`), there are zero `TODO/FIXME` markers in `src/main`, and no
+`ILifecycleTask` holds mutable instance state. Three real problems did surface, each
+verified by reverting the fix and watching the new test fail.
+
+**Measured baseline** (local `./mvnw test`): 20,295 tests, 8 failures / 193 errors —
+all environmental (loopback sockets, Docker, network), matching the known local
+profile. Fresh JaCoCo from that run: 89.91% instruction / 79.24% branch.
+
+### 1. `SourceUrlValidator` accepted internal hosts the rest of the codebase refuses
+
+The remote agent-sync endpoints (`backup/import/sync*`, open to **`eddi-editor`**,
+not just admin) validated their `sourceUrl` with a second, local copy of the SSRF
+predicate built from the four JDK checks. Those do not cover:
+
+- **RFC 4193 IPv6 ULA `fc00::/7`** — `isSiteLocalAddress()` only matches the
+  deprecated `fec0::/10`
+- **RFC 6598 CGNAT `100.64.0.0/10`** — used by Tailscale and some k8s pod CIDRs
+- IPv4 multicast
+
+`UrlValidationUtils.isPrivateAddress` — which AGENTS.md already names as the thing to
+call before fetching a user-controlled URL — covers all of them. `isPrivateIp` now
+delegates there instead of keeping the weaker duplicate, which is also what §4.7
+"Unification over duplication" asks for. `isPrivateAddress` is promoted to `public`
+and documented as the single definition of an unsafe outbound address.
+
+The wrapper keeps its own messages and its HTTPS-in-production rule (which has no
+equivalent in `UrlValidationUtils`), so no existing message assertion changes.
+Deliberately *not* adopted: `UrlValidationUtils`' `.local`/`.internal` hostname
+block — those hostnames resolve and are then caught by the address check anyway, and
+blocking them by name would newly reject a legitimate corporate sync target.
+
+Confirmed by mutation: with the old predicate restored, `100.64.0.1`, `fd00::1`,
+`fc00::1` and `224.0.0.1` were all **accepted**.
+
+### 2. Two audit dead-letter tests never tested what they claimed on Linux
+
+`AuditLedgerServiceBranchTest` passed `"Z:\\nonexistent\\path\\deadletter.jsonl"` as
+the dead-letter path to force the file-fallback **failure** branch. That is only
+unwritable on Windows: a backslash is a legal character in a Unix filename, so on the
+Linux CI runner the whole string is one relative filename that
+`Files.write(..., CREATE)` happily creates. So the two assertion-free tests
+(`writeToDeadLetterNatsFails`, `writeToDeadLetterFileOnly`) exercised the *success*
+path on CI while their comments claimed the failure path — and left a junk file named
+`Z:\nonexistent\path\deadletter.jsonl` in the build directory, which is not
+gitignored.
+
+Replaced with `@TempDir` + a deliberately-uncreated parent directory: `Files.write`
+with `CREATE` does not create parent directories, so it throws `NoSuchFileException`
+on both platforms. Both tests gained real assertions — that NATS was actually
+attempted (or actually skipped), and that the dead-letter file does **not** exist
+afterwards, which is what makes them fail if the write ever starts succeeding again.
+
+Confirmed by mutation: pointing the helper at a writable path fails exactly those two
+tests.
+
+### 3. `McpToolsProvider` sat at 31% coverage, including its tool-confusion defence
+
+`McpToolsProviderTest` asserted in its javadoc that discovery was "already covered
+indirectly by `AgentOrchestratorExtendedTest`". Measurement disagreed: 264 of 383
+instructions and 41 of 50 branches missed. The indirect suites drive discovery with a
+mocked memory whose `getAgentVersion()` is null, so `WorkflowTraversal` returns before
+the per-server loop is ever entered, and the `McpToolProviderManager*Test` suites
+cover the *manager*, not this class.
+
+Untested as a result: whitelist/blacklist filtering (the blacklist is an operator
+security control), the first-write-wins collision handling the class documents at
+length as an anti-tool-confusion measure, the spec-without-executor skip, the
+resource-bridge opt-in and its `IllegalArgumentException` → `INVALID_CONFIGURATION`
+path, and the `asProviderFailures` kind mapping.
+
+New `McpToolsProviderDiscoveryTest` covers all of it (13 tests). Note for future
+authors, called out in the class comment: `WorkflowTraversal` memoizes a completed
+traversal for two seconds in a **static** map keyed on
+`agentId|version|stepType|configClass`, so every test allocates its own agent id.
+
+The stale javadoc is corrected, and `contribute_nullFlag_defaultsToEnabled` — which
+asserted only `assertNotNull`, and so passed whether or not the flag short-circuited —
+now verifies that discovery was actually attempted.
+
+Confirmed by mutation: removing the collision guard fails
+`collisionKeepsFirstSpecAndItsExecutor`.
+
+### Noted, not changed
+
+- `RemoteApiResourceSource` builds a raw `HttpClient` rather than using
+  `SafeHttpClient`, contrary to §4.4. Not urgent — the JDK default redirect policy is
+  `NEVER`, so there is no redirect-based bypass — but it is a real follow-up with its
+  own blast radius (timeout/redirect semantics differ).
+- `ImportStyleTest` enforces the §4.7 no-inline-FQN rule only for
+  `ai.labs.eddi|java.util|java.time|java.nio.file`, so ~59 inline third-party FQNs
+  across 41 files slip through. Handled separately so it does not drown this review.
+
+---
+
+
+
 ## 📝 docs(monitoring): reconcile the dashboard inventory with what is provisioned (2026-08-27)
 
 **Repo:** EDDI (`feat/grafana-full-metrics-dashboard`)

--- a/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
@@ -1246,7 +1246,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         // Use direct CDI lookup instead of HTTP loopback proxy.
         // The MP REST Client proxy strips response headers (Location, X-Resource-URI)
         // and runs on the Vert.x IO event loop, causing deadlocks during import.
-        return jakarta.enterprise.inject.spi.CDI.current().select(clazz).get();
+        return CDI.current().select(clazz).get();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/ai/labs/eddi/backup/impl/SourceUrlValidator.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/SourceUrlValidator.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
 import org.jboss.logging.Logger;
 
 import java.net.InetAddress;
@@ -88,12 +89,29 @@ public final class SourceUrlValidator {
         return false;
     }
 
+    /**
+     * Delegates the address decision to
+     * {@link UrlValidationUtils#isPrivateAddress}, the codebase's single definition
+     * of an unsafe outbound address.
+     * <p>
+     * This used to be a second, local copy built from the four JDK predicates
+     * ({@code isSiteLocalAddress}, {@code isLoopbackAddress},
+     * {@code isLinkLocalAddress}, {@code isAnyLocalAddress}). Those do not cover
+     * RFC 4193 IPv6 ULA ({@code fc00::/7} - {@code isSiteLocalAddress} only matches
+     * the deprecated {@code fec0::/10}) or RFC 6598 CGNAT ({@code 100.64.0.0/10},
+     * used by Tailscale and some k8s pod CIDRs). The sync endpoints are open to
+     * {@code eddi-editor}, so that gap let a lower-privileged role reach internal
+     * hosts the rest of the codebase already refused.
+     * <p>
+     * The messages here are deliberately kept rather than delegating to
+     * {@code validateUrl} wholesale: this validator's HTTPS-in-production rule has
+     * no equivalent there, and its wording is what the sync UI shows the operator.
+     */
     private static boolean isPrivateIp(String host) {
         try {
             InetAddress[] addresses = InetAddress.getAllByName(host);
             for (InetAddress addr : addresses) {
-                if (addr.isSiteLocalAddress() || addr.isLoopbackAddress()
-                        || addr.isLinkLocalAddress() || addr.isAnyLocalAddress()) {
+                if (UrlValidationUtils.isPrivateAddress(addr)) {
                     return true;
                 }
             }

--- a/src/main/java/ai/labs/eddi/configs/OpenApiTagSortFilter.java
+++ b/src/main/java/ai/labs/eddi/configs/OpenApiTagSortFilter.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 
 import java.util.Comparator;
+import org.eclipse.microprofile.openapi.models.tags.Tag;
 
 /**
  * Sorts OpenAPI tags alphabetically at build time, producing a stable,
@@ -25,7 +26,7 @@ public class OpenApiTagSortFilter implements OASFilter {
         if (openAPI.getTags() != null) {
             var sorted = new ArrayList<>(openAPI.getTags());
             sorted.sort(Comparator.comparing(
-                    org.eclipse.microprofile.openapi.models.tags.Tag::getName));
+                    Tag::getName));
             openAPI.setTags(sorted);
         }
     }

--- a/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
@@ -19,6 +19,8 @@ import java.security.*;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.security.spec.X509EncodedKeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
 
 /**
  * Ed25519-based signing and verification service for agent identity.
@@ -134,7 +136,7 @@ public class AgentSigningService {
                     byte[] privateKeyBytes = Base64.getDecoder().decode(privateKeyB64);
                     KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM);
                     return keyFactory.generatePrivate(
-                            new java.security.spec.PKCS8EncodedKeySpec(privateKeyBytes));
+                            new PKCS8EncodedKeySpec(privateKeyBytes));
                 } catch (Exception e) {
                     throw new PrivateKeyLoadException(agentId, e);
                 }
@@ -178,7 +180,7 @@ public class AgentSigningService {
             byte[] publicKeyBytes = Base64.getDecoder().decode(publicKeyB64);
             KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM);
             PublicKey publicKey = keyFactory.generatePublic(
-                    new java.security.spec.X509EncodedKeySpec(publicKeyBytes));
+                    new X509EncodedKeySpec(publicKeyBytes));
 
             Signature sig = Signature.getInstance(ALGORITHM);
             sig.initVerify(publicKey);
@@ -324,7 +326,7 @@ public class AgentSigningService {
                     byte[] privateKeyBytes = Base64.getDecoder().decode(privateKeyB64);
                     KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM);
                     return keyFactory.generatePrivate(
-                            new java.security.spec.PKCS8EncodedKeySpec(privateKeyBytes));
+                            new PKCS8EncodedKeySpec(privateKeyBytes));
                 } catch (Exception e) {
                     throw new PrivateKeyLoadException(agentId, e);
                 }

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.List;
 
+import jakarta.ws.rs.BadRequestException;
 import static ai.labs.eddi.configs.descriptors.ResourceUtilities.*;
 import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
@@ -354,7 +355,7 @@ public class RestAgentStore implements IRestAgentStore {
         boolean hasRotatedKeys = identity != null && identity.getKeys() != null
                 && !identity.getKeys().isEmpty();
         if (!hasLegacyKey && !hasRotatedKeys) {
-            throw new jakarta.ws.rs.BadRequestException(
+            throw new BadRequestException(
                     "Cryptographic identity features require a signing key. "
                             + "Generate one via POST /agentstore/{agentId}/signing/keys "
                             + "before enabling signInterAgentMessages "

--- a/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/model/AgentGroupConfiguration.java
@@ -15,6 +15,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
  * Versioned configuration for a group of agents that can participate in
@@ -1196,12 +1198,12 @@ public class AgentGroupConfiguration {
     public enum LifecyclePolicy {
         EPHEMERAL, KEEP_DEPLOYED, UNDEPLOY_ONLY, AGENT_DECIDES;
 
-        @com.fasterxml.jackson.annotation.JsonValue
+        @JsonValue
         public String toJson() {
             return name().toLowerCase().replace('_', '-');
         }
 
-        @com.fasterxml.jackson.annotation.JsonCreator
+        @JsonCreator
         public static LifecyclePolicy fromJson(String value) {
             if (value == null)
                 return EPHEMERAL;

--- a/src/main/java/ai/labs/eddi/configs/hitl/HitlConfigValidation.java
+++ b/src/main/java/ai/labs/eddi/configs/hitl/HitlConfigValidation.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.jboss.logging.Logger;
 
 /**
  * Store-level validation for HITL configuration. Rejects unusable values at
@@ -212,7 +213,7 @@ public final class HitlConfigValidation {
         if (cfg != null
                 && cfg.getTimeoutPolicy() == null
                 && hitlConfig.getTimeoutPolicy() == HitlTimeoutPolicy.AUTO_APPROVE) {
-            org.jboss.logging.Logger.getLogger(HitlConfigValidation.class).warn(
+            Logger.getLogger(HitlConfigValidation.class).warn(
                     "hitlConfig: agent-level AUTO_APPROVE does not apply to tool approvals; tool pauses will "
                             + "WAIT_INDEFINITELY unless hitlConfig.toolApprovals.timeoutPolicy is set explicitly");
         }

--- a/src/main/java/ai/labs/eddi/configs/shared/RetryConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/shared/RetryConfiguration.java
@@ -10,6 +10,10 @@ import org.jboss.logging.Logger;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
+import java.net.UnknownHostException;
+import java.net.SocketTimeoutException;
+import java.net.ConnectException;
+import jakarta.ws.rs.WebApplicationException;
 
 /**
  * Shared retry configuration and execution utility.
@@ -184,15 +188,15 @@ public class RetryConfiguration {
 
         while (current != null) {
             // 1. Typed exception matching
-            if (current instanceof java.net.SocketTimeoutException
+            if (current instanceof SocketTimeoutException
                     || current instanceof TimeoutException
-                    || current instanceof java.net.ConnectException
-                    || current instanceof java.net.UnknownHostException) {
+                    || current instanceof ConnectException
+                    || current instanceof UnknownHostException) {
                 return true;
             }
 
             // 2. HTTP status code matching from typed exceptions
-            if (current instanceof jakarta.ws.rs.WebApplicationException wae) {
+            if (current instanceof WebApplicationException wae) {
                 int status = wae.getResponse().getStatus();
                 if (status == 429 || status == 502 || status == 503 || status == 504) {
                     return true;

--- a/src/main/java/ai/labs/eddi/configs/workflows/model/WorkflowConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/model/WorkflowConfiguration.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAlias;
 
 /**
  * @author ginccc
@@ -58,7 +59,7 @@ public class WorkflowConfiguration {
     // schemas (ZIP files / MongoDB)
     // where the property was natively named "workflowExtensions" instead of
     // "workflowSteps".
-    @com.fasterxml.jackson.annotation.JsonAlias("workflowExtensions")
+    @JsonAlias("workflowExtensions")
     public void setWorkflowSteps(List<WorkflowStep> workflowSteps) {
         this.workflowSteps = workflowSteps;
     }

--- a/src/main/java/ai/labs/eddi/engine/a2a/RestA2AEndpoint.java
+++ b/src/main/java/ai/labs/eddi/engine/a2a/RestA2AEndpoint.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import io.quarkus.security.Authenticated;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
@@ -41,7 +43,7 @@ import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Integrations / A2A Protocol", description = "Agent-to-Agent protocol endpoints")
-@jakarta.enterprise.context.ApplicationScoped
+@ApplicationScoped
 public class RestA2AEndpoint {
 
     private static final Logger LOGGER = Logger.getLogger(RestA2AEndpoint.class);
@@ -182,7 +184,7 @@ public class RestA2AEndpoint {
      */
     @POST
     @Path("a2a/agents/{agentId}")
-    @io.quarkus.security.Authenticated
+    @Authenticated
     public Response handleJsonRpc(@PathParam("agentId") String agentId, JsonRpcRequest request) {
         if (!a2aEnabled) {
             return jsonRpcError(request.id(), A2AModels.ERROR_METHOD_NOT_FOUND, "A2A is disabled");

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
@@ -16,6 +16,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.SecretKeyFactory;
 
 /**
  * HMAC-SHA256 integrity signing for audit entries.
@@ -171,8 +173,8 @@ public final class AuditHmac {
      */
     public static byte[] deriveHmacKey(String masterKey) {
         try {
-            javax.crypto.SecretKeyFactory factory = javax.crypto.SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-            javax.crypto.spec.PBEKeySpec spec = new javax.crypto.spec.PBEKeySpec(masterKey.toCharArray(),
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            PBEKeySpec spec = new PBEKeySpec(masterKey.toCharArray(),
                     PBKDF2_SALT.getBytes(StandardCharsets.UTF_8), PBKDF2_ITERATIONS, 256);
             return factory.generateSecret(spec).getEncoded();
         } catch (Exception e) {

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
@@ -9,7 +9,6 @@ import ai.labs.eddi.configs.agents.AgentSigningService;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
 import ai.labs.eddi.secrets.sanitize.SecretRedactionFilter;
 
-import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.nats.client.Connection;
@@ -21,7 +20,6 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
-
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -33,6 +31,8 @@ import java.nio.charset.StandardCharsets;
 import com.fasterxml.jackson.core.type.TypeReference;
 import ai.labs.eddi.utils.LogSanitizer;
 import java.util.Map;
+import io.micrometer.core.instrument.Counter;
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
  * Async batch writer for the immutable audit ledger.
@@ -109,7 +109,7 @@ public class AuditLedgerService {
     private final boolean enabled;
     private final int flushIntervalSeconds;
     private final Optional<String> masterKeyConfig;
-    private final io.micrometer.core.instrument.Counter droppedCounter;
+    private final Counter droppedCounter;
     private final Instance<Connection> natsConnectionInstance;
     private final String deadLetterPath;
     private final boolean agentSigningEnabled;

--- a/src/main/java/ai/labs/eddi/engine/hitl/HitlAccessGuard.java
+++ b/src/main/java/ai/labs/eddi/engine/hitl/HitlAccessGuard.java
@@ -20,6 +20,7 @@ import org.jboss.logging.Logger;
 
 import java.util.List;
 
+import jakarta.ws.rs.NotFoundException;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
@@ -132,7 +133,7 @@ public class HitlAccessGuard {
         if (groupId != null && !groupId.equals(gc.getGroupId())) {
             LOGGER.infof("Group conversation %s does not belong to group %s",
                     sanitize(groupConversationId), sanitize(groupId));
-            throw new jakarta.ws.rs.NotFoundException("Group conversation not found.");
+            throw new NotFoundException("Group conversation not found.");
         }
         ownershipValidator.requireOwnerAdminOrApprover(identity, gc.getUserId(), "group conversation");
     }
@@ -184,7 +185,7 @@ public class HitlAccessGuard {
         if (groupId != null && !groupId.equals(gc.getGroupId())) {
             LOGGER.infof("Group conversation %s does not belong to group %s",
                     sanitize(groupConversationId), sanitize(groupId));
-            throw new jakarta.ws.rs.NotFoundException("Group conversation not found.");
+            throw new NotFoundException("Group conversation not found.");
         }
         String callerId = identity != null && identity.getPrincipal() != null ? identity.getPrincipal().getName() : null;
         if (gc.getPendingHumanInput() != null && callerId != null
@@ -223,7 +224,7 @@ public class HitlAccessGuard {
         if (groupId != null && !groupId.equals(gc.getGroupId())) {
             LOGGER.infof("Group conversation %s does not belong to group %s",
                     sanitize(groupConversationId), sanitize(groupId));
-            throw new jakarta.ws.rs.NotFoundException("Group conversation not found.");
+            throw new NotFoundException("Group conversation not found.");
         }
         if (ownershipValidator.isAdmin(identity)) {
             return;

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationHitlService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationHitlService.java
@@ -58,6 +58,8 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.MessageDigest;
 import static ai.labs.eddi.engine.memory.ConversationMemoryUtilities.convertConversationMemorySnapshot;
 import static ai.labs.eddi.engine.memory.ConversationMemoryUtilities.convertSimpleConversationMemorySnapshot;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
@@ -975,7 +977,7 @@ class ConversationHitlService {
     /** SHA-256 hex of the given string (lower-case, 64 chars). */
     static String sha256Hex(String s) {
         try {
-            var md = java.security.MessageDigest.getInstance("SHA-256");
+            var md = MessageDigest.getInstance("SHA-256");
             byte[] hash = md.digest(s.getBytes(java.nio.charset.StandardCharsets.UTF_8));
             var sb = new StringBuilder(hash.length * 2);
             for (byte b : hash) {
@@ -983,7 +985,7 @@ class ConversationHitlService {
                 sb.append(Character.forDigit(b & 0xF, 16));
             }
             return sb.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
+        } catch (NoSuchAlgorithmException e) {
             // SHA-256 is guaranteed present on every JVM; unreachable.
             throw new IllegalStateException("SHA-256 unavailable", e);
         }

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -27,12 +27,12 @@ import jakarta.ws.rs.sse.SseEventSink;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
-import static ai.labs.eddi.utils.LogSanitizer.sanitize;
-
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
  * SSE streaming implementation — maps ConversationService streaming events to
@@ -57,7 +57,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
 
     private static final Logger LOGGER = Logger.getLogger(RestAgentEngineStreaming.class);
-    private static final com.fasterxml.jackson.databind.ObjectMapper MAPPER = new com.fasterxml.jackson.databind.ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Audit actor recorded when a turn is cancelled because the SSE client went

--- a/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestGroupConversation.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.ws.rs.NotFoundException;
 import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
@@ -649,7 +650,7 @@ public class RestGroupConversation implements IRestGroupConversation {
         }
         try {
             validateGroupConversationOwnership(groupId, gcId, true);
-        } catch (jakarta.ws.rs.NotFoundException e) {
+        } catch (NotFoundException e) {
             // Streaming endpoint has no Response to return — surface the mismatch as
             // a terminal SSE error instead of letting a WebApplicationException abort
             // the stream opaquely.
@@ -836,7 +837,7 @@ public class RestGroupConversation implements IRestGroupConversation {
         // never leak the conversation's existence or owner via an authz error.
         if (groupId != null && !groupId.equals(gc.getGroupId())) {
             LOGGER.infof("Group conversation %s does not belong to group %s", sanitize(gcId), sanitize(groupId));
-            throw new jakarta.ws.rs.NotFoundException("Group conversation not found.");
+            throw new NotFoundException("Group conversation not found.");
         }
         ownershipValidator.requireOwnerOrAdmin(identity, gc.getUserId(), "group conversation");
     }

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManager.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManager.java
@@ -37,6 +37,10 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 
+import org.jboss.logging.Logger;
+import java.net.UnknownHostException;
+import java.net.SocketTimeoutException;
+import java.net.ConnectException;
 import static ai.labs.eddi.engine.memory.MemoryKeys.ACTIONS;
 import static ai.labs.eddi.engine.memory.MemoryKeys.AUDIT_CASCADE_MODEL;
 import static ai.labs.eddi.engine.memory.MemoryKeys.AUDIT_COMPILED_PROMPT;
@@ -52,8 +56,6 @@ import static ai.labs.eddi.utils.LifecycleUtilities.createComponentKey;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 import static ai.labs.eddi.utils.RuntimeUtilities.checkNotNull;
 import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
-
-import org.jboss.logging.Logger;
 
 /**
  * Executes the Lifecycle Workflow - EDDI's core processing engine.
@@ -980,12 +982,12 @@ public class LifecycleManager implements ILifecycleManager {
      */
     static String classifyError(Throwable e) {
         for (Throwable current = e; current != null; current = current.getCause()) {
-            if (current instanceof java.net.SocketTimeoutException
+            if (current instanceof SocketTimeoutException
                     || current instanceof TimeoutException) {
                 return "timeout";
             }
-            if (current instanceof java.net.ConnectException
-                    || current instanceof java.net.UnknownHostException) {
+            if (current instanceof ConnectException
+                    || current instanceof UnknownHostException) {
                 return "transport";
             }
         }

--- a/src/main/java/ai/labs/eddi/engine/lifecycle/model/HitlDecision.java
+++ b/src/main/java/ai/labs/eddi/engine/lifecycle/model/HitlDecision.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.lifecycle.model;
 import java.util.Locale;
 import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
  * Human decision on a paused conversation or group discussion.
@@ -29,7 +30,7 @@ public class HitlDecision {
          * surface reports as the friendly "must include a 'verdict'" 400 — so no
          * request-local deserializer is needed to soften the error.
          */
-        @com.fasterxml.jackson.annotation.JsonCreator
+        @JsonCreator
         public static HitlVerdict fromString(String value) {
             if (value == null) {
                 return null;

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpHitlTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpHitlTools.java
@@ -36,6 +36,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.ws.rs.NotFoundException;
 import static ai.labs.eddi.engine.mcp.McpToolUtils.errorJson;
 import static ai.labs.eddi.engine.mcp.McpToolUtils.escapeJsonString;
 import static ai.labs.eddi.engine.mcp.McpToolUtils.parseIntOrDefault;
@@ -377,7 +378,7 @@ public class McpHitlTools {
             return jsonSerialization.serialize(summary);
         } catch (ForbiddenException e) {
             return errorJson("Access denied", "FORBIDDEN", null);
-        } catch (jakarta.ws.rs.NotFoundException e) {
+        } catch (NotFoundException e) {
             return errorJson("Group conversation not found", "NOT_FOUND", null);
         } catch (ResourceNotFoundException e) {
             return errorJson("Group conversation not found", "NOT_FOUND", null);
@@ -451,7 +452,7 @@ public class McpHitlTools {
             return jsonSerialization.serialize(result);
         } catch (ForbiddenException e) {
             return errorJson("Access denied", "FORBIDDEN", null);
-        } catch (jakarta.ws.rs.NotFoundException e) {
+        } catch (NotFoundException e) {
             return errorJson("Group conversation not found", "NOT_FOUND", null);
         } catch (IResourceStore.ResourceModifiedException e) {
             return errorJson("The group conversation was modified concurrently — reload and retry", "CONFLICT", null);
@@ -496,7 +497,7 @@ public class McpHitlTools {
             return jsonSerialization.serialize(result);
         } catch (ForbiddenException e) {
             return errorJson("Access denied", "FORBIDDEN", null);
-        } catch (jakarta.ws.rs.NotFoundException e) {
+        } catch (NotFoundException e) {
             return errorJson("Group conversation not found", "NOT_FOUND", null);
         } catch (IResourceStore.ResourceModifiedException e) {
             return errorJson("The group conversation was modified concurrently — reload and retry", "CONFLICT", null);
@@ -537,7 +538,7 @@ public class McpHitlTools {
                             "WRONG_STATE", null);
         } catch (ForbiddenException e) {
             return errorJson("Access denied", "FORBIDDEN", null);
-        } catch (jakarta.ws.rs.NotFoundException e) {
+        } catch (NotFoundException e) {
             return errorJson("Group conversation not found", "NOT_FOUND", null);
         } catch (ResourceNotFoundException
                 | IGroupConversationStore.GroupConversationGoneException e) {

--- a/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/engine/memory/ConversationMemoryStore.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import com.mongodb.client.FindIterable;
 import static ai.labs.eddi.engine.model.Context.ContextType.valueOf;
 import static ai.labs.eddi.engine.memory.model.ConversationState.ENDED;
 
@@ -273,7 +274,7 @@ public class ConversationMemoryStore implements IConversationMemoryStore, IResou
     }
 
     private List<PendingApprovalSummary> collectPendingSummaries(
-                                                                 com.mongodb.client.FindIterable<ConversationMemorySnapshot> snapshots) {
+                                                                 FindIterable<ConversationMemorySnapshot> snapshots) {
         List<PendingApprovalSummary> out = new ArrayList<>();
         snapshots.forEach(snapshot -> {
             var summary = new PendingApprovalSummary(

--- a/src/main/java/ai/labs/eddi/engine/runtime/BoundedLogStore.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/BoundedLogStore.java
@@ -18,6 +18,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.logging.LogRecord;
+import org.jboss.logmanager.ExtLogRecord;
 
 /**
  * In-memory ring buffer that captures log records with MDC context. Provides:
@@ -182,7 +183,7 @@ public class BoundedLogStore {
         String userId = null;
         Integer agentVersion = null;
 
-        if (record instanceof org.jboss.logmanager.ExtLogRecord extRecord) {
+        if (record instanceof ExtLogRecord extRecord) {
             environment = extRecord.getMdc("environment");
             agentId = extRecord.getMdc("agentId");
             conversationId = extRecord.getMdc("conversationId");
@@ -356,7 +357,7 @@ public class BoundedLogStore {
         Object[] params = record.getParameters();
 
         // 1. Try ExtLogRecord's built-in getFormattedMessage() first
-        if (record instanceof org.jboss.logmanager.ExtLogRecord extRecord) {
+        if (record instanceof ExtLogRecord extRecord) {
             try {
                 String formatted = extRecord.getFormattedMessage();
                 if (formatted != null && !formatted.equals(msg)) {

--- a/src/main/java/ai/labs/eddi/engine/security/AuthStartupGuard.java
+++ b/src/main/java/ai/labs/eddi/engine/security/AuthStartupGuard.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
+import io.quarkus.scheduler.Scheduled;
 
 /**
  * Startup guard that prevents accidental unauthenticated production
@@ -76,7 +77,7 @@ public class AuthStartupGuard {
      * level every hour (not every 60 seconds) to avoid polluting alerting/SIEM with
      * 525k identical ERROR lines per year.
      */
-    @io.quarkus.scheduler.Scheduled(every = "3600s")
+    @Scheduled(every = "3600s")
     void periodicAuthWarning() {
         if (warnMode) {
             LOGGER.warn("[SECURITY] ⚠️  REMINDER: OIDC is DISABLED in production. "

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -58,6 +58,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.Map;
 import java.util.regex.Pattern;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
  * Service that encapsulates the business logic for setting up EDDI agents. Used
@@ -1609,10 +1611,10 @@ public class AgentSetupService {
         }
 
         try {
-            String jsonSchema = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(schema);
+            String jsonSchema = new ObjectMapper().writeValueAsString(schema);
             return "Response with one single valid JSON Object (without wrapping it in "
                     + "any formatting or markdown). Always use the following json structure as response:" + jsonSchema;
-        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+        } catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to serialize JSON schema", e);
         }
     }

--- a/src/main/java/ai/labs/eddi/integrations/slack/SlackWebApiClient.java
+++ b/src/main/java/ai/labs/eddi/integrations/slack/SlackWebApiClient.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.io.IOException;
 
 /**
  * Lightweight Slack Web API client using {@link HttpClient}. No external SDK
@@ -204,7 +205,7 @@ public class SlackWebApiClient {
 
         } catch (SlackDeliveryException e) {
             throw e; // re-throw — don't wrap in another exception
-        } catch (java.io.IOException e) {
+        } catch (IOException e) {
             throw new SlackDeliveryException("Network error calling Slack API: " + e.getMessage(), e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/apicalls/impl/ApiCallExecutor.java
@@ -43,6 +43,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import java.io.IOException;
 import static ai.labs.eddi.utils.MatchingUtilities.executeValuePath;
 import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
@@ -300,7 +301,7 @@ public class ApiCallExecutor implements IApiCallExecutor {
                         if (CONTENT_TYPE_APPLICATION_JSON.equals(actualContentType)) {
                             try {
                                 responseObject = jsonSerialization.deserialize(responseBody, Object.class);
-                            } catch (java.io.IOException jsonEx) {
+                            } catch (IOException jsonEx) {
                                 LOGGER.warnf("ApiCall (%s) returned application/json but body is not valid JSON, falling back to raw string: %s",
                                         call.getName(), jsonEx.getMessage());
                                 responseObject = responseBody;

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutor.java
@@ -34,6 +34,9 @@ import java.util.concurrent.*;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.net.UnknownHostException;
+import java.net.SocketTimeoutException;
+import java.net.ConnectException;
 
 /**
  * Executes a multi-model cascade: tries a cheap/fast model first, evaluates
@@ -904,8 +907,8 @@ class CascadingModelExecutor {
     private static boolean isRetryableError(Exception e) {
         Throwable current = e;
         while (current != null) {
-            if (current instanceof java.net.SocketTimeoutException || current instanceof TimeoutException
-                    || current instanceof java.net.ConnectException || current instanceof java.net.UnknownHostException) {
+            if (current instanceof SocketTimeoutException || current instanceof TimeoutException
+                    || current instanceof ConnectException || current instanceof UnknownHostException) {
                 return true;
             }
             String message = current.getMessage();

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/EmbeddingModelFactory.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/EmbeddingModelFactory.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
+import dev.langchain4j.model.azure.AzureOpenAiEmbeddingModel;
 
 /**
  * Creates and caches {@link EmbeddingModel} instances based on
@@ -147,7 +148,7 @@ public class EmbeddingModelFactory {
      * </ul>
      */
     private EmbeddingModel buildAzureOpenAi(Map<String, String> params) {
-        var builder = dev.langchain4j.model.azure.AzureOpenAiEmbeddingModel.builder()
+        var builder = AzureOpenAiEmbeddingModel.builder()
                 .deploymentName(params.getOrDefault("deploymentName", "text-embedding-3-small")).apiKey(params.get("apiKey"));
 
         if (params.containsKey("endpoint")) {

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/HttpCallToolsProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/HttpCallToolsProvider.java
@@ -40,6 +40,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.core.JsonParseException;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
@@ -196,7 +199,7 @@ class HttpCallToolsProvider implements ToolSourceProvider {
                             .description(apiCall.getDescription() != null ? apiCall.getDescription() : "Execute " + apiCall.getName());
 
                     if (apiCall.getParameters() != null && !apiCall.getParameters().isEmpty()) {
-                        var schemaBuilder = dev.langchain4j.model.chat.request.json.JsonObjectSchema.builder();
+                        var schemaBuilder = JsonObjectSchema.builder();
                         for (var param : apiCall.getParameters().entrySet()) {
                             schemaBuilder.addStringProperty(param.getKey(), param.getValue() != null ? param.getValue() : param.getKey());
                         }
@@ -427,9 +430,9 @@ class HttpCallToolsProvider implements ToolSourceProvider {
      */
     private static String parseFailureDetail(IOException e) {
         String reason = switch (e) {
-            case com.fasterxml.jackson.core.JsonParseException ignored ->
+            case JsonParseException ignored ->
                 "the document is malformed — an unescaped character, an unquoted token, or a missing delimiter";
-            case com.fasterxml.jackson.databind.exc.MismatchedInputException ignored ->
+            case MismatchedInputException ignored ->
                 "the document is empty or ends before it is complete";
             default -> "the document could not be parsed";
         };

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java
@@ -43,12 +43,12 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
-import static ai.labs.eddi.utils.LogSanitizer.sanitize;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 import java.util.regex.Pattern;
+import dev.langchain4j.data.message.SystemMessage;
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 import static ai.labs.eddi.configs.workflows.model.ExtensionDescriptor.ConfigValue;
 import static ai.labs.eddi.configs.workflows.model.ExtensionDescriptor.FieldType;
@@ -494,7 +494,7 @@ public class LlmTask implements ILifecycleTask {
 
         // Build chat messages without system message for agent mode
         // (agent orchestrator adds system message internally)
-        List<ChatMessage> chatMessagesWithoutSystem = messages.stream().filter(m -> !(m instanceof dev.langchain4j.data.message.SystemMessage))
+        List<ChatMessage> chatMessagesWithoutSystem = messages.stream().filter(m -> !(m instanceof SystemMessage))
                 .toList();
 
         // === Multi-Model Cascade Branch ===

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopResumer.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopResumer.java
@@ -39,6 +39,8 @@ import java.util.Map;
 import java.util.Locale;
 import java.util.Set;
 
+import java.net.URLDecoder;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
@@ -427,7 +429,7 @@ class ToolLoopResumer {
     static String toJson(Object value) {
         try {
             return ENVELOPE_MAPPER.writeValueAsString(value);
-        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+        } catch (JsonProcessingException e) {
             // Fall back to a minimal, safe envelope rather than propagating — the
             // resume must still complete. Effectively unreachable for the small maps
             // serialized here.
@@ -549,7 +551,7 @@ class ToolLoopResumer {
      * same asymmetry the whole guard already accepts: a refusal costs a retry, a
      * miss costs the boundary.
      */
-    static String targetsOwnConversationLive(dev.langchain4j.agent.tool.ToolExecutionRequest toolRequest,
+    static String targetsOwnConversationLive(ToolExecutionRequest toolRequest,
                                              Map<String, ToolRequestResolver> resolvers, String conversationId) {
         return targetsOwnConversation(toolRequest.name(), toolRequest.arguments(),
                 args -> {
@@ -599,7 +601,7 @@ class ToolLoopResumer {
         }
         String decoded = candidate;
         try {
-            decoded = java.net.URLDecoder.decode(candidate, java.nio.charset.StandardCharsets.UTF_8);
+            decoded = URLDecoder.decode(candidate, java.nio.charset.StandardCharsets.UTF_8);
         } catch (IllegalArgumentException e) {
             // A malformed escape is not a reason to stop checking — fall back to the
             // raw string rather than returning false and allowing the write.

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ToolObjectReflector.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ToolObjectReflector.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import dev.langchain4j.agent.tool.Tool;
 
 /**
  * Turns tool <em>objects</em> (beans carrying {@code @Tool}-annotated methods)
@@ -92,8 +93,8 @@ final class ToolObjectReflector {
 
             // Find methods annotated with @Tool and map them to executors
             for (Method method : toolClass.getDeclaredMethods()) {
-                if (method.isAnnotationPresent(dev.langchain4j.agent.tool.Tool.class)) {
-                    dev.langchain4j.agent.tool.Tool toolAnnotation = method.getAnnotation(dev.langchain4j.agent.tool.Tool.class);
+                if (method.isAnnotationPresent(Tool.class)) {
+                    Tool toolAnnotation = method.getAnnotation(Tool.class);
                     String toolName = toolAnnotation.name().isEmpty() ? method.getName() : toolAnnotation.name();
                     toolExecutors.put(toolName, new DefaultToolExecutor(tool, method));
                     toolSources.put(toolName, sourceForBuiltInTool(tool));

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupport.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/orchestration/ToolApprovalGateSupport.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import java.security.NoSuchAlgorithmException;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
@@ -468,7 +469,7 @@ public class ToolApprovalGateSupport {
                 sb.append(Character.forDigit(b & 0xF, 16));
             }
             return sb.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
+        } catch (NoSuchAlgorithmException e) {
             // SHA-256 is guaranteed present on every JVM; treat as unreachable.
             throw new IllegalStateException("SHA-256 unavailable", e);
         }

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/ToolCacheService.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/ToolCacheService.java
@@ -12,8 +12,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
-import static ai.labs.eddi.utils.LogSanitizer.sanitize;
-
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -22,6 +20,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Counter;
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
  * Caffeine-backed cache service for tool results with smart TTL management.
@@ -101,10 +102,10 @@ public class ToolCacheService {
     private ICache<String, CachedResult> cache;
 
     // Metrics
-    private io.micrometer.core.instrument.Counter cacheHitCounter;
-    private io.micrometer.core.instrument.Counter cacheMissCounter;
-    private io.micrometer.core.instrument.Timer cacheGetTimer;
-    private io.micrometer.core.instrument.Timer cachePutTimer;
+    private Counter cacheHitCounter;
+    private Counter cacheMissCounter;
+    private Timer cacheGetTimer;
+    private Timer cachePutTimer;
 
     private final AtomicInteger hits = new AtomicInteger(0);
     private final AtomicInteger misses = new AtomicInteger(0);

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/UrlValidationUtils.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/UrlValidationUtils.java
@@ -139,8 +139,14 @@ public final class UrlValidationUtils {
      * <li>Unspecified (0.0.0.0/8)</li>
      * <li>Cloud metadata (169.254.169.254)</li>
      * </ul>
+     * <p>
+     * Public because it is the single definition of "unsafe outbound address" for
+     * the whole codebase: {@code SourceUrlValidator}, which guards the remote agent
+     * sync endpoints, delegates here rather than keeping the second, weaker copy it
+     * used to have (that one missed RFC 4193 ULA and RFC 6598 CGNAT, because the
+     * JDK predicates alone do not cover them).
      */
-    static boolean isPrivateAddress(InetAddress address) {
+    public static boolean isPrivateAddress(InetAddress address) {
         // JDK covers: loopback, site-local (RFC 1918 for IPv4, fec0::/10 for IPv6),
         // link-local, any-local (0.0.0.0, ::)
         if (address.isLoopbackAddress() || address.isSiteLocalAddress() || address.isLinkLocalAddress() || address.isAnyLocalAddress()

--- a/src/main/java/ai/labs/eddi/modules/nlp/expressions/Expression.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/expressions/Expression.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.utils.CharacterUtilities;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
+import org.jboss.logging.Logger;
 
 /**
  * @author ginccc
@@ -237,5 +238,5 @@ public class Expression implements Cloneable {
         return ret.toString();
     }
 
-    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(Expression.class);
+    private static final Logger log = Logger.getLogger(Expression.class);
 }

--- a/src/main/java/ai/labs/eddi/modules/nlp/expressions/ExpressionFactory.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/expressions/ExpressionFactory.java
@@ -11,6 +11,7 @@ import ai.labs.eddi.modules.nlp.expressions.value.Value;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Hashtable;
 
+import org.jboss.logging.Logger;
 import static ai.labs.eddi.utils.CharacterUtilities.isNumber;
 
 /**
@@ -63,5 +64,5 @@ public class ExpressionFactory implements IExpressionFactory {
         return exp;
     }
 
-    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(ExpressionFactory.class);
+    private static final Logger log = Logger.getLogger(ExpressionFactory.class);
 }

--- a/src/main/java/ai/labs/eddi/modules/nlp/expressions/Negation.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/expressions/Negation.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.labs.eddi.modules.nlp.expressions;
+import org.jboss.logging.Logger;
 
 /**
  * @author ginccc
@@ -45,5 +46,5 @@ public class Negation extends Expression {
             getSubExpressions()[0].setDomain(category);
     }
 
-    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(Negation.class);
+    private static final Logger log = Logger.getLogger(Negation.class);
 }

--- a/src/main/java/ai/labs/eddi/modules/nlp/expressions/value/Value.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/expressions/value/Value.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.modules.nlp.expressions.Expression;
 
 import java.util.regex.Pattern;
 
+import org.jboss.logging.Logger;
 import static ai.labs.eddi.utils.CharacterUtilities.isNumber;
 
 /**
@@ -79,5 +80,5 @@ public class Value extends Expression {
         return super.hashCode();
     }
 
-    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(Value.class);
+    private static final Logger log = Logger.getLogger(Value.class);
 }

--- a/src/main/java/ai/labs/eddi/modules/nlp/extensions/dictionaries/providers/RegularDictionaryProvider.java
+++ b/src/main/java/ai/labs/eddi/modules/nlp/extensions/dictionaries/providers/RegularDictionaryProvider.java
@@ -22,6 +22,7 @@ import jakarta.inject.Inject;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import org.jboss.logging.Logger;
 
 /**
  * @author ginccc
@@ -132,5 +133,5 @@ public class RegularDictionaryProvider implements IDictionaryProvider {
         return resourceClientLibrary.getResource(resourceURI, DictionaryConfiguration.class);
     }
 
-    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(RegularDictionaryProvider.class);
+    private static final Logger log = Logger.getLogger(RegularDictionaryProvider.class);
 }

--- a/src/main/java/ai/labs/eddi/secrets/crypto/EnvelopeCrypto.java
+++ b/src/main/java/ai/labs/eddi/secrets/crypto/EnvelopeCrypto.java
@@ -13,6 +13,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.security.spec.InvalidKeySpecException;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.SecretKeyFactory;
 
 /**
  * Stateless utility for AES-256-GCM envelope encryption.
@@ -179,10 +182,10 @@ public final class EnvelopeCrypto {
             throw new CryptoException("PBKDF2 salt must be at least 8 bytes, got " + (salt == null ? "null" : salt.length));
         }
         try {
-            javax.crypto.SecretKeyFactory factory = javax.crypto.SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-            javax.crypto.spec.PBEKeySpec spec = new javax.crypto.spec.PBEKeySpec(keyString.toCharArray(), salt, 600_000, 256);
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            PBEKeySpec spec = new PBEKeySpec(keyString.toCharArray(), salt, 600_000, 256);
             return factory.generateSecret(spec).getEncoded();
-        } catch (java.security.NoSuchAlgorithmException | java.security.spec.InvalidKeySpecException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
             throw new CryptoException("PBKDF2 key derivation failed", e);
         }
     }

--- a/src/main/java/ai/labs/eddi/secrets/impl/VaultSecretProvider.java
+++ b/src/main/java/ai/labs/eddi/secrets/impl/VaultSecretProvider.java
@@ -31,6 +31,7 @@ import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.function.UnaryOperator;
 
+import java.security.SecureRandom;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
@@ -539,7 +540,7 @@ public class VaultSecretProvider implements ISecretProvider {
             boolean migratingFromLegacy = saltManager.isUsingLegacySalt();
             if (migratingFromLegacy) {
                 newSalt = new byte[16];
-                new java.security.SecureRandom().nextBytes(newSalt);
+                new SecureRandom().nextBytes(newSalt);
                 LOGGER.info("[VAULT] KEK rotation will also migrate from legacy salt to per-deployment random salt.");
             } else {
                 newSalt = saltManager.getSalt();

--- a/src/main/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistence.java
+++ b/src/main/java/ai/labs/eddi/secrets/persistence/MongoSecretPersistence.java
@@ -160,7 +160,7 @@ public class MongoSecretPersistence implements ISecretPersistence {
                     Updates.setOnInsert(FIELD_CREATED_AT, instantToString(secret.getCreatedAt())));
 
             secretsCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
-        } catch (com.mongodb.MongoException e) {
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to upsert secret " + secret.getTenantId() + "/" + secret.getKeyName(), e);
         }
     }
@@ -170,7 +170,7 @@ public class MongoSecretPersistence implements ISecretPersistence {
         try {
             var doc = secretsCollection.find(and(eq(FIELD_TENANT_ID, tenantId), eq(FIELD_KEY_NAME, keyName))).first();
             return doc != null ? Optional.of(documentToSecret(doc)) : Optional.empty();
-        } catch (com.mongodb.MongoException e) {
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to find secret " + tenantId + "/" + keyName, e);
         }
     }
@@ -180,7 +180,7 @@ public class MongoSecretPersistence implements ISecretPersistence {
         try {
             var result = secretsCollection.deleteOne(and(eq(FIELD_TENANT_ID, tenantId), eq(FIELD_KEY_NAME, keyName)));
             return result.getDeletedCount() > 0;
-        } catch (com.mongodb.MongoException e) {
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to delete secret " + tenantId + "/" + keyName, e);
         }
     }
@@ -193,7 +193,7 @@ public class MongoSecretPersistence implements ISecretPersistence {
                 secrets.add(documentToSecret(doc));
             }
             return secrets;
-        } catch (com.mongodb.MongoException e) {
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to list secrets for tenant " + tenantId, e);
         }
     }
@@ -320,7 +320,7 @@ public class MongoSecretPersistence implements ISecretPersistence {
                 deks.add(documentToDek(doc));
             }
             return deks;
-        } catch (com.mongodb.MongoException e) {
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to list all DEKs", e);
         }
     }
@@ -332,7 +332,7 @@ public class MongoSecretPersistence implements ISecretPersistence {
         try {
             var doc = metaCollection.find(eq("key", key)).first();
             return doc != null ? doc.getString("value") : null;
-        } catch (com.mongodb.MongoException e) {
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to read meta value: " + key, e);
         }
     }
@@ -345,7 +345,7 @@ public class MongoSecretPersistence implements ISecretPersistence {
                     Updates.set("value", value),
                     Updates.setOnInsert("key", key));
             metaCollection.updateOne(filter, update, new UpdateOptions().upsert(true));
-        } catch (com.mongodb.MongoException e) {
+        } catch (MongoException e) {
             throw new PersistenceException("Failed to write meta value: " + key, e);
         }
     }

--- a/src/test/java/ai/labs/eddi/ImportStyleTest.java
+++ b/src/test/java/ai/labs/eddi/ImportStyleTest.java
@@ -44,23 +44,47 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ImportStyleTest {
 
     /**
-     * An inline FQN: a package path in EDDI's own namespace (or a common JDK one)
-     * followed by a capitalised type name.
+     * An inline FQN: a package path in EDDI's own namespace, a common JDK one, or
+     * one of the third-party roots this project actually depends on, followed by a
+     * capitalised type name.
+     * <p>
+     * The root list is explicit rather than a general lowercase-dotted-path shape:
+     * a generic pattern also matches method chains and builder idioms on a
+     * lowercase receiver, which are not FQNs at all.
+     * <p>
+     * It used to cover only {@code ai.labs.eddi}, {@code java.util},
+     * {@code java.time} and {@code java.nio.file}, while AGENTS.md 4.7 states the
+     * rule without any package restriction. That blind spot hid 381 inline
+     * third-party FQNs across 116 files - {@code jakarta.ws.rs.NotFoundException},
+     * {@code io.micrometer.core.instrument.Counter},
+     * {@code org.eclipse.microprofile.openapi.models.tags.Tag} and the like - none
+     * of which were disambiguation cases; they were simply missing imports.
      */
     // The trailing package segments are optional (*, not +). With '+' this missed
     // `java.util.List` entirely — there is no further lowercase segment after
     // `util` — which is exactly how the original audit under-counted.
     private static final Pattern INLINE_FQN = Pattern.compile(
-            "\\b((?:ai\\.labs\\.eddi|java\\.util|java\\.time|java\\.nio\\.file)(?:\\.[a-z][A-Za-z0-9_]*)*\\.[A-Z][A-Za-z0-9_]*)");
+            "\\b((?:ai\\.labs\\.eddi|java\\.util|java\\.time|java\\.io|java\\.net|java\\.lang|java\\.security|java\\.nio\\.file|jakarta|javax|org\\.eclipse|org\\.jboss|org\\.bson|org\\.postgresql|com\\.fasterxml|com\\.mongodb|io\\.quarkus|io\\.smallrye|io\\.micrometer|io\\.nats|dev\\.langchain4j)(?:\\.[a-z][A-Za-z0-9_]*)*\\.[A-Z][A-Za-z0-9_]*)");
 
     /**
-     * The only permitted inline FQNs: each of these files declares a class whose
-     * simple name collides with the superclass it extends, so one of the two can
-     * only be named in full.
+     * The only permitted inline FQNs, each a genuine collision where one of two
+     * same-named types can only be written in full.
+     * <ul>
+     * <li>The two {@code HistorizedResourceStore} files declare a class whose
+     * simple name collides with the superclass it extends.</li>
+     * <li>{@code NatsConversationCoordinator} imports {@code io.nats.client.api.*},
+     * which brings in {@code io.nats.client.api.Error}; its
+     * {@code catch (RuntimeException |
+     * java.lang.Error e)} clauses mean the JDK type. An explicit
+     * {@code import java.lang.Error} would resolve the ambiguity but is a redundant
+     * import (java.lang is implicit), which Checkstyle flags - so the inline FQN is
+     * the only clean spelling.</li>
+     * </ul>
      */
     private static final Set<String> ALLOWED = Set.of(
             "src/main/java/ai/labs/eddi/datastore/mongo/HistorizedResourceStore.java",
-            "src/main/java/ai/labs/eddi/datastore/mongo/ModifiableHistorizedResourceStore.java");
+            "src/main/java/ai/labs/eddi/datastore/mongo/ModifiableHistorizedResourceStore.java",
+            "src/main/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinator.java");
 
     /** Blanks out comments and string literals so neither is ever matched. */
     private static String stripNonCode(String source) {

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
@@ -37,6 +37,8 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.Instance;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -589,11 +591,11 @@ class RestImportServiceExtendedTest {
             // readSnippetDescriptors returns empty → no existing snippets
             when(snippetStore.readSnippetDescriptors(eq(""), eq(0), eq(0))).thenReturn(List.of());
 
-            try (var cdiMock = org.mockito.Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class)) {
-                var cdi = mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdi);
-                var instance = (jakarta.enterprise.inject.Instance<IRestPromptSnippetStore>) mock(
-                        jakarta.enterprise.inject.Instance.class);
+            try (var cdiMock = org.mockito.Mockito.mockStatic(CDI.class)) {
+                var cdi = mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdi);
+                var instance = (Instance<IRestPromptSnippetStore>) mock(
+                        Instance.class);
                 when(cdi.select(IRestPromptSnippetStore.class)).thenReturn(instance);
                 when(instance.get()).thenReturn(snippetStore);
 
@@ -667,11 +669,11 @@ class RestImportServiceExtendedTest {
             existingSnippet.setName("safety_prompt");
             when(snippetStore.readSnippet(existingSnippetId, 1)).thenReturn(existingSnippet);
 
-            try (var cdiMock = org.mockito.Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class)) {
-                var cdi = mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdi);
-                var instance = (jakarta.enterprise.inject.Instance<IRestPromptSnippetStore>) mock(
-                        jakarta.enterprise.inject.Instance.class);
+            try (var cdiMock = org.mockito.Mockito.mockStatic(CDI.class)) {
+                var cdi = mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdi);
+                var instance = (Instance<IRestPromptSnippetStore>) mock(
+                        Instance.class);
                 when(cdi.select(IRestPromptSnippetStore.class)).thenReturn(instance);
                 when(instance.get()).thenReturn(snippetStore);
 
@@ -850,12 +852,12 @@ class RestImportServiceExtendedTest {
                     "eddi://ai.labs.agent/agentstore/agents/" + newAgentId + "?version=1"));
             when(documentDescriptorStore.readDescriptor(newAgentId, 1)).thenReturn(existingDescriptor);
 
-            try (var cdiMock = org.mockito.Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class)) {
-                var cdi = mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdi);
+            try (var cdiMock = org.mockito.Mockito.mockStatic(CDI.class)) {
+                var cdi = mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdi);
 
-                var agentStoreInstance = (jakarta.enterprise.inject.Instance<IAgentStore>) mock(
-                        jakarta.enterprise.inject.Instance.class);
+                var agentStoreInstance = (Instance<IAgentStore>) mock(
+                        Instance.class);
                 when(cdi.select(IAgentStore.class)).thenReturn(agentStoreInstance);
                 when(agentStoreInstance.get()).thenReturn(agentStore);
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUncoveredBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUncoveredBranchTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import jakarta.ws.rs.core.Response;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -717,10 +718,10 @@ class RestImportServiceUncoveredBranchTest {
         @DisplayName("status 201 passes silently")
         void status201Passes() throws Exception {
             Method method = RestImportService.class.getDeclaredMethod(
-                    "checkIfCreatedResponse", jakarta.ws.rs.core.Response.class);
+                    "checkIfCreatedResponse", Response.class);
             method.setAccessible(true);
 
-            var response = jakarta.ws.rs.core.Response.status(201).build();
+            var response = Response.status(201).build();
             method.invoke(service, response); // Should not throw
         }
 
@@ -728,10 +729,10 @@ class RestImportServiceUncoveredBranchTest {
         @DisplayName("non-201 status logs error but does not throw")
         void nonCreatedStatus() throws Exception {
             Method method = RestImportService.class.getDeclaredMethod(
-                    "checkIfCreatedResponse", jakarta.ws.rs.core.Response.class);
+                    "checkIfCreatedResponse", Response.class);
             method.setAccessible(true);
 
-            var response = jakarta.ws.rs.core.Response.status(400).build();
+            var response = Response.status(400).build();
             method.invoke(service, response); // Should not throw, just logs
         }
 
@@ -739,10 +740,10 @@ class RestImportServiceUncoveredBranchTest {
         @DisplayName("status 500 logs error but does not throw")
         void serverError() throws Exception {
             Method method = RestImportService.class.getDeclaredMethod(
-                    "checkIfCreatedResponse", jakarta.ws.rs.core.Response.class);
+                    "checkIfCreatedResponse", Response.class);
             method.setAccessible(true);
 
-            var response = jakarta.ws.rs.core.Response.status(500).build();
+            var response = Response.status(500).build();
             method.invoke(service, response); // Should not throw
         }
     }

--- a/src/test/java/ai/labs/eddi/backup/impl/SourceUrlValidatorTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/SourceUrlValidatorTest.java
@@ -108,6 +108,34 @@ class SourceUrlValidatorTest {
         }
 
         @Test
+        @DisplayName("should reject RFC 6598 CGNAT addresses (100.64.0.0/10)")
+        void rejectsCarrierGradeNat() {
+            // Not covered by InetAddress.isSiteLocalAddress(); Tailscale and some
+            // k8s pod networks allocate here, so an editor could otherwise reach
+            // internal peers through the sync endpoints.
+            assertThrows(IllegalArgumentException.class,
+                    () -> SourceUrlValidator.validate("http://100.64.0.1:8080", true));
+        }
+
+        @Test
+        @DisplayName("should reject RFC 4193 IPv6 unique local addresses (fc00::/7)")
+        void rejectsIpv6UniqueLocal() {
+            // isSiteLocalAddress() only matches the deprecated fec0::/10, so ULA
+            // addresses used to pass this validator while failing every other one.
+            assertThrows(IllegalArgumentException.class,
+                    () -> SourceUrlValidator.validate("http://[fd00::1]:8080", true));
+            assertThrows(IllegalArgumentException.class,
+                    () -> SourceUrlValidator.validate("http://[fc00::1]:8080", true));
+        }
+
+        @Test
+        @DisplayName("should reject IPv4 multicast addresses")
+        void rejectsMulticast() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> SourceUrlValidator.validate("http://224.0.0.1:8080", true));
+        }
+
+        @Test
         @DisplayName("should reject unresolvable hosts (fail closed)")
         void rejectsUnresolvableHost() {
             var ex = assertThrows(IllegalArgumentException.class,

--- a/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
@@ -48,6 +48,8 @@ import org.mockito.Mockito;
 import java.net.URI;
 import java.util.*;
 
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.Instance;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -314,12 +316,12 @@ class UpgradeExecutorTest {
             when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(llmStore);
 
@@ -383,20 +385,20 @@ class UpgradeExecutorTest {
             when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
 
                 // CDI lookup for IRestRagStore (getStore in resolveExtensionOps)
-                var instanceRestRag = (jakarta.enterprise.inject.Instance<IRestRagStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var instanceRestRag = (Instance<IRestRagStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestRagStore.class)).thenReturn(instanceRestRag);
                 when(instanceRestRag.get()).thenReturn(ragRestStore);
 
                 // CDI lookup for IRagStore (dispatchCreateDirect)
-                var instanceRag = (jakarta.enterprise.inject.Instance<IRagStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var instanceRag = (Instance<IRagStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRagStore.class)).thenReturn(instanceRag);
                 when(instanceRag.get()).thenReturn(ragDirectStore);
 
@@ -444,12 +446,12 @@ class UpgradeExecutorTest {
             when(wfDirectStore.create(any())).thenReturn(wfResourceId);
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceWf = (jakarta.enterprise.inject.Instance<IWorkflowStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceWf = (Instance<IWorkflowStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IWorkflowStore.class)).thenReturn(instanceWf);
                 when(instanceWf.get()).thenReturn(wfDirectStore);
 
@@ -585,10 +587,10 @@ class UpgradeExecutorTest {
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
 
                 URI result = executor.executeUpgrade(source, "target-1", null, null);
 
@@ -635,12 +637,12 @@ class UpgradeExecutorTest {
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(llmStore);
 
@@ -678,12 +680,12 @@ class UpgradeExecutorTest {
             setupPreviewAndAgent("target-1", 1, diffs);
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceWf = (jakarta.enterprise.inject.Instance<IWorkflowStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceWf = (Instance<IWorkflowStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IWorkflowStore.class)).thenReturn(instanceWf);
                 when(instanceWf.get()).thenThrow(new RuntimeException("CDI lookup failed"));
 
@@ -738,12 +740,12 @@ class UpgradeExecutorTest {
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(targetWfConfig);
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(llmStore);
 
@@ -904,12 +906,12 @@ class UpgradeExecutorTest {
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(Mockito.mock(IRestLlmStore.class));
 
@@ -1011,12 +1013,12 @@ class UpgradeExecutorTest {
             // Workflow config (empty)
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
 
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
 
-                var instance = (jakarta.enterprise.inject.Instance) Mockito.mock(jakarta.enterprise.inject.Instance.class);
+                var instance = (Instance) Mockito.mock(Instance.class);
                 when(cdiInstance.select(restStoreClass)).thenReturn(instance);
                 when(instance.get()).thenReturn(mockStore);
 

--- a/src/test/java/ai/labs/eddi/configs/agents/model/AgentConfigurationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/model/AgentConfigurationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import java.net.URI;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -190,7 +191,7 @@ class AgentConfigurationTest {
         @Test
         void setters() {
             var cc = new AgentConfiguration.ChannelConnector();
-            cc.setType(java.net.URI.create("eddi://channel/slack"));
+            cc.setType(URI.create("eddi://channel/slack"));
             cc.setConfig(Map.of("token", "xoxb-123"));
             assertEquals("eddi://channel/slack", cc.getType().toString());
             assertEquals("xoxb-123", cc.getConfig().get("token"));

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExtendedTest.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.ws.rs.BadRequestException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -102,7 +103,7 @@ class RestAgentStoreExtendedTest {
         @DisplayName("invalid workflow URI returns error list")
         void invalidWorkflowUri() {
             // A completely invalid URI should cause a BadRequestException
-            assertThrows(jakarta.ws.rs.BadRequestException.class, () -> restAgentStore.readAgentDescriptors(
+            assertThrows(BadRequestException.class, () -> restAgentStore.readAgentDescriptors(
                     null, 0, 10, "invalid-uri", false));
         }
 
@@ -426,7 +427,7 @@ class RestAgentStoreExtendedTest {
             identity.setKeys(List.of()); // empty
             config.setIdentity(identity);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.createAgent(config));
         }
 
@@ -439,7 +440,7 @@ class RestAgentStoreExtendedTest {
             config.setSecurity(security);
             config.setIdentity(null);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.createAgent(config));
         }
     }

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.ws.rs.BadRequestException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -225,7 +226,7 @@ class RestAgentStoreTest {
             security.setSignInterAgentMessages(true);
             config.setSecurity(security);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.createAgent(config));
         }
 
@@ -237,7 +238,7 @@ class RestAgentStoreTest {
             security.setRequirePeerVerification(true);
             config.setSecurity(security);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.createAgent(config));
         }
 
@@ -295,7 +296,7 @@ class RestAgentStoreTest {
             security.setSignInterAgentMessages(true);
             config.setSecurity(security);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.updateAgent(AGENT_ID, 1, config));
         }
 
@@ -311,7 +312,7 @@ class RestAgentStoreTest {
 
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(sourceConfig);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.duplicateAgent(AGENT_ID, 1, false));
         }
 

--- a/src/test/java/ai/labs/eddi/configs/hitl/HitlConfigValidationWiringTest.java
+++ b/src/test/java/ai/labs/eddi/configs/hitl/HitlConfigValidationWiringTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -175,7 +176,7 @@ class HitlConfigValidationWiringTest {
 
             // Deserialize via the SAME serializer the import service uses.
             IJsonSerialization jsonSerialization = new JsonSerialization(
-                    new com.fasterxml.jackson.databind.ObjectMapper());
+                    new ObjectMapper());
             AgentConfiguration imported = jsonSerialization.deserialize(agentJson, AgentConfiguration.class);
 
             var ex = assertThrows(IllegalArgumentException.class,
@@ -188,7 +189,7 @@ class HitlConfigValidationWiringTest {
         @DisplayName("an imported agent config with NO hitlConfig imports cleanly (backward compat)")
         void importAcceptsMissingHitl() throws Exception {
             IJsonSerialization jsonSerialization = new JsonSerialization(
-                    new com.fasterxml.jackson.databind.ObjectMapper());
+                    new ObjectMapper());
             AgentConfiguration imported = jsonSerialization.deserialize("{}", AgentConfiguration.class);
 
             // Absent hitlConfig is a no-op — agents predating HITL must keep importing.

--- a/src/test/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStoreDeepCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/configs/mcpcalls/rest/RestMcpCallsStoreDeepCoverageTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -50,7 +51,7 @@ class RestMcpCallsStoreDeepCoverageTest {
         @DisplayName("returns tool list with parameters")
         void successWithParams() throws Exception {
             var spec1 = ToolSpecification.builder().name("tool1").description("desc1").build();
-            var paramSchema = dev.langchain4j.model.chat.request.json.JsonObjectSchema.builder()
+            var paramSchema = JsonObjectSchema.builder()
                     .addStringProperty("param1")
                     .build();
             var spec2 = ToolSpecification.builder().name("tool2").description("desc2")

--- a/src/test/java/ai/labs/eddi/configs/migration/MigrationManagerTest.java
+++ b/src/test/java/ai/labs/eddi/configs/migration/MigrationManagerTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import java.util.*;
 import java.util.ArrayList;
 
+import com.mongodb.client.FindIterable;
 import static ai.labs.eddi.configs.migration.MigrationManager.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -407,8 +408,8 @@ class MigrationManagerTest {
             MongoCollection<Document> conversationMemoryColl = mock(MongoCollection.class, "conversationMemoryColl");
             when(database.getCollection(anyString())).thenReturn(defaultColl);
             when(database.getCollection(COLLECTION_CONVERSATION_MEMORY)).thenReturn(conversationMemoryColl);
-            when(defaultColl.find()).thenReturn(mock(com.mongodb.client.FindIterable.class));
-            when(conversationMemoryColl.find()).thenReturn(mock(com.mongodb.client.FindIterable.class));
+            when(defaultColl.find()).thenReturn(mock(FindIterable.class));
+            when(conversationMemoryColl.find()).thenReturn(mock(FindIterable.class));
 
             var managerWithMemories = new MigrationManager(database, migrationLogStore, false);
             when(migrationLogStore.readMigrationLog(MIGRATION_CONFIRMATION)).thenReturn(null);

--- a/src/test/java/ai/labs/eddi/configs/migration/V6RenameMigrationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/migration/V6RenameMigrationTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.bson.types.ObjectId;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -668,13 +669,13 @@ class V6RenameMigrationTest {
             var envDoc = new Document("botId", "agent-1")
                     .append("botVersion", 2)
                     .append("environment", "unrestricted")
-                    .append("_id", new org.bson.types.ObjectId());
+                    .append("_id", new ObjectId());
 
             MongoCollection<Document> envCol = mock(MongoCollection.class);
             when(envCol.estimatedDocumentCount()).thenReturn(1L);
 
-            com.mongodb.client.FindIterable<Document> envIterable = mock(com.mongodb.client.FindIterable.class);
-            com.mongodb.client.MongoCursor<Document> envCursor = mock(com.mongodb.client.MongoCursor.class);
+            FindIterable<Document> envIterable = mock(FindIterable.class);
+            MongoCursor<Document> envCursor = mock(MongoCursor.class);
             when(envCursor.hasNext()).thenReturn(true, false);
             when(envCursor.next()).thenReturn(envDoc);
             when(envIterable.iterator()).thenReturn(envCursor);
@@ -787,13 +788,13 @@ class V6RenameMigrationTest {
 
             // Agent document with old field name 'packages'
             var agentDoc = new Document("packages", List.of("workflow-ref"))
-                    .append("_id", new org.bson.types.ObjectId());
+                    .append("_id", new ObjectId());
 
             MongoCollection<Document> agentCol = mock(MongoCollection.class);
             when(agentCol.estimatedDocumentCount()).thenReturn(1L);
 
-            com.mongodb.client.FindIterable<Document> agentIterable = mock(com.mongodb.client.FindIterable.class);
-            com.mongodb.client.MongoCursor<Document> agentCursor = mock(com.mongodb.client.MongoCursor.class);
+            FindIterable<Document> agentIterable = mock(FindIterable.class);
+            MongoCursor<Document> agentCursor = mock(MongoCursor.class);
             when(agentCursor.hasNext()).thenReturn(true, false);
             when(agentCursor.next()).thenReturn(agentDoc);
             when(agentIterable.iterator()).thenReturn(agentCursor);
@@ -837,13 +838,13 @@ class V6RenameMigrationTest {
             // Workflow document with old URI
             var workflowDoc = new Document(
                     "extension", "eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/h1?version=1")
-                    .append("_id", new org.bson.types.ObjectId());
+                    .append("_id", new ObjectId());
 
             MongoCollection<Document> workflowCol = mock(MongoCollection.class);
             when(workflowCol.estimatedDocumentCount()).thenReturn(1L);
 
-            com.mongodb.client.FindIterable<Document> iterable = mock(com.mongodb.client.FindIterable.class);
-            com.mongodb.client.MongoCursor<Document> cursor = mock(com.mongodb.client.MongoCursor.class);
+            FindIterable<Document> iterable = mock(FindIterable.class);
+            MongoCursor<Document> cursor = mock(MongoCursor.class);
             when(cursor.hasNext()).thenReturn(true, false);
             when(cursor.next()).thenReturn(workflowDoc);
             doReturn(cursor).when(iterable).iterator();
@@ -884,13 +885,13 @@ class V6RenameMigrationTest {
             when(migrationLogStore.readMigrationLog(anyString())).thenReturn(null);
 
             var envDoc = new Document("environment", "restricted")
-                    .append("_id", new org.bson.types.ObjectId());
+                    .append("_id", new ObjectId());
 
             MongoCollection<Document> envCol = mock(MongoCollection.class);
             when(envCol.estimatedDocumentCount()).thenReturn(1L);
 
-            com.mongodb.client.FindIterable<Document> envIterable = mock(com.mongodb.client.FindIterable.class);
-            com.mongodb.client.MongoCursor<Document> envCursor = mock(com.mongodb.client.MongoCursor.class);
+            FindIterable<Document> envIterable = mock(FindIterable.class);
+            MongoCursor<Document> envCursor = mock(MongoCursor.class);
             when(envCursor.hasNext()).thenReturn(true, false);
             when(envCursor.next()).thenReturn(envDoc);
             when(envIterable.iterator()).thenReturn(envCursor);

--- a/src/test/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStoreTest.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+import com.mongodb.client.model.UpdateOptions;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -96,8 +97,8 @@ class MongoUserMemoryStoreTest {
     @DisplayName("mergeProperties — skips empty properties")
     void mergePropertiesEmpty() throws Exception {
         store.mergeProperties(TEST_USER, new Properties());
-        verify(collection, never()).updateOne(any(org.bson.conversions.Bson.class), any(org.bson.conversions.Bson.class),
-                any(com.mongodb.client.model.UpdateOptions.class));
+        verify(collection, never()).updateOne(any(Bson.class), any(Bson.class),
+                any(UpdateOptions.class));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/properties/mongo/PropertiesMigrationServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/properties/mongo/PropertiesMigrationServiceTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import com.mongodb.client.ListCollectionNamesIterable;
 import static org.mockito.Mockito.*;
 
 class PropertiesMigrationServiceTest {
@@ -291,8 +292,8 @@ class PropertiesMigrationServiceTest {
      * of strings.
      */
     @SuppressWarnings("unchecked")
-    private static com.mongodb.client.ListCollectionNamesIterable mockIterableOf(String... names) {
-        var iterable = mock(com.mongodb.client.ListCollectionNamesIterable.class);
+    private static ListCollectionNamesIterable mockIterableOf(String... names) {
+        var iterable = mock(ListCollectionNamesIterable.class);
         doReturn(mockCursorOf(names)).when(iterable).iterator();
         return iterable;
     }

--- a/src/test/java/ai/labs/eddi/configs/workflows/mongo/WorkflowStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/mongo/WorkflowStoreTest.java
@@ -20,6 +20,7 @@ import org.mockito.ArgumentCaptor;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.net.URI;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -145,7 +146,7 @@ class WorkflowStoreTest {
         when(resourceStorage.getCurrentVersion("111111111111111111111111")).thenReturn(1);
 
         DocumentDescriptor descriptor = new DocumentDescriptor();
-        descriptor.setResource(java.net.URI.create("eddi://ai.labs.workflow/workflowstore/workflows/111111111111111111111111?version=1"));
+        descriptor.setResource(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/111111111111111111111111?version=1"));
         when(documentDescriptorStore.readDescriptor("111111111111111111111111", 1)).thenReturn(descriptor);
 
         List<DocumentDescriptor> result = store.getWorkflowDescriptorsContainingResource(resourceURI, false);

--- a/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreCrudTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreCrudTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.util.*;
 
+import jakarta.ws.rs.BadRequestException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -123,7 +124,7 @@ class RestWorkflowStoreCrudTest {
         void malformedUri() {
             // Malformed URI — createMalFormattedResourceUriException throws
             // BadRequestException
-            assertThrows(jakarta.ws.rs.BadRequestException.class, () -> sut.readWorkflowDescriptors("", 0, 20, "not-a-valid-uri", false));
+            assertThrows(BadRequestException.class, () -> sut.readWorkflowDescriptors("", 0, 20, "not-a-valid-uri", false));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/datastore/mongo/MongoConversationMemoryStoreTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/MongoConversationMemoryStoreTest.java
@@ -35,6 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.List;
 import java.util.Map;
 
+import com.mongodb.ConnectionString;
 import static org.bson.codecs.configuration.CodecRegistries.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -82,7 +83,7 @@ class MongoConversationMemoryStoreTest {
                         new JacksonProvider(bsonMapper)));
 
         var settings = MongoClientSettings.builder()
-                .applyConnectionString(new com.mongodb.ConnectionString(MONGO.getConnectionString()))
+                .applyConnectionString(new ConnectionString(MONGO.getConnectionString()))
                 .codecRegistry(codecRegistry)
                 .build();
 

--- a/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageBranchTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageBranchTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.function.Consumer;
 
+import org.bson.BsonDocument;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -151,7 +152,7 @@ class MongoResourceStorageBranchTest {
 
             Document doc = new Document("_id", new ObjectId(VALID_ID)).append("_version", 1);
             FindIterable<Document> iterable = mock(FindIterable.class);
-            when(currentCollection.find(any(org.bson.BsonDocument.class))).thenReturn(iterable);
+            when(currentCollection.find(any(BsonDocument.class))).thenReturn(iterable);
             when(iterable.sort(any(Document.class))).thenReturn(iterable);
             when(iterable.limit(anyInt())).thenReturn(iterable);
             when(iterable.skip(anyInt())).thenReturn(iterable);
@@ -181,7 +182,7 @@ class MongoResourceStorageBranchTest {
             when(qfs.getConnectingType()).thenReturn(IResourceFilter.QueryFilters.ConnectingType.OR);
 
             FindIterable<Document> iterable = mock(FindIterable.class);
-            when(currentCollection.find(any(org.bson.BsonDocument.class))).thenReturn(iterable);
+            when(currentCollection.find(any(BsonDocument.class))).thenReturn(iterable);
             when(iterable.sort(any(Document.class))).thenReturn(iterable);
             when(iterable.limit(anyInt())).thenReturn(iterable);
             when(iterable.skip(anyInt())).thenReturn(iterable);
@@ -205,7 +206,7 @@ class MongoResourceStorageBranchTest {
             when(qfs.getConnectingType()).thenReturn(IResourceFilter.QueryFilters.ConnectingType.AND);
 
             FindIterable<Document> iterable = mock(FindIterable.class);
-            when(currentCollection.find(any(org.bson.BsonDocument.class))).thenReturn(iterable);
+            when(currentCollection.find(any(BsonDocument.class))).thenReturn(iterable);
             when(iterable.sort(any(Document.class))).thenReturn(iterable);
             when(iterable.limit(anyInt())).thenReturn(iterable);
             when(iterable.skip(anyInt())).thenReturn(iterable);

--- a/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.mongodb.client.result.UpdateResult;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -345,7 +346,7 @@ class MongoResourceStorageTest {
         when(currentCollection.withWriteConcern(any())).thenReturn(durableCurrent);
         when(historyCollection.withWriteConcern(any())).thenReturn(durableHistory);
 
-        var updateResult = mock(com.mongodb.client.result.UpdateResult.class);
+        var updateResult = mock(UpdateResult.class);
         when(updateResult.getMatchedCount()).thenReturn(1L);
         when(durableCurrent.replaceOne(any(Bson.class), any(Document.class))).thenReturn(updateResult);
 
@@ -370,7 +371,7 @@ class MongoResourceStorageTest {
         when(currentCollection.withWriteConcern(any())).thenReturn(durableCurrent);
         when(historyCollection.withWriteConcern(any())).thenReturn(durableHistory);
 
-        var updateResult = mock(com.mongodb.client.result.UpdateResult.class);
+        var updateResult = mock(UpdateResult.class);
         when(updateResult.getMatchedCount()).thenReturn(0L);
         when(durableCurrent.replaceOne(any(Bson.class), any(Document.class))).thenReturn(updateResult);
 
@@ -437,7 +438,7 @@ class MongoResourceStorageTest {
         when(documentBuilder.toString(any())).thenReturn("{\"state\":\"AWAITING_APPROVAL\"}");
         IResourceStorage.IResource<String> resource = storage.newResource(VALID_ID, 2, "test");
 
-        var updateResult = mock(com.mongodb.client.result.UpdateResult.class);
+        var updateResult = mock(UpdateResult.class);
         when(updateResult.getMatchedCount()).thenReturn(1L);
         when(currentCollection.replaceOne(any(Bson.class), any(Document.class))).thenReturn(updateResult);
 
@@ -452,7 +453,7 @@ class MongoResourceStorageTest {
         when(documentBuilder.toString(any())).thenReturn("{\"state\":\"AWAITING_APPROVAL\"}");
         IResourceStorage.IResource<String> resource = storage.newResource(VALID_ID, 2, "test");
 
-        var updateResult = mock(com.mongodb.client.result.UpdateResult.class);
+        var updateResult = mock(UpdateResult.class);
         when(updateResult.getMatchedCount()).thenReturn(0L);
         when(currentCollection.replaceOne(any(Bson.class), any(Document.class))).thenReturn(updateResult);
         // No document with that id exists any more → deleted.
@@ -468,7 +469,7 @@ class MongoResourceStorageTest {
         when(documentBuilder.toString(any())).thenReturn("{\"state\":\"AWAITING_APPROVAL\"}");
         IResourceStorage.IResource<String> resource = storage.newResource(VALID_ID, 2, "test");
 
-        var updateResult = mock(com.mongodb.client.result.UpdateResult.class);
+        var updateResult = mock(UpdateResult.class);
         when(updateResult.getMatchedCount()).thenReturn(0L);
         when(currentCollection.replaceOne(any(Bson.class), any(Document.class))).thenReturn(updateResult);
         // The document exists, but its field value changed under us → mismatch.

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresJournalExtraCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresJournalExtraCoverageTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.security.ForbiddenException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -241,7 +242,7 @@ class PostgresJournalExtraCoverageTest {
             when(groupConversationService.readGroupConversation("gc1"))
                     .thenThrow(new RuntimeException("store down"));
 
-            assertThrows(io.quarkus.security.ForbiddenException.class,
+            assertThrows(ForbiddenException.class,
                     () -> guard.requireGroupConversationHitlAccess("g1", "gc1"));
         }
 

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresTestBase.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresTestBase.java
@@ -12,6 +12,9 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import org.postgresql.ds.PGSimpleDataSource;
+import java.lang.annotation.Annotation;
+import jakarta.enterprise.util.TypeLiteral;
 
 /**
  * Shared Testcontainers base for PostgreSQL adapter integration tests.
@@ -45,7 +48,7 @@ public abstract class PostgresTestBase {
      * Returns a real JDBC DataSource pointing at the shared Testcontainer.
      */
     protected static DataSource createDataSource() {
-        var ds = new org.postgresql.ds.PGSimpleDataSource();
+        var ds = new PGSimpleDataSource();
         ds.setUrl(PG.getJdbcUrl());
         ds.setUser(PG.getUsername());
         ds.setPassword(PG.getPassword());
@@ -93,16 +96,16 @@ public abstract class PostgresTestBase {
         }
 
         @Override
-        public Instance<DataSource> select(java.lang.annotation.Annotation... qualifiers) {
+        public Instance<DataSource> select(Annotation... qualifiers) {
             throw new UnsupportedOperationException();
         }
         @Override
-        public <U extends DataSource> Instance<U> select(Class<U> subtype, java.lang.annotation.Annotation... qualifiers) {
+        public <U extends DataSource> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
             throw new UnsupportedOperationException();
         }
         @Override
-        public <U extends DataSource> Instance<U> select(jakarta.enterprise.util.TypeLiteral<U> subtype,
-                                                         java.lang.annotation.Annotation... qualifiers) {
+        public <U extends DataSource> Instance<U> select(TypeLiteral<U> subtype,
+                                                         Annotation... qualifiers) {
             throw new UnsupportedOperationException();
         }
         @Override

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
@@ -17,9 +17,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 
@@ -38,6 +41,27 @@ class AuditLedgerServiceBranchTest {
     private IAuditStore auditStore;
 
     private MeterRegistry meterRegistry;
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * A dead-letter path whose write is guaranteed to fail on every platform.
+     * <p>
+     * The parent directory is deliberately never created, and {@code Files.write}
+     * with {@code CREATE} does not create parent directories - so the write throws
+     * {@code NoSuchFileException} on Linux and Windows alike.
+     * <p>
+     * This used to be a hardcoded {@code Z:\nonexistent\...}, which is unwritable
+     * only on Windows: a backslash is a legal character in a Unix filename, so on
+     * the Linux CI runner that whole string was one relative filename which
+     * {@code CREATE} happily created. The tests below then exercised the file
+     * fallback's SUCCESS path while claiming to cover its failure path, and left a
+     * junk file in the build directory.
+     */
+    private String unwritableDeadLetterPath() {
+        return tempDir.resolve("no-such-dir").resolve("deadletter.jsonl").toString();
+    }
 
     @BeforeEach
     void setUp() throws Exception {
@@ -349,7 +373,7 @@ class AuditLedgerServiceBranchTest {
         // Use a temp file path that likely fails (to cover the file-fallback error
         // path)
         var service = new AuditLedgerService(auditStore, true, 60,
-                Optional.empty(), "Z:\\nonexistent\\path\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
+                Optional.empty(), unwritableDeadLetterPath(), false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
                 true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
@@ -359,6 +383,13 @@ class AuditLedgerServiceBranchTest {
         service.flush();
         service.flush();
         service.flush(); // triggers dead letter
+
+        // NATS was actually attempted: without this the test would still pass if
+        // writeToDeadLetter were never reached at all.
+        verify(js, atLeastOnce()).publish(anyString(), any(byte[].class));
+        // ...and the file fallback genuinely failed rather than quietly succeeding.
+        assertFalse(Files.exists(Path.of(unwritableDeadLetterPath())),
+                "the dead-letter write must fail, otherwise this test does not cover the failure path");
 
         // Should not throw even though both NATS and file fail
         service.shutdown();
@@ -376,7 +407,7 @@ class AuditLedgerServiceBranchTest {
 
         // Use a nonexistent path to test error handling
         var service = new AuditLedgerService(auditStore, true, 60,
-                Optional.empty(), "Z:\\nonexistent\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
+                Optional.empty(), unwritableDeadLetterPath(), false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
                 true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
@@ -386,6 +417,13 @@ class AuditLedgerServiceBranchTest {
         service.flush();
         service.flush();
         service.flush(); // triggers dead letter
+
+        // NATS is unresolvable, so the file fallback is the path under test...
+        verify(natsInstance, atLeastOnce()).isResolvable();
+        verify(natsInstance, never()).get();
+        // ...and it failed, rather than creating the file and passing vacuously.
+        assertFalse(Files.exists(Path.of(unwritableDeadLetterPath())),
+                "the dead-letter write must fail, otherwise this test does not cover the failure path");
 
         // Should handle file write failure gracefully
         service.shutdown();
@@ -454,7 +492,7 @@ class AuditLedgerServiceBranchTest {
         doReturn(conn).when(natsInstance).get();
 
         var service = new AuditLedgerService(auditStore, true, 60,
-                Optional.empty(), "Z:\\nonexistent\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
+                Optional.empty(), unwritableDeadLetterPath(), false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
                 true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 

--- a/src/test/java/ai/labs/eddi/engine/hitl/HitlAccessGuardTest.java
+++ b/src/test/java/ai/labs/eddi/engine/hitl/HitlAccessGuardTest.java
@@ -21,6 +21,7 @@ import java.security.Principal;
 import java.time.Instant;
 import java.util.List;
 
+import jakarta.ws.rs.NotFoundException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -211,7 +212,7 @@ class HitlAccessGuardTest {
         when(gc.getGroupId()).thenReturn("g2");
         when(groupConversationService.readGroupConversation("gc1")).thenReturn(gc);
 
-        assertThrows(jakarta.ws.rs.NotFoundException.class,
+        assertThrows(NotFoundException.class,
                 () -> guard.requireGroupConversationHitlAccess("g1", "gc1"));
         verify(ownershipValidator, never()).requireOwnerAdminOrApprover(any(), any(), any());
     }
@@ -279,7 +280,7 @@ class HitlAccessGuardTest {
         humanPausedGc();
         callerNamed("hannah");
 
-        assertThrows(jakarta.ws.rs.NotFoundException.class,
+        assertThrows(NotFoundException.class,
                 () -> guard.requireGroupHumanInputAccess("other-group", "gc1", "hannah"));
     }
 
@@ -315,7 +316,7 @@ class HitlAccessGuardTest {
                 .when(ownershipValidator).requireOwnerAdminOrApprover(any(), any(), any());
 
         assertThrows(ForbiddenException.class, () -> guard.requireGroupConversationReadAccess("g1", "gc1"));
-        assertThrows(jakarta.ws.rs.NotFoundException.class,
+        assertThrows(NotFoundException.class,
                 () -> guard.requireGroupConversationReadAccess("other-group", "gc1"));
     }
 

--- a/src/test/java/ai/labs/eddi/engine/hitl/tools/HitlJournalCodecCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/hitl/tools/HitlJournalCodecCoverageTest.java
@@ -33,6 +33,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.bson.BsonString;
+import org.bson.BsonDouble;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import com.mongodb.ServerAddress;
+import com.mongodb.MongoClientSettings;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -83,10 +88,10 @@ class HitlJournalCodecCoverageTest {
      */
     private static MongoCommandException commandException(int code) {
         BsonDocument response = new BsonDocument()
-                .append("ok", new org.bson.BsonDouble(0))
+                .append("ok", new BsonDouble(0))
                 .append("code", new BsonInt32(code))
-                .append("errmsg", new org.bson.BsonString("simulated code " + code));
-        return new MongoCommandException(response, new com.mongodb.ServerAddress());
+                .append("errmsg", new BsonString("simulated code " + code));
+        return new MongoCommandException(response, new ServerAddress());
     }
 
     @Nested
@@ -233,7 +238,7 @@ class HitlJournalCodecCoverageTest {
             var updateCaptor = org.mockito.ArgumentCaptor.forClass(Bson.class);
             verify(collection).updateOne(any(Bson.class), updateCaptor.capture());
             BsonDocument rendered = updateCaptor.getValue()
-                    .toBsonDocument(Document.class, com.mongodb.MongoClientSettings.getDefaultCodecRegistry());
+                    .toBsonDocument(Document.class, MongoClientSettings.getDefaultCodecRegistry());
             String cappedResult = rendered.getDocument("$set").getString("resultCapped").getValue();
             assertEquals(small, cappedResult, "an under-cap value must be stored verbatim");
         }
@@ -248,7 +253,7 @@ class HitlJournalCodecCoverageTest {
             var updateCaptor = org.mockito.ArgumentCaptor.forClass(Bson.class);
             verify(collection).updateOne(any(Bson.class), updateCaptor.capture());
             BsonDocument rendered = updateCaptor.getValue()
-                    .toBsonDocument(Document.class, com.mongodb.MongoClientSettings.getDefaultCodecRegistry());
+                    .toBsonDocument(Document.class, MongoClientSettings.getDefaultCodecRegistry());
             assertTrue(rendered.getDocument("$set").isNull("resultCapped"),
                     "a null result must be stored as BSON null, not a string");
         }
@@ -293,8 +298,8 @@ class HitlJournalCodecCoverageTest {
     @DisplayName("ToolApprovalGate branches")
     class Gate {
 
-        private static dev.langchain4j.agent.tool.ToolExecutionRequest req(String id, String name) {
-            return dev.langchain4j.agent.tool.ToolExecutionRequest.builder().id(id).name(name).arguments("{}").build();
+        private static ToolExecutionRequest req(String id, String name) {
+            return ToolExecutionRequest.builder().id(id).name(name).arguments("{}").build();
         }
 
         private static ToolApprovalsConfig cfg(List<String> require, List<String> exempt) {

--- a/src/test/java/ai/labs/eddi/engine/hitl/tools/mongo/HitlToolJournalStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/hitl/tools/mongo/HitlToolJournalStoreTest.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
+import com.mongodb.MongoClientSettings;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -103,7 +104,7 @@ class HitlToolJournalStoreTest {
         assertTrue(uniqueOptions.isUnique(), "the key index must be unique");
 
         BsonDocument renderedKey = uniqueKey
-                .toBsonDocument(Document.class, com.mongodb.MongoClientSettings.getDefaultCodecRegistry());
+                .toBsonDocument(Document.class, MongoClientSettings.getDefaultCodecRegistry());
         assertEquals(List.of("conversationId", "pauseEpoch", "callId"),
                 List.copyOf(renderedKey.keySet()),
                 "unique index must compose exactly (conversationId, pauseEpoch, callId) in order");
@@ -216,7 +217,7 @@ class HitlToolJournalStoreTest {
             var updateCaptor = org.mockito.ArgumentCaptor.forClass(Bson.class);
             verify(collection).updateOne(any(Bson.class), updateCaptor.capture());
             BsonDocument rendered = updateCaptor.getValue()
-                    .toBsonDocument(Document.class, com.mongodb.MongoClientSettings.getDefaultCodecRegistry());
+                    .toBsonDocument(Document.class, MongoClientSettings.getDefaultCodecRegistry());
             String cappedResult = rendered.getDocument("$set").getString("resultCapped").getValue();
             assertEquals(32 * 1024, cappedResult.getBytes(java.nio.charset.StandardCharsets.UTF_8).length);
         }
@@ -235,7 +236,7 @@ class HitlToolJournalStoreTest {
             var updateCaptor = org.mockito.ArgumentCaptor.forClass(Bson.class);
             verify(collection).updateOne(any(Bson.class), updateCaptor.capture());
             BsonDocument rendered = updateCaptor.getValue()
-                    .toBsonDocument(Document.class, com.mongodb.MongoClientSettings.getDefaultCodecRegistry());
+                    .toBsonDocument(Document.class, MongoClientSettings.getDefaultCodecRegistry());
             String cappedResult = rendered.getDocument("$set").getString("resultCapped").getValue();
 
             byte[] cappedBytes = cappedResult.getBytes(java.nio.charset.StandardCharsets.UTF_8);

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceHitlTest.java
@@ -47,6 +47,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 
+import jakarta.enterprise.event.Event;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -98,14 +99,14 @@ class ConversationServiceHitlTest {
     private ConversationService conversationService;
     // Held reference (not the shared no-op fixture) so the cancel-path HITL event
     // firing (G5) can be verified.
-    private jakarta.enterprise.event.Event<HitlResumeCompletedEvent> hitlResumeCompletedEvent;
+    private Event<HitlResumeCompletedEvent> hitlResumeCompletedEvent;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
     void setUp() {
         MockitoAnnotations.openMocks(this);
         doReturn(conversationStateCache).when(cacheFactory).getCache("conversationState");
-        hitlResumeCompletedEvent = mock(jakarta.enterprise.event.Event.class);
+        hitlResumeCompletedEvent = mock(Event.class);
         conversationService = new ConversationService(
                 agentFactory, conversationMemoryStore, conversationDescriptorStore,
                 userMemoryStore, conversationCoordinator, conversationSetup,

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceTest.java
@@ -60,6 +60,7 @@ import org.mockito.MockitoAnnotations;
 import java.util.*;
 import java.util.Stack;
 
+import jakarta.enterprise.event.Event;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -111,14 +112,14 @@ class ConversationServiceTest {
     private ConversationService conversationService;
     // Held reference (not the shared no-op fixture) so HITL event-firing paths
     // (G5) can be verified.
-    private jakarta.enterprise.event.Event<HitlResumeCompletedEvent> hitlResumeCompletedEvent;
+    private Event<HitlResumeCompletedEvent> hitlResumeCompletedEvent;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
     void setUp() {
         MockitoAnnotations.openMocks(this);
         doReturn(conversationStateCache).when(cacheFactory).getCache("conversationState");
-        hitlResumeCompletedEvent = mock(jakarta.enterprise.event.Event.class);
+        hitlResumeCompletedEvent = mock(Event.class);
         conversationService = new ConversationService(
                 agentFactory, conversationMemoryStore, conversationDescriptorStore,
                 userMemoryStore, conversationCoordinator, conversationSetup,

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupApprovalRequestTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupApprovalRequestTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("GroupApprovalRequest")
@@ -122,7 +123,7 @@ class GroupApprovalRequestTest {
     @DisplayName("verdict casing (#39)")
     class VerdictCasing {
 
-        private final com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        private final ObjectMapper mapper = new ObjectMapper();
 
         @Test
         @DisplayName("lowercase verdict deserializes to APPROVED (matches case-insensitive taskApprovals)")

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceToolPauseTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceToolPauseTest.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.micrometer.core.instrument.Counter;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -153,7 +154,7 @@ class GroupConversationServiceToolPauseTest {
     private double skippedCount() throws Exception {
         var field = GroupConversationService.class.getDeclaredField("counterGroupMemberPauseSkipped");
         field.setAccessible(true);
-        var counter = (io.micrometer.core.instrument.Counter) field.get(service);
+        var counter = (Counter) field.get(service);
         return counter.count();
     }
 

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceUncoveredBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceUncoveredBranchTest.java
@@ -52,6 +52,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Counter;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -102,11 +105,11 @@ class GroupConversationServiceUncoveredBranchTest {
     @Mock
     private NonceCacheService nonceCacheService;
     @Mock
-    private io.micrometer.core.instrument.MeterRegistry meterRegistry;
+    private MeterRegistry meterRegistry;
     @Mock
-    private io.micrometer.core.instrument.Timer timer;
+    private Timer timer;
     @Mock
-    private io.micrometer.core.instrument.Counter counter;
+    private Counter counter;
 
     private GroupConversationService service;
 

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.ws.rs.NotFoundException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -327,7 +328,7 @@ class RestAgentEngineTest {
             restAgentEngine.sayWithinContext("conv-1", false, false,
                     List.of(), inputData, asyncResponse);
 
-            verify(asyncResponse).resume(any(jakarta.ws.rs.NotFoundException.class));
+            verify(asyncResponse).resume(any(NotFoundException.class));
         }
 
         @Test
@@ -406,7 +407,7 @@ class RestAgentEngineTest {
             restAgentEngine.sayWithinContext("conv-1", false, false,
                     List.of(), inputData, asyncResponse);
 
-            verify(asyncResponse).resume(any(jakarta.ws.rs.NotFoundException.class));
+            verify(asyncResponse).resume(any(NotFoundException.class));
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/RestCoordinatorAdminTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestCoordinatorAdminTest.java
@@ -16,6 +16,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.ws.rs.sse.SseEventSink;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.OutboundSseEvent;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -151,9 +154,9 @@ class RestCoordinatorAdminTest {
             var status = new CoordinatorStatus("in-memory", true, "OK", 0, 0L, 0L, Map.of());
             when(coordinator.getStatus()).thenReturn(status);
 
-            var eventSink = mock(jakarta.ws.rs.sse.SseEventSink.class);
-            var sse = mock(jakarta.ws.rs.sse.Sse.class, RETURNS_DEEP_STUBS);
-            var event = mock(jakarta.ws.rs.sse.OutboundSseEvent.class);
+            var eventSink = mock(SseEventSink.class);
+            var sse = mock(Sse.class, RETURNS_DEEP_STUBS);
+            var event = mock(OutboundSseEvent.class);
 
             when(sse.newEventBuilder().name(anyString()).data(any()).build()).thenReturn(event);
 
@@ -168,8 +171,8 @@ class RestCoordinatorAdminTest {
         void handlesInitialStatusError() {
             when(coordinator.getStatus()).thenThrow(new RuntimeException("Status unavailable"));
 
-            var eventSink = mock(jakarta.ws.rs.sse.SseEventSink.class);
-            var sse = mock(jakarta.ws.rs.sse.Sse.class);
+            var eventSink = mock(SseEventSink.class);
+            var sse = mock(Sse.class);
 
             // Should not throw — error is caught internally
             assertDoesNotThrow(() -> restCoordinatorAdmin.streamEvents(eventSink, sse));

--- a/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationHitlTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationHitlTest.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.ws.rs.NotFoundException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -335,7 +336,7 @@ class RestGroupConversationHitlTest {
         @Test
         @DisplayName("approver sees all of the group's pending summaries")
         void approverSeesAll() throws Exception {
-            var principal = mock(java.security.Principal.class);
+            var principal = mock(Principal.class);
             when(principal.getName()).thenReturn("reviewer");
             when(identity.getPrincipal()).thenReturn(principal);
             when(identity.hasRole("eddi-admin")).thenReturn(false);
@@ -602,7 +603,7 @@ class RestGroupConversationHitlTest {
             decision.setVerdict(HitlVerdict.APPROVED);
             request.setDecision(decision);
 
-            assertThrows(jakarta.ws.rs.NotFoundException.class,
+            assertThrows(NotFoundException.class,
                     () -> restGroupConversation.approveGroupPhase(OTHER_GROUP, GC_ID, request),
                     "approving under the wrong group path must 404, not act on the conversation");
         }
@@ -613,7 +614,7 @@ class RestGroupConversationHitlTest {
             asAdmin(ADMIN_ID);
             when(groupService.readGroupConversation(GC_ID)).thenReturn(makeGc(OWNER_ID));
 
-            assertThrows(jakarta.ws.rs.NotFoundException.class,
+            assertThrows(NotFoundException.class,
                     () -> restGroupConversation.cancelDiscussion(OTHER_GROUP, GC_ID),
                     "cancelling under the wrong group path must 404");
         }
@@ -624,7 +625,7 @@ class RestGroupConversationHitlTest {
             asAdmin(ADMIN_ID);
             when(groupService.readGroupConversation(GC_ID)).thenReturn(makeGc(OWNER_ID));
 
-            assertThrows(jakarta.ws.rs.NotFoundException.class,
+            assertThrows(NotFoundException.class,
                     () -> restGroupConversation.getGroupApprovalStatus(OTHER_GROUP, GC_ID, "summary"),
                     "reading approval-status under the wrong group path must 404");
         }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestGroupConversationTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import java.security.Principal;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -332,7 +333,7 @@ class RestGroupConversationTest {
             when(ownershipValidator.isAuthEnabled()).thenReturn(true);
             when(identity.isAnonymous()).thenReturn(false);
             when(identity.hasRole("eddi-admin")).thenReturn(false);
-            var principal = mock(java.security.Principal.class);
+            var principal = mock(Principal.class);
             when(principal.getName()).thenReturn("user-1");
             when(identity.getPrincipal()).thenReturn(principal);
 

--- a/src/test/java/ai/labs/eddi/engine/internal/RestLogAdminTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestLogAdminTest.java
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import jakarta.ws.rs.sse.SseEventSink;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.OutboundSseEvent;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -117,9 +120,9 @@ class RestLogAdminTest {
                     .thenReturn(List.of(entry));
             when(boundedLogStore.addListener(any())).thenReturn("listener-1");
 
-            var eventSink = mock(jakarta.ws.rs.sse.SseEventSink.class);
-            var sse = mock(jakarta.ws.rs.sse.Sse.class, RETURNS_DEEP_STUBS);
-            var event = mock(jakarta.ws.rs.sse.OutboundSseEvent.class);
+            var eventSink = mock(SseEventSink.class);
+            var sse = mock(Sse.class, RETURNS_DEEP_STUBS);
+            var event = mock(OutboundSseEvent.class);
 
             // The stub chain must mirror RestLogAdmin#sendEvent exactly. With
             // RETURNS_DEEP_STUBS an unmatched link silently yields a *different* deep
@@ -133,7 +136,7 @@ class RestLogAdminTest {
                     .data(any(Class.class), any())
                     .build())
                     .thenReturn(event);
-            when(eventSink.send(any(jakarta.ws.rs.sse.OutboundSseEvent.class)))
+            when(eventSink.send(any(OutboundSseEvent.class)))
                     .thenReturn(CompletableFuture.completedFuture(null));
             when(eventSink.isClosed()).thenReturn(true); // close immediately to prevent cleanup thread from running long
 
@@ -151,8 +154,8 @@ class RestLogAdminTest {
             when(boundedLogStore.getEntries(any(), any(), any(), anyInt())).thenReturn(List.of());
             when(boundedLogStore.addListener(any())).thenReturn("listener-2");
 
-            var eventSink = mock(jakarta.ws.rs.sse.SseEventSink.class);
-            var sse = mock(jakarta.ws.rs.sse.Sse.class);
+            var eventSink = mock(SseEventSink.class);
+            var sse = mock(Sse.class);
             when(eventSink.isClosed()).thenReturn(true);
 
             restLogAdmin.streamLogs(null, null, null, eventSink, sse);

--- a/src/test/java/ai/labs/eddi/engine/lifecycle/model/HitlDecisionTest.java
+++ b/src/test/java/ai/labs/eddi/engine/lifecycle/model/HitlDecisionTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("HitlDecision")
@@ -179,7 +180,7 @@ class HitlDecisionTest {
     @DisplayName("Jackson deserialization round-trip")
     class JacksonRoundTrip {
 
-        private final com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        private final ObjectMapper mapper = new ObjectMapper();
 
         @Test
         @DisplayName("request body with lowercase verdict deserializes via @JsonCreator")

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsCrudTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsCrudTest.java
@@ -40,10 +40,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
+import io.quarkus.security.identity.SecurityIdentity;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 
 /**
  * Unit tests for McpAdminTools Phase 8a.2 — update_resource, create_resource,
@@ -105,7 +107,7 @@ class McpAdminToolsCrudTest {
         scheduleStore = mock(IScheduleStore.class);
         scheduleFireExecutor = mock(ScheduleFireExecutor.class);
         schedulePollerService = mock(SchedulePollerService.class);
-        var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
+        var mockIdentity = mock(SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
         tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization, strictConfigurationParser(), scheduleStore,
                 scheduleFireExecutor, schedulePollerService,
@@ -578,9 +580,9 @@ class McpAdminToolsCrudTest {
     @Test
     void createResource_unknownField_reportsTheKnownFieldsMessage() {
         var strictTools = new McpAdminTools(mock(IRestInterfaceFactory.class), agentAdmin, jsonSerialization,
-                new StrictConfigurationParser(new com.fasterxml.jackson.databind.ObjectMapper()), scheduleStore,
+                new StrictConfigurationParser(new ObjectMapper()), scheduleStore,
                 scheduleFireExecutor, schedulePollerService,
-                mock(io.quarkus.security.identity.SecurityIdentity.class), false);
+                mock(SecurityIdentity.class), false);
 
         String result = strictTools.createResource("propertysetter",
                 "{\"setProperties\":[{\"name\":\"x\",\"valueString\":\"y\"}]}");

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsExtendedTest.java
@@ -47,10 +47,11 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.*;
 
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
+import io.quarkus.security.identity.SecurityIdentity;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 
 /**
  * Extended tests for McpAdminTools — schedule management, channel integrations,
@@ -119,7 +120,7 @@ class McpAdminToolsExtendedTest {
         lenient().when(jsonSerialization.serialize(any())).thenReturn("{}");
         lenient().when(schedulePollerService.getInstanceId()).thenReturn("test-instance");
 
-        var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
+        var mockIdentity = mock(SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
 
         tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization,

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsTest.java
@@ -28,10 +28,12 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import ai.labs.eddi.configs.rest.StrictConfigurationParser;
+import java.net.URI;
+import io.quarkus.security.identity.SecurityIdentity;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import ai.labs.eddi.configs.rest.StrictConfigurationParser;
 
 /**
  * Unit tests for McpAdminTools — MCP tools for Agent administration.
@@ -65,7 +67,7 @@ class McpAdminToolsTest {
         var schedulePollerService = mock(SchedulePollerService.class);
 
         lenient().when(jsonSerialization.serialize(any())).thenReturn("{}");
-        var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
+        var mockIdentity = mock(SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
         tools = new McpAdminTools(restInterfaceFactory, agentAdmin, jsonSerialization, strictConfigurationParser(), scheduleStore,
                 scheduleFireExecutor, schedulePollerService,
@@ -181,7 +183,7 @@ class McpAdminToolsTest {
     @Test
     void createAgent_createsAndPatchesDescriptor() throws IOException {
         when(AgentStore.createAgent(any(AgentConfiguration.class)))
-                .thenReturn(Response.created(java.net.URI.create("/agentstore/agents/" + AGENT_ID + "?version=1")).build());
+                .thenReturn(Response.created(URI.create("/agentstore/agents/" + AGENT_ID + "?version=1")).build());
         when(jsonSerialization.serialize(any())).thenReturn("{\"action\":\"created\",\"agentId\":\"test-agent-id\",\"name\":\"My Agent\"}");
 
         String result = tools.createAgent("My Agent", "Test description", null);
@@ -204,7 +206,7 @@ class McpAdminToolsTest {
     @Test
     void createAgent_withWorkflowUris() throws IOException {
         when(AgentStore.createAgent(any(AgentConfiguration.class)))
-                .thenReturn(Response.created(java.net.URI.create("/agentstore/agents/" + AGENT_ID + "?version=1")).build());
+                .thenReturn(Response.created(URI.create("/agentstore/agents/" + AGENT_ID + "?version=1")).build());
         when(jsonSerialization.serialize(any())).thenReturn("{\"action\":\"created\"}");
 
         tools.createAgent("Agent", null, "eddi://ai.labs.workflow/workflowstore/workflows/pkg1?version=1");
@@ -217,7 +219,7 @@ class McpAdminToolsTest {
     @Test
     void createAgent_descriptorPatchFailure_stillReturnsSuccess() throws IOException {
         when(AgentStore.createAgent(any(AgentConfiguration.class)))
-                .thenReturn(Response.created(java.net.URI.create("/agentstore/agents/" + AGENT_ID + "?version=1")).build());
+                .thenReturn(Response.created(URI.create("/agentstore/agents/" + AGENT_ID + "?version=1")).build());
         doThrow(new RuntimeException("Patch failed")).when(descriptorStore).patchDescriptor(any(), anyInt(), any());
         when(jsonSerialization.serialize(any())).thenReturn("{\"action\":\"created\"}");
 

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsExtendedTest.java
@@ -91,7 +91,7 @@ class McpConversationToolsExtendedTest {
         when(restInterfaceFactory.get(IRestDocumentDescriptorStore.class)).thenReturn(descriptorStore);
 
         lenient().when(jsonSerialization.serialize(any())).thenReturn("{}");
-        mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
+        mockIdentity = mock(SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
         // Authorization disabled: the guard admits every caller.
         conversationAccessGuard = new ConversationAccessGuard(mockIdentity, new OwnershipValidator(false),
@@ -183,7 +183,7 @@ class McpConversationToolsExtendedTest {
                 .thenThrow(new RestInterfaceFactory.RestInterfaceFactoryException("Factory error", new RuntimeException("cause")));
         when(failingFactory.get(IRestDocumentDescriptorStore.class)).thenReturn(descriptorStore);
 
-        var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
+        var mockIdentity = mock(SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
         var localTools = new McpConversationTools(conversationService, agentAdmin, agentStore,
                 failingFactory, jsonSerialization, boundedLogStore, auditStore,

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpConversationToolsTest.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.security.identity.SecurityIdentity;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -79,7 +80,7 @@ class McpConversationToolsTest {
         RestAgentEngine = mock(IRestAgentEngine.class);
         // Default: lenient serialize returns empty JSON
         lenient().when(jsonSerialization.serialize(any())).thenReturn("{}");
-        var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
+        var mockIdentity = mock(SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
         // Authorization disabled: the guard admits every caller (an unstubbed
         // descriptor store reads back no descriptor, i.e. no owner to check against).

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpGroupToolsTest.java
@@ -29,6 +29,10 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+import java.security.Principal;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.common.annotation.Blocking;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -47,7 +51,7 @@ class McpGroupToolsTest {
 
     private static GroupTemplateService templateService() {
         var service = new GroupTemplateService(
-                new com.fasterxml.jackson.databind.ObjectMapper());
+                new ObjectMapper());
         service.loadTemplates();
         return service;
     }
@@ -60,7 +64,7 @@ class McpGroupToolsTest {
         workspaceStore = mock(IGroupWorkspaceStore.class);
         lenient().when(jsonSerialization.serialize(any())).thenReturn("{}");
 
-        var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
+        var mockIdentity = mock(SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
         // authorization disabled — OwnershipValidator's checks are no-ops, matching the
         // pre-existing tests. Ownership enforcement is covered separately below.
@@ -489,7 +493,7 @@ class McpGroupToolsTest {
         assertEquals(String.class, method.getReturnType(),
                 "discuss_with_group must keep a non-reactive return type; returning Uni/Multi would make "
                         + "quarkus-mcp-server schedule this blocking work on the Vert.x event loop");
-        assertNull(method.getAnnotation(io.smallrye.common.annotation.NonBlocking.class),
+        assertNull(method.getAnnotation(NonBlocking.class),
                 "discuss_with_group does blocking work and must never be marked @NonBlocking");
     }
 
@@ -498,7 +502,7 @@ class McpGroupToolsTest {
         var method = McpGroupTools.class.getMethod("start_group_discussion", String.class, String.class, String.class);
         assertEquals(String.class, method.getReturnType(),
                 "start_group_discussion must keep a non-reactive return type for the same reason");
-        assertNull(method.getAnnotation(io.smallrye.common.annotation.NonBlocking.class),
+        assertNull(method.getAnnotation(NonBlocking.class),
                 "start_group_discussion must never be marked @NonBlocking");
     }
 
@@ -517,7 +521,7 @@ class McpGroupToolsTest {
         for (Class<?> toolClass : List.of(McpGroupTools.class, McpHitlTools.class, McpConversationTools.class,
                 McpAdminTools.class, McpSetupTools.class, McpMemoryTools.class, McpDocTools.class, McpGdprTools.class)) {
             for (var method : toolClass.getDeclaredMethods()) {
-                assertNull(method.getAnnotation(io.smallrye.common.annotation.Blocking.class),
+                assertNull(method.getAnnotation(Blocking.class),
                         toolClass.getSimpleName() + "." + method.getName() + " carries @Blocking. It is redundant "
                                 + "(a non-reactive return type already resolves to WORKER_THREAD) and Quarkus 3.38's "
                                 + "ExecutionModelAnnotationsProcessor rejects it, breaking quarkus:dev.");
@@ -534,7 +538,7 @@ class McpGroupToolsTest {
     private McpGroupTools toolsAsUser(String callerId, String role) {
         var identity = mock(SecurityIdentity.class);
         lenient().when(identity.isAnonymous()).thenReturn(false);
-        var principal = mock(java.security.Principal.class);
+        var principal = mock(Principal.class);
         lenient().when(principal.getName()).thenReturn(callerId);
         lenient().when(identity.getPrincipal()).thenReturn(principal);
         lenient().when(identity.hasRole(role)).thenReturn(true);
@@ -549,7 +553,7 @@ class McpGroupToolsTest {
     private McpGroupTools toolsAsAdmin(String callerId) {
         var identity = mock(SecurityIdentity.class);
         lenient().when(identity.isAnonymous()).thenReturn(false);
-        var principal = mock(java.security.Principal.class);
+        var principal = mock(Principal.class);
         lenient().when(principal.getName()).thenReturn(callerId);
         lenient().when(identity.getPrincipal()).thenReturn(principal);
         lenient().when(identity.hasRole(anyString())).thenReturn(true);

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpHitlToolsCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpHitlToolsCoverageTest.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.ws.rs.NotFoundException;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -322,7 +323,7 @@ class McpHitlToolsCoverageTest {
     @Test
     void getGroupApprovalStatus_jaxrsNotFound_returnsNotFound() throws Exception {
         when(groupConversationService.readGroupConversation("gc1"))
-                .thenThrow(new jakarta.ws.rs.NotFoundException("gone"));
+                .thenThrow(new NotFoundException("gone"));
         String out = tools.getGroupApprovalStatus("g1", "gc1", "summary");
         assertTrue(out.contains("\"errorCode\":\"NOT_FOUND\""), out);
     }
@@ -408,7 +409,7 @@ class McpHitlToolsCoverageTest {
     @Test
     void approveGroup_jaxrsNotFound_returnsNotFound() throws Exception {
         when(groupConversationService.resumeDiscussion(eq("gc1"), any(), isNull()))
-                .thenThrow(new jakarta.ws.rs.NotFoundException("gone"));
+                .thenThrow(new NotFoundException("gone"));
         String out = tools.approveGroupPhase("g1", "gc1", "APPROVED", null, null);
         assertTrue(out.contains("\"errorCode\":\"NOT_FOUND\""), out);
     }
@@ -507,7 +508,7 @@ class McpHitlToolsCoverageTest {
     @Test
     void cancelGroup_jaxrsNotFound_returnsNotFound() throws Exception {
         when(groupConversationService.cancelDiscussion(eq("gc1"), any()))
-                .thenThrow(new jakarta.ws.rs.NotFoundException("gone"));
+                .thenThrow(new NotFoundException("gone"));
         String out = tools.cancelGroupDiscussion("g1", "gc1");
         assertTrue(out.contains("\"errorCode\":\"NOT_FOUND\""), out);
     }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpHitlToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpHitlToolsTest.java
@@ -25,6 +25,7 @@ import java.security.Principal;
 import java.util.List;
 import java.util.Map;
 
+import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -191,7 +192,7 @@ class McpHitlToolsTest {
 
     @Test
     void approveGroup_malformedTaskApprovals_returnsBadRequest() throws Exception {
-        when(json.deserialize(eq("{bad"), eq(Map.class))).thenThrow(new java.io.IOException("parse"));
+        when(json.deserialize(eq("{bad"), eq(Map.class))).thenThrow(new IOException("parse"));
         String out = tools.approveGroupPhase("g1", "gc1", "APPROVED", null, "{bad");
         assertTrue(out.contains("\"errorCode\":\"BAD_REQUEST\""), out);
         verifyNoInteractions(groupConversationService);

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpSetupToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpSetupToolsTest.java
@@ -34,6 +34,7 @@ import org.mockito.ArgumentCaptor;
 import java.net.URI;
 import java.util.List;
 
+import io.quarkus.security.identity.SecurityIdentity;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -90,7 +91,7 @@ class McpSetupToolsTest {
         when(secretProvider.isAvailable()).thenReturn(false);
 
         service = new AgentSetupService(restInterfaceFactory, agentAdmin, secretProvider, "http://localhost:11434");
-        var mockIdentity = mock(io.quarkus.security.identity.SecurityIdentity.class);
+        var mockIdentity = mock(SecurityIdentity.class);
         lenient().when(mockIdentity.isAnonymous()).thenReturn(true);
         tools = new McpSetupTools(service, jsonSerialization, mockIdentity, false);
     }
@@ -267,7 +268,7 @@ class McpSetupToolsTest {
         when(AgentStore.createAgent(any())).thenReturn(Response.created(URI.create("/agentstore/agents/agent-1?version=1")).build());
 
         var vaultTools = new McpSetupTools(vaultService, jsonSerialization,
-                mock(io.quarkus.security.identity.SecurityIdentity.class), false);
+                mock(SecurityIdentity.class), false);
 
         vaultTools.setupAgent("Vault Agent", "You are helpful", "openai", "gpt-4o", "sk-live-secret", null, null, null,
                 null, null, null, null, false, null);

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpToolFilterTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpToolFilterTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import dev.langchain4j.agent.tool.Tool;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -210,7 +211,7 @@ class McpToolFilterTest {
         Map<String, String> builtinTools = new LinkedHashMap<>();
         for (Class<?> clazz : discoverClassesUnder("ai.labs.eddi.modules.llm.tools", true)) {
             for (Method method : clazz.getDeclaredMethods()) {
-                var tool = method.getAnnotation(dev.langchain4j.agent.tool.Tool.class);
+                var tool = method.getAnnotation(Tool.class);
                 if (tool == null) {
                     continue;
                 }

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpToolSchemaValidationTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpToolSchemaValidationTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import dev.langchain4j.agent.tool.Tool;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -83,7 +84,7 @@ class McpToolSchemaValidationTest {
         for (Class<?> toolClass : TOOL_CLASSES) {
             for (Method method : toolClass.getDeclaredMethods()) {
                 // Check methods with langchain4j @Tool annotation
-                if (!method.isAnnotationPresent(dev.langchain4j.agent.tool.Tool.class)) {
+                if (!method.isAnnotationPresent(Tool.class)) {
                     continue;
                 }
 

--- a/src/test/java/ai/labs/eddi/engine/memory/rest/RestConversationStoreOwnershipTest.java
+++ b/src/test/java/ai/labs/eddi/engine/memory/rest/RestConversationStoreOwnershipTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -193,7 +194,7 @@ class RestConversationStoreOwnershipTest {
         when(conversationDescriptorStore.readDescriptors(anyString(), any(), anyInt(), anyInt(), anyBoolean()))
                 .thenReturn(List.of(descriptor("conv-foreign-a", INTRUDER), descriptor("conv-foreign-b", INTRUDER)));
 
-        var registry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+        var registry = new SimpleMeterRegistry();
         var store = asOwner();
         store.meterRegistry = registry;
 

--- a/src/test/java/ai/labs/eddi/engine/model/EngineModelsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/model/EngineModelsTest.java
@@ -144,7 +144,7 @@ class EngineModelsTest {
 
     @Test
     void logEntry_jacksonRoundTrip() throws Exception {
-        var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        var mapper = new ObjectMapper();
         var entry = new LogEntry(1700000000L, "ERROR", "logger",
                 "Something failed", "test", "a1", 1,
                 "c1", "u1", "i1");
@@ -157,7 +157,7 @@ class EngineModelsTest {
 
     @Test
     void logEntry_jsonExcludesNulls() throws Exception {
-        var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        var mapper = new ObjectMapper();
         var entry = new LogEntry(0L, "INFO", "log", "msg",
                 null, null, null, null, null, null);
         var json = mapper.writeValueAsString(entry);

--- a/src/test/java/ai/labs/eddi/engine/rest/RestOperatorMetricsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/rest/RestOperatorMetricsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import io.micrometer.core.instrument.Counter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -78,7 +79,7 @@ class RestOperatorMetricsTest {
         assertThrows(BadRequestException.class, () -> rest.reportCanaryResult(new OperatorCanaryReport("PASS", 100L)));
         assertThrows(BadRequestException.class, () -> rest.reportCanaryResult(new OperatorCanaryReport("", 100L)));
         assertThrows(BadRequestException.class, () -> rest.reportCanaryResult(new OperatorCanaryReport(null, 100L)));
-        assertEquals(0.0, registry.find("eddi.operator.canary").counters().stream().mapToDouble(io.micrometer.core.instrument.Counter::count)
+        assertEquals(0.0, registry.find("eddi.operator.canary").counters().stream().mapToDouble(Counter::count)
                 .sum());
     }
 

--- a/src/test/java/ai/labs/eddi/engine/runtime/BoundedLogStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/BoundedLogStoreTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+import org.jboss.logmanager.ExtLogRecord;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -414,7 +415,7 @@ class BoundedLogStoreTest {
 
         @Test
         void captureWithExtLogRecordAndMdc_shouldExtractMdcFields() {
-            var extRecord = new org.jboss.logmanager.ExtLogRecord(
+            var extRecord = new ExtLogRecord(
                     Level.SEVERE, "ExtLogRecord test",
                     "com.example.ExtService");
             extRecord.setLoggerName("com.example.ExtService");
@@ -443,7 +444,7 @@ class BoundedLogStoreTest {
 
         @Test
         void captureWithExtLogRecord_invalidAgentVersion_shouldHandleGracefully() {
-            var extRecord = new org.jboss.logmanager.ExtLogRecord(
+            var extRecord = new ExtLogRecord(
                     Level.INFO, "Invalid ext version",
                     "com.example.ExtService");
             extRecord.setLoggerName("com.example.ExtService");
@@ -471,7 +472,7 @@ class BoundedLogStoreTest {
 
         @Test
         void captureWithExtLogRecordPrintfPattern_shouldFormatCorrectly() {
-            var extRecord = new org.jboss.logmanager.ExtLogRecord(
+            var extRecord = new ExtLogRecord(
                     Level.WARNING, "%s, line %d in %s",
                     "com.example.ScriptEngine");
             extRecord.setLoggerName("com.example.ScriptEngine");

--- a/src/test/java/ai/labs/eddi/engine/runtime/DatabaseLogsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/DatabaseLogsTest.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
+import com.mongodb.client.MongoCursor;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -306,7 +307,7 @@ class DatabaseLogsTest {
         when(findIterable.limit(anyInt())).thenReturn(findIterable);
         when(findIterable.skip(anyInt())).thenReturn(findIterable);
 
-        com.mongodb.client.MongoCursor<Document> cursor = mock(com.mongodb.client.MongoCursor.class);
+        MongoCursor<Document> cursor = mock(MongoCursor.class);
         Iterator<Document> iter = docs.iterator();
         when(cursor.hasNext()).thenAnswer(inv -> iter.hasNext());
         when(cursor.next()).thenAnswer(inv -> iter.next());

--- a/src/test/java/ai/labs/eddi/engine/runtime/LogRecordRedactorTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/LogRecordRedactorTest.java
@@ -13,6 +13,7 @@ import java.io.StringWriter;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+import java.net.ConnectException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -85,7 +86,7 @@ class LogRecordRedactorTest {
     @DisplayName("a throwable message carrying a credentialed URL is replaced, keeping its type and trace")
     void redactsThrowableMessage() {
         ExtLogRecord record = extRecord("MCP handshake failed");
-        var original = new java.net.ConnectException("failed to connect to https://mcp.example.com?apiKey=" + KEY);
+        var original = new ConnectException("failed to connect to https://mcp.example.com?apiKey=" + KEY);
         record.setThrown(original);
 
         assertTrue(LogRecordRedactor.redactInPlace(record));

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/CronDescriberExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/CronDescriberExtendedTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -178,7 +179,7 @@ class CronDescriberExtendedTest {
         @Test
         @DisplayName("should fall back to String.valueOf for negative value in single-element set")
         void negativeValueSingleElement() throws Exception {
-            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
+            Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
             formatSet.setAccessible(true);
 
             String[] labels = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
@@ -193,7 +194,7 @@ class CronDescriberExtendedTest {
         @Test
         @DisplayName("should fall back to String.valueOf for negative values in multi-element set")
         void negativeValueMultiElement() throws Exception {
-            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
+            Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
             formatSet.setAccessible(true);
 
             String[] labels = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
@@ -208,7 +209,7 @@ class CronDescriberExtendedTest {
         @Test
         @DisplayName("should handle value equal to labels.length (out of bounds)")
         void valueAtBoundary() throws Exception {
-            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
+            Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
             formatSet.setAccessible(true);
 
             String[] labels = {"A", "B", "C"};
@@ -220,7 +221,7 @@ class CronDescriberExtendedTest {
         @Test
         @DisplayName("should handle valid value at max index")
         void validMaxIndex() throws Exception {
-            java.lang.reflect.Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
+            Method formatSet = CronDescriber.class.getDeclaredMethod("formatSet", Set.class, String[].class);
             formatSet.setAccessible(true);
 
             String[] labels = {"A", "B", "C"};

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/DreamServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/DreamServiceTest.java
@@ -22,6 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import java.net.UnknownHostException;
+import java.net.SocketTimeoutException;
+import java.net.ConnectException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -42,7 +46,7 @@ class DreamServiceTest {
         agentStore = mock(IAgentStore.class);
         summarizationService = mock(SummarizationService.class);
         dreamService = new DreamService(store, agentStore, summarizationService, new SimpleMeterRegistry(),
-                new com.fasterxml.jackson.databind.ObjectMapper());
+                new ObjectMapper());
         dreamService.initMetrics();
 
         dreamConfig = new AgentConfiguration.DreamConfig();
@@ -796,7 +800,7 @@ class DreamServiceTest {
         assertTrue(DreamService.isTransientLlmFailure(new RuntimeException("status 503")));
         assertTrue(DreamService.isTransientLlmFailure(new RuntimeException("Overloaded")));
         assertTrue(DreamService.isTransientLlmFailure(
-                new RuntimeException("llm call failed", new java.net.SocketTimeoutException("read timed out"))));
+                new RuntimeException("llm call failed", new SocketTimeoutException("read timed out"))));
 
         assertFalse(DreamService.isTransientLlmFailure(new RuntimeException("401 Unauthorized")));
         assertFalse(DreamService.isTransientLlmFailure(new RuntimeException("model 'nope' does not exist")));
@@ -817,15 +821,15 @@ class DreamServiceTest {
      */
     @Test
     void isTransientLlmFailure_treatsAnUnresolvableHostAsPermanent() {
-        assertFalse(DreamService.isTransientLlmFailure(new java.net.UnknownHostException("api.wrong-endpoint.invalid")),
+        assertFalse(DreamService.isTransientLlmFailure(new UnknownHostException("api.wrong-endpoint.invalid")),
                 "an unresolvable host is a misconfiguration; reporting success forever hides it");
         assertFalse(DreamService.isTransientLlmFailure(
-                new RuntimeException("llm call failed", new java.net.UnknownHostException("api.wrong-endpoint.invalid"))),
+                new RuntimeException("llm call failed", new UnknownHostException("api.wrong-endpoint.invalid"))),
                 "also when wrapped — the classifier walks the cause chain");
 
         // Still transient: resolved but refused, i.e. a service that may come back.
         assertTrue(DreamService.isTransientLlmFailure(
-                new RuntimeException("llm call failed", new java.net.ConnectException("connection refused"))));
+                new RuntimeException("llm call failed", new ConnectException("connection refused"))));
     }
 
     /** Exception whose cause is itself — guards the cause-chain walk. */

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/NatsConversationCoordinatorBranchTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 
+import io.nats.client.impl.NatsJetStreamMetaData;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -105,7 +106,7 @@ class NatsConversationCoordinatorBranchTest {
             when(msg.getData()).thenReturn(payload.getBytes(StandardCharsets.UTF_8));
             when(msg.getSubject()).thenReturn("eddi.deadletter.conv-1");
 
-            io.nats.client.impl.NatsJetStreamMetaData metaData = mock(io.nats.client.impl.NatsJetStreamMetaData.class);
+            NatsJetStreamMetaData metaData = mock(NatsJetStreamMetaData.class);
             when(metaData.streamSequence()).thenReturn(42L);
             when(msg.metaData()).thenReturn(metaData);
 

--- a/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreExpandedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreExpandedTest.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.security.identity.SecurityIdentity;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -57,7 +58,7 @@ class RestScheduleStoreExpandedTest {
         setField(sut, "scheduleStore", scheduleStore);
         setField(sut, "fireExecutor", fireExecutor);
         setField(sut, "pollerService", pollerService);
-        setField(sut, "identity", mock(io.quarkus.security.identity.SecurityIdentity.class));
+        setField(sut, "identity", mock(SecurityIdentity.class));
         setField(sut, "ownershipValidator", ownershipValidator);
         setField(sut, "defaultTimeZone", "UTC");
         setField(sut, "minIntervalSeconds", 60L);

--- a/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/schedule/rest/RestScheduleStoreTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.ws.rs.NotFoundException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -542,7 +543,7 @@ class RestScheduleStoreTest {
 
         // A missing schedule must not be reported as forbidden — otherwise the guard
         // becomes an oracle for which schedule ids exist.
-        assertThrows(jakarta.ws.rs.NotFoundException.class, () -> rest.updateSchedule("gone", makeCronSchedule("gone")));
+        assertThrows(NotFoundException.class, () -> rest.updateSchedule("gone", makeCronSchedule("gone")));
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreTest.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import com.mongodb.client.MongoCursor;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -160,7 +161,7 @@ class MongoTenantQuotaStoreTest {
         void empty() {
             FindIterable<Document> emptyIterable = mock(FindIterable.class);
             when(quotasCollection.find()).thenReturn(emptyIterable);
-            com.mongodb.client.MongoCursor<Document> emptyCursor = mock(com.mongodb.client.MongoCursor.class);
+            MongoCursor<Document> emptyCursor = mock(MongoCursor.class);
             when(emptyCursor.hasNext()).thenReturn(false);
             doReturn(emptyCursor).when(emptyIterable).iterator();
 
@@ -184,7 +185,7 @@ class MongoTenantQuotaStoreTest {
 
             FindIterable<Document> iter = mock(FindIterable.class);
             when(quotasCollection.find()).thenReturn(iter);
-            com.mongodb.client.MongoCursor<Document> cursor = mock(com.mongodb.client.MongoCursor.class);
+            MongoCursor<Document> cursor = mock(MongoCursor.class);
             Iterator<Document> docIter = List.of(doc1, doc2).iterator();
             when(cursor.hasNext()).thenAnswer(inv -> docIter.hasNext());
             when(cursor.next()).thenAnswer(inv -> docIter.next());

--- a/src/test/java/ai/labs/eddi/integration/ContainerBaseIT.java
+++ b/src/test/java/ai/labs/eddi/integration/ContainerBaseIT.java
@@ -19,6 +19,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import org.jboss.logmanager.LogManager;
 
 /**
  * Base class for container-based integration tests.
@@ -119,7 +120,7 @@ public abstract class ContainerBaseIT extends BaseIntegrationIT {
                 COPY --chown=185 docs/ /deployments/docs/
                 USER 185
                 EXPOSE 7070
-                ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dfile.encoding=UTF8 -Deddi.docs.path=/deployments/docs"
+                ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=LogManager -Dfile.encoding=UTF8 -Deddi.docs.path=/deployments/docs"
                 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
                 ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
                 """;

--- a/src/test/java/ai/labs/eddi/integration/LogAdminIT.java
+++ b/src/test/java/ai/labs/eddi/integration/LogAdminIT.java
@@ -10,6 +10,8 @@ import io.restassured.http.ContentType;
 import java.util.List;
 import org.junit.jupiter.api.*;
 
+import java.net.URI;
+import java.net.HttpURLConnection;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
@@ -103,8 +105,8 @@ public class LogAdminIT {
     void streamLogs_returnsSseContentType() throws Exception {
         // SSE is a long-lived connection — RestAssured blocks. Use raw HTTP with
         // timeout.
-        var url = java.net.URI.create("http://localhost:8081" + BASE + "/stream").toURL();
-        var conn = (java.net.HttpURLConnection) url.openConnection();
+        var url = URI.create("http://localhost:8081" + BASE + "/stream").toURL();
+        var conn = (HttpURLConnection) url.openConnection();
         conn.setReadTimeout(3000); // 3 second timeout
         conn.setConnectTimeout(3000);
         conn.setRequestProperty("Accept", "text/event-stream");

--- a/src/test/java/ai/labs/eddi/integrations/openai/OpenAiConversationBridgeTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/openai/OpenAiConversationBridgeTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import java.io.ByteArrayOutputStream;
 import static ai.labs.eddi.integrations.openai.OpenAiTestFixtures.AGENT_ID_SUPPORT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -439,7 +440,7 @@ class OpenAiConversationBridgeTest {
     void streamingAlsoRequestsDetailedSnapshots() throws Exception {
         givenStreamingEmits(handler -> handler.onComplete(snapshotWithText("Hi", ConversationState.READY)));
 
-        bridge.stream(statelessTurn(), new OpenAiSseWriter(new java.io.ByteArrayOutputStream(),
+        bridge.stream(statelessTurn(), new OpenAiSseWriter(new ByteArrayOutputStream(),
                 objectMapper, "id", "m", 1L, false));
 
         verify(conversationService).sayStreaming(any(), eq(true), eq(true), any(), any(), any());
@@ -572,7 +573,7 @@ class OpenAiConversationBridgeTest {
         // Rule-based agents produce text at onComplete, not as tokens.
         givenStreamingEmits(handler -> handler.onComplete(snapshotWithText("block reply", ConversationState.READY)));
         var turn = statelessTurn();
-        var out = new java.io.ByteArrayOutputStream();
+        var out = new ByteArrayOutputStream();
 
         bridge.stream(turn, new OpenAiSseWriter(out, objectMapper, "id", "m", 1L, false));
 
@@ -588,7 +589,7 @@ class OpenAiConversationBridgeTest {
             handler.onComplete(snapshotWithText("streamed", ConversationState.READY));
         });
         var turn = statelessTurn();
-        var out = new java.io.ByteArrayOutputStream();
+        var out = new ByteArrayOutputStream();
 
         bridge.stream(turn, new OpenAiSseWriter(out, objectMapper, "id", "m", 1L, false));
 
@@ -603,7 +604,7 @@ class OpenAiConversationBridgeTest {
         // otherwise read.
         givenStreamingEmits(handler -> handler.onError(new NullPointerException()));
         var turn = statelessTurn();
-        var out = new java.io.ByteArrayOutputStream();
+        var out = new ByteArrayOutputStream();
 
         bridge.stream(turn, new OpenAiSseWriter(out, objectMapper, "id", "m", 1L, false));
 
@@ -636,7 +637,7 @@ class OpenAiConversationBridgeTest {
         }).when(conversationService).sayStreaming(any(), anyBoolean(), anyBoolean(), any(), any(), any());
 
         var turn = statelessTurn();
-        var out = new java.io.ByteArrayOutputStream();
+        var out = new ByteArrayOutputStream();
 
         bridge.stream(turn, new OpenAiSseWriter(out, objectMapper, "id", "m", 1L, false));
 
@@ -653,7 +654,7 @@ class OpenAiConversationBridgeTest {
             // Deliberately silent: an undocumented path must not hang the client.
         });
         var turn = statelessTurn();
-        var out = new java.io.ByteArrayOutputStream();
+        var out = new ByteArrayOutputStream();
 
         bridge.stream(turn, new OpenAiSseWriter(out, objectMapper, "id", "m", 1L, false));
 

--- a/src/test/java/ai/labs/eddi/integrations/slack/SlackSignatureVerifierTest.java
+++ b/src/test/java/ai/labs/eddi/integrations/slack/SlackSignatureVerifierTest.java
@@ -13,6 +13,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.Mac;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SlackSignatureVerifierTest {
@@ -171,8 +173,8 @@ class SlackSignatureVerifierTest {
      */
     private static String computeHmac(String secret, String baseString) {
         try {
-            var mac = javax.crypto.Mac.getInstance("HmacSHA256");
-            mac.init(new javax.crypto.spec.SecretKeySpec(
+            var mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(
                     secret.getBytes(java.nio.charset.StandardCharsets.UTF_8), "HmacSHA256"));
             byte[] hash = mac.doFinal(baseString.getBytes(java.nio.charset.StandardCharsets.UTF_8));
 

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/PrePostUtilsTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/PrePostUtilsTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -351,7 +352,7 @@ class PrePostUtilsTest {
             instruction.setScope(Property.Scope.conversation);
             instruction.setConvertToObject(true);
 
-            when(jsonSerialization.deserialize("{invalid}")).thenThrow(new java.io.IOException("parse error"));
+            when(jsonSerialization.deserialize("{invalid}")).thenThrow(new IOException("parse error"));
 
             prePostUtils.executePropertyInstructions(List.of(instruction), 0, false, memory, templateData);
 

--- a/src/test/java/ai/labs/eddi/modules/apicalls/impl/RequestRedactorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/apicalls/impl/RequestRedactorTest.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.net.URLEncoder;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -208,7 +209,7 @@ class RequestRedactorTest {
             // matches Bearer\s+. That produced a value redacted in queryParams and
             // plaintext one field away in uri.
             var map = new HashMap<String, Object>();
-            map.put(IRequest.KEY_URI, "https://x/y?auth=" + java.net.URLEncoder.encode(BEARER, java.nio.charset.StandardCharsets.UTF_8));
+            map.put(IRequest.KEY_URI, "https://x/y?auth=" + URLEncoder.encode(BEARER, java.nio.charset.StandardCharsets.UTF_8));
             redactor.redactRequestMap(map);
             String redacted = map.get(IRequest.KEY_URI).toString();
             assertFalse(redacted.contains("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), redacted);
@@ -217,7 +218,7 @@ class RequestRedactorTest {
         @Test
         void anEncodedVaultReferenceIsStillRedacted() {
             var map = new HashMap<String, Object>();
-            map.put(IRequest.KEY_URI, "https://x/y?k=" + java.net.URLEncoder.encode("${vault:billing}", java.nio.charset.StandardCharsets.UTF_8));
+            map.put(IRequest.KEY_URI, "https://x/y?k=" + URLEncoder.encode("${vault:billing}", java.nio.charset.StandardCharsets.UTF_8));
             redactor.redactRequestMap(map);
             assertFalse(map.get(IRequest.KEY_URI).toString().contains("billing"), map.get(IRequest.KEY_URI).toString());
         }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/A2AToolProviderManagerDeepBranchTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/A2AToolProviderManagerDeepBranchTest.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.*;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -370,7 +371,7 @@ class A2AToolProviderManagerDeepBranchTest {
             // Execute the tool to trigger executeA2ATask
             var toolName = result.toolSpecs().get(0).name();
             var executor = result.executors().get(toolName);
-            var toolRequest = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+            var toolRequest = ToolExecutionRequest.builder()
                     .name(toolName)
                     .arguments("{\"message\": \"test\"}")
                     .build();
@@ -405,7 +406,7 @@ class A2AToolProviderManagerDeepBranchTest {
             var result = manager.discoverTools(List.of(config));
             var toolName = result.toolSpecs().get(0).name();
             var executor = result.executors().get(toolName);
-            var toolRequest = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+            var toolRequest = ToolExecutionRequest.builder()
                     .name(toolName)
                     .arguments("{\"message\": \"test\"}")
                     .build();
@@ -438,7 +439,7 @@ class A2AToolProviderManagerDeepBranchTest {
             var result = manager.discoverTools(List.of(config));
             var toolName = result.toolSpecs().get(0).name();
             var executor = result.executors().get(toolName);
-            var toolRequest = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+            var toolRequest = ToolExecutionRequest.builder()
                     .name(toolName)
                     .arguments("{\"message\": \"test\"}")
                     .build();
@@ -471,7 +472,7 @@ class A2AToolProviderManagerDeepBranchTest {
             var result = manager.discoverTools(List.of(config));
             var toolName = result.toolSpecs().get(0).name();
             var executor = result.executors().get(toolName);
-            var toolRequest = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+            var toolRequest = ToolExecutionRequest.builder()
                     .name(toolName)
                     .arguments("{\"message\": \"test\"}")
                     .build();
@@ -508,7 +509,7 @@ class A2AToolProviderManagerDeepBranchTest {
             var result = manager.discoverTools(List.of(config));
             var toolName = result.toolSpecs().get(0).name();
             var executor = result.executors().get(toolName);
-            var toolRequest = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+            var toolRequest = ToolExecutionRequest.builder()
                     .name(toolName)
                     .arguments("{\"message\": \"test\"}")
                     .build();
@@ -541,7 +542,7 @@ class A2AToolProviderManagerDeepBranchTest {
             var result = manager.discoverTools(List.of(config));
             var toolName = result.toolSpecs().get(0).name();
             var executor = result.executors().get(toolName);
-            var toolRequest = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+            var toolRequest = ToolExecutionRequest.builder()
                     .name(toolName)
                     .arguments("{\"message\": \"test\"}")
                     .build();
@@ -579,7 +580,7 @@ class A2AToolProviderManagerDeepBranchTest {
             var result = manager.discoverTools(List.of(config));
             var toolName = result.toolSpecs().get(0).name();
             var executor = result.executors().get(toolName);
-            var toolRequest = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+            var toolRequest = ToolExecutionRequest.builder()
                     .name(toolName)
                     .arguments("{\"message\": \"test\"}")
                     .build();

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorCoverageTest.java
@@ -66,6 +66,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+import io.micrometer.core.instrument.Counter;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -1364,10 +1365,10 @@ class AgentOrchestratorCoverageTest {
     /** Delta of the named decision-tagged counter across whatever `action` does. */
     private static double approvalCountDelta(String decision, Runnable action) {
         double before = Metrics.globalRegistry.find("eddi.operator.write.approval").tag("decision", decision).counters().stream()
-                .mapToDouble(io.micrometer.core.instrument.Counter::count).sum();
+                .mapToDouble(Counter::count).sum();
         action.run();
         double after = Metrics.globalRegistry.find("eddi.operator.write.approval").tag("decision", decision).counters().stream()
-                .mapToDouble(io.micrometer.core.instrument.Counter::count).sum();
+                .mapToDouble(Counter::count).sum();
         return after - before;
     }
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorLocalToolAssemblyTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorLocalToolAssemblyTest.java
@@ -204,7 +204,7 @@ class AgentOrchestratorLocalToolAssemblyTest {
         var whitelist = List.of("calculator", "converse_with_agent");
 
         var specs = orchestrator().buildToolSetup(task(true, whitelist), memoryWithUserMemory()).builtInSpecs();
-        var names = specs.stream().map(dev.langchain4j.agent.tool.ToolSpecification::name).toList();
+        var names = specs.stream().map(ToolSpecification::name).toList();
 
         // The DISPATCH name, not the canonical slug: the whitelist is keyed by slug
         // ("calculator") but the assembled spec carries the @Tool method name.
@@ -238,7 +238,7 @@ class AgentOrchestratorLocalToolAssemblyTest {
         task.setToolLoadingStrategy(LlmConfiguration.ToolLoadingStrategy.LAZY);
 
         var names = orchestrator().buildToolSetup(task, memory()).toolSpecs().stream()
-                .map(dev.langchain4j.agent.tool.ToolSpecification::name).toList();
+                .map(ToolSpecification::name).toList();
 
         assertTrue(names.contains("discover_tools"), "LAZY must still advertise the meta-tool: " + names);
     }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AgentOrchestratorTest.java
@@ -34,6 +34,7 @@ import org.mockito.MockitoAnnotations;
 import java.lang.reflect.Method;
 import java.util.*;
 
+import dev.langchain4j.service.tool.ToolExecutor;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -740,7 +741,7 @@ class AgentOrchestratorTest {
         ToolSpecification spec = ToolSpecification.builder()
                 .name("test_tool").description("desc").build();
         List<ToolSpecification> specs = List.of(spec);
-        Map<String, dev.langchain4j.service.tool.ToolExecutor> executors = Map.of();
+        Map<String, ToolExecutor> executors = Map.of();
 
         var result = new AgentOrchestrator.HttpCallToolsResult(specs, executors, Map.of(), Map.of());
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/AttachmentForwarderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/AttachmentForwarderTest.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import java.io.IOException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import static ai.labs.eddi.engine.memory.MemoryKeys.ATTACHMENTS;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -67,12 +69,12 @@ class AttachmentForwarderTest {
      * The registry backing the most recently built forwarder — for counter
      * assertions.
      */
-    private io.micrometer.core.instrument.simple.SimpleMeterRegistry meterRegistry;
+    private SimpleMeterRegistry meterRegistry;
 
     private AttachmentForwarder newForwarder(long perFile, long aggregate) {
         var capability = new ModelCapabilityService(k -> Optional.empty());
         var extractor = new AttachmentTextExtractor(10_000);
-        meterRegistry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+        meterRegistry = new SimpleMeterRegistry();
         return new AttachmentForwarder(store, capability, extractor, httpClient,
                 meterRegistry, perFile, aggregate);
     }
@@ -627,7 +629,7 @@ class AttachmentForwarderTest {
     @Test
     void downloadException_addsNote() throws Exception {
         mockAttachments(urlImage());
-        doThrow(new java.io.IOException("boom")).when(httpClient).sendValidated(any(), any());
+        doThrow(new IOException("boom")).when(httpClient).sendValidated(any(), any());
         List<ChatMessage> messages = messages(UserMessage.from("look"));
 
         forwarder.forward(messages, memory, "gemini", "gemini-2.0-flash");
@@ -668,7 +670,7 @@ class AttachmentForwarderTest {
 
     @Test
     void metrics_recordForwardedAndErrors() {
-        var registry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+        var registry = new SimpleMeterRegistry();
         var f = new AttachmentForwarder(store, new ModelCapabilityService(k -> Optional.empty()),
                 new AttachmentTextExtractor(10_000), httpClient, registry, 10L * 1024 * 1024, 20L * 1024 * 1024);
         Attachment ok = new Attachment();

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutorCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutorCoverageTest.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import java.net.ConnectException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -659,7 +660,7 @@ class CascadingModelExecutorCoverageTest {
 
         ChatModel down = mock(ChatModel.class);
         // Wrap the checked ConnectException as a cause (message itself does not match).
-        when(down.chat(anyList())).thenThrow(new RuntimeException("network fault", new java.net.ConnectException("refused")));
+        when(down.chat(anyList())).thenThrow(new RuntimeException("network fault", new ConnectException("refused")));
         ChatModel up = modelReturning("recovered");
         ChatModelRegistry registry = mock(ChatModelRegistry.class);
         when(registry.getOrCreate(eq("down"), anyMap())).thenReturn(down);

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutorEnterpriseTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutorEnterpriseTest.java
@@ -32,6 +32,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -413,8 +416,8 @@ class CascadingModelExecutorEnterpriseTest {
         ChatModel cheap = mock(ChatModel.class);
         when(cheap.chat(anyList())).thenReturn(ChatResponse.builder()
                 .aiMessage(AiMessage.from("The full answer is definitely that we should"))
-                .metadata(dev.langchain4j.model.chat.response.ChatResponseMetadata.builder()
-                        .finishReason(dev.langchain4j.model.output.FinishReason.LENGTH).build())
+                .metadata(ChatResponseMetadata.builder()
+                        .finishReason(FinishReason.LENGTH).build())
                 .build());
 
         ChatModelRegistry registry = mock(ChatModelRegistry.class);
@@ -441,8 +444,8 @@ class CascadingModelExecutorEnterpriseTest {
     private static ChatModel modelReturning(String text, int in, int out, int total) {
         ChatModel model = mock(ChatModel.class);
         when(model.chat(anyList())).thenReturn(ChatResponse.builder().aiMessage(AiMessage.from(text))
-                .metadata(dev.langchain4j.model.chat.response.ChatResponseMetadata.builder()
-                        .tokenUsage(new dev.langchain4j.model.output.TokenUsage(in, out, total)).build())
+                .metadata(ChatResponseMetadata.builder()
+                        .tokenUsage(new TokenUsage(in, out, total)).build())
                 .build());
         return model;
     }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/DynamicAgentGuardrailResolutionTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/DynamicAgentGuardrailResolutionTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -68,7 +69,7 @@ class DynamicAgentGuardrailResolutionTest {
 
     /** The same policy as it comes back from the store: a plain map. */
     private static Map<String, Object> asStoredMap(DynamicAgentConfig config) {
-        return MAPPER.convertValue(config, new com.fasterxml.jackson.core.type.TypeReference<>() {
+        return MAPPER.convertValue(config, new TypeReference<>() {
         });
     }
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverage2Test.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/LlmTaskCoverage2Test.java
@@ -45,6 +45,8 @@ import org.mockito.Mock;
 
 import java.util.*;
 
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.SystemMessage;
 import static ai.labs.eddi.engine.memory.MemoryKeys.ACTIONS;
 import static dev.langchain4j.data.message.AiMessage.aiMessage;
 import static org.junit.jupiter.api.Assertions.*;
@@ -927,8 +929,8 @@ class LlmTaskCoverage2Test {
 
     private static List<ChatMessage> cascadeMessages() {
         var messages = new ArrayList<ChatMessage>();
-        messages.add(dev.langchain4j.data.message.SystemMessage.from("You are helpful"));
-        messages.add(dev.langchain4j.data.message.UserMessage.from("Hello"));
+        messages.add(SystemMessage.from("You are helpful"));
+        messages.add(UserMessage.from("Hello"));
         return messages;
     }
 
@@ -1032,7 +1034,7 @@ class LlmTaskCoverage2Test {
 
         verify(model).chat(msgCaptor.capture());
         var sent = (List<ChatMessage>) msgCaptor.getValue();
-        var sysText = ((dev.langchain4j.data.message.SystemMessage) sent.get(0)).text();
+        var sysText = ((SystemMessage) sent.get(0)).text();
         assertTrue(sysText.startsWith("You are helpful"), "existing system message preserved");
         assertTrue(sysText.contains("confidence"), "confidence instruction appended to existing system message");
     }

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolProviderManagerAdditionalTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolProviderManagerAdditionalTest.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -310,7 +312,7 @@ class McpToolProviderManagerAdditionalTest {
         @Test
         @DisplayName("outcomes are counted without leaking a URL or a credential")
         void discoveryOutcomesAreCountedSafely() throws Exception {
-            var registry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+            var registry = new SimpleMeterRegistry();
             // A spy with the network seam stubbed: pointing the real client at an
             // unreachable host would make this test depend on DNS and wait out the
             // 30-second default timeout.
@@ -324,7 +326,7 @@ class McpToolProviderManagerAdditionalTest {
             spied.discoverTools(List.of(config));
 
             var tagValues = registry.getMeters().stream().flatMap(m -> m.getId().getTags().stream())
-                    .map(io.micrometer.core.instrument.Tag::getValue).toList();
+                    .map(Tag::getValue).toList();
             assertFalse(tagValues.contains("super-secret-literal-key"), "a credential must never become a metric tag");
             assertFalse(tagValues.stream().anyMatch(v -> v.contains("unreachable-metrics-test")),
                     "a server URL is unbounded cardinality and must not be a tag: " + tagValues);

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderDiscoveryTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderDiscoveryTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration.WorkflowStep;
+import ai.labs.eddi.engine.memory.IConversationMemory;
+import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.modules.llm.tools.spi.ProviderFailure;
+import ai.labs.eddi.modules.llm.tools.spi.ToolAssemblyContext;
+import ai.labs.eddi.modules.llm.tools.spi.ToolRequestResolver;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link McpToolsProvider#discover}, which {@code McpToolsProviderTest}
+ * left to "indirect" coverage that measurement showed did not exist: these
+ * paths sat at 31% instruction coverage, including the tool-name collision
+ * defence the class documents at length.
+ * <p>
+ * The indirect suites stop earlier than they look. {@code
+ * AgentOrchestratorExtendedTest} and {@code AgentOrchestratorCoverage2Test}
+ * drive discovery with a mocked memory whose {@code getAgentVersion()} is null,
+ * so {@code WorkflowTraversal} returns empty before the per-server loop is
+ * entered, and the {@code McpToolProviderManager*Test} suites exercise the
+ * <em>manager</em> - the filtering, collision and bridge logic tested here
+ * lives in the provider.
+ * <p>
+ * <b>Every test uses a distinct agent id.</b> {@code WorkflowTraversal}
+ * memoizes a completed traversal for two seconds, keyed on
+ * {@code agentId|version|stepType|configClass}, in a {@code static} map - so
+ * sharing an id across tests in one JVM makes a later test silently reuse an
+ * earlier one's workflow.
+ */
+class McpToolsProviderDiscoveryTest {
+
+    private static final String MCPCALLS_TYPE = "eddi://ai.labs.mcpcalls";
+
+    /** Distinct per test - see the class comment on the static traversal cache. */
+    private static final AtomicInteger AGENT_SEQ = new AtomicInteger();
+
+    private IConversationMemory memory;
+    private IRestAgentStore agentStore;
+    private IRestWorkflowStore workflowStore;
+    private IResourceClientLibrary resourceClientLibrary;
+    private McpToolProviderManager manager;
+    private String agentId;
+
+    @BeforeEach
+    void setUp() {
+        memory = mock(IConversationMemory.class);
+        agentStore = mock(IRestAgentStore.class);
+        workflowStore = mock(IRestWorkflowStore.class);
+        resourceClientLibrary = mock(IResourceClientLibrary.class);
+        manager = mock(McpToolProviderManager.class);
+        agentId = "mcp-agent-" + AGENT_SEQ.incrementAndGet();
+    }
+
+    private McpToolsProvider provider() {
+        return new McpToolsProvider(agentStore, workflowStore, resourceClientLibrary, manager);
+    }
+
+    private void wireAgentWithSteps(List<WorkflowStep> steps) throws Exception {
+        when(memory.getAgentId()).thenReturn(agentId);
+        when(memory.getAgentVersion()).thenReturn(1);
+
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of(
+                URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-" + agentId + "?version=1")));
+        when(agentStore.readAgent(agentId, 1)).thenReturn(agentConfig);
+
+        var wfConfig = new WorkflowConfiguration();
+        wfConfig.setWorkflowSteps(steps);
+        when(workflowStore.readWorkflow("wf-" + agentId, 1)).thenReturn(wfConfig);
+    }
+
+    private static WorkflowStep mcpStep(String configId) {
+        var step = new WorkflowStep();
+        step.setType(URI.create(MCPCALLS_TYPE));
+        step.setConfig(Map.of("uri", "eddi://ai.labs.mcpcalls/mcpcallsstore/mcpcalls/" + configId + "?version=1"));
+        return step;
+    }
+
+    /**
+     * Wires memory to agent to workflow to one mcpcalls step carrying
+     * {@code config}.
+     */
+    private void wireWorkflowWith(McpCallsConfiguration config) throws Exception {
+        wireAgentWithSteps(List.of(mcpStep("mc-1")));
+        when(resourceClientLibrary.getResource(any(URI.class), any())).thenReturn(config);
+    }
+
+    private static McpCallsConfiguration mcpConfig(String name, String url) {
+        var c = new McpCallsConfiguration();
+        c.setName(name);
+        c.setMcpServerUrl(url);
+        c.setTransport("http");
+        return c;
+    }
+
+    private static ToolSpecification spec(String name) {
+        return ToolSpecification.builder().name(name).description("d-" + name).build();
+    }
+
+    private static ToolExecutor executor() {
+        return (request, memoryId) -> "ok";
+    }
+
+    private static List<String> names(List<ToolSpecification> specs) {
+        return specs.stream().map(ToolSpecification::name).toList();
+    }
+
+    // ==================== whitelist / blacklist ====================
+
+    @Test
+    @DisplayName("whitelist keeps only the named tools")
+    void whitelistFiltersOutEverythingElse() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setToolsWhitelist(List.of("keep"));
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("keep"), spec("drop")),
+                Map.of("keep", executor(), "drop", executor())));
+
+        var result = provider().discover(memory);
+
+        assertEquals(List.of("keep"), names(result.toolSpecs()));
+        assertTrue(result.executors().containsKey("keep"));
+        assertFalse(result.executors().containsKey("drop"));
+    }
+
+    @Test
+    @DisplayName("blacklist removes a tool the server still advertises")
+    void blacklistRemovesNamedTool() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setToolsBlacklist(List.of("dangerous"));
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("safe"), spec("dangerous")),
+                Map.of("safe", executor(), "dangerous", executor())));
+
+        var result = provider().discover(memory);
+
+        assertEquals(List.of("safe"), names(result.toolSpecs()));
+        assertFalse(result.executors().containsKey("dangerous"),
+                "a blacklisted tool must not reach the model - this is an operator security control");
+    }
+
+    @Test
+    @DisplayName("an empty whitelist is not treated as allow-nothing")
+    void emptyWhitelistKeepsEverything() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setToolsWhitelist(List.of());
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("a")), Map.of("a", executor())));
+
+        assertEquals(1, provider().discover(memory).toolSpecs().size());
+    }
+
+    // ==================== executor pairing / collisions ====================
+
+    @Test
+    @DisplayName("a spec with no executor is skipped rather than shipped unpaired")
+    void specWithoutExecutorIsSkipped() throws Exception {
+        wireWorkflowWith(mcpConfig("srv", "http://mcp.example/sse"));
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("orphan")), Map.of()));
+
+        var result = provider().discover(memory);
+
+        assertTrue(result.toolSpecs().isEmpty());
+        assertTrue(result.executors().isEmpty());
+    }
+
+    @Test
+    @DisplayName("tool-name collision keeps the first server's spec AND its executor")
+    void collisionKeepsFirstSpecAndItsExecutor() throws Exception {
+        wireAgentWithSteps(List.of(mcpStep("a"), mcpStep("b")));
+
+        when(resourceClientLibrary.getResource(any(URI.class), any())).thenReturn(
+                mcpConfig("first", "http://first.example/sse"),
+                mcpConfig("second", "http://second.example/sse"));
+
+        ToolSpecification firstSpec = spec("shared");
+        ToolExecutor firstExecutor = executor();
+        ToolExecutor secondExecutor = executor();
+        when(manager.discoverTools(anyList()))
+                .thenReturn(new McpToolProviderManager.McpToolsResult(
+                        List.of(firstSpec), Map.of("shared", firstExecutor)))
+                .thenReturn(new McpToolProviderManager.McpToolsResult(
+                        List.of(spec("shared")), Map.of("shared", secondExecutor)));
+
+        var result = provider().discover(memory);
+
+        // One entry only, and crucially the spec and the executor come from the SAME
+        // server. The bug this guards against paired the first server's spec with the
+        // last server's executor: the model is shown one signature while a different
+        // server's tool runs.
+        assertEquals(1, result.toolSpecs().size());
+        assertSame(firstSpec, result.toolSpecs().get(0));
+        assertSame(firstExecutor, result.executors().get("shared"));
+    }
+
+    // ==================== resource bridge ====================
+
+    @Test
+    @DisplayName("resource bridge tools are added when exposeResources is true")
+    void resourceBridgeIsOptIn() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setExposeResources(Boolean.TRUE);
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("normal")), Map.of("normal", executor())));
+        when(manager.resourceBridgeTools(any())).thenReturn(new McpToolProviderManager.McpResourceBridge(
+                List.of(spec("srv_list_resources")), Map.of("srv_list_resources", executor())));
+
+        var discovered = names(provider().discover(memory).toolSpecs());
+
+        assertTrue(discovered.contains("srv_list_resources"));
+        assertTrue(discovered.contains("normal"));
+    }
+
+    @Test
+    @DisplayName("resource bridge is skipped when exposeResources is absent")
+    void resourceBridgeSkippedWhenNotOptedIn() throws Exception {
+        wireWorkflowWith(mcpConfig("srv", "http://mcp.example/sse"));
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("normal")), Map.of("normal", executor())));
+
+        assertEquals(List.of("normal"), names(provider().discover(memory).toolSpecs()));
+    }
+
+    @Test
+    @DisplayName("resource-bridge tools bypass the whitelist (EDDI synthesizes them)")
+    void resourceBridgeIgnoresWhitelist() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setExposeResources(Boolean.TRUE);
+        config.setToolsWhitelist(List.of("nothing-matches"));
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("normal")), Map.of("normal", executor())));
+        when(manager.resourceBridgeTools(any())).thenReturn(new McpToolProviderManager.McpResourceBridge(
+                List.of(spec("srv_read_resource")), Map.of("srv_read_resource", executor())));
+
+        assertEquals(List.of("srv_read_resource"), names(provider().discover(memory).toolSpecs()));
+    }
+
+    @Test
+    @DisplayName("a rejected bridge config becomes an INVALID_CONFIGURATION failure, not a thrown exception")
+    void resourceBridgeRejectionIsReportedAsFailure() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setExposeResources(Boolean.TRUE);
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("normal")), Map.of("normal", executor())));
+        when(manager.resourceBridgeTools(any())).thenThrow(new IllegalArgumentException("bad bridge"));
+
+        var result = provider().discover(memory);
+
+        // The server's own tools survive a bad bridge config.
+        assertEquals(List.of("normal"), names(result.toolSpecs()));
+        assertEquals(1, result.failures().size());
+        assertEquals(McpToolProviderManager.McpFailureKind.INVALID_CONFIGURATION, result.failures().get(0).kind());
+        assertEquals("srv", result.failures().get(0).serverName());
+    }
+
+    // ==================== failures / resolvers ====================
+
+    @Test
+    @DisplayName("per-server failures are carried out of discovery")
+    void serverFailuresArePropagated() throws Exception {
+        wireWorkflowWith(mcpConfig("srv", "http://mcp.example/sse"));
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(), Map.of(),
+                List.of(new McpToolProviderManager.McpServerFailure("srv", "http://mcp.example/sse",
+                        McpToolProviderManager.McpFailureKind.CONNECTION_FAILURE, "refused"))));
+
+        var result = provider().discover(memory);
+
+        assertEquals(1, result.failures().size());
+        assertEquals(McpToolProviderManager.McpFailureKind.CONNECTION_FAILURE, result.failures().get(0).kind());
+    }
+
+    @Test
+    @DisplayName("contribute maps every failure kind onto ProviderFailure")
+    void contributeMapsAllFailureKinds() throws Exception {
+        wireWorkflowWith(mcpConfig("srv", "http://mcp.example/sse"));
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(), Map.of(),
+                List.of(
+                        new McpToolProviderManager.McpServerFailure("s1", "u",
+                                McpToolProviderManager.McpFailureKind.INVALID_CONFIGURATION, "m1"),
+                        new McpToolProviderManager.McpServerFailure("s2", "u",
+                                McpToolProviderManager.McpFailureKind.CONNECTION_FAILURE, "m2"),
+                        new McpToolProviderManager.McpServerFailure("s3", "u",
+                                McpToolProviderManager.McpFailureKind.CIRCUIT_OPEN, "m3"),
+                        new McpToolProviderManager.McpServerFailure("s4", "u",
+                                McpToolProviderManager.McpFailureKind.AUTHENTICATION_REQUIRED, "m4"))));
+
+        var task = new LlmConfiguration.Task();
+        var ctx = new ToolAssemblyContext(memory, task, null, null, "user-1", agentId, null);
+
+        var contribution = provider().contribute(ctx);
+
+        assertEquals(List.of(
+                ProviderFailure.Kind.INVALID_CONFIGURATION,
+                ProviderFailure.Kind.CONNECTION_FAILURE,
+                ProviderFailure.Kind.CIRCUIT_OPEN,
+                ProviderFailure.Kind.AUTHENTICATION_REQUIRED),
+                contribution.failures().stream().map(ProviderFailure::kind).toList());
+        assertTrue(contribution.failures().stream().allMatch(f -> "mcp".equals(f.source())));
+    }
+
+    @Test
+    @DisplayName("a resolver is pinned for every surviving tool, and only those")
+    void resolversArePinnedForSurvivingTools() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setToolsBlacklist(List.of("dropped"));
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("kept"), spec("dropped")),
+                Map.of("kept", executor(), "dropped", executor())));
+
+        var resolvers = new HashMap<String, ToolRequestResolver>();
+        provider().discover(memory, resolvers);
+
+        assertEquals(Set.of("kept"), resolvers.keySet());
+    }
+
+    @Test
+    @DisplayName("a store failure degrades to an empty result instead of propagating")
+    void storeFailureIsSwallowed() throws Exception {
+        when(memory.getAgentId()).thenReturn(agentId);
+        when(memory.getAgentVersion()).thenReturn(1);
+        when(agentStore.readAgent(agentId, 1)).thenThrow(new RuntimeException("store down"));
+
+        var result = provider().discover(memory);
+
+        assertTrue(result.toolSpecs().isEmpty());
+        assertTrue(result.failures().isEmpty());
+    }
+}

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderTest.java
@@ -19,10 +19,17 @@ import static org.mockito.Mockito.*;
  * Focused unit tests for {@link McpToolsProvider}, extracted from {@code
  * AgentOrchestrator} during the R2 (step 2) refactor. Covers {@code
  * contribute}'s enable/disable gate — new surface introduced by the extraction
- * (the check moved down from {@code buildToolSetup}). Discovery itself is
- * already covered indirectly by {@code AgentOrchestratorExtendedTest} and
- * directly by the {@code McpToolProviderManager*Test} suites (unchanged by this
- * move), re-verified green through the new delegator.
+ * (the check moved down from {@code buildToolSetup}).
+ * <p>
+ * This comment used to claim discovery was "already covered indirectly by
+ * {@code AgentOrchestratorExtendedTest}". It was not: those suites pass a
+ * mocked memory whose {@code getAgentVersion()} is null, so
+ * {@code WorkflowTraversal} returns before the per-server loop, and the
+ * {@code McpToolProviderManager*Test} suites cover the manager rather than this
+ * class. The measured result was 31% instruction coverage on
+ * {@link McpToolsProvider}. Discovery — filtering, collisions, the resource
+ * bridge and failure mapping — is now covered directly by
+ * {@code McpToolsProviderDiscoveryTest}.
  *
  * @author tests
  */
@@ -61,13 +68,20 @@ class McpToolsProviderTest {
     void contribute_nullFlag_defaultsToEnabled() {
         var memory = mock(IConversationMemory.class);
         when(memory.getAgentId()).thenReturn("agent-1");
+        when(memory.getAgentVersion()).thenReturn(7);
         var task = new LlmConfiguration.Task();
         task.setEnableMcpCallTools(null);
         var ctx = new ToolAssemblyContext(memory, task, null, null, "user-1", "agent-1", null);
 
-        var contribution = provider(mock(McpToolProviderManager.class)).contribute(ctx);
+        var restAgentStore = mock(IRestAgentStore.class);
+        var contribution = new McpToolsProvider(restAgentStore, mock(IRestWorkflowStore.class),
+                mock(IResourceClientLibrary.class), mock(McpToolProviderManager.class)).contribute(ctx);
 
+        // The point of the test is that a null flag does NOT short-circuit: discovery
+        // has to be attempted. assertNotNull alone passed either way, because the
+        // disabled path also returns a non-null empty contribution.
         assertNotNull(contribution);
+        verify(restAgentStore).readAgent("agent-1", 7);
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/SummarizationServiceTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/SummarizationServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.Map;
 
+import dev.langchain4j.model.output.TokenUsage;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -155,7 +156,7 @@ class SummarizationServiceTest {
         var aiMessage = AiMessage.from("summary text");
         var chatResponse = ChatResponse.builder()
                 .aiMessage(aiMessage)
-                .tokenUsage(new dev.langchain4j.model.output.TokenUsage(500, 100))
+                .tokenUsage(new TokenUsage(500, 100))
                 .build();
         when(chatModel.chat(any(ChatRequest.class))).thenReturn(chatResponse);
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/ToolLoopResumerSelfConversationTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/ToolLoopResumerSelfConversationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -167,7 +168,7 @@ class ToolLoopResumerSelfConversationTest {
     @Test
     @DisplayName("live path: refuses an ungated call whose resolved URI is the agent's own conversation")
     void livePathRefusesSelfTargetedCall() {
-        var request = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+        var request = ToolExecutionRequest.builder()
                 .name("say").arguments("{}").build();
 
         String reason = ToolLoopResumer.targetsOwnConversationLive(request,
@@ -179,7 +180,7 @@ class ToolLoopResumerSelfConversationTest {
     @Test
     @DisplayName("live path: allows an ungated call to a different conversation")
     void livePathAllowsOtherConversation() {
-        var request = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+        var request = ToolExecutionRequest.builder()
                 .name("say").arguments("{}").build();
 
         assertNull(ToolLoopResumer.targetsOwnConversationLive(request,
@@ -189,7 +190,7 @@ class ToolLoopResumerSelfConversationTest {
     @Test
     @DisplayName("live path: falls back to the raw arguments when no resolver exists")
     void livePathFallsBackToArguments() {
-        var request = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+        var request = ToolExecutionRequest.builder()
                 .name("say").arguments("{\"conversationId\":\"" + CONVERSATION_ID + "\"}").build();
 
         assertNotNull(ToolLoopResumer.targetsOwnConversationLive(request, Map.of(), CONVERSATION_ID));
@@ -198,7 +199,7 @@ class ToolLoopResumerSelfConversationTest {
     @Test
     @DisplayName("live path: tolerates a null resolver map and a blank conversation id")
     void livePathToleratesMissingInputs() {
-        var request = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+        var request = ToolExecutionRequest.builder()
                 .name("say").arguments("{}").build();
 
         assertNull(ToolLoopResumer.targetsOwnConversationLive(request, null, null));

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/impl/PdfReaderToolTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/impl/PdfReaderToolTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.net.http.HttpResponse;
+import java.net.http.HttpRequest;
+import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -166,10 +169,10 @@ class PdfReaderToolTest {
         @org.junit.jupiter.api.DisplayName("extractTextFromPdf — non-200 status returns error")
         @SuppressWarnings("unchecked")
         void extractText_non200_returnsError() throws Exception {
-            var mockResponse = (java.net.http.HttpResponse<Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+            var mockResponse = (HttpResponse<Path>) org.mockito.Mockito.mock(HttpResponse.class);
             org.mockito.Mockito.when(mockResponse.statusCode()).thenReturn(404);
             org.mockito.Mockito.doReturn(mockResponse).when(mockedHttpClient).send(
-                    org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
+                    org.mockito.ArgumentMatchers.any(HttpRequest.class),
                     org.mockito.ArgumentMatchers.any());
 
             String result = mockedTool.extractTextFromPdf("https://example.com/notfound.pdf");
@@ -182,10 +185,10 @@ class PdfReaderToolTest {
         @org.junit.jupiter.api.DisplayName("extractTextFromPdfPages — non-200 status returns error")
         @SuppressWarnings("unchecked")
         void extractPages_non200_returnsError() throws Exception {
-            var mockResponse = (java.net.http.HttpResponse<Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+            var mockResponse = (HttpResponse<Path>) org.mockito.Mockito.mock(HttpResponse.class);
             org.mockito.Mockito.when(mockResponse.statusCode()).thenReturn(500);
             org.mockito.Mockito.doReturn(mockResponse).when(mockedHttpClient).send(
-                    org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
+                    org.mockito.ArgumentMatchers.any(HttpRequest.class),
                     org.mockito.ArgumentMatchers.any());
 
             String result = mockedTool.extractTextFromPdfPages("https://example.com/doc.pdf", 1, 3);
@@ -198,10 +201,10 @@ class PdfReaderToolTest {
         @org.junit.jupiter.api.DisplayName("getPdfInfo — non-200 status returns error")
         @SuppressWarnings("unchecked")
         void pdfInfo_non200_returnsError() throws Exception {
-            var mockResponse = (java.net.http.HttpResponse<Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+            var mockResponse = (HttpResponse<Path>) org.mockito.Mockito.mock(HttpResponse.class);
             org.mockito.Mockito.when(mockResponse.statusCode()).thenReturn(403);
             org.mockito.Mockito.doReturn(mockResponse).when(mockedHttpClient).send(
-                    org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
+                    org.mockito.ArgumentMatchers.any(HttpRequest.class),
                     org.mockito.ArgumentMatchers.any());
 
             String result = mockedTool.getPdfInfo("https://example.com/forbidden.pdf");
@@ -213,8 +216,8 @@ class PdfReaderToolTest {
         @Test
         @org.junit.jupiter.api.DisplayName("extractTextFromPdf — IOException returns error")
         void extractText_ioException_returnsError() throws Exception {
-            org.mockito.Mockito.doThrow(new java.io.IOException("Connection refused")).when(mockedHttpClient).send(
-                    org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
+            org.mockito.Mockito.doThrow(new IOException("Connection refused")).when(mockedHttpClient).send(
+                    org.mockito.ArgumentMatchers.any(HttpRequest.class),
                     org.mockito.ArgumentMatchers.any());
 
             String result = mockedTool.extractTextFromPdf("https://example.com/doc.pdf");
@@ -226,8 +229,8 @@ class PdfReaderToolTest {
         @Test
         @org.junit.jupiter.api.DisplayName("extractTextFromPdfPages — IOException returns error")
         void extractPages_ioException_returnsError() throws Exception {
-            org.mockito.Mockito.doThrow(new java.io.IOException("Timeout")).when(mockedHttpClient).send(
-                    org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
+            org.mockito.Mockito.doThrow(new IOException("Timeout")).when(mockedHttpClient).send(
+                    org.mockito.ArgumentMatchers.any(HttpRequest.class),
                     org.mockito.ArgumentMatchers.any());
 
             String result = mockedTool.extractTextFromPdfPages("https://example.com/doc.pdf", 1, 5);
@@ -239,8 +242,8 @@ class PdfReaderToolTest {
         @Test
         @org.junit.jupiter.api.DisplayName("getPdfInfo — IOException returns error")
         void pdfInfo_ioException_returnsError() throws Exception {
-            org.mockito.Mockito.doThrow(new java.io.IOException("DNS failed")).when(mockedHttpClient).send(
-                    org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
+            org.mockito.Mockito.doThrow(new IOException("DNS failed")).when(mockedHttpClient).send(
+                    org.mockito.ArgumentMatchers.any(HttpRequest.class),
                     org.mockito.ArgumentMatchers.any());
 
             String result = mockedTool.getPdfInfo("https://example.com/doc.pdf");
@@ -253,7 +256,7 @@ class PdfReaderToolTest {
         @org.junit.jupiter.api.DisplayName("extractTextFromPdf — InterruptedException returns error")
         void extractText_interruptedException_returnsError() throws Exception {
             org.mockito.Mockito.doThrow(new InterruptedException("Interrupted")).when(mockedHttpClient).send(
-                    org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
+                    org.mockito.ArgumentMatchers.any(HttpRequest.class),
                     org.mockito.ArgumentMatchers.any());
 
             String result = mockedTool.extractTextFromPdf("https://example.com/doc.pdf");
@@ -365,12 +368,12 @@ class PdfReaderToolTest {
                 Files.copy(sourcePdf, target,
                         StandardCopyOption.REPLACE_EXISTING);
 
-                var mockResponse = (java.net.http.HttpResponse<Path>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+                var mockResponse = (HttpResponse<Path>) org.mockito.Mockito.mock(HttpResponse.class);
                 org.mockito.Mockito.when(mockResponse.statusCode()).thenReturn(200);
                 org.mockito.Mockito.when(mockResponse.body()).thenReturn(target);
                 return mockResponse;
             }).when(mockedHttpClient).send(
-                    org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
+                    org.mockito.ArgumentMatchers.any(HttpRequest.class),
                     org.mockito.ArgumentMatchers.any());
         }
 

--- a/src/test/java/ai/labs/eddi/modules/llm/tools/impl/WebSearchToolTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/tools/impl/WebSearchToolTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.net.http.HttpResponse;
+import java.net.http.HttpRequest;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -502,7 +504,7 @@ class WebSearchToolTest {
         @SuppressWarnings("unchecked")
         @Test
         void searchWeb_duckDuckGoSuccess_returnsResults() throws Exception {
-            var response = (java.net.http.HttpResponse<String>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+            var response = (HttpResponse<String>) org.mockito.Mockito.mock(HttpResponse.class);
             org.mockito.Mockito.when(response.statusCode()).thenReturn(200);
             org.mockito.Mockito.when(response.body()).thenReturn("""
                     {
@@ -524,10 +526,10 @@ class WebSearchToolTest {
         @SuppressWarnings("unchecked")
         @Test
         void searchWeb_duckDuckGoNon200_returnsError() throws Exception {
-            var response = (java.net.http.HttpResponse<String>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+            var response = (HttpResponse<String>) org.mockito.Mockito.mock(HttpResponse.class);
             org.mockito.Mockito.when(response.statusCode()).thenReturn(429);
             org.mockito.Mockito.doReturn(response).when(mockedClient).send(
-                    org.mockito.ArgumentMatchers.any(java.net.http.HttpRequest.class),
+                    org.mockito.ArgumentMatchers.any(HttpRequest.class),
                     org.mockito.ArgumentMatchers.any());
 
             String result = mockedTool.searchWeb("test", 5);
@@ -551,7 +553,7 @@ class WebSearchToolTest {
             cxField.setAccessible(true);
             cxField.set(mockedTool, Optional.of("test-cx"));
 
-            var response = (java.net.http.HttpResponse<String>) org.mockito.Mockito.mock(java.net.http.HttpResponse.class);
+            var response = (HttpResponse<String>) org.mockito.Mockito.mock(HttpResponse.class);
             org.mockito.Mockito.when(response.statusCode()).thenReturn(200);
             org.mockito.Mockito.when(response.body()).thenReturn("""
                     {"items":[{"title":"Google Result","snippet":"Google snippet","link":"https://g.com"}]}

--- a/src/test/java/ai/labs/eddi/modules/rag/RagIngestionServiceTest.java
+++ b/src/test/java/ai/labs/eddi/modules/rag/RagIngestionServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 
 import java.util.Map;
 
+import dev.langchain4j.data.embedding.Embedding;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -47,8 +48,8 @@ class RagIngestionServiceTest {
         when(embeddingModelFactory.getOrCreate(any())).thenReturn(embeddingModel);
         when(embeddingStoreFactory.getOrCreate(any(), anyString())).thenReturn(embeddingStore);
         when(embeddingModel.embed(any(TextSegment.class)))
-                .thenReturn(Response.from(dev.langchain4j.data.embedding.Embedding.from(new float[]{0.1f})));
-        when(embeddingModel.embed(anyString())).thenReturn(Response.from(dev.langchain4j.data.embedding.Embedding.from(new float[]{0.1f})));
+                .thenReturn(Response.from(Embedding.from(new float[]{0.1f})));
+        when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(new float[]{0.1f})));
 
         var config = createConfig();
 


### PR DESCRIPTION
A review pass for dead code, defects and thin test coverage. Three real problems and one
under-enforced guard; each behavioural fix is **mutation-verified** (revert the fix, confirm
the new test fails).

Dead code came up essentially empty — every candidate turned out framework-wired
(`OpenApiTagSortFilter` via Quarkus `@OpenApiFilter`, `LifecycleModule` as a CDI producer,
`URIMessageBodyProvider` as a JAX-RS `@Provider`), there are zero `TODO/FIXME` markers in
`src/main`, and no `ILifecycleTask` holds mutable instance state.

---

## 1. `SourceUrlValidator` accepted internal hosts the rest of the codebase refuses

The remote agent-sync endpoints (`backup/import/sync*`) validated `sourceUrl` with a second,
local copy of the SSRF address predicate built from the four JDK checks. Those do not cover:

| Range | Why the JDK misses it |
| --- | --- |
| RFC 4193 IPv6 ULA `fc00::/7` | `isSiteLocalAddress()` only matches the deprecated `fec0::/10` |
| RFC 6598 CGNAT `100.64.0.0/10` | not a site-local range; used by Tailscale and some k8s pod CIDRs |
| IPv4 multicast `224.0.0.0/4` | not covered by any of the four predicates |

These endpoints are `@RolesAllowed({"eddi-admin", "eddi-editor"})`, so the gap was reachable by
the **lower-privileged** role. `isPrivateIp` now delegates to
`UrlValidationUtils.isPrivateAddress` — which AGENTS.md already names as the thing to call
before fetching a user-controlled URL — instead of keeping the weaker duplicate. That is also
what §4.7 "Unification over duplication" asks for. `isPrivateAddress` is promoted to `public`
and documented as the single definition of an unsafe outbound address.

**Mutation-verified:** with the old predicate restored, `100.64.0.1`, `fd00::1`, `fc00::1` and
`224.0.0.1` were all *accepted*.

The wrapper keeps its own messages and its HTTPS-in-production rule (which has no equivalent in
`UrlValidationUtils`), so no existing message assertion changes. Deliberately **not** adopted:
`UrlValidationUtils`' `.local`/`.internal` hostname block — those hostnames resolve and are then
caught by the address check anyway, and blocking them by name would newly reject a legitimate
corporate sync target.

## 2. Two audit dead-letter tests never tested what they claimed on Linux

`AuditLedgerServiceBranchTest` forced the file-fallback **failure** branch with
`"Z:\nonexistent\path\deadletter.jsonl"`. That is unwritable only on Windows — a backslash is a
legal character in a Unix filename, so on the Linux CI runner the whole string is one relative
filename that `Files.write(..., CREATE)` happily creates.

So the two assertion-free tests exercised the *success* path on CI while their comments claimed
the failure path, and left a junk file named `Z:\nonexistent\path\deadletter.jsonl` in the build
directory — which is not gitignored.

Replaced with `@TempDir` plus a deliberately-uncreated parent directory (`CREATE` does not create
parent directories, so it throws `NoSuchFileException` on both platforms). Both tests gained real
assertions: that NATS was actually attempted (or actually skipped), and that the dead-letter file
does **not** exist afterwards — which is what makes them fail if the write starts succeeding again.

**Mutation-verified:** pointing the helper at a writable path fails exactly those two tests.

## 3. `McpToolsProvider` sat at 31% coverage, including its tool-confusion defence

`McpToolsProviderTest`'s javadoc asserted discovery was "already covered indirectly by
`AgentOrchestratorExtendedTest`". Measurement disagreed — **264 of 383 instructions and 41 of 50
branches missed**. The indirect suites drive discovery with a mocked memory whose
`getAgentVersion()` is null, so `WorkflowTraversal` returns before the per-server loop is ever
entered, and the `McpToolProviderManager*Test` suites cover the *manager*, not this class.

Left untested as a result: whitelist/blacklist filtering (the blacklist is an operator security
control), the first-write-wins collision handling the class documents at length as an
anti-tool-confusion measure, the spec-without-executor skip, the resource-bridge opt-in and its
`IllegalArgumentException` to `INVALID_CONFIGURATION` path, and the `asProviderFailures` mapping.

New `McpToolsProviderDiscoveryTest` covers all of it — **31.1% to 93.5%**, branches missed 41 to 10.
The stale javadoc is corrected, and `contribute_nullFlag_defaultsToEnabled` (which asserted only
`assertNotNull`, so passed whether or not the flag short-circuited) now verifies discovery was
actually attempted.

**Mutation-verified:** removing the collision guard fails `collisionKeepsFirstSpecAndItsExecutor`.

> Note for future test authors, recorded in the new class comment: `WorkflowTraversal` memoizes a
> completed traversal for two seconds in a **static** map keyed on
> `agentId|version|stepType|configClass`, so every test allocates its own agent id.

## 4. `ImportStyleTest` did not enforce the rule it documents

Second commit, kept separate because it is purely mechanical.

The guard for AGENTS.md §4.7 ("never inline a fully-qualified name") matched only
`ai.labs.eddi|java.util|java.time|java.nio.file`, so every third-party FQN was invisible to it —
the rule was enforced on roughly a tenth of the surface it claims. Measured blind spot:
**381 inline FQNs across 118 files** (`jakarta`, `javax`, `org.eclipse`, `org.jboss`,
`com.fasterxml`, `io.quarkus`, `io.smallrye`, `io.micrometer`, `io.nats`, `org.bson`,
`com.mongodb`, `org.postgresql`, `dev.langchain4j`, plus `java.io` / `java.net` / `java.lang` /
`java.security`).

Essentially none were the disambiguation case §4.7 permits — they were simply missing imports.
Rather than park 118 files in an allowlist (the silent drift the test's own doc warns against),
the pattern is widened to an explicit root list and the violations fixed. The root list stays
explicit rather than a general lowercase-dotted-path shape, because a generic pattern also
matches method chains and builder idioms on a lowercase receiver, which are not FQNs at all.

**One genuine collision surfaced and is allowlisted:** `NatsConversationCoordinator` imports
`io.nats.client.api.*`, which brings in `io.nats.client.api.Error`, so its
`catch (RuntimeException | java.lang.Error e)` clauses need the inline FQN — rewriting them makes
the reference ambiguous and the file stops compiling, while an explicit `import java.lang.Error`
is a redundant import Checkstyle flags. Worth recording that the automated rewrite's conflict
check consulted only *single-type* imports, so a name introduced by a wildcard import was
invisible to it; the compiler caught it.

No behaviour changes in this commit — every edit swaps an inline FQN for the identical type named
by a top-level import, or moves an import line.

---

## Verification

Measured locally against a pre-change baseline on the same machine (the local suite has a known
set of environmental failures — loopback sockets, Docker, network — per the AGENTS.md sandbox
caveat):

| | Baseline | After |
| --- | --- | --- |
| Tests run | 20,295 | **20,311** (+16) |
| Failures / Errors | 8 / 193 | **8 / 193** |
| Failing classes | 11 | **same 11, identical set** |
| Instruction coverage | 89.91% | **90.01%** |
| Branch coverage | 79.24% | **79.38%** |

The failing-class *set* was diffed, not just the counts — that catches a swap where one class
newly breaks and another newly passes. `McpToolsProvider` 31.1% to 93.5%; `SourceUrlValidator`
96.3%. Checkstyle is unchanged at its pre-existing violation count.

Verified with a **clean** `test-compile` rather than an incremental one, since a type-level
refactor otherwise reuses stale `.class` files and hides breaks in unedited callers. Rebased onto
current `main` (which had picked up the caller-supplied-connections work) and re-verified: the
widened guard passes against that newly-landed code too.

## Deliberately left alone

- `RemoteApiResourceSource` builds a raw `HttpClient` rather than using `SafeHttpClient`,
  contrary to §4.4. Real, but a distinct change with its own blast radius (redirect/timeout
  semantics differ), and not urgent — the JDK default redirect policy is `NEVER`, so there is no
  redirect-based bypass.
- The remaining measured coverage gaps, chiefly `RestImportService`'s partial-failure/rollback
  paths (1,165 missed instructions, 118 branches).
