### PR TITLE
fix(review): close an SSRF gap, and two tests that passed for the wrong reason

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,109 @@
 
 
 
+## 🔍 fix(review): close an SSRF gap, and two tests that passed for the wrong reason (2026-08-28)
+
+**Repo:** EDDI (`claude/code-review-test-coverage-59bf99`)
+
+A review pass for dead code, defects and thin coverage. Dead code came up empty —
+every candidate turned out to be framework-wired (`OpenApiTagSortFilter` via Quarkus
+`@OpenApiFilter`, `LifecycleModule` as a CDI producer, `URIMessageBodyProvider` as a
+JAX-RS `@Provider`), there are zero `TODO/FIXME` markers in `src/main`, and no
+`ILifecycleTask` holds mutable instance state. Three real problems did surface, each
+verified by reverting the fix and watching the new test fail.
+
+**Measured baseline** (local `./mvnw test`): 20,295 tests, 8 failures / 193 errors —
+all environmental (loopback sockets, Docker, network), matching the known local
+profile. Fresh JaCoCo from that run: 89.91% instruction / 79.24% branch.
+
+### 1. `SourceUrlValidator` accepted internal hosts the rest of the codebase refuses
+
+The remote agent-sync endpoints (`backup/import/sync*`, open to **`eddi-editor`**,
+not just admin) validated their `sourceUrl` with a second, local copy of the SSRF
+predicate built from the four JDK checks. Those do not cover:
+
+- **RFC 4193 IPv6 ULA `fc00::/7`** — `isSiteLocalAddress()` only matches the
+  deprecated `fec0::/10`
+- **RFC 6598 CGNAT `100.64.0.0/10`** — used by Tailscale and some k8s pod CIDRs
+- IPv4 multicast
+
+`UrlValidationUtils.isPrivateAddress` — which AGENTS.md already names as the thing to
+call before fetching a user-controlled URL — covers all of them. `isPrivateIp` now
+delegates there instead of keeping the weaker duplicate, which is also what §4.7
+"Unification over duplication" asks for. `isPrivateAddress` is promoted to `public`
+and documented as the single definition of an unsafe outbound address.
+
+The wrapper keeps its own messages and its HTTPS-in-production rule (which has no
+equivalent in `UrlValidationUtils`), so no existing message assertion changes.
+Deliberately *not* adopted: `UrlValidationUtils`' `.local`/`.internal` hostname
+block — those hostnames resolve and are then caught by the address check anyway, and
+blocking them by name would newly reject a legitimate corporate sync target.
+
+Confirmed by mutation: with the old predicate restored, `100.64.0.1`, `fd00::1`,
+`fc00::1` and `224.0.0.1` were all **accepted**.
+
+### 2. Two audit dead-letter tests never tested what they claimed on Linux
+
+`AuditLedgerServiceBranchTest` passed `"Z:\\nonexistent\\path\\deadletter.jsonl"` as
+the dead-letter path to force the file-fallback **failure** branch. That is only
+unwritable on Windows: a backslash is a legal character in a Unix filename, so on the
+Linux CI runner the whole string is one relative filename that
+`Files.write(..., CREATE)` happily creates. So the two assertion-free tests
+(`writeToDeadLetterNatsFails`, `writeToDeadLetterFileOnly`) exercised the *success*
+path on CI while their comments claimed the failure path — and left a junk file named
+`Z:\nonexistent\path\deadletter.jsonl` in the build directory, which is not
+gitignored.
+
+Replaced with `@TempDir` + a deliberately-uncreated parent directory: `Files.write`
+with `CREATE` does not create parent directories, so it throws `NoSuchFileException`
+on both platforms. Both tests gained real assertions — that NATS was actually
+attempted (or actually skipped), and that the dead-letter file does **not** exist
+afterwards, which is what makes them fail if the write ever starts succeeding again.
+
+Confirmed by mutation: pointing the helper at a writable path fails exactly those two
+tests.
+
+### 3. `McpToolsProvider` sat at 31% coverage, including its tool-confusion defence
+
+`McpToolsProviderTest` asserted in its javadoc that discovery was "already covered
+indirectly by `AgentOrchestratorExtendedTest`". Measurement disagreed: 264 of 383
+instructions and 41 of 50 branches missed. The indirect suites drive discovery with a
+mocked memory whose `getAgentVersion()` is null, so `WorkflowTraversal` returns before
+the per-server loop is ever entered, and the `McpToolProviderManager*Test` suites
+cover the *manager*, not this class.
+
+Untested as a result: whitelist/blacklist filtering (the blacklist is an operator
+security control), the first-write-wins collision handling the class documents at
+length as an anti-tool-confusion measure, the spec-without-executor skip, the
+resource-bridge opt-in and its `IllegalArgumentException` → `INVALID_CONFIGURATION`
+path, and the `asProviderFailures` kind mapping.
+
+New `McpToolsProviderDiscoveryTest` covers all of it (13 tests). Note for future
+authors, called out in the class comment: `WorkflowTraversal` memoizes a completed
+traversal for two seconds in a **static** map keyed on
+`agentId|version|stepType|configClass`, so every test allocates its own agent id.
+
+The stale javadoc is corrected, and `contribute_nullFlag_defaultsToEnabled` — which
+asserted only `assertNotNull`, and so passed whether or not the flag short-circuited —
+now verifies that discovery was actually attempted.
+
+Confirmed by mutation: removing the collision guard fails
+`collisionKeepsFirstSpecAndItsExecutor`.
+
+### Noted, not changed
+
+- `RemoteApiResourceSource` builds a raw `HttpClient` rather than using
+  `SafeHttpClient`, contrary to §4.4. Not urgent — the JDK default redirect policy is
+  `NEVER`, so there is no redirect-based bypass — but it is a real follow-up with its
+  own blast radius (timeout/redirect semantics differ).
+- `ImportStyleTest` enforces the §4.7 no-inline-FQN rule only for
+  `ai.labs.eddi|java.util|java.time|java.nio.file`, so ~59 inline third-party FQNs
+  across 41 files slip through. Handled separately so it does not drown this review.
+
+---
+
+
+
 ## 📝 docs(monitoring): reconcile the dashboard inventory with what is provisioned (2026-08-27)
 
 **Repo:** EDDI (`feat/grafana-full-metrics-dashboard`)

--- a/src/main/java/ai/labs/eddi/backup/impl/SourceUrlValidator.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/SourceUrlValidator.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
 import org.jboss.logging.Logger;
 
 import java.net.InetAddress;
@@ -88,12 +89,29 @@ public final class SourceUrlValidator {
         return false;
     }
 
+    /**
+     * Delegates the address decision to
+     * {@link UrlValidationUtils#isPrivateAddress}, the codebase's single definition
+     * of an unsafe outbound address.
+     * <p>
+     * This used to be a second, local copy built from the four JDK predicates
+     * ({@code isSiteLocalAddress}, {@code isLoopbackAddress},
+     * {@code isLinkLocalAddress}, {@code isAnyLocalAddress}). Those do not cover
+     * RFC 4193 IPv6 ULA ({@code fc00::/7} - {@code isSiteLocalAddress} only matches
+     * the deprecated {@code fec0::/10}) or RFC 6598 CGNAT ({@code 100.64.0.0/10},
+     * used by Tailscale and some k8s pod CIDRs). The sync endpoints are open to
+     * {@code eddi-editor}, so that gap let a lower-privileged role reach internal
+     * hosts the rest of the codebase already refused.
+     * <p>
+     * The messages here are deliberately kept rather than delegating to
+     * {@code validateUrl} wholesale: this validator's HTTPS-in-production rule has
+     * no equivalent there, and its wording is what the sync UI shows the operator.
+     */
     private static boolean isPrivateIp(String host) {
         try {
             InetAddress[] addresses = InetAddress.getAllByName(host);
             for (InetAddress addr : addresses) {
-                if (addr.isSiteLocalAddress() || addr.isLoopbackAddress()
-                        || addr.isLinkLocalAddress() || addr.isAnyLocalAddress()) {
+                if (UrlValidationUtils.isPrivateAddress(addr)) {
                     return true;
                 }
             }

--- a/src/main/java/ai/labs/eddi/modules/llm/tools/UrlValidationUtils.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/tools/UrlValidationUtils.java
@@ -139,8 +139,14 @@ public final class UrlValidationUtils {
      * <li>Unspecified (0.0.0.0/8)</li>
      * <li>Cloud metadata (169.254.169.254)</li>
      * </ul>
+     * <p>
+     * Public because it is the single definition of "unsafe outbound address" for
+     * the whole codebase: {@code SourceUrlValidator}, which guards the remote agent
+     * sync endpoints, delegates here rather than keeping the second, weaker copy it
+     * used to have (that one missed RFC 4193 ULA and RFC 6598 CGNAT, because the
+     * JDK predicates alone do not cover them).
      */
-    static boolean isPrivateAddress(InetAddress address) {
+    public static boolean isPrivateAddress(InetAddress address) {
         // JDK covers: loopback, site-local (RFC 1918 for IPv4, fec0::/10 for IPv6),
         // link-local, any-local (0.0.0.0, ::)
         if (address.isLoopbackAddress() || address.isSiteLocalAddress() || address.isLinkLocalAddress() || address.isAnyLocalAddress()

--- a/src/test/java/ai/labs/eddi/backup/impl/SourceUrlValidatorTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/SourceUrlValidatorTest.java
@@ -108,6 +108,34 @@ class SourceUrlValidatorTest {
         }
 
         @Test
+        @DisplayName("should reject RFC 6598 CGNAT addresses (100.64.0.0/10)")
+        void rejectsCarrierGradeNat() {
+            // Not covered by InetAddress.isSiteLocalAddress(); Tailscale and some
+            // k8s pod networks allocate here, so an editor could otherwise reach
+            // internal peers through the sync endpoints.
+            assertThrows(IllegalArgumentException.class,
+                    () -> SourceUrlValidator.validate("http://100.64.0.1:8080", true));
+        }
+
+        @Test
+        @DisplayName("should reject RFC 4193 IPv6 unique local addresses (fc00::/7)")
+        void rejectsIpv6UniqueLocal() {
+            // isSiteLocalAddress() only matches the deprecated fec0::/10, so ULA
+            // addresses used to pass this validator while failing every other one.
+            assertThrows(IllegalArgumentException.class,
+                    () -> SourceUrlValidator.validate("http://[fd00::1]:8080", true));
+            assertThrows(IllegalArgumentException.class,
+                    () -> SourceUrlValidator.validate("http://[fc00::1]:8080", true));
+        }
+
+        @Test
+        @DisplayName("should reject IPv4 multicast addresses")
+        void rejectsMulticast() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> SourceUrlValidator.validate("http://224.0.0.1:8080", true));
+        }
+
+        @Test
         @DisplayName("should reject unresolvable hosts (fail closed)")
         void rejectsUnresolvableHost() {
             var ex = assertThrows(IllegalArgumentException.class,

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
@@ -17,9 +17,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 
@@ -38,6 +41,27 @@ class AuditLedgerServiceBranchTest {
     private IAuditStore auditStore;
 
     private MeterRegistry meterRegistry;
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * A dead-letter path whose write is guaranteed to fail on every platform.
+     * <p>
+     * The parent directory is deliberately never created, and {@code Files.write}
+     * with {@code CREATE} does not create parent directories - so the write throws
+     * {@code NoSuchFileException} on Linux and Windows alike.
+     * <p>
+     * This used to be a hardcoded {@code Z:\nonexistent\...}, which is unwritable
+     * only on Windows: a backslash is a legal character in a Unix filename, so on
+     * the Linux CI runner that whole string was one relative filename which
+     * {@code CREATE} happily created. The tests below then exercised the file
+     * fallback's SUCCESS path while claiming to cover its failure path, and left a
+     * junk file in the build directory.
+     */
+    private String unwritableDeadLetterPath() {
+        return tempDir.resolve("no-such-dir").resolve("deadletter.jsonl").toString();
+    }
 
     @BeforeEach
     void setUp() throws Exception {
@@ -349,7 +373,7 @@ class AuditLedgerServiceBranchTest {
         // Use a temp file path that likely fails (to cover the file-fallback error
         // path)
         var service = new AuditLedgerService(auditStore, true, 60,
-                Optional.empty(), "Z:\\nonexistent\\path\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
+                Optional.empty(), unwritableDeadLetterPath(), false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
                 true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
@@ -359,6 +383,13 @@ class AuditLedgerServiceBranchTest {
         service.flush();
         service.flush();
         service.flush(); // triggers dead letter
+
+        // NATS was actually attempted: without this the test would still pass if
+        // writeToDeadLetter were never reached at all.
+        verify(js, atLeastOnce()).publish(anyString(), any(byte[].class));
+        // ...and the file fallback genuinely failed rather than quietly succeeding.
+        assertFalse(Files.exists(Path.of(unwritableDeadLetterPath())),
+                "the dead-letter write must fail, otherwise this test does not cover the failure path");
 
         // Should not throw even though both NATS and file fail
         service.shutdown();
@@ -376,7 +407,7 @@ class AuditLedgerServiceBranchTest {
 
         // Use a nonexistent path to test error handling
         var service = new AuditLedgerService(auditStore, true, 60,
-                Optional.empty(), "Z:\\nonexistent\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
+                Optional.empty(), unwritableDeadLetterPath(), false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
                 true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
@@ -386,6 +417,13 @@ class AuditLedgerServiceBranchTest {
         service.flush();
         service.flush();
         service.flush(); // triggers dead letter
+
+        // NATS is unresolvable, so the file fallback is the path under test...
+        verify(natsInstance, atLeastOnce()).isResolvable();
+        verify(natsInstance, never()).get();
+        // ...and it failed, rather than creating the file and passing vacuously.
+        assertFalse(Files.exists(Path.of(unwritableDeadLetterPath())),
+                "the dead-letter write must fail, otherwise this test does not cover the failure path");
 
         // Should handle file write failure gracefully
         service.shutdown();
@@ -454,7 +492,7 @@ class AuditLedgerServiceBranchTest {
         doReturn(conn).when(natsInstance).get();
 
         var service = new AuditLedgerService(auditStore, true, 60,
-                Optional.empty(), "Z:\\nonexistent\\deadletter.jsonl", false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
+                Optional.empty(), unwritableDeadLetterPath(), false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
                 true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderDiscoveryTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderDiscoveryTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration.WorkflowStep;
+import ai.labs.eddi.engine.memory.IConversationMemory;
+import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.modules.llm.tools.spi.ProviderFailure;
+import ai.labs.eddi.modules.llm.tools.spi.ToolAssemblyContext;
+import ai.labs.eddi.modules.llm.tools.spi.ToolRequestResolver;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link McpToolsProvider#discover}, which {@code McpToolsProviderTest}
+ * left to "indirect" coverage that measurement showed did not exist: these
+ * paths sat at 31% instruction coverage, including the tool-name collision
+ * defence the class documents at length.
+ * <p>
+ * The indirect suites stop earlier than they look. {@code
+ * AgentOrchestratorExtendedTest} and {@code AgentOrchestratorCoverage2Test}
+ * drive discovery with a mocked memory whose {@code getAgentVersion()} is null,
+ * so {@code WorkflowTraversal} returns empty before the per-server loop is
+ * entered, and the {@code McpToolProviderManager*Test} suites exercise the
+ * <em>manager</em> - the filtering, collision and bridge logic tested here
+ * lives in the provider.
+ * <p>
+ * <b>Every test uses a distinct agent id.</b> {@code WorkflowTraversal}
+ * memoizes a completed traversal for two seconds, keyed on
+ * {@code agentId|version|stepType|configClass}, in a {@code static} map - so
+ * sharing an id across tests in one JVM makes a later test silently reuse an
+ * earlier one's workflow.
+ */
+class McpToolsProviderDiscoveryTest {
+
+    private static final String MCPCALLS_TYPE = "eddi://ai.labs.mcpcalls";
+
+    /** Distinct per test - see the class comment on the static traversal cache. */
+    private static final AtomicInteger AGENT_SEQ = new AtomicInteger();
+
+    private IConversationMemory memory;
+    private IRestAgentStore agentStore;
+    private IRestWorkflowStore workflowStore;
+    private IResourceClientLibrary resourceClientLibrary;
+    private McpToolProviderManager manager;
+    private String agentId;
+
+    @BeforeEach
+    void setUp() {
+        memory = mock(IConversationMemory.class);
+        agentStore = mock(IRestAgentStore.class);
+        workflowStore = mock(IRestWorkflowStore.class);
+        resourceClientLibrary = mock(IResourceClientLibrary.class);
+        manager = mock(McpToolProviderManager.class);
+        agentId = "mcp-agent-" + AGENT_SEQ.incrementAndGet();
+    }
+
+    private McpToolsProvider provider() {
+        return new McpToolsProvider(agentStore, workflowStore, resourceClientLibrary, manager);
+    }
+
+    private void wireAgentWithSteps(List<WorkflowStep> steps) throws Exception {
+        when(memory.getAgentId()).thenReturn(agentId);
+        when(memory.getAgentVersion()).thenReturn(1);
+
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of(
+                URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf-" + agentId + "?version=1")));
+        when(agentStore.readAgent(agentId, 1)).thenReturn(agentConfig);
+
+        var wfConfig = new WorkflowConfiguration();
+        wfConfig.setWorkflowSteps(steps);
+        when(workflowStore.readWorkflow("wf-" + agentId, 1)).thenReturn(wfConfig);
+    }
+
+    private static WorkflowStep mcpStep(String configId) {
+        var step = new WorkflowStep();
+        step.setType(URI.create(MCPCALLS_TYPE));
+        step.setConfig(Map.of("uri", "eddi://ai.labs.mcpcalls/mcpcallsstore/mcpcalls/" + configId + "?version=1"));
+        return step;
+    }
+
+    /**
+     * Wires memory to agent to workflow to one mcpcalls step carrying
+     * {@code config}.
+     */
+    private void wireWorkflowWith(McpCallsConfiguration config) throws Exception {
+        wireAgentWithSteps(List.of(mcpStep("mc-1")));
+        when(resourceClientLibrary.getResource(any(URI.class), any())).thenReturn(config);
+    }
+
+    private static McpCallsConfiguration mcpConfig(String name, String url) {
+        var c = new McpCallsConfiguration();
+        c.setName(name);
+        c.setMcpServerUrl(url);
+        c.setTransport("http");
+        return c;
+    }
+
+    private static ToolSpecification spec(String name) {
+        return ToolSpecification.builder().name(name).description("d-" + name).build();
+    }
+
+    private static ToolExecutor executor() {
+        return (request, memoryId) -> "ok";
+    }
+
+    private static List<String> names(List<ToolSpecification> specs) {
+        return specs.stream().map(ToolSpecification::name).toList();
+    }
+
+    // ==================== whitelist / blacklist ====================
+
+    @Test
+    @DisplayName("whitelist keeps only the named tools")
+    void whitelistFiltersOutEverythingElse() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setToolsWhitelist(List.of("keep"));
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("keep"), spec("drop")),
+                Map.of("keep", executor(), "drop", executor())));
+
+        var result = provider().discover(memory);
+
+        assertEquals(List.of("keep"), names(result.toolSpecs()));
+        assertTrue(result.executors().containsKey("keep"));
+        assertFalse(result.executors().containsKey("drop"));
+    }
+
+    @Test
+    @DisplayName("blacklist removes a tool the server still advertises")
+    void blacklistRemovesNamedTool() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setToolsBlacklist(List.of("dangerous"));
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("safe"), spec("dangerous")),
+                Map.of("safe", executor(), "dangerous", executor())));
+
+        var result = provider().discover(memory);
+
+        assertEquals(List.of("safe"), names(result.toolSpecs()));
+        assertFalse(result.executors().containsKey("dangerous"),
+                "a blacklisted tool must not reach the model - this is an operator security control");
+    }
+
+    @Test
+    @DisplayName("an empty whitelist is not treated as allow-nothing")
+    void emptyWhitelistKeepsEverything() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setToolsWhitelist(List.of());
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("a")), Map.of("a", executor())));
+
+        assertEquals(1, provider().discover(memory).toolSpecs().size());
+    }
+
+    // ==================== executor pairing / collisions ====================
+
+    @Test
+    @DisplayName("a spec with no executor is skipped rather than shipped unpaired")
+    void specWithoutExecutorIsSkipped() throws Exception {
+        wireWorkflowWith(mcpConfig("srv", "http://mcp.example/sse"));
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("orphan")), Map.of()));
+
+        var result = provider().discover(memory);
+
+        assertTrue(result.toolSpecs().isEmpty());
+        assertTrue(result.executors().isEmpty());
+    }
+
+    @Test
+    @DisplayName("tool-name collision keeps the first server's spec AND its executor")
+    void collisionKeepsFirstSpecAndItsExecutor() throws Exception {
+        wireAgentWithSteps(List.of(mcpStep("a"), mcpStep("b")));
+
+        when(resourceClientLibrary.getResource(any(URI.class), any())).thenReturn(
+                mcpConfig("first", "http://first.example/sse"),
+                mcpConfig("second", "http://second.example/sse"));
+
+        ToolSpecification firstSpec = spec("shared");
+        ToolExecutor firstExecutor = executor();
+        ToolExecutor secondExecutor = executor();
+        when(manager.discoverTools(anyList()))
+                .thenReturn(new McpToolProviderManager.McpToolsResult(
+                        List.of(firstSpec), Map.of("shared", firstExecutor)))
+                .thenReturn(new McpToolProviderManager.McpToolsResult(
+                        List.of(spec("shared")), Map.of("shared", secondExecutor)));
+
+        var result = provider().discover(memory);
+
+        // One entry only, and crucially the spec and the executor come from the SAME
+        // server. The bug this guards against paired the first server's spec with the
+        // last server's executor: the model is shown one signature while a different
+        // server's tool runs.
+        assertEquals(1, result.toolSpecs().size());
+        assertSame(firstSpec, result.toolSpecs().get(0));
+        assertSame(firstExecutor, result.executors().get("shared"));
+    }
+
+    // ==================== resource bridge ====================
+
+    @Test
+    @DisplayName("resource bridge tools are added when exposeResources is true")
+    void resourceBridgeIsOptIn() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setExposeResources(Boolean.TRUE);
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("normal")), Map.of("normal", executor())));
+        when(manager.resourceBridgeTools(any())).thenReturn(new McpToolProviderManager.McpResourceBridge(
+                List.of(spec("srv_list_resources")), Map.of("srv_list_resources", executor())));
+
+        var discovered = names(provider().discover(memory).toolSpecs());
+
+        assertTrue(discovered.contains("srv_list_resources"));
+        assertTrue(discovered.contains("normal"));
+    }
+
+    @Test
+    @DisplayName("resource bridge is skipped when exposeResources is absent")
+    void resourceBridgeSkippedWhenNotOptedIn() throws Exception {
+        wireWorkflowWith(mcpConfig("srv", "http://mcp.example/sse"));
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("normal")), Map.of("normal", executor())));
+
+        assertEquals(List.of("normal"), names(provider().discover(memory).toolSpecs()));
+    }
+
+    @Test
+    @DisplayName("resource-bridge tools bypass the whitelist (EDDI synthesizes them)")
+    void resourceBridgeIgnoresWhitelist() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setExposeResources(Boolean.TRUE);
+        config.setToolsWhitelist(List.of("nothing-matches"));
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("normal")), Map.of("normal", executor())));
+        when(manager.resourceBridgeTools(any())).thenReturn(new McpToolProviderManager.McpResourceBridge(
+                List.of(spec("srv_read_resource")), Map.of("srv_read_resource", executor())));
+
+        assertEquals(List.of("srv_read_resource"), names(provider().discover(memory).toolSpecs()));
+    }
+
+    @Test
+    @DisplayName("a rejected bridge config becomes an INVALID_CONFIGURATION failure, not a thrown exception")
+    void resourceBridgeRejectionIsReportedAsFailure() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setExposeResources(Boolean.TRUE);
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("normal")), Map.of("normal", executor())));
+        when(manager.resourceBridgeTools(any())).thenThrow(new IllegalArgumentException("bad bridge"));
+
+        var result = provider().discover(memory);
+
+        // The server's own tools survive a bad bridge config.
+        assertEquals(List.of("normal"), names(result.toolSpecs()));
+        assertEquals(1, result.failures().size());
+        assertEquals(McpToolProviderManager.McpFailureKind.INVALID_CONFIGURATION, result.failures().get(0).kind());
+        assertEquals("srv", result.failures().get(0).serverName());
+    }
+
+    // ==================== failures / resolvers ====================
+
+    @Test
+    @DisplayName("per-server failures are carried out of discovery")
+    void serverFailuresArePropagated() throws Exception {
+        wireWorkflowWith(mcpConfig("srv", "http://mcp.example/sse"));
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(), Map.of(),
+                List.of(new McpToolProviderManager.McpServerFailure("srv", "http://mcp.example/sse",
+                        McpToolProviderManager.McpFailureKind.CONNECTION_FAILURE, "refused"))));
+
+        var result = provider().discover(memory);
+
+        assertEquals(1, result.failures().size());
+        assertEquals(McpToolProviderManager.McpFailureKind.CONNECTION_FAILURE, result.failures().get(0).kind());
+    }
+
+    @Test
+    @DisplayName("contribute maps every failure kind onto ProviderFailure")
+    void contributeMapsAllFailureKinds() throws Exception {
+        wireWorkflowWith(mcpConfig("srv", "http://mcp.example/sse"));
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(), Map.of(),
+                List.of(
+                        new McpToolProviderManager.McpServerFailure("s1", "u",
+                                McpToolProviderManager.McpFailureKind.INVALID_CONFIGURATION, "m1"),
+                        new McpToolProviderManager.McpServerFailure("s2", "u",
+                                McpToolProviderManager.McpFailureKind.CONNECTION_FAILURE, "m2"),
+                        new McpToolProviderManager.McpServerFailure("s3", "u",
+                                McpToolProviderManager.McpFailureKind.CIRCUIT_OPEN, "m3"),
+                        new McpToolProviderManager.McpServerFailure("s4", "u",
+                                McpToolProviderManager.McpFailureKind.AUTHENTICATION_REQUIRED, "m4"))));
+
+        var task = new LlmConfiguration.Task();
+        var ctx = new ToolAssemblyContext(memory, task, null, null, "user-1", agentId, null);
+
+        var contribution = provider().contribute(ctx);
+
+        assertEquals(List.of(
+                ProviderFailure.Kind.INVALID_CONFIGURATION,
+                ProviderFailure.Kind.CONNECTION_FAILURE,
+                ProviderFailure.Kind.CIRCUIT_OPEN,
+                ProviderFailure.Kind.AUTHENTICATION_REQUIRED),
+                contribution.failures().stream().map(ProviderFailure::kind).toList());
+        assertTrue(contribution.failures().stream().allMatch(f -> "mcp".equals(f.source())));
+    }
+
+    @Test
+    @DisplayName("a resolver is pinned for every surviving tool, and only those")
+    void resolversArePinnedForSurvivingTools() throws Exception {
+        var config = mcpConfig("srv", "http://mcp.example/sse");
+        config.setToolsBlacklist(List.of("dropped"));
+        wireWorkflowWith(config);
+
+        when(manager.discoverTools(anyList())).thenReturn(new McpToolProviderManager.McpToolsResult(
+                List.of(spec("kept"), spec("dropped")),
+                Map.of("kept", executor(), "dropped", executor())));
+
+        var resolvers = new HashMap<String, ToolRequestResolver>();
+        provider().discover(memory, resolvers);
+
+        assertEquals(Set.of("kept"), resolvers.keySet());
+    }
+
+    @Test
+    @DisplayName("a store failure degrades to an empty result instead of propagating")
+    void storeFailureIsSwallowed() throws Exception {
+        when(memory.getAgentId()).thenReturn(agentId);
+        when(memory.getAgentVersion()).thenReturn(1);
+        when(agentStore.readAgent(agentId, 1)).thenThrow(new RuntimeException("store down"));
+
+        var result = provider().discover(memory);
+
+        assertTrue(result.toolSpecs().isEmpty());
+        assertTrue(result.failures().isEmpty());
+    }
+}

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/McpToolsProviderTest.java
@@ -19,10 +19,17 @@ import static org.mockito.Mockito.*;
  * Focused unit tests for {@link McpToolsProvider}, extracted from {@code
  * AgentOrchestrator} during the R2 (step 2) refactor. Covers {@code
  * contribute}'s enable/disable gate — new surface introduced by the extraction
- * (the check moved down from {@code buildToolSetup}). Discovery itself is
- * already covered indirectly by {@code AgentOrchestratorExtendedTest} and
- * directly by the {@code McpToolProviderManager*Test} suites (unchanged by this
- * move), re-verified green through the new delegator.
+ * (the check moved down from {@code buildToolSetup}).
+ * <p>
+ * This comment used to claim discovery was "already covered indirectly by
+ * {@code AgentOrchestratorExtendedTest}". It was not: those suites pass a
+ * mocked memory whose {@code getAgentVersion()} is null, so
+ * {@code WorkflowTraversal} returns before the per-server loop, and the
+ * {@code McpToolProviderManager*Test} suites cover the manager rather than this
+ * class. The measured result was 31% instruction coverage on
+ * {@link McpToolsProvider}. Discovery — filtering, collisions, the resource
+ * bridge and failure mapping — is now covered directly by
+ * {@code McpToolsProviderDiscoveryTest}.
  *
  * @author tests
  */
@@ -61,13 +68,20 @@ class McpToolsProviderTest {
     void contribute_nullFlag_defaultsToEnabled() {
         var memory = mock(IConversationMemory.class);
         when(memory.getAgentId()).thenReturn("agent-1");
+        when(memory.getAgentVersion()).thenReturn(7);
         var task = new LlmConfiguration.Task();
         task.setEnableMcpCallTools(null);
         var ctx = new ToolAssemblyContext(memory, task, null, null, "user-1", "agent-1", null);
 
-        var contribution = provider(mock(McpToolProviderManager.class)).contribute(ctx);
+        var restAgentStore = mock(IRestAgentStore.class);
+        var contribution = new McpToolsProvider(restAgentStore, mock(IRestWorkflowStore.class),
+                mock(IResourceClientLibrary.class), mock(McpToolProviderManager.class)).contribute(ctx);
 
+        // The point of the test is that a null flag does NOT short-circuit: discovery
+        // has to be attempted. assertNotNull alone passed either way, because the
+        // disabled path also returns a non-null empty contribution.
         assertNotNull(contribution);
+        verify(restAgentStore).readAgent("agent-1", 7);
     }
 
     @Test


### PR DESCRIPTION
A review pass for dead code, defects and thin test coverage. Three real problems, each
**mutation-verified** — revert the fix, confirm the new test fails.

Dead code came up essentially empty: every candidate turned out framework-wired
(`OpenApiTagSortFilter` via Quarkus `@OpenApiFilter`, `LifecycleModule` as a CDI producer,
`URIMessageBodyProvider` as a JAX-RS `@Provider`), there are zero `TODO/FIXME` markers in
`src/main`, and no `ILifecycleTask` holds mutable instance state.

> Split out of #724, which combined these fixes with a 118-file mechanical refactor and so
> tripped CodeRabbit's 100-file limit — the security fix got no bot review. The refactor is
> now its own PR; this one is 7 files.

---

## 1. `SourceUrlValidator` accepted internal hosts the rest of the codebase refuses

The remote agent-sync endpoints (`backup/import/sync*`) validated `sourceUrl` with a second,
local copy of the SSRF address predicate built from the four JDK checks. Those do not cover:

| Range | Why the JDK misses it |
| --- | --- |
| RFC 4193 IPv6 ULA `fc00::/7` | `isSiteLocalAddress()` only matches the deprecated `fec0::/10` |
| RFC 6598 CGNAT `100.64.0.0/10` | not a site-local range; used by Tailscale and some k8s pod CIDRs |
| IPv4 multicast `224.0.0.0/4` | not covered by any of the four predicates |

These endpoints are `@RolesAllowed({"eddi-admin", "eddi-editor"})`, so the gap was reachable by
the **lower-privileged** role. `isPrivateIp` now delegates to
`UrlValidationUtils.isPrivateAddress` — which AGENTS.md already names as the thing to call
before fetching a user-controlled URL — instead of keeping the weaker duplicate. That is also
what §4.7 "Unification over duplication" asks for. `isPrivateAddress` is promoted to `public`
and documented as the single definition of an unsafe outbound address.

**Mutation-verified:** with the old predicate restored, `100.64.0.1`, `fd00::1`, `fc00::1` and
`224.0.0.1` were all *accepted*.

The wrapper keeps its own messages and its HTTPS-in-production rule (which has no equivalent in
`UrlValidationUtils`), so no existing message assertion changes. Deliberately **not** adopted:
`UrlValidationUtils`' `.local`/`.internal` hostname block — those hostnames resolve and are then
caught by the address check anyway, and blocking them by name would newly reject a legitimate
corporate sync target.

## 2. Two audit dead-letter tests never tested what they claimed on Linux

`AuditLedgerServiceBranchTest` forced the file-fallback **failure** branch with
`"Z:\nonexistent\path\deadletter.jsonl"`. That is unwritable only on Windows — a backslash is a
legal character in a Unix filename, so on the Linux CI runner the whole string is one relative
filename that `Files.write(..., CREATE)` happily creates.

So the two assertion-free tests exercised the *success* path on CI while their comments claimed
the failure path, and left a junk file named `Z:\nonexistent\path\deadletter.jsonl` in the build
directory — which is not gitignored.

Replaced with `@TempDir` plus a deliberately-uncreated parent directory (`CREATE` does not create
parent directories, so it throws `NoSuchFileException` on both platforms). Both tests gained real
assertions: that NATS was actually attempted (or actually skipped), and that the dead-letter file
does **not** exist afterwards — which is what makes them fail if the write starts succeeding again.

**Mutation-verified:** pointing the helper at a writable path fails exactly those two tests.

## 3. `McpToolsProvider` sat at 31% coverage, including its tool-confusion defence

`McpToolsProviderTest`'s javadoc asserted discovery was "already covered indirectly by
`AgentOrchestratorExtendedTest`". Measurement disagreed — **264 of 383 instructions and 41 of 50
branches missed**. The indirect suites drive discovery with a mocked memory whose
`getAgentVersion()` is null, so `WorkflowTraversal` returns before the per-server loop is ever
entered, and the `McpToolProviderManager*Test` suites cover the *manager*, not this class.

Left untested as a result: whitelist/blacklist filtering (the blacklist is an operator security
control), the first-write-wins collision handling the class documents at length as an
anti-tool-confusion measure, the spec-without-executor skip, the resource-bridge opt-in and its
`IllegalArgumentException` to `INVALID_CONFIGURATION` path, and the `asProviderFailures` mapping.

New `McpToolsProviderDiscoveryTest` covers all of it — **31.1% to 93.5%**, branches missed 41 to 10.
The stale javadoc is corrected, and `contribute_nullFlag_defaultsToEnabled` (which asserted only
`assertNotNull`, so passed whether or not the flag short-circuited) now verifies discovery was
actually attempted.

**Mutation-verified:** removing the collision guard fails `collisionKeepsFirstSpecAndItsExecutor`.

> Note for future test authors, recorded in the new class comment: `WorkflowTraversal` memoizes a
> completed traversal for two seconds in a **static** map keyed on
> `agentId|version|stepType|configClass`, so every test allocates its own agent id.

---

## Verification

Measured locally against a pre-change baseline on the same machine (the local suite has a known
set of environmental failures — loopback sockets, Docker, network — per the AGENTS.md sandbox
caveat):

| | Baseline | After |
| --- | --- | --- |
| Tests run | 20,295 | **20,311** (+16) |
| Failures / Errors | 8 / 193 | **8 / 193** |
| Failing classes | 11 | **same 11, identical set** |
| Instruction coverage | 89.91% | **90.01%** |
| Branch coverage | 79.24% | **79.38%** |

The failing-class *set* was diffed, not just the counts — that catches a swap where one class
newly breaks and another newly passes. `McpToolsProvider` 31.1% to 93.5%; `SourceUrlValidator`
96.3%.

(Those totals were measured on the branch that also carried the import-style refactor; this PR
is the behavioural subset of it, re-verified green on its own after rebasing onto current `main`.)

## Deliberately left alone

- `RemoteApiResourceSource` builds a raw `HttpClient` rather than using `SafeHttpClient`,
  contrary to §4.4. Real, but a distinct change with its own blast radius (redirect/timeout
  semantics differ), and not urgent — the JDK default redirect policy is `NEVER`, so there is no
  redirect-based bypass.
- The remaining measured coverage gaps, chiefly `RestImportService`'s partial-failure/rollback
  paths (1,165 missed instructions, 118 branches).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote URL protection by rejecting additional unsafe address ranges, including IPv6 unique-local, CGNAT, and multicast addresses.

* **Tests**
  * Added coverage for remote URL validation and tool discovery scenarios, including filtering, collisions, configuration errors, and failure handling.
  * Strengthened dead-letter failure tests for consistent behavior across operating systems.
  * Improved verification that tool discovery remains enabled when configuration flags are unspecified.

* **Documentation**
  * Added a changelog entry documenting these fixes and test coverage improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->