### PR TITLE
fix(backup): repair agent export, import and sync

### DIFF
--- a/docs/agent-sync-architecture.md
+++ b/docs/agent-sync-architecture.md
@@ -36,8 +36,20 @@ Resources are matched from source to target using a deterministic, structural ap
 |---|---|---|
 | **Agent** | Direct (by `targetAgentId` parameter) | User explicitly selects the target |
 | **Workflows** | Position index (0-based) in agent's workflow list | Workflows have a defined order; position is stable |
-| **Extensions** | `WorkflowStep.type` URI (e.g., `ai.labs.llm`) | Each type appears at most once per workflow |
+| **Extensions** | Extension reference key — `<stepType>#<occurrence>/<path>`, e.g. `eddi://ai.labs.llm#0/config` | Position within the workflow is stable, and the occurrence ordinal keeps two steps of the same type apart |
 | **Snippets** | `PromptSnippet.name` (natural key) | Names are unique by convention |
+
+Extension keys all come from one scan (`WorkflowExtensions.scan`) that the export
+ZIP, a remote instance and the local target each use, which is what makes the two
+sides join. Two properties of that key matter:
+
+- **The URI is read from the step's `config` map, not its `extensions` map.**
+  `config.uri` is where the engine itself looks; `extensions` carries nested
+  things such as the parser's `dictionaries` list, whose entries have a
+  `config.uri` of their own and are scanned as well.
+- **A step type may repeat.** A workflow with a pre-LLM and a post-LLM
+  `eddi://ai.labs.httpcalls` step keeps an entry for each, told apart by the
+  `#<occurrence>` ordinal, instead of collapsing onto one.
 
 ### Why Not Match by ID?
 

--- a/docs/agent-sync-guide.md
+++ b/docs/agent-sync-guide.md
@@ -120,6 +120,38 @@ curl -X POST "http://localhost:7070/backup/import/sync?sourceUrl=https://source-
   -H "X-Source-Authorization: Bearer <token>"
 ```
 
+### Response codes
+
+Every execute endpoint answers with one of three **2xx** statuses. A client must branch on
+the status code — checking `response.ok` alone reports a half-applied sync as a success:
+
+| Status | Meaning |
+|--------|---------|
+| `200 OK` | Source and target already agree. Nothing was written, no version was burned. |
+| `201 Created` | Everything landed and something was written. |
+| `207 Multi-Status` | **Partially applied** — `failures[]` in the body names every resource that could not be written. |
+
+The body of a single sync is an `UpgradeResult`:
+
+```json
+{
+  "agentUri": "eddi://ai.labs.agent/agentstore/agents/local-agent-id?version=8",
+  "agentUpdated": true,
+  "updated": 3,
+  "created": 0,
+  "skipped": 5,
+  "failures": [
+    { "sourceId": "…", "resourceType": "langchain", "name": "GPT Config", "reason": "…" }
+  ]
+}
+```
+
+`/backup/import/sync/batch` answers a JSON array of `BatchSyncResult`
+(`sourceAgentId`, `targetAgentId`, `result`, `error`) — one entry per request, in request
+order, whether it succeeded or not. It answers `500` only when *every* agent failed, and
+`207` when some did. A batch **preview** row that failed carries `sourceAgentName: null`
+and an `error` field rather than encoding the failure into the agent's name.
+
 ### 5. Execute Batch Sync
 
 Sync multiple agents in one call. The request body is a JSON array of `SyncRequest` objects:
@@ -194,8 +226,9 @@ Agent Sync uses **structural matching** — not ID matching — to pair source a
 
 - **In-place upgrade:** Target resource IDs are preserved. URI references, deployments, and triggers continue to work
 - **Version increments:** Each updated resource gets a new version (history preserved)
-- **Secret scrubbing:** API keys and vault references are **never** transferred. The target instance uses its own secrets
-- **SSRF protection:** The remote URL is validated (HTTPS required in production, private IPs blocked)
+- **Secret scrubbing:** API keys and vault references are **never** transferred. The target instance uses its own secrets — and a value the source scrubbed is put back from the target's own configuration before anything is compared or written, so a credential neither leaks nor gets overwritten with a placeholder, and a config that differs *only* by the placeholder still counts as unchanged
+- **SSRF protection:** The remote URL is validated (HTTPS required in production, private IPs blocked), and redirects are never followed — a 3xx from the source surfaces as a failed read rather than re-sending the bearer token elsewhere
+- **New extensions are refused, not orphaned:** an extension the target workflow has no step for cannot be referenced once written, so it is reported in `failures[]` instead of being created as an unreferenced resource. Add the step to the target workflow (or import the source workflow as a new one) and sync again
 
 ## Upgrade Strategy (ZIP Import)
 
@@ -227,7 +260,14 @@ curl -X POST "http://localhost:7070/backup/export/agent-id/preview?agentVersion=
 curl -X POST "http://localhost:7070/backup/export/agent-id?agentVersion=1&selectedResources=res1,res2,res3"
 ```
 
-The preview returns a resource tree with selectability flags. Agent and workflow skeletons are always included — you can deselect individual extensions, behavior rules, or prompt snippets.
+The preview returns a resource tree with selectability flags. Agent and workflow skeletons are always included — you can deselect individual extensions, behavior rules, prompt snippets or scheduled triggers.
+
+Snippets and schedules have their own parameters (`selectedSnippets`, `selectedSchedules`).
+Deselecting an extension **keeps the workflow step that referenced it** — the archive states
+what the source deployment actually runs, and the importer decides what to do with a reference
+it cannot satisfy: `merge` answers it from the target's own copy, `create` drops the step and
+logs a warning. See [Import/Export an Agent → Selecting What to Export](import-export-an-agent.md#selecting-what-to-export)
+for the three-state semantics of each parameter and for the archive retention window.
 
 ## See Also
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,72 @@ bottom of this file and are never archived.
 
 ---
 
+## 🔁 fix(backup): repair agent export, import and sync (2026-09-04)
+
+**Repo:** EDDI (`fix/review-agent-sync`)
+
+From the whole-repository code review. **Granular sync/upgrade did nothing at all**, and
+its preview said otherwise — the single most serious finding of the review, and it was
+broken three independent ways at once.
+
+1. `UpgradeExecutor` asked `StructuralMatcher.buildPreview` for a *content-less* preview
+   (`includeContent=false`), so `sourceJson` and `targetJson` were both null for every
+   matched resource. The action then reduced to `Objects.equals(null, null)` → `SKIP`, and
+   the executor skips every SKIP. Every resource that already existed in the target was
+   silently left untouched.
+2. Extension URIs were read from `step.getExtensions()`, but the engine stores them in
+   `step.getConfig().get("uri")`, so the target extension map came back empty.
+3. The ZIP and remote sources keyed their extension maps by resource-store authority
+   (`ai.labs.rules`) while the target keyed by workflow step type
+   (`eddi://ai.labs.behavior`), so the two sides could never join even with (1) and (2)
+   fixed.
+
+The REST preview endpoints pass `includeContent=true` and therefore showed real
+differences. An operator saw a diff, applied it, received success, and nothing changed.
+
+**Fixed** by a new `WorkflowExtensions` — one scan that is the single source of truth for
+how a workflow points at its extension configs. Both producers and the matcher derive
+keys from it, so source and target are guaranteed to join. The canonical key is
+`<stepType>#<occurrence>/<path>`, which also fixes a workflow with two steps of the same
+type collapsing onto one key and repointing both at the second resource. The diff action
+is now decided from content that is always loaded; `includeContent` governs only what is
+returned to the caller.
+
+### Also in this branch
+
+- **Exported ZIPs were never deleted** and accumulated in the working directory. They now
+  land in `tmp/archives/` and are swept by age (`eddi.backup.export.retention-minutes`,
+  default 60); the 404 message states the real retention instead of a fictional one.
+- **A non-ASCII agent name produced an undownloadable archive.** `URLEncoder` output like
+  `M%C3%BCller+Bot` was written literally to disk, and the download endpoint's character
+  class then rejected the decoded form. Names are slugified instead, and a
+  `Content-Disposition` header carries the readable filename.
+- **Schedules were exported but never imported** — silently dropped on every round trip
+  while the ZIP visibly contained them. Import now reads them, repoints them at the new
+  agent with fire bookkeeping reset, and rolls them back with the rest of the transaction.
+- **A v5 export ZIP imported nothing and reported 200.** The importer only looked for
+  `.agent.json`, never the v5 `.bot.json` it deliberately still accepts elsewhere.
+- **`strategy=upgrade` without `targetAgentId`** silently fell through to create, producing
+  a duplicate agent; it is now a 400 naming the parameter.
+- **A selectively-exported ZIP could not be re-imported**: a deselected extension file is
+  absent from the archive while the workflow still references it, and `readResources`
+  handed the resulting null straight to `store.create()`.
+
+### Regression coverage
+
+Every behavioural change is pinned by a test **proven to fail with its fix reverted**.
+`ExtensionSourceKeyContractTest` writes a real archive to disk and stubs a real remote,
+then asserts both producers emit identical canonical keys *and* that every extension joins
+the target as UPDATE rather than CREATE; its fixture deliberately carries two `httpcalls`
+steps so the collapse-by-type defect is caught too.
+
+Two tests are recorded honestly as characterization rather than guards: the snippet
+name-fallback row is what `main` always emitted, and `RestUtilities.createConflictException`
+was a behaviourally identical refactor. Neither can fail without its change, and both say
+so.
+
+---
+
 ## 📋 docs(config): document the four workspace properties that were breaking `main` (2026-08-30)
 
 **Repo:** EDDI (`fix/connection-extra-auth-params-code-verifier`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,51 @@ bottom of this file and are never archived.
 
 ---
 
+## 🔑 fix(backup): a reordered config list could hand one endpoint another's credential (2026-09-07)
+
+**Repo:** EDDI (`fix/review-backup-sync`)
+
+Three review comments and a round of CodeQL alerts. The first is the serious one.
+
+**Secrets were restored into the wrong entry.** `ScrubbedSecrets.merge` paired source and target
+list elements by index. An httpCalls config whose entries had been reordered between export and
+sync therefore kept each source entry's own `uri` while taking the target's value at that position:
+the billing call kept `https://billing.example.com` and received the *analytics* token. An
+inserted entry was worse — a newly added call to an attacker-chosen host inherited the credential
+that had been at its index. That is a credential disclosure to whatever endpoint sits at the other
+position, not merely a lost secret.
+
+Elements are now bound by stable identity (`name`, `id`, `key`) wherever they carry one, requiring
+a unique target match. Elements with none — a bare string in an array — fall back to position only
+when the lists are the same length and the two elements are identical in everything the scrubber
+did not replace. Anything else refuses and keeps its placeholder, which the caller already logs for
+the operator. Refusing beats guessing here: a lost secret costs an operator one re-entered key, a
+misplaced one goes to somebody else's server.
+
+**A workflow-only change was dropped and reported as skipped.** When a workflow diff was `UPDATE`
+with no extension changes, nothing wrote the source config, so reordered steps or an added
+condition silently did not arrive — and the run said "skipped", so the operator was told nothing
+had gone wrong. The executor now adopts the source workflow, but only when every extension
+reference it carries also exists in the target at the same canonical key; otherwise it refuses and
+names the step, the same refusal the branch already makes for a new extension. Adopted references
+are repointed onto the target's own resource URIs, because a cross-instance source names the
+*other* instance's ids. A source workflow with no steps is refused outright rather than emptying a
+live pipeline, and an adoption that comes out identical to the target is suppressed so a
+cross-instance no-op does not burn a version.
+
+**A dispatch test asserted something that could not fail.** It checked `agentUri()` was non-null,
+which is returned whether or not anything was written, so a miswired store row passed. It now
+asserts the result carries no failures and that the store was actually invoked; two sibling tests
+that provoked a failure and asserted nothing about it were strengthened the same way.
+
+**Log injection.** Snippet names, extension types and names, workflow and agent ids all come from
+the archive and reached the log unsanitized. Every log argument in `UpgradeExecutor` and
+`SourceUrlValidator` now goes through `LogSanitizer.sanitize`. Most of those values happen to be
+URI-derived and so cannot carry a control character, but a snippet name is free-form text and
+genuinely could — that is the one the new test drives.
+
+---
+
 ## 🧪 test(backup): replace the tests that could not fail, close the CodeQL round (2026-09-06)
 
 **Repo:** EDDI (`fix/review-backup-sync`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,28 @@ bottom of this file and are never archived.
 
 ---
 
+## 🔁 test(backup): reach the rollback path without a multi-agent archive (2026-09-07)
+
+**Repo:** EDDI (`fix/review-backup-sync`)
+
+Merging main brought in two import-rollback tests from #733 that build an archive with **two** agent
+files, land the first and fail the second. This branch independently forbids that: `singleAgentFileIn`
+rejects a multi-agent archive, because an operator who approved importing one agent was getting
+several, with the `Location` header pointing at whichever file happened to be enumerated last.
+
+Both are right, and as written they cannot both hold. The guard stays; the tests were reshaped to
+reach the same rollback through a single-agent archive whose **schedule write** fails. That is the
+first step after the Agent is created and registered, which the production comment at the call site
+already says is deliberate: schedules carry the id of the agent they fire, so they are written after
+the Agent but before descriptor bookkeeping, "so a failure there still rolls them back".
+
+Every assertion survives in substance — the Agent is registered, its row is deleted, and it is taken
+back out of the capability index; and for the second test, a registry that throws on `unregister`
+still must not abandon the workflow delete that follows it. Proven by deleting `unregisterCapabilities`
+from the rollback: `Wanted but not invoked: capabilityRegistryService.unregister(...)`.
+
+---
+
 ## 🔑 fix(backup): a reordered config list could hand one endpoint another's credential (2026-09-07)
 
 **Repo:** EDDI (`fix/review-backup-sync`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,43 @@ bottom of this file and are never archived.
 
 ---
 
+## 🧪 test(backup): replace the tests that could not fail, close the CodeQL round (2026-09-06)
+
+**Repo:** EDDI (`fix/review-backup-sync`)
+
+Two passes on the same branch: 22 review comments (mostly CodeQL log-injection alerts) and a
+mutation audit of the tests this branch had added.
+
+**Every alert was already closed in the source, but two had no test that could fail if the fix
+were removed.** Those guards were added. The rest were verified line by line against the working
+tree rather than against the previous pass's notes.
+
+**The mutation audit is the more useful half.** Fable re-ran each new test with the production
+change surgically reverted and found several that passed anyway — coverage without a contract.
+They are now rewritten to assert what the changed line actually implements:
+
+- The snippet-rollback test asserted a call count; it now proves that a snippet created during a
+  failed import is recorded on the `ImportTransaction` and deleted again by `rollbackCreatedResources`,
+  and that a snippet *merged* into an existing one is never deleted.
+- `BackupMetrics.upgradeCompleted` was checked by reading counters back, which cannot distinguish
+  `increment(0)` from no call at all — both leave a `SimpleMeterRegistry` counter at zero. It now
+  asserts the calls themselves against a recording registry.
+- The workflow pass-through tests asserted a rendered string that a re-serialised model also
+  produces. They now assert the archive's own text survives byte for byte, which catches the real
+  loss: re-rendering adds an `extensions` field the archive never carried.
+- The extension-failure test now asserts the exact key set the matcher builds from the target,
+  including the occurrence ordinal, rather than a substring a wrongly-keyed map would also satisfy.
+
+**Recorded gaps, stated rather than papered over.** Two defensive lines cannot be pinned by a unit
+test and their tests were deleted rather than left as decoration: `recordCreatedSnippet`'s
+null-URI guard and `resolveSnippetIdsByName`'s null-listing guard both sit inside a broader
+`catch (Exception)`, so removing either still leaves the class green. A test that cannot fail is
+worse than no test, because it hides the hole.
+
+Diff coverage of the branch's changed lines: 94.1% line, 84.2% branch.
+
+---
+
 ## 🔁 fix(backup): repair agent export, import and sync (2026-09-04)
 
 **Repo:** EDDI (`fix/review-agent-sync`)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -249,6 +249,23 @@ Full guide: [attachments-guide.md](attachments-guide.md).
 
 ---
 
+## Backup, export & import
+
+Full guide: [import-export-an-agent.md](import-export-an-agent.md).
+
+| Property | Default | Description |
+|---|---|---|
+| `eddi.backup.export.retention-minutes` | `60` | How long a finished export archive stays downloadable |
+
+> `POST /backup/export/{agentId}` writes a ZIP under `tmp/archives/` and answers
+> with a `Location` header the client then GETs, so the file has to outlive the
+> request. Nothing else deletes it: every export first sweeps archives older
+> than this window. Raise it if a client may take longer than this between the
+> POST and the GET; lower it to bound disk use on an instance that exports on a
+> cron.
+
+---
+
 ## Protocols & integrations
 
 ### MCP

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -256,13 +256,16 @@ Full guide: [import-export-an-agent.md](import-export-an-agent.md).
 | Property | Default | Description |
 |---|---|---|
 | `eddi.backup.export.retention-minutes` | `60` | How long a finished export archive stays downloadable |
+| `eddi.backup.export.sweep-interval` | `15m` | How often the retention sweep runs on its own, independently of exports |
 
 > `POST /backup/export/{agentId}` writes a ZIP under `tmp/archives/` and answers
 > with a `Location` header the client then GETs, so the file has to outlive the
-> request. Nothing else deletes it: every export first sweeps archives older
-> than this window. Raise it if a client may take longer than this between the
-> POST and the GET; lower it to bound disk use on an instance that exports on a
-> cron.
+> request. Nothing else deletes it: the sweep runs before every export *and* on
+> the interval above, so an instance that stops exporting still reclaims what it
+> already wrote. It also removes the loose `tmp/*.zip` archives earlier releases
+> left behind, which are no longer downloadable. Raise the retention if a client
+> may take longer than that between the POST and the GET; lower it to bound disk
+> use on an instance that exports on a cron.
 
 ---
 

--- a/docs/import-export-an-agent.md
+++ b/docs/import-export-an-agent.md
@@ -27,8 +27,47 @@ When you export an agent, EDDI packages:
 - ✅ Version information
 - ✅ Configuration metadata
 - ✅ **Origin IDs** (resource identifiers for merge tracking)
+- ✅ **Prompt snippets** the agent's configurations reference, under `snippets/`
+- ✅ **Scheduled triggers** (cron and heartbeat) of the agent, under `schedules/`
 
 **Note**: Conversations and conversation history are **NOT** exported (only configurations).
+HITL approval-timeout schedules are not exported either: they are safety timers for one
+pending approval on that deployment, and the import surface refuses to mint them for anybody.
+
+### Selecting What to Export
+
+Three independent query parameters filter the archive. Each is **three-state**: absent means
+"no selection was expressed for this type" and exports all of it, a value filters, and a
+present-but-empty value means "none of them".
+
+| Parameter           | Filters                                | Absent           | Empty (`&selectedSnippets=`) |
+| ------------------- | -------------------------------------- | ---------------- | ---------------------------- |
+| `selectedResources` | Extension resources (by resource id)    | all of them      | all of them (blank = no filter) |
+| `selectedSnippets`  | Prompt snippets (by resource id)        | all referenced   | none                         |
+| `selectedSchedules` | Scheduled triggers (by schedule id)     | all of the agent | none                         |
+
+`selectedResources` is the exception: it is the older parameter and only a **non-blank**
+value filters, so a blank one is a full export. Agent and workflow skeletons are always
+included.
+
+When `selectedResources` omits an extension, the exported workflow **keeps the step that
+referenced it** — the archive states what the source deployment actually runs. What happens
+to a reference the archive cannot satisfy is the importer's call, because only it knows the
+strategy: **`merge` answers it from the target's own copy** of that configuration (and
+`400`s naming the resource when the target has none), while **`create` drops the step** —
+there is nothing on a brand-new agent to answer it with — and logs a warning naming it.
+
+> Dropping the step on export instead makes `merge` destructive: it replaces the target's
+> workflow with the archived one, so exporting only the behaviour rules from staging and
+> merging them into production would delete production's own LLM and output steps.
+
+### Archive Retention
+
+A finished archive lives under `tmp/archives/` and is deleted after
+`eddi.backup.export.retention-minutes` (default `60`). The sweep runs both before each
+export and on a timer (`eddi.backup.export.sweep-interval`, default `15m`), so an instance
+that stops exporting still reclaims what it wrote. Read the filename from the `Location`
+header and download it within the window; afterwards the download answers `404`.
 
 ### Import Strategies
 
@@ -158,6 +197,15 @@ curl -X POST -H "Content-Type: application/zip" \
   --data-binary @agent123-3.zip \
   "http://prod.eddi.com/backup/import?strategy=merge&selectedResources=origin-beh-1,origin-http-1"
 ```
+
+> **`selectedResources` covers every preview row, not just the extensions.** Naming two
+> extension ids deselects everything else the preview listed — including the archive's
+> **scheduled triggers**, which are then not imported. The answer says so: the `201`
+> carries `X-Schedules-Skipped: <count>` whenever the selection left schedules out, and
+> the same count is logged at `INFO`. List the schedule `sourceId`s alongside the
+> extension ones if you want them, or omit the parameter entirely to take the whole
+> archive. Prompt snippets are the one exception: they are matched by name and imported
+> regardless of the selection.
 
 **Scenario 4: Disaster Recovery**
 
@@ -339,6 +387,11 @@ curl -X POST -H "Content-Type: application/zip" \
   "http://localhost:7070/backup/import?strategy=merge&selectedResources=origin-id-1,origin-id-2"
 ```
 
+`selectedResources` is one flat list over **every** row the preview returned — extensions
+and scheduled triggers alike — so anything not named is left out. A selection of extension
+ids therefore imports no schedules; the response then carries `X-Schedules-Skipped: <count>`
+and the same count is logged at `INFO`. Omit the parameter to import the whole archive.
+
 > **Important:** The agent will not be deployed after import — you must deploy it yourself using the [Deployment API](deployment-management-of-agents.md).
 
 ---
@@ -360,6 +413,66 @@ curl -X POST -H "Content-Type: application/zip" \
 ```
 
 The upgrade strategy matches resources by **structure** (workflow position, extension type, snippet name) rather than by origin ID. See [Agent Sync](agent-sync-guide.md) for details on how structural matching works.
+
+### Upgrade response codes
+
+An upgrade (and every `/backup/sync` call, which shares the same executor) answers with one
+of three statuses. **All three are 2xx**, so a client must branch on the status code, not on
+`response.ok`:
+
+| Status                 | Meaning                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------- |
+| `200 OK`               | Source and target already agree. Nothing was written and no agent version was burned.        |
+| `201 Created`          | Everything landed and something was written.                                                 |
+| `207 Multi-Status`     | **Partially applied.** The body's `failures[]` names every resource that could not be written. |
+
+The body is an `UpgradeResult` (`agentUri`, `agentUpdated`, `updated`, `created`, `skipped`,
+`failures[]`) on all three, and the `Location` header is present on all three.
+
+### Restoring an EDDI 5.x archive
+
+A genuine 5.x export names its agent file `<id>.bot.json` and its workflow file
+`<id>.package.json` with a `packageExtensions` step list. Both are accepted, and legacy
+`eddi://` URIs are rewritten to their v6 form on the way in.
+
+### What happens to schedules on import
+
+Imported schedules are repointed at the agent the import just wrote, and everything belonging
+to the source deployment is reset: `nextFire` is recomputed from the cron expression (an
+archived one is either long past — firing during the restore — or absent, so it would never
+fire), `agentVersion` goes back to `0` ("latest"), and the tenant and persistent conversation
+are cleared. Every write goes through the ordinary schedule API, so the same rules apply as
+when creating a schedule by hand: a schedule may not run as another user unless you are an
+administrator, its agent's USE gate is checked, and its cron expression is validated. A
+schedule that is refused fails the whole import with that status.
+
+**`userId` is source-deployment state too.** It is the identity every fire *acts as*, minted by
+whichever identity provider the source instance used, so it is kept only when it is already
+your own and cleared otherwise — the imported schedule then runs as the system scheduler until
+you assign an owner. Two consequences worth knowing: you can import somebody else's archive
+without being an administrator, and a **Dream consolidation** schedule arrives with no owner and
+rejects its first fire with a message naming the field to set. Set `userId` on it after the
+import (`PUT /schedulestore/schedules/{id}`) — that is deliberately louder than silently
+consolidating the memories of whichever local user happens to hold the archived id.
+
+With `strategy=merge`, a schedule whose **name** matches one the target agent already has is
+updated in place rather than added, so re-importing the same agent does not accumulate
+duplicate cron jobs. Such an update replaces what the schedule *does* — cron, message, agent —
+but never **who it runs as**: when the archive brings no identity of its own (the usual case,
+per the paragraph above), the owner already on the target is kept. Otherwise every promotion
+reset that schedule to the system scheduler, which stops Dream consolidation and drops the
+schedule's ownership protection. The target's HITL approval timers are excluded from that name matching —
+they are per-conversation safety timers, never part of an agent's configuration, and the export
+side leaves them out for the same reason. If the import fails after a schedule was overwritten,
+the target's original is written back as part of the rollback. The merge preview says so:
+a schedule whose name the target already uses is listed as `UPDATE` with that schedule's id,
+not as `CREATE`.
+
+Schedules also honour `selectedResources`: unticking one in the import preview keeps it out.
+Because that parameter is a single flat list across every preview row, a caller who names
+only extension ids leaves **all** of them out — the import answers `X-Schedules-Skipped: <count>`
+and logs the same number at `INFO`, rather than a bare `201` for an agent whose nightly job
+did not come back. Name the schedule ids too, or leave `selectedResources` off.
 
 ## Live Sync (Without ZIP)
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -68,7 +68,8 @@ Log in to Grafana with `admin` / `admin`, then open **Dashboards → EDDI** — 
 `Persistent Memory — Dream & Summarization` ·
 `Integrations — MCP, A2A Identity, OpenAI-compatible API` ·
 `Capability Registry & Connections` · `Secrets Vault` · `Tenancy, Quotas & Audit` ·
-`Platform Operator` · `NATS JetStream` · `Runtime context (Quarkus / JVM built-ins)`
+`Platform Operator` · `NATS JetStream` · `Backup — Export, Import & Sync` ·
+`Runtime context (Quarkus / JVM built-ins)`
 
 ---
 
@@ -466,6 +467,27 @@ eddi_openai_request_duration_seconds        # Request latency (timer)
 eddi_openai_conversations_created_total     # Conversations created via the /v1 adapter
 eddi_caller_identity_resolution_total       # Caller-identity resolutions; tags: outcome, reference
 ```
+
+### Backup, Export & Sync Metrics
+
+```text
+eddi_backup_export_count_total                    # Agent exports attempted
+eddi_backup_export_failure_count_total            # Exports that failed
+eddi_backup_import_count_total                    # Archive imports attempted
+eddi_backup_import_failure_count_total            # Imports that failed
+eddi_backup_upgrade_count_total                   # Upgrade/sync runs attempted (ZIP upgrade, /sync, /sync/batch)
+eddi_backup_upgrade_failure_count_total           # Upgrade/sync runs that failed outright
+eddi_backup_upgrade_resource_updated_count_total  # Resources updated in place by a sync
+eddi_backup_upgrade_resource_created_count_total  # Resources created in the target by a sync
+eddi_backup_upgrade_resource_skipped_count_total  # Matched resources whose content was already identical
+eddi_backup_upgrade_resource_failure_count_total  # Resources a sync could not process (the 207 body lists them)
+```
+
+> The four `resource` counters are what answer "the sync returned 201 but
+> nothing changed". All-skipped means source and target already agree; a
+> `created` line where `updated` is expected means the matcher is not joining
+> source and target extensions and every sync is duplicating the configuration
+> tree.
 
 ### Session & Listing Metrics
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -483,8 +483,10 @@ eddi_backup_upgrade_resource_skipped_count_total  # Matched resources whose cont
 eddi_backup_upgrade_resource_failure_count_total  # Resources a sync could not process (the 207 body lists them)
 ```
 
-> The four `resource` counters are what answer "the sync returned 201 but
-> nothing changed". All-skipped means source and target already agree; a
+> The four `resource` counters explain a successful no-op. An all-skipped run is
+> answered with `200 OK`: source and target already agree, nothing was written and
+> no agent version was burned. (`201 Created` means something *was* written,
+> `207 Multi-Status` that part of it failed — see `IRestImportService`.) A
 > `created` line where `updated` is expected means the matcher is not joining
 > source and target extensions and every sync is duplicating the configuration
 > tree.

--- a/docs/monitoring/eddi-full-metrics-dashboard.json
+++ b/docs/monitoring/eddi-full-metrics-dashboard.json
@@ -10803,6 +10803,390 @@
       ]
     },
     {
+      "id": 158,
+      "type": "row",
+      "title": "Backup — Export, Import & Sync",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "panels": [
+        {
+          "id": 159,
+          "type": "timeseries",
+          "title": "Export & import rate",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "`eddi_backup_export_count_total` and `eddi_backup_import_count_total` — archive operations attempted.",
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(eddi_backup_export_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "export"
+            },
+            {
+              "refId": "B",
+              "expr": "sum(rate(eddi_backup_import_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "import"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": false,
+                "axisSoftMin": 0,
+                "stacking": {
+                  "mode": "none",
+                  "group": "A"
+                },
+                "gradientMode": "none",
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 160,
+          "type": "timeseries",
+          "title": "Export & import failures",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "`eddi_backup_export_failure_count_total` and `eddi_backup_import_failure_count_total`. A rising import failure rate with a flat export rate usually means archives from another version.",
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(eddi_backup_export_failure_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "export failed"
+            },
+            {
+              "refId": "B",
+              "expr": "sum(rate(eddi_backup_import_failure_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "import failed"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": false,
+                "axisSoftMin": 0,
+                "stacking": {
+                  "mode": "none",
+                  "group": "A"
+                },
+                "gradientMode": "none",
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 161,
+          "type": "timeseries",
+          "title": "Upgrade / sync runs",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "`eddi_backup_upgrade_count_total` and `eddi_backup_upgrade_failure_count_total` — one pair of increments per agent synced, whether from a ZIP or from a remote instance.",
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 30
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(eddi_backup_upgrade_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "attempted"
+            },
+            {
+              "refId": "B",
+              "expr": "sum(rate(eddi_backup_upgrade_failure_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "failed"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": false,
+                "axisSoftMin": 0,
+                "stacking": {
+                  "mode": "none",
+                  "group": "A"
+                },
+                "gradientMode": "none",
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 162,
+          "type": "timeseries",
+          "title": "Upgrade resource outcomes",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Per-resource outcome of a sync: `eddi_backup_upgrade_resource_updated_count_total`, `eddi_backup_upgrade_resource_created_count_total`, `eddi_backup_upgrade_resource_skipped_count_total`, `eddi_backup_upgrade_resource_failure_count_total`. All-skipped runs mean source and target already agree; a created line where an updated one is expected means the matcher is not joining.",
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 30
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(eddi_backup_upgrade_resource_updated_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "updated"
+            },
+            {
+              "refId": "B",
+              "expr": "sum(rate(eddi_backup_upgrade_resource_created_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "created"
+            },
+            {
+              "refId": "C",
+              "expr": "sum(rate(eddi_backup_upgrade_resource_skipped_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "skipped"
+            },
+            {
+              "refId": "D",
+              "expr": "sum(rate(eddi_backup_upgrade_resource_failure_count_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "failed"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": false,
+                "axisSoftMin": 0,
+                "stacking": {
+                  "mode": "none",
+                  "group": "A"
+                },
+                "gradientMode": "none",
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        }
+      ]
+    },
+    {
       "id": 152,
       "type": "row",
       "title": "Runtime context (Quarkus / JVM built-ins)",
@@ -10811,7 +11195,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 24
       },
       "panels": [
         {

--- a/src/main/java/ai/labs/eddi/backup/IResourceSource.java
+++ b/src/main/java/ai/labs/eddi/backup/IResourceSource.java
@@ -69,9 +69,17 @@ public interface IResourceSource extends AutoCloseable {
      * @param config
      *            the full workflow configuration
      * @param extensions
-     *            map of step type URI → extension data. Key is the
-     *            WorkflowStep.type string (e.g., "ai.labs.llm"). Each type appears
-     *            at most once per workflow, making the match deterministic.
+     *            map of extension reference key → extension data. The key is
+     *            {@code <stepType>#<occurrence>/<path>}, as produced by
+     *            {@code WorkflowExtensions.scan} — e.g.
+     *            {@code eddi://ai.labs.llm#0/config} or
+     *            {@code eddi://ai.labs.parser#0/extensions/dictionaries/0/config}.
+     *            Every producer (ZIP, remote instance) and the local target derive
+     *            the key from that one scan, which is what makes the two sides
+     *            join. The occurrence ordinal is part of the key deliberately: a
+     *            workflow may carry several steps of the same type — a pre-LLM and
+     *            a post-LLM httpCalls step, say — and each keeps its own entry
+     *            rather than collapsing onto one.
      */
     record WorkflowSourceData(
             String sourceId,
@@ -91,7 +99,8 @@ public interface IResourceSource extends AutoCloseable {
      * @param type
      *            the file extension type (e.g., "langchain", "httpcalls")
      * @param stepType
-     *            the WorkflowStep.type URI (e.g., "ai.labs.llm")
+     *            the WorkflowStep.type URI as the workflow actually stores it,
+     *            scheme included (e.g., {@code eddi://ai.labs.llm})
      * @param contentJson
      *            the full serialized config JSON
      */

--- a/src/main/java/ai/labs/eddi/backup/IRestExportService.java
+++ b/src/main/java/ai/labs/eddi/backup/IRestExportService.java
@@ -27,12 +27,20 @@ public interface IRestExportService {
 
     @POST
     @Path("{agentId}")
-    @Operation(description = "Export a Agent as a ZIP file. When selectedResources is provided, "
-            + "only those resource IDs are included in the ZIP (agent + workflow skeletons are always included).")
+    @Operation(description = "Export an agent as a ZIP file. When selectedResources is provided, "
+            + "only those extension resource IDs are included in the ZIP (agent + workflow skeletons "
+            + "are always included). Snippets and schedules are selected through their own parameters, "
+            + "because their preview rows are newer than selectedResources: omit a parameter and every "
+            + "referenced snippet / every schedule of the agent is exported, pass it (even empty) and "
+            + "only the listed IDs are. "
+            + "The Location header names the finished archive, which is kept for "
+            + "eddi.backup.export.retention-minutes and then deleted.")
     Response exportAgent(@PathParam("agentId") String agentId,
                          @QueryParam("agentVersion")
                          @DefaultValue("1") Integer agentVersion,
-                         @QueryParam("selectedResources") String selectedResourceIds);
+                         @QueryParam("selectedResources") String selectedResourceIds,
+                         @QueryParam("selectedSnippets") String selectedSnippetIds,
+                         @QueryParam("selectedSchedules") String selectedScheduleIds);
 
     @POST
     @Path("{agentId}/preview")

--- a/src/main/java/ai/labs/eddi/backup/IRestExportService.java
+++ b/src/main/java/ai/labs/eddi/backup/IRestExportService.java
@@ -27,12 +27,19 @@ public interface IRestExportService {
 
     @POST
     @Path("{agentId}")
-    @Operation(description = "Export an agent as a ZIP file. When selectedResources is provided, "
-            + "only those extension resource IDs are included in the ZIP (agent + workflow skeletons "
-            + "are always included). Snippets and schedules are selected through their own parameters, "
+    @Operation(description = "Export an agent as a ZIP file. Only a NON-BLANK selectedResources "
+            + "filters: then just those extension resource IDs are included in the ZIP, and the "
+            + "exported workflow still carries the steps that reference the omitted ones, so an import "
+            + "with strategy=merge answers them from the target's own copies instead of deleting those "
+            + "steps from it; strategy=create drops such a step (agent + workflow skeletons are always "
+            + "included). A blank or absent "
+            + "selectedResources is a full export of every extension resource. "
+            + "Snippets and schedules are selected through their own parameters, "
             + "because their preview rows are newer than selectedResources: omit a parameter and every "
             + "referenced snippet / every schedule of the agent is exported, pass it (even empty) and "
-            + "only the listed IDs are. "
+            + "only the listed IDs are. HITL approval-timeout schedules are never exported — they are "
+            + "safety timers for one pending approval on this deployment, and the import surface "
+            + "refuses to mint them for anybody. "
             + "The Location header names the finished archive, which is kept for "
             + "eddi.backup.export.retention-minutes and then deleted.")
     Response exportAgent(@PathParam("agentId") String agentId,

--- a/src/main/java/ai/labs/eddi/backup/IRestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/IRestImportService.java
@@ -27,10 +27,17 @@ import java.util.List;
 public interface IRestImportService {
     @POST
     @Consumes("application/zip")
-    @Operation(description = "Import a Agent from a zip file. "
+    @Operation(description = "Import an agent from a zip file. "
             + "strategy=create (default) always creates new resources. "
             + "strategy=merge looks up existing resources by origin ID and updates them. "
-            + "strategy=upgrade syncs content into the targetAgentId by structural matching.")
+            + "strategy=upgrade syncs content into the targetAgentId by structural matching, and requires it. "
+            + "An unknown strategy, or upgrade without targetAgentId, is a 400. "
+            + "An archive containing no agent configuration file, or more than one, is a 400. "
+            + "Agent files named <id>.agent.json (v6) and <id>.bot.json (v5) are both accepted, "
+            + "and any schedules/ directory in the archive is recreated for the imported agent. "
+            + "An upgrade answers 201 when something was written, 200 when source and target were already "
+            + "identical, and 207 Multi-Status when some resources failed — the body is an UpgradeResult "
+            + "listing per-resource outcomes.")
     Response importAgent(InputStream zippedAgentConfigFiles,
                          @QueryParam("strategy")
                          @DefaultValue("create") String strategy,
@@ -80,7 +87,10 @@ public interface IRestImportService {
 
     @POST
     @Path("/sync")
-    @Operation(description = "Execute a single-agent sync from a remote EDDI instance to a local target agent.")
+    @Operation(description = "Execute a single-agent sync from a remote EDDI instance to a local target agent. "
+            + "Answers 201 when something was written, 200 when source and target were already identical "
+            + "(no agent version is burned), and 207 Multi-Status when some resources failed; the body is "
+            + "an UpgradeResult listing per-resource outcomes.")
     Response executeSync(@QueryParam("sourceUrl") String sourceUrl,
                          @QueryParam("sourceAgentId") String sourceAgentId,
                          @QueryParam("sourceAgentVersion") Integer sourceVersion,
@@ -93,7 +103,10 @@ public interface IRestImportService {
     @Path("/sync/batch")
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(description = "Execute a multi-agent sync from a remote EDDI instance. "
-            + "Each request specifies a source→target agent pair with selected resources and workflow order.")
+            + "Each request specifies a source→target agent pair with selected resources and workflow order. "
+            + "The body is one result per request, in request order, each carrying either an UpgradeResult "
+            + "or the error that stopped it: 200 when all succeeded, 207 Multi-Status when some failed, "
+            + "500 when every one did.")
     Response executeSyncBatch(@QueryParam("sourceUrl") String sourceUrl,
                               List<SyncRequest> requests,
                               @HeaderParam("X-Source-Authorization") String sourceAuth);

--- a/src/main/java/ai/labs/eddi/backup/IRestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/IRestImportService.java
@@ -34,10 +34,28 @@ public interface IRestImportService {
             + "An unknown strategy, or upgrade without targetAgentId, is a 400. "
             + "An archive containing no agent configuration file, or more than one, is a 400. "
             + "Agent files named <id>.agent.json (v6) and <id>.bot.json (v5) are both accepted, "
-            + "and any schedules/ directory in the archive is recreated for the imported agent. "
+            + "as is a v5 <id>.package.json workflow whose step list is keyed packageExtensions. "
+            + "Any schedules/ directory in the archive is recreated for the imported agent through the "
+            + "ordinary schedule API, so the same rules apply as when creating a schedule by hand: one "
+            + "marked as a HITL approval timeout is a 400 for everyone, the agent's USE gate is checked, "
+            + "and its cron expression is validated. nextFire is recomputed and agentVersion reset to "
+            + "latest. userId belongs to the source deployment and is kept only when it already names the "
+            + "importing caller, so an imported schedule otherwise runs as the system scheduler until an "
+            + "owner is assigned. With strategy=merge a schedule whose name matches one the target agent "
+            + "already has is updated in place rather than duplicated — except the target's HITL approval "
+            + "timers, which are never matched — keeping the owner the target had assigned, and the "
+            + "overwritten original is written back if the import fails afterwards. Schedule names are not "
+            + "unique, so a name carried by more than one schedule on either side is created rather than "
+            + "matched — a visible duplicate beats overwriting an arbitrary one of them. "
+            + "selectedResources deselects schedules by schedule id like any "
+            + "other preview row: it is one flat list over every row, so naming extension ids only "
+            + "leaves out every schedule in the archive. The answer then carries "
+            + "X-Schedules-Skipped with that count rather than a bare 201. Omit selectedResources to "
+            + "import everything. "
             + "An upgrade answers 201 when something was written, 200 when source and target were already "
             + "identical, and 207 Multi-Status when some resources failed — the body is an UpgradeResult "
-            + "listing per-resource outcomes.")
+            + "listing per-resource outcomes. All three are 2xx, so a client must branch on the status "
+            + "code rather than on response.ok.")
     Response importAgent(InputStream zippedAgentConfigFiles,
                          @QueryParam("strategy")
                          @DefaultValue("create") String strategy,
@@ -90,7 +108,8 @@ public interface IRestImportService {
     @Operation(description = "Execute a single-agent sync from a remote EDDI instance to a local target agent. "
             + "Answers 201 when something was written, 200 when source and target were already identical "
             + "(no agent version is burned), and 207 Multi-Status when some resources failed; the body is "
-            + "an UpgradeResult listing per-resource outcomes.")
+            + "an UpgradeResult listing per-resource outcomes. All three are 2xx, so a client must branch "
+            + "on the status code rather than on response.ok.")
     Response executeSync(@QueryParam("sourceUrl") String sourceUrl,
                          @QueryParam("sourceAgentId") String sourceAgentId,
                          @QueryParam("sourceAgentVersion") Integer sourceVersion,

--- a/src/main/java/ai/labs/eddi/backup/IZipArchive.java
+++ b/src/main/java/ai/labs/eddi/backup/IZipArchive.java
@@ -13,8 +13,15 @@ import java.nio.file.Path;
  * @author ginccc
  */
 public interface IZipArchive {
-    void createZip(String sourceDirPath, String targetZipPath) throws IOException;
 
+    /**
+     * Zips {@code sourceDirPath} into {@code targetZipPath}.
+     * <p>
+     * {@code allowedBaseDir} is mandatory and is the containment boundary: the
+     * target must resolve below it. A two-argument overload used to default that
+     * boundary to the process working directory, which permitted writing an archive
+     * anywhere under the whole checkout; it had no production caller.
+     */
     void createZip(String sourceDirPath, String targetZipPath, Path allowedBaseDir) throws IOException;
 
     void unzip(InputStream zipFile, File targetDir) throws IOException;

--- a/src/main/java/ai/labs/eddi/backup/impl/AbstractBackupService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/AbstractBackupService.java
@@ -24,6 +24,10 @@ abstract class AbstractBackupService {
     static final String MCPCALLS_EXT = "mcpcalls";
     static final String RAG_EXT = "rag";
     static final String SNIPPET_EXT = "snippet";
+    static final String SCHEDULE_EXT = "schedule";
+
+    /** Directory inside an export archive that holds the agent's schedules. */
+    static final String SCHEDULES_DIR = "schedules";
 
     // ---- V6 canonical URI patterns ----
     static final Pattern DICTIONARY_URI_PATTERN = Pattern.compile("\"eddi://ai.labs.dictionary/dictionarystore/dictionaries/.*?\"");
@@ -35,16 +39,14 @@ abstract class AbstractBackupService {
     static final Pattern MCPCALLS_URI_PATTERN = Pattern.compile("\"eddi://ai.labs.mcpcalls/mcpcallsstore/mcpcalls/.*?\"");
     static final Pattern RAG_URI_PATTERN = Pattern.compile("\"eddi://ai.labs.rag/ragstore/rags/.*?\"");
 
-    // ---- Legacy (v5) URI patterns for backwards-compatible ZIP import ----
-    static final Pattern LEGACY_DICTIONARY_URI_PATTERN = Pattern
-            .compile("\"eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/.*?\"");
-    static final Pattern LEGACY_BEHAVIOR_URI_PATTERN = Pattern.compile("\"eddi://ai.labs.behavior/behaviorstore/behaviorsets/.*?\"");
-    static final Pattern LEGACY_HTTPCALLS_URI_PATTERN = Pattern.compile("\"eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/.*?\"");
-    static final Pattern LEGACY_LANGCHAIN_URI_PATTERN = Pattern.compile("\"eddi://ai.labs.langchain/langchainstore/langchains/.*?\"");
-    static final Pattern LEGACY_WORKFLOW_URI_PATTERN = Pattern.compile("\"eddi://ai.labs.package/packagestore/packages/.*?\"");
-    static final Pattern LEGACY_AGENT_URI_PATTERN = Pattern.compile("\"eddi://ai.labs.bot/botstore/bots/.*?\"");
-
-    /** Legacy → v6 URI authority + store path rewrites for import normalization. */
+    /**
+     * Legacy → v6 URI authority + store path rewrites for import normalization.
+     * <p>
+     * This table is the <em>only</em> v5 compatibility mechanism. A parallel set of
+     * {@code LEGACY_*_URI_PATTERN} regexes used to sit beside it with no production
+     * call site at all, which invited the next person to register a legacy type in
+     * the table that does nothing.
+     */
     static final String[][] LEGACY_URI_REWRITES = {
             {"eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/",
                     "eddi://ai.labs.dictionary/dictionarystore/dictionaries/"},

--- a/src/main/java/ai/labs/eddi/backup/impl/BackupMetrics.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/BackupMetrics.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Counters for the export/import/upgrade flows.
+ * <p>
+ * The whole backup package emitted no metrics, so there was no way to alert on
+ * export or sync failure rates and no number showing how many resources a sync
+ * had skipped versus updated — the exact questions an operator asks when a sync
+ * "did nothing".
+ *
+ * @since 6.3.0
+ */
+@ApplicationScoped
+public class BackupMetrics {
+
+    private final MeterRegistry meterRegistry;
+
+    private Counter exportAttempts;
+    private Counter exportFailures;
+    private Counter importAttempts;
+    private Counter importFailures;
+    private Counter upgradeAttempts;
+    private Counter upgradeFailures;
+    private Counter upgradeResourcesUpdated;
+    private Counter upgradeResourcesCreated;
+    private Counter upgradeResourcesSkipped;
+    private Counter upgradeResourceFailures;
+
+    @Inject
+    public BackupMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    void initMetrics() {
+        exportAttempts = meterRegistry.counter("eddi.backup.export.count");
+        exportFailures = meterRegistry.counter("eddi.backup.export.failure.count");
+        importAttempts = meterRegistry.counter("eddi.backup.import.count");
+        importFailures = meterRegistry.counter("eddi.backup.import.failure.count");
+        upgradeAttempts = meterRegistry.counter("eddi.backup.upgrade.count");
+        upgradeFailures = meterRegistry.counter("eddi.backup.upgrade.failure.count");
+        upgradeResourcesUpdated = meterRegistry.counter("eddi.backup.upgrade.resource.updated.count");
+        upgradeResourcesCreated = meterRegistry.counter("eddi.backup.upgrade.resource.created.count");
+        upgradeResourcesSkipped = meterRegistry.counter("eddi.backup.upgrade.resource.skipped.count");
+        upgradeResourceFailures = meterRegistry.counter("eddi.backup.upgrade.resource.failure.count");
+    }
+
+    public void exportAttempted() {
+        increment(exportAttempts);
+    }
+
+    public void exportFailed() {
+        increment(exportFailures);
+    }
+
+    public void importAttempted() {
+        increment(importAttempts);
+    }
+
+    public void importFailed() {
+        increment(importFailures);
+    }
+
+    public void upgradeAttempted() {
+        increment(upgradeAttempts);
+    }
+
+    public void upgradeFailed() {
+        increment(upgradeFailures);
+    }
+
+    /** Per-resource outcome of one upgrade run. */
+    public void upgradeCompleted(int updated, int created, int skipped, int failed) {
+        increment(upgradeResourcesUpdated, updated);
+        increment(upgradeResourcesCreated, created);
+        increment(upgradeResourcesSkipped, skipped);
+        increment(upgradeResourceFailures, failed);
+    }
+
+    private static void increment(Counter counter) {
+        increment(counter, 1);
+    }
+
+    /**
+     * Counters are null until {@code @PostConstruct} has run, which is the case for
+     * an instance built directly in a unit test. Metrics must never be the reason a
+     * backup operation fails.
+     */
+    private static void increment(Counter counter, int amount) {
+        if (counter != null && amount > 0) {
+            counter.increment(amount);
+        }
+    }
+}

--- a/src/main/java/ai/labs/eddi/backup/impl/RemoteApiResourceSource.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RemoteApiResourceSource.java
@@ -71,32 +71,19 @@ public class RemoteApiResourceSource implements IResourceSource {
     private List<SnippetSourceData> snippetDataList;
 
     /**
-     * Extension type mappings: step type URI → REST path segment. The REST path
-     * segment is the portion of the URL that identifies the store for this
-     * extension type.
+     * Descriptor listings already fetched from the remote instance, keyed by
+     * descriptors path. A listing is unpaged ({@code limit=0}) and returns every
+     * descriptor of that type in the whole remote deployment, so fetching it once
+     * per workflow and once per extension — purely to fill a display name — turned
+     * a single preview into dozens of full downloads.
+     * <p>
+     * An instance of this class serves exactly one sync request on one thread, so a
+     * plain HashMap is enough.
      */
-    private static final Map<String, String> STEP_TYPE_TO_REST_PATH = Map.of(
-            "ai.labs.dictionary", "/dictionarystore/dictionaries/",
-            "ai.labs.rules", "/rulestore/rulesets/",
-            "ai.labs.apicalls", "/apicallstore/apicalls/",
-            "ai.labs.llm", "/llmstore/llms/",
-            "ai.labs.property", "/propertysetterstore/propertysetters/",
-            "ai.labs.output", "/outputstore/outputsets/",
-            "ai.labs.mcpcalls", "/mcpcallsstore/mcpcalls/",
-            "ai.labs.rag", "/ragstore/rags/");
+    private final Map<String, Map<String, String>> descriptorNamesByPath = new HashMap<>();
 
-    /**
-     * Step type URI → file extension label (for ExtensionSourceData.type).
-     */
-    private static final Map<String, String> STEP_TYPE_TO_EXT_LABEL = Map.of(
-            "ai.labs.dictionary", "regulardictionary",
-            "ai.labs.rules", "behavior",
-            "ai.labs.apicalls", "httpcalls",
-            "ai.labs.llm", "langchain",
-            "ai.labs.property", "property",
-            "ai.labs.output", "output",
-            "ai.labs.mcpcalls", "mcpcalls",
-            "ai.labs.rag", "rag");
+    /** Whether this instance owns {@link #httpClient} and must close it. */
+    private final boolean ownsHttpClient;
 
     public RemoteApiResourceSource(String baseUrl, String agentId, Integer agentVersion,
             String authToken, IJsonSerialization jsonSerialization) {
@@ -108,18 +95,45 @@ public class RemoteApiResourceSource implements IResourceSource {
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(CONNECT_TIMEOUT)
                 .build();
+        this.ownsHttpClient = true;
     }
 
     // Visible for testing
     RemoteApiResourceSource(String baseUrl, String agentId, Integer agentVersion,
             String authToken, IJsonSerialization jsonSerialization,
             HttpClient httpClient) {
+        this(baseUrl, agentId, agentVersion, authToken, jsonSerialization, httpClient, false);
+    }
+
+    /**
+     * Visible for testing. The owned-client branch of {@link #close()} is otherwise
+     * only reachable through the public constructor, which builds a real
+     * {@link HttpClient} — and that opens a selector, which needs a loopback socket
+     * a sandboxed build does not have.
+     */
+    RemoteApiResourceSource(String baseUrl, String agentId, Integer agentVersion,
+            String authToken, IJsonSerialization jsonSerialization,
+            HttpClient httpClient, boolean ownsHttpClient) {
         this.baseUrl = normalizeBaseUrl(baseUrl);
         this.agentId = agentId;
         this.agentVersion = agentVersion;
         this.authToken = authToken;
         this.jsonSerialization = jsonSerialization;
         this.httpClient = httpClient;
+        this.ownsHttpClient = ownsHttpClient;
+    }
+
+    /**
+     * Closes the HTTP client this instance created. Callers already wrap every
+     * source in try-with-resources; without this override they inherited
+     * {@link IResourceSource#close()}'s no-op, so a batch sync over N agents left N
+     * clients — each with a selector thread and an executor — alive until GC.
+     */
+    @Override
+    public void close() {
+        if (ownsHttpClient) {
+            httpClient.close();
+        }
     }
 
     @Override
@@ -153,13 +167,19 @@ public class RemoteApiResourceSource implements IResourceSource {
 
         List<URI> workflowUris = agent.config().getWorkflows();
         for (int i = 0; i < workflowUris.size(); i++) {
+            if (Thread.currentThread().isInterrupted()) {
+                // Per-workflow failures are tolerated, a cancellation is not: carrying on
+                // would keep hitting the remote instance after the thread was asked to stop
+                // and report a truncated read as a complete one.
+                throw new RuntimeException("Interrupted while reading workflows from remote " + baseUrl);
+            }
             try {
                 WorkflowSourceData wfData = readSingleWorkflow(workflowUris.get(i), i);
                 if (wfData != null) {
                     workflowDataList.add(wfData);
                 }
             } catch (Exception e) {
-                LOGGER.warnf("Failed to read workflow %d from remote %s: %s", i, baseUrl, e.getMessage());
+                LOGGER.warnf(e, "Failed to read workflow %d from remote %s", i, baseUrl);
             }
         }
 
@@ -221,16 +241,15 @@ public class RemoteApiResourceSource implements IResourceSource {
      */
     public static List<DocumentDescriptor> listRemoteAgentDescriptors(
                                                                       String baseUrl, String authToken, IJsonSerialization jsonSerialization) {
-        try {
-            String normalized = normalizeBaseUrl(baseUrl);
-            HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(CONNECT_TIMEOUT)
-                    .build();
+        String normalized = normalizeBaseUrl(baseUrl);
+        if (!normalized.endsWith("/")) {
+            normalized += "/";
+        }
+        URI baseUri = URI.create(normalized);
 
-            if (!normalized.endsWith("/")) {
-                normalized += "/";
-            }
-            URI baseUri = URI.create(normalized);
+        try (HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .build()) {
 
             // codeql[java/ssrf] False Positive: It is an intended feature to connect to a
             // user-provided remote EDDI instance
@@ -251,6 +270,12 @@ public class RemoteApiResourceSource implements IResourceSource {
             DocumentDescriptor[] descriptors = jsonSerialization.deserialize(
                     response.body(), DocumentDescriptor[].class);
             return descriptors != null ? List.of(descriptors) : List.of();
+        } catch (InterruptedException e) {
+            // Never swallow an interrupt: the caller (or the container shutting down)
+            // asked this thread to stop, and a lost flag means the next blocking call
+            // simply carries on.
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while listing agents from remote instance " + baseUrl, e);
         } catch (Exception e) {
             throw new RuntimeException("Failed to list agents from remote instance " + baseUrl + ": " + e.getMessage(), e);
         }
@@ -260,8 +285,14 @@ public class RemoteApiResourceSource implements IResourceSource {
 
     private WorkflowSourceData readSingleWorkflow(URI workflowUri, int positionIndex) throws IOException {
         IResourceId wfResId = RestUtilities.extractResourceId(workflowUri);
-        if (wfResId == null)
+        // extractResourceId answers with an id of null for a URI that carries no
+        // resource segment, so the null check has to be on the id: without it the
+        // read went out as /workflowstore/workflows/null?version=0.
+        if (wfResId == null || wfResId.getId() == null) {
+            LOGGER.warnf("Agent %s on %s references a workflow URI with no resource id: %s",
+                    agentId, baseUrl, workflowUri);
             return null;
+        }
 
         String workflowId = wfResId.getId();
         int version = wfResId.getVersion();
@@ -278,46 +309,24 @@ public class RemoteApiResourceSource implements IResourceSource {
     }
 
     /**
-     * Reads all extension configs referenced by a workflow configuration by parsing
-     * each workflow step and fetching the extension resource from the remote
-     * instance.
+     * Reads all extension configs referenced by a workflow configuration, keyed by
+     * the canonical {@link WorkflowExtensions} key so the map joins with the one
+     * {@link StructuralMatcher} builds from the local target workflow.
      */
     private Map<String, ExtensionSourceData> readExtensionsFromWorkflow(WorkflowConfiguration config) {
         Map<String, ExtensionSourceData> extensions = new LinkedHashMap<>();
 
-        for (WorkflowConfiguration.WorkflowStep step : config.getWorkflowSteps()) {
-            URI stepType = step.getType();
-            if (stepType == null)
-                continue;
-
-            Object uriObj = step.getExtensions().get("uri");
-            if (uriObj == null)
-                continue;
-
-            URI extUri = URI.create(uriObj.toString());
-            IResourceId extResId = RestUtilities.extractResourceId(extUri);
-            if (extResId == null)
-                continue;
-
-            String stepTypeStr = stepType.toString();
-            String restPath = STEP_TYPE_TO_REST_PATH.get(stepTypeStr);
-            String extLabel = STEP_TYPE_TO_EXT_LABEL.get(stepTypeStr);
-            if (restPath == null || extLabel == null) {
-                LOGGER.debugf("Unknown step type: %s", stepTypeStr);
-                continue;
-            }
-
+        for (WorkflowExtensions.ExtensionRef ref : WorkflowExtensions.scan(config)) {
+            String restPath = ref.type().restPath();
+            String extId = ref.resourceId().getId();
             try {
-                String contentJson = httpGet(restPath + extResId.getId() + "?version=" + extResId.getVersion());
+                String contentJson = httpGet(restPath + extId + "?version=" + ref.resourceId().getVersion());
+                String name = readRemoteDescriptorName(descriptorsPathOf(restPath), extId);
 
-                // Try to read the descriptor name
-                String name = tryReadDescriptorName(restPath, extResId.getId());
-
-                extensions.put(stepTypeStr, new ExtensionSourceData(
-                        extResId.getId(), name, extLabel, stepTypeStr, contentJson));
+                extensions.put(ref.key(), new ExtensionSourceData(
+                        extId, name, ref.fileExtension(), ref.stepType(), contentJson));
             } catch (Exception e) {
-                LOGGER.debugf("Could not read remote extension %s/%s: %s",
-                        stepTypeStr, extResId.getId(), e.getMessage());
+                LOGGER.debugf("Could not read remote extension %s: %s", ref.extensionUri(), e.getMessage());
             }
         }
 
@@ -327,63 +336,69 @@ public class RemoteApiResourceSource implements IResourceSource {
     /**
      * Resolves the latest version of the agent when no explicit version was
      * provided. Reads the agent descriptor list and finds the matching entry.
+     * <p>
+     * Failing to resolve is an error, not a reason to guess: falling back to
+     * version 1 silently synced an arbitrarily old configuration into the target
+     * whenever the descriptor listing was paginated, access-scoped, or briefly
+     * unavailable.
      */
     private int resolveLatestAgentVersion() {
+        DocumentDescriptor[] descriptors;
         try {
             String json = httpGet("/agentstore/agents/descriptors?index=0&limit=0");
-            DocumentDescriptor[] descriptors = jsonSerialization.deserialize(json, DocumentDescriptor[].class);
-            if (descriptors != null) {
-                for (DocumentDescriptor desc : descriptors) {
-                    IResourceId resId = RestUtilities.extractResourceId(desc.getResource());
-                    if (resId != null && agentId.equals(resId.getId())) {
-                        return resId.getVersion();
-                    }
+            descriptors = jsonSerialization.deserialize(json, DocumentDescriptor[].class);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not determine the latest version of agent " + agentId
+                    + " on " + baseUrl + ": " + e.getMessage(), e);
+        }
+
+        if (descriptors != null) {
+            for (DocumentDescriptor desc : descriptors) {
+                IResourceId resId = RestUtilities.extractResourceId(desc.getResource());
+                if (resId != null && agentId.equals(resId.getId())) {
+                    return resId.getVersion();
                 }
             }
-        } catch (Exception e) {
-            LOGGER.debugf("Could not resolve latest version for %s: %s", agentId, e.getMessage());
         }
-        return 1; // fallback
+
+        throw new RuntimeException("Agent " + agentId + " is not listed on " + baseUrl
+                + " — cannot determine its latest version. Pass an explicit sourceAgentVersion.");
     }
 
     /**
-     * Tries to find a resource's name from the descriptor endpoint.
+     * Name of a resource, taken from its store's descriptor listing. The listing is
+     * fetched at most once per store per request — see
+     * {@link #descriptorNamesByPath}.
      */
     private String readRemoteDescriptorName(String descriptorsPath, String resourceId) {
+        return descriptorNamesByPath
+                .computeIfAbsent(descriptorsPath, this::loadDescriptorNames)
+                .get(resourceId);
+    }
+
+    private Map<String, String> loadDescriptorNames(String descriptorsPath) {
+        Map<String, String> names = new HashMap<>();
         try {
             String json = httpGet(descriptorsPath + "?index=0&limit=0");
             DocumentDescriptor[] descriptors = jsonSerialization.deserialize(json, DocumentDescriptor[].class);
             if (descriptors != null) {
                 for (DocumentDescriptor desc : descriptors) {
                     IResourceId resId = RestUtilities.extractResourceId(desc.getResource());
-                    if (resId != null && resourceId.equals(resId.getId())) {
-                        return desc.getName();
+                    if (resId != null && resId.getId() != null && desc.getName() != null) {
+                        names.putIfAbsent(resId.getId(), desc.getName());
                     }
                 }
             }
         } catch (Exception e) {
-            LOGGER.debugf("Could not read remote descriptor name for %s: %s", resourceId, e.getMessage());
+            LOGGER.debugf("Could not read remote descriptors from %s: %s", descriptorsPath, e.getMessage());
         }
-        return null;
+        return names;
     }
 
-    /**
-     * Best-effort name read for extension resources.
-     */
-    private String tryReadDescriptorName(String storePath, String resourceId) {
-        // Derive descriptors path from store path:
-        // e.g., "/llmstore/llms/" → "/llmstore/llms/descriptors"
-        String descriptorsPath = storePath;
-        if (descriptorsPath.endsWith("/")) {
-            descriptorsPath = descriptorsPath.substring(0, descriptorsPath.length() - 1);
-        }
-        descriptorsPath = descriptorsPath + "/descriptors";
-
-        try {
-            return readRemoteDescriptorName(descriptorsPath, resourceId);
-        } catch (Exception e) {
-            return null;
-        }
+    /** e.g. {@code /llmstore/llms/} → {@code /llmstore/llms/descriptors}. */
+    private static String descriptorsPathOf(String storePath) {
+        String path = storePath.endsWith("/") ? storePath.substring(0, storePath.length() - 1) : storePath;
+        return path + "/descriptors";
     }
 
     /**
@@ -424,7 +439,13 @@ public class RemoteApiResourceSource implements IResourceSource {
             }
 
             return response.body();
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            // Restore the flag before unwinding: readWorkflows catches per-workflow
+            // failures and carries on, so a swallowed interrupt meant a cancelled or
+            // shutting-down batch sync kept issuing HTTP calls to the remote instance.
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while reading " + baseUrl + path, e);
+        } catch (IOException e) {
             throw new RuntimeException("Failed to connect to remote " + baseUrl + path + ": " + e.getMessage(), e);
         }
     }
@@ -435,22 +456,17 @@ public class RemoteApiResourceSource implements IResourceSource {
         // Remove trailing slash
         String normalized = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
 
-        try {
-            // Validate URL to mitigate SSRF concerns by ensuring a valid network scheme and
-            // host.
-            // Note: Connecting to a user-provided instance is an intended feature.
-            URI uri = URI.create(normalized);
-            String scheme = uri.getScheme();
-            if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
-                throw new IllegalArgumentException("Only HTTP or HTTPS schemes are allowed: " + url);
-            }
-            if (uri.getHost() == null || uri.getHost().isBlank()) {
-                throw new IllegalArgumentException("Invalid base URL host: " + url);
-            }
-        } catch (IllegalArgumentException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Invalid base URL: " + url, e);
+        // Validate URL to mitigate SSRF concerns by ensuring a valid network scheme and
+        // host. Note: Connecting to a user-provided instance is an intended feature.
+        // URI.create and the guards below can only produce IllegalArgumentException,
+        // so there is nothing else to catch and re-wrap here.
+        URI uri = URI.create(normalized);
+        String scheme = uri.getScheme();
+        if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+            throw new IllegalArgumentException("Only HTTP or HTTPS schemes are allowed: " + url);
+        }
+        if (uri.getHost() == null || uri.getHost().isBlank()) {
+            throw new IllegalArgumentException("Invalid base URL host: " + url);
         }
 
         return normalized;

--- a/src/main/java/ai/labs/eddi/backup/impl/RemoteApiResourceSource.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RemoteApiResourceSource.java
@@ -11,6 +11,7 @@ import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.utils.LogSanitizer;
 import ai.labs.eddi.utils.RestUtilities;
 import org.jboss.logging.Logger;
 
@@ -92,10 +93,29 @@ public class RemoteApiResourceSource implements IResourceSource {
         this.agentVersion = agentVersion;
         this.authToken = authToken;
         this.jsonSerialization = jsonSerialization;
-        this.httpClient = HttpClient.newBuilder()
-                .connectTimeout(CONNECT_TIMEOUT)
-                .build();
+        this.httpClient = configure(HttpClient.newBuilder()).build();
         this.ownsHttpClient = true;
+    }
+
+    /**
+     * The configuration every {@link HttpClient} this class owns is built with.
+     * <p>
+     * Redirects are stated rather than inherited. A redirect is never followed, so
+     * a remote instance answering 3xx can never bounce the caller's
+     * X-Source-Authorization bearer at an address of its choosing: the hop surfaces
+     * as a non-200 status and the read fails. This is the JDK's default too, and
+     * saying so is what stops a later edit from changing it without anyone
+     * noticing.
+     * <p>
+     * Both build sites go through here, and it is package-private, so that the
+     * policy can be asserted directly. Building a real client to read it back is
+     * not an option in a sandboxed build: {@code HttpClient.build()} opens a
+     * selector, which needs a loopback socket.
+     */
+    static HttpClient.Builder configure(HttpClient.Builder builder) {
+        return builder
+                .connectTimeout(CONNECT_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NEVER);
     }
 
     // Visible for testing
@@ -179,7 +199,7 @@ public class RemoteApiResourceSource implements IResourceSource {
                     workflowDataList.add(wfData);
                 }
             } catch (Exception e) {
-                LOGGER.warnf(e, "Failed to read workflow %d from remote %s", i, baseUrl);
+                LOGGER.warnf(e, "Failed to read workflow %d from remote %s", i, LogSanitizer.sanitize(baseUrl));
             }
         }
 
@@ -213,11 +233,13 @@ public class RemoteApiResourceSource implements IResourceSource {
                                 resId.getId(), snippet.getName(), snippet));
                     }
                 } catch (Exception e) {
-                    LOGGER.debugf("Could not read remote snippet %s: %s", desc.getName(), e.getMessage());
+                    LOGGER.debugf("Could not read remote snippet %s: %s",
+                            LogSanitizer.sanitize(desc.getName()), LogSanitizer.sanitize(e.getMessage()));
                 }
             }
         } catch (Exception e) {
-            LOGGER.warnf("Failed to read snippets from remote %s: %s", baseUrl, e.getMessage());
+            LOGGER.warnf("Failed to read snippets from remote %s: %s",
+                    LogSanitizer.sanitize(baseUrl), LogSanitizer.sanitize(e.getMessage()));
         }
 
         return snippetDataList;
@@ -247,9 +269,7 @@ public class RemoteApiResourceSource implements IResourceSource {
         }
         URI baseUri = URI.create(normalized);
 
-        try (HttpClient client = HttpClient.newBuilder()
-                .connectTimeout(CONNECT_TIMEOUT)
-                .build()) {
+        try (HttpClient client = configure(HttpClient.newBuilder()).build()) {
 
             // codeql[java/ssrf] False Positive: It is an intended feature to connect to a
             // user-provided remote EDDI instance
@@ -290,7 +310,8 @@ public class RemoteApiResourceSource implements IResourceSource {
         // read went out as /workflowstore/workflows/null?version=0.
         if (wfResId == null || wfResId.getId() == null) {
             LOGGER.warnf("Agent %s on %s references a workflow URI with no resource id: %s",
-                    agentId, baseUrl, workflowUri);
+                    LogSanitizer.sanitize(agentId), LogSanitizer.sanitize(baseUrl),
+                    LogSanitizer.sanitize(String.valueOf(workflowUri)));
             return null;
         }
 
@@ -326,7 +347,8 @@ public class RemoteApiResourceSource implements IResourceSource {
                 extensions.put(ref.key(), new ExtensionSourceData(
                         extId, name, ref.fileExtension(), ref.stepType(), contentJson));
             } catch (Exception e) {
-                LOGGER.debugf("Could not read remote extension %s: %s", ref.extensionUri(), e.getMessage());
+                LOGGER.debugf("Could not read remote extension %s: %s",
+                        LogSanitizer.sanitize(String.valueOf(ref.extensionUri())), LogSanitizer.sanitize(e.getMessage()));
             }
         }
 
@@ -390,7 +412,8 @@ public class RemoteApiResourceSource implements IResourceSource {
                 }
             }
         } catch (Exception e) {
-            LOGGER.debugf("Could not read remote descriptors from %s: %s", descriptorsPath, e.getMessage());
+            LOGGER.debugf("Could not read remote descriptors from %s: %s",
+                    LogSanitizer.sanitize(descriptorsPath), LogSanitizer.sanitize(e.getMessage()));
         }
         return names;
     }

--- a/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
@@ -38,6 +38,7 @@ import ai.labs.eddi.utils.FileUtilities;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
@@ -46,12 +47,13 @@ import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
 
 import java.io.*;
 import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
+import java.text.Normalizer;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -84,7 +86,30 @@ public class RestExportService extends AbstractBackupService implements IRestExp
     private final Path tmpPath = Paths.get(FileUtilities.buildPath(System.getProperty("user.dir"), "tmp"));
 
     private static final Logger LOGGER = Logger.getLogger(RestExportService.class);
-    private static final String SCHEDULE_EXT = "schedule";
+
+    /**
+     * Sub-directory of {@code tmp/} holding finished ZIPs that are waiting to be
+     * downloaded. Keeping them in their own directory is what makes
+     * {@link #sweepExpiredArchives()} able to delete by age without ever looking at
+     * the export scratch tree or the import staging root.
+     */
+    private static final String EXPORT_ARCHIVE_ROOT = "archives";
+
+    /**
+     * How long a finished archive is kept. Nothing deleted these before: the
+     * scratch tree was cleaned up but the ZIP itself was written to {@code tmp/}
+     * and stayed there forever, so every export permanently consumed disk while the
+     * 404 message claimed archives "are not kept indefinitely".
+     */
+    private static final int DEFAULT_ARCHIVE_RETENTION_MINUTES = 60;
+
+    @ConfigProperty(name = "eddi.backup.export.retention-minutes", defaultValue = "60")
+    int archiveRetentionMinutes;
+
+    /**
+     * Maximum number of characters of the agent name kept in the archive filename.
+     */
+    private static final int MAX_NAME_SLUG_LENGTH = 60;
 
     /**
      * Sub-directory of {@code tmp/} under which every export builds its own
@@ -105,13 +130,16 @@ public class RestExportService extends AbstractBackupService implements IRestExp
     private static final Pattern SNIPPET_REF_PATTERN = Pattern.compile("snippets\\.([a-zA-Z0-9_\\-]+)");
 
     private final ResourceAccessGuard resourceAccessGuard;
+    private final BackupMetrics metrics;
 
     @Inject
     public RestExportService(IDocumentDescriptorStore documentDescriptorStore, IAgentStore agentStore, IWorkflowStore workflowStore,
             IDictionaryStore regularDictionaryStore, IRuleSetStore behaviorStore, IApiCallsStore httpCallsStore, ILlmStore llmStore,
             IPropertySetterStore propertySetterStore, IOutputStore outputStore, IMcpCallsStore mcpCallsStore, IRagStore ragStore,
             IPromptSnippetStore snippetStore, IJsonSerialization jsonSerialization, IZipArchive zipArchive,
-            SecretScrubber secretScrubber, IScheduleStore scheduleStore, ResourceAccessGuard resourceAccessGuard) {
+            SecretScrubber secretScrubber, IScheduleStore scheduleStore, ResourceAccessGuard resourceAccessGuard,
+            BackupMetrics metrics) {
+        this.metrics = metrics;
         this.resourceAccessGuard = resourceAccessGuard;
         this.documentDescriptorStore = documentDescriptorStore;
         this.agentStore = agentStore;
@@ -136,27 +164,71 @@ public class RestExportService extends AbstractBackupService implements IRestExp
         try {
             agentFilename = sanitizeFileName(agentFilename);
 
-            Path zipFilePath = Paths.get(tmpPath.toString(), agentFilename).normalize();
+            Path archiveDir = archiveDirectory();
+            Path zipFilePath = archiveDir.resolve(agentFilename).normalize();
 
-            Path tmpDirPath = Paths.get(tmpPath.toString()).toAbsolutePath().normalize();
-            if (!zipFilePath.startsWith(tmpDirPath)) {
+            if (!zipFilePath.startsWith(archiveDir)) {
                 throw new SecurityException("Invalid file path detected.");
             }
 
-            return Response.ok(new BufferedInputStream(new FileInputStream(zipFilePath.toFile()))).build();
+            return Response.ok(new BufferedInputStream(new FileInputStream(zipFilePath.toFile())))
+                    .header("Content-Disposition", "attachment; filename=\"" + agentFilename + "\"")
+                    .build();
         } catch (FileNotFoundException e) {
             // An archive that is not there is a 404, not a 500. sneakyThrow'ing the
             // FileNotFoundException produced an unlogged 500 error page — easy to hit,
             // since export and download share this path and differ only by method, so
             // a mistyped or expired filename looked like a server fault.
             throw new NotFoundException("No exported archive named '" + agentFilename
-                    + "'. Archives are produced by POST on this path and are not kept indefinitely.");
+                    + "'. Archives are produced by POST on this path and are kept for "
+                    + retentionMinutes() + " minutes.");
+        }
+    }
+
+    /** {@code tmp/archives/}, created on demand. */
+    private Path archiveDirectory() {
+        return Paths.get(tmpPath.toString(), EXPORT_ARCHIVE_ROOT).toAbsolutePath().normalize();
+    }
+
+    private int retentionMinutes() {
+        return archiveRetentionMinutes > 0 ? archiveRetentionMinutes : DEFAULT_ARCHIVE_RETENTION_MINUTES;
+    }
+
+    /**
+     * Deletes finished archives older than the retention window. Runs before each
+     * export rather than on a scheduler: export is the only thing that creates
+     * these files, so sweeping here bounds the directory to what was produced
+     * within one retention window.
+     * <p>
+     * Failures are logged, never thrown — housekeeping must not fail an export.
+     */
+    private void sweepExpiredArchives() {
+        Path archiveDir = archiveDirectory();
+        if (!Files.isDirectory(archiveDir)) {
+            return;
+        }
+        Instant cutoff = Instant.now().minus(Duration.ofMinutes(retentionMinutes()));
+        try (var archives = Files.list(archiveDir)) {
+            archives.filter(Files::isRegularFile).forEach(archive -> {
+                try {
+                    if (Files.getLastModifiedTime(archive).toInstant().isBefore(cutoff)) {
+                        Files.deleteIfExists(archive);
+                        LOGGER.debugf("Deleted expired export archive %s", archive.getFileName());
+                    }
+                } catch (IOException e) {
+                    LOGGER.debugf("Could not evaluate export archive %s: %s", archive, e.getMessage());
+                }
+            });
+        } catch (IOException e) {
+            LOGGER.warnf("Could not sweep expired export archives in %s: %s", archiveDir, e.getMessage());
         }
     }
 
     @Override
-    public Response exportAgent(String agentId, Integer agentVersion, String selectedResourceIds) {
+    public Response exportAgent(String agentId, Integer agentVersion, String selectedResourceIds,
+                                String selectedSnippetIds, String selectedScheduleIds) {
         Path scratchRoot = null;
+        metrics.exportAttempted();
         try {
             // Validate agentId early before any path construction (CodeQL
             // java/path-injection)
@@ -170,6 +242,8 @@ public class RestExportService extends AbstractBackupService implements IRestExp
 
             // Parse selective export filter — null means "export all"
             Set<String> selectedIds = parseSelectedResourceIds(selectedResourceIds);
+            Set<String> selectedSnippets = parseTypedSelection(selectedSnippetIds);
+            Set<String> selectedSchedules = parseTypedSelection(selectedScheduleIds);
 
             AgentConfiguration agentConfig = agentStore.read(agentId, agentVersion);
 
@@ -233,20 +307,32 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                 collectSelectedConfigs(allExtensionConfigs, outputConfigs, selectedIds);
             }
 
-            // Export only snippets actually referenced by the exported configs
+            // Export only snippets actually referenced by the exported configs — and,
+            // when the caller made a snippet selection, only the ones it kept. The
+            // preview renders snippet rows as deselectable, so ignoring the selection
+            // here put back exactly the deployment-specific prompt text a user had
+            // unticked.
             Set<String> referencedSnippetNames = extractReferencedSnippetNames(allExtensionConfigs);
-            exportSnippets(agentPath, referencedSnippetNames);
+            exportSnippets(agentPath, referencedSnippetNames, selectedSnippets);
 
-            // Export schedules for this agent
-            exportSchedules(agentId, agentPath);
+            // Export schedules for this agent, likewise filtered only by the caller's
+            // own schedule selection.
+            exportSchedules(agentId, agentPath, selectedSchedules);
 
+            sweepExpiredArchives();
+            Path archiveDir = Files.createDirectories(archiveDirectory());
             String zipFilename = prepareZipFilename(agentDocumentDescriptor, agentId, agentVersion);
-            String targetZipPath = FileUtilities.buildPath(tmpPath.toString(), zipFilename);
+            String targetZipPath = FileUtilities.buildPath(archiveDir.toString(), zipFilename);
             this.zipArchive.createZip(agentPath.toString(), targetZipPath, tmpPath);
             return Response.ok().location(URI.create("/backup/export/" + zipFilename)).build();
+        } catch (RuntimeException e) {
+            metrics.exportFailed();
+            throw e;
         } catch (IResourceStore.ResourceNotFoundException e) {
+            metrics.exportFailed();
             throw sneakyThrow(e);
         } catch (IResourceStore.ResourceStoreException | IOException | CallbackMatcher.CallbackMatcherException e) {
+            metrics.exportFailed();
             throw sneakyThrow(e);
         } finally {
             // The ZIP is built at this point, so the loose files it was built from
@@ -353,9 +439,21 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                 addExtensionContentForSnippetScan(allExtensionConfigs, wfJson);
             }
             Set<String> referencedSnippetNames = extractReferencedSnippetNames(allExtensionConfigs);
+            // Emit the snippet's real resource id, like every other row: the
+            // selection filter compares resource ids, so a row keyed by name could
+            // never be matched by a client echoing it back.
+            Map<String, IResourceId> snippetIdsByName = resolveSnippetIdsByName(referencedSnippetNames);
             for (String snippetName : referencedSnippetNames) {
-                resources.add(new ExportableResource(snippetName, null, "snippet", snippetName, null, -1, false));
+                IResourceId snippetId = snippetIdsByName.get(snippetName);
+                resources.add(new ExportableResource(
+                        snippetId != null ? snippetId.getId() : snippetName,
+                        snippetId != null ? snippetId.getVersion() : null,
+                        "snippet", snippetName, null, -1, false));
             }
+
+            // Scheduled triggers. They were written into every archive but appeared in
+            // no preview, so an operator could not see what a restore would bring back.
+            addScheduleResources(resources, agentId);
 
             return new ExportPreview(agentId, agentName, agentVersion, resources);
 
@@ -400,31 +498,100 @@ public class RestExportService extends AbstractBackupService implements IRestExp
 
     private void addExtensionContentForSnippetScan(List<String> allConfigs, String wfJson) {
         try {
-            for (IResourceId resId : readConfigs(llmStore, extractResourcesUris(wfJson, LANGCHAIN_URI_PATTERN)).keySet()) {
-                allConfigs.add(jsonSerialization.serialize(llmStore.read(resId.getId(), resId.getVersion())));
-            }
-            for (IResourceId resId : readConfigs(httpCallsStore, extractResourcesUris(wfJson, HTTPCALLS_URI_PATTERN)).keySet()) {
-                allConfigs.add(jsonSerialization.serialize(httpCallsStore.read(resId.getId(), resId.getVersion())));
-            }
-            for (IResourceId resId : readConfigs(propertySetterStore, extractResourcesUris(wfJson, PROPERTY_URI_PATTERN)).keySet()) {
-                allConfigs.add(jsonSerialization.serialize(propertySetterStore.read(resId.getId(), resId.getVersion())));
-            }
-            for (IResourceId resId : readConfigs(outputStore, extractResourcesUris(wfJson, OUTPUT_URI_PATTERN)).keySet()) {
-                allConfigs.add(jsonSerialization.serialize(outputStore.read(resId.getId(), resId.getVersion())));
-            }
+            // readConfigs already loaded every value; iterating keySet() and reading
+            // each resource a second time doubled the datastore round-trips of an
+            // interactive preview for no benefit.
+            collectSerializedConfigs(allConfigs, llmStore, wfJson, LANGCHAIN_URI_PATTERN);
+            collectSerializedConfigs(allConfigs, httpCallsStore, wfJson, HTTPCALLS_URI_PATTERN);
+            collectSerializedConfigs(allConfigs, propertySetterStore, wfJson, PROPERTY_URI_PATTERN);
+            collectSerializedConfigs(allConfigs, outputStore, wfJson, OUTPUT_URI_PATTERN);
         } catch (Exception e) {
             LOGGER.debugf("Could not scan extension content for snippets: %s", e.getMessage());
         }
     }
 
-    private String prepareZipFilename(DocumentDescriptor agentDocumentDescriptor, String agentId, Integer agentVersion)
-            throws UnsupportedEncodingException {
+    private void collectSerializedConfigs(List<String> allConfigs, IResourceStore<?> store,
+                                          String wfJson, Pattern uriPattern)
+            throws Exception {
+        for (Object config : readConfigs(store, extractResourcesUris(wfJson, uriPattern)).values()) {
+            allConfigs.add(jsonSerialization.serialize(config));
+        }
+    }
+
+    /**
+     * Resolves the resource id of each referenced snippet by name, using the same
+     * access-scoped descriptor sweep the export itself performs.
+     */
+    private Map<String, IResourceId> resolveSnippetIdsByName(Set<String> referencedNames) {
+        Map<String, IResourceId> byName = new LinkedHashMap<>();
+        if (referencedNames.isEmpty()) {
+            return byName;
+        }
+        try {
+            List<DocumentDescriptor> descriptors = documentDescriptorStore.readDescriptors(
+                    "ai.labs.snippet", "", 0, IDescriptorStore.NO_LIMIT, false, resourceAccessGuard.listingScope());
+            if (descriptors == null) {
+                return byName;
+            }
+            for (DocumentDescriptor descriptor : descriptors) {
+                try {
+                    IResourceId resourceId = RestUtilities.extractResourceId(descriptor.getResource());
+                    if (resourceId == null) {
+                        continue;
+                    }
+                    PromptSnippet snippet = snippetStore.read(resourceId.getId(), resourceId.getVersion());
+                    if (snippet != null && referencedNames.contains(snippet.getName())) {
+                        byName.putIfAbsent(snippet.getName(), resourceId);
+                    }
+                } catch (Exception e) {
+                    LOGGER.debugf("Could not resolve snippet id for preview: %s", e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debugf("Could not list snippet descriptors for preview: %s", e.getMessage());
+        }
+        return byName;
+    }
+
+    /**
+     * Builds the archive's filename, which doubles as the key of the download URL.
+     * <p>
+     * The name is slugified, not percent-encoded: {@code URLEncoder} produced
+     * {@code M%C3%BCller+Bot-...zip}, JAX-RS percent-decoded the path parameter
+     * back on the way in, and {@link #sanitizeFileName(String)} then rejected both
+     * the decoded {@code ü} and the literal {@code %} — so an agent whose name had
+     * any non-ASCII character exported successfully into an archive that could
+     * never be downloaded.
+     */
+    private String prepareZipFilename(DocumentDescriptor agentDocumentDescriptor, String agentId, Integer agentVersion) {
         String zipFilename = "";
-        if (!isNullOrEmpty(agentDocumentDescriptor.getName())) {
-            zipFilename = URLEncoder.encode(agentDocumentDescriptor.getName() + "-", StandardCharsets.UTF_8);
+        if (agentDocumentDescriptor != null && !isNullOrEmpty(agentDocumentDescriptor.getName())) {
+            String slug = slugifyForFilename(agentDocumentDescriptor.getName());
+            if (!slug.isEmpty()) {
+                zipFilename = slug + "-";
+            }
         }
         zipFilename += agentId + "-" + agentVersion + ".zip";
         return zipFilename;
+    }
+
+    /**
+     * Reduces a display name to the character class the download endpoint accepts
+     * ({@code [A-Za-z0-9_.+-]}). Accents are folded rather than dropped, so "Müller
+     * Bot" becomes "Muller-Bot" instead of "Mller-Bot".
+     */
+    static String slugifyForFilename(String name) {
+        // NFKD splits "ü" into "u" plus a combining diaeresis; the mark has to be
+        // dropped, not replaced, or the fold produces "Mu-ller" instead of "Muller".
+        String folded = Normalizer.normalize(name, Normalizer.Form.NFKD)
+                .replaceAll("\\p{M}+", "");
+        String slug = folded.replaceAll("[^A-Za-z0-9_.-]+", "-");
+        slug = slug.replaceAll("-{2,}", "-");
+        slug = slug.replaceAll("^[-.]+", "").replaceAll("-+$", "");
+        if (slug.length() > MAX_NAME_SLUG_LENGTH) {
+            slug = slug.substring(0, MAX_NAME_SLUG_LENGTH).replaceAll("-+$", "");
+        }
+        return slug;
     }
 
     private Map<IResourceId, String> convertConfigsToString(Map<IResourceId, ?> configurationMap) {
@@ -496,7 +663,37 @@ public class RestExportService extends AbstractBackupService implements IRestExp
         if (isNullOrEmpty(selectedResourceIds) || selectedResourceIds.isBlank()) {
             return null;
         }
-        return Arrays.stream(selectedResourceIds.split(","))
+        return splitIds(selectedResourceIds);
+    }
+
+    /**
+     * Parses the selection of a resource type that {@code selectedResources} never
+     * carried — snippets, whose preview row used to be keyed by name rather than by
+     * resource id, and schedules, which appeared in no preview at all.
+     * <p>
+     * Filtering those two by {@code selectedResources} turned every selective
+     * export from a client built against the previous contract into a silent
+     * partial backup: such a client sends a set holding neither a snippet resource
+     * id nor a schedule id, so the archive came out with no snippets and no
+     * schedules — invisible until a restore came up with its cron jobs gone.
+     * <p>
+     * Hence three states rather than two: an <em>absent</em> parameter
+     * ({@code null}) means "no selection was expressed for this type" and exports
+     * all of it, while a <em>present</em> parameter filters — including a
+     * present-but-empty one, which is how a client says "none of them".
+     *
+     * @return {@code null} when the parameter was absent, otherwise the (possibly
+     *         empty) set of selected resource ids
+     */
+    private Set<String> parseTypedSelection(String selectedIds) {
+        if (selectedIds == null) {
+            return null;
+        }
+        return splitIds(selectedIds);
+    }
+
+    private Set<String> splitIds(String csv) {
+        return Arrays.stream(csv.split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -630,8 +827,12 @@ public class RestExportService extends AbstractBackupService implements IRestExp
     /**
      * Exports only snippets whose {@code name} is in the referenced set. If the
      * referenced set is empty, no snippets are exported.
+     *
+     * @param selectedSnippetIds
+     *            the caller's snippet selection, or {@code null} when it expressed
+     *            none — see {@link #parseTypedSelection(String)}
      */
-    private void exportSnippets(Path agentPath, Set<String> referencedNames) {
+    private void exportSnippets(Path agentPath, Set<String> referencedNames, Set<String> selectedSnippetIds) {
         if (referencedNames.isEmpty()) {
             return;
         }
@@ -659,8 +860,13 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                     if (snippet == null || snippet.getName() == null)
                         continue;
 
-                    // Only export snippets actually referenced by this agent
+                    // Only export snippets actually referenced by this agent...
                     if (!referencedNames.contains(snippet.getName())) {
+                        continue;
+                    }
+                    // ...and, when the caller expressed a snippet selection, only
+                    // those it kept.
+                    if (selectedSnippetIds != null && !selectedSnippetIds.contains(resourceId.getId())) {
                         continue;
                     }
 
@@ -694,15 +900,47 @@ public class RestExportService extends AbstractBackupService implements IRestExp
         }
     }
 
-    private void exportSchedules(String agentId, Path agentPath) {
+    /**
+     * Lists the agent's scheduled triggers as deselectable preview rows. Failure to
+     * read them is not failure to preview: the rest of the preview is still useful.
+     */
+    private void addScheduleResources(List<ExportableResource> resources, String agentId) {
+        try {
+            for (ScheduleConfiguration schedule : scheduleStore.readSchedulesByAgentId(agentId)) {
+                if (schedule == null || schedule.getId() == null) {
+                    continue;
+                }
+                resources.add(new ExportableResource(schedule.getId(), null, SCHEDULE_EXT,
+                        schedule.getName(), null, -1, false));
+            }
+        } catch (Exception e) {
+            LOGGER.warnf("Could not list schedules of agent %s for the export preview: %s", agentId, e.getMessage());
+        }
+    }
+
+    /**
+     * Writes the agent's scheduled triggers into the archive.
+     *
+     * @param selectedScheduleIds
+     *            the caller's schedule selection, or {@code null} when it expressed
+     *            none — see {@link #parseTypedSelection(String)}
+     */
+    private void exportSchedules(String agentId, Path agentPath, Set<String> selectedScheduleIds) {
         try {
             List<ScheduleConfiguration> schedules = scheduleStore.readSchedulesByAgentId(agentId);
             if (schedules.isEmpty()) {
                 return;
             }
 
-            Path schedulesDir = Files.createDirectories(Paths.get(agentPath.toString(), "schedules"));
+            Path schedulesDir = Files.createDirectories(Paths.get(agentPath.toString(), SCHEDULES_DIR));
+            int exported = 0;
             for (ScheduleConfiguration schedule : schedules) {
+                // When the caller expressed a schedule selection, only the ones it
+                // kept.
+                if (selectedScheduleIds != null && !selectedScheduleIds.contains(schedule.getId())) {
+                    continue;
+                }
+                exported++;
                 String json = jsonSerialization.serialize(schedule);
                 json = secretScrubber.scrubJson(json);
                 String filename = schedule.getId() + "." + SCHEDULE_EXT + ".json";
@@ -712,7 +950,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
                     writer.write(json);
                 }
             }
-            LOGGER.infof("Exported %d schedule(s) for Agent %s", schedules.size(), agentId);
+            LOGGER.infof("Exported %d schedule(s) for Agent %s", exported, agentId);
         } catch (Exception e) {
             LOGGER.warnf("Failed to export schedules for Agent %s: %s", agentId, e.getMessage());
         }

--- a/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestExportService.java
@@ -27,6 +27,7 @@ import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.configs.propertysetter.IPropertySetterStore;
 import ai.labs.eddi.configs.dictionary.IDictionaryStore;
+import ai.labs.eddi.engine.hitl.HitlSchedules;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
@@ -36,6 +37,7 @@ import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.secrets.sanitize.SecretScrubber;
 import ai.labs.eddi.utils.FileUtilities;
 import ai.labs.eddi.utils.RestUtilities;
+import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -195,32 +197,56 @@ public class RestExportService extends AbstractBackupService implements IRestExp
     }
 
     /**
-     * Deletes finished archives older than the retention window. Runs before each
-     * export rather than on a scheduler: export is the only thing that creates
-     * these files, so sweeping here bounds the directory to what was produced
-     * within one retention window.
+     * The retention sweep on a timer, so an instance that stops exporting still
+     * reclaims what it already wrote. Sweeping only from {@link #exportAgent} meant
+     * the last archives an instance produced sat on disk until the next export —
+     * which on a deployment that exports occasionally is indefinitely.
+     */
+    @Scheduled(every = "${eddi.backup.export.sweep-interval:15m}", delayed = "1m",
+               identity = "backup-export-archive-retention")
+    void sweepExpiredArchivesOnSchedule() {
+        sweepExpiredArchives();
+    }
+
+    /**
+     * Deletes finished archives older than the retention window, and the loose
+     * {@code tmp/*.zip} files releases before this one left behind.
+     * <p>
+     * Runs both on a timer and before each export: the timer bounds an idle
+     * instance, and sweeping on the way in keeps a burst of exports from
+     * accumulating a retention window's worth of archives between ticks.
      * <p>
      * Failures are logged, never thrown — housekeeping must not fail an export.
      */
     private void sweepExpiredArchives() {
-        Path archiveDir = archiveDirectory();
-        if (!Files.isDirectory(archiveDir)) {
+        Instant cutoff = Instant.now().minus(Duration.ofMinutes(retentionMinutes()));
+        sweepExpiredZipsIn(archiveDirectory(), cutoff);
+        // Archives used to be written straight into tmp/. Nothing ever deleted them,
+        // and they are no longer downloadable either — getAgentZipArchive resolves
+        // only under tmp/archives — so an instance upgraded in place would otherwise
+        // keep every historical export forever.
+        sweepExpiredZipsIn(tmpPath.toAbsolutePath().normalize(), cutoff);
+    }
+
+    private void sweepExpiredZipsIn(Path directory, Instant cutoff) {
+        if (!Files.isDirectory(directory)) {
             return;
         }
-        Instant cutoff = Instant.now().minus(Duration.ofMinutes(retentionMinutes()));
-        try (var archives = Files.list(archiveDir)) {
-            archives.filter(Files::isRegularFile).forEach(archive -> {
-                try {
-                    if (Files.getLastModifiedTime(archive).toInstant().isBefore(cutoff)) {
-                        Files.deleteIfExists(archive);
-                        LOGGER.debugf("Deleted expired export archive %s", archive.getFileName());
-                    }
-                } catch (IOException e) {
-                    LOGGER.debugf("Could not evaluate export archive %s: %s", archive, e.getMessage());
-                }
-            });
+        try (var archives = Files.list(directory)) {
+            archives.filter(Files::isRegularFile)
+                    .filter(archive -> archive.getFileName().toString().endsWith(".zip"))
+                    .forEach(archive -> {
+                        try {
+                            if (Files.getLastModifiedTime(archive).toInstant().isBefore(cutoff)) {
+                                Files.deleteIfExists(archive);
+                                LOGGER.debugf("Deleted expired export archive %s", archive.getFileName());
+                            }
+                        } catch (IOException e) {
+                            LOGGER.debugf("Could not evaluate export archive %s: %s", archive, e.getMessage());
+                        }
+                    });
         } catch (IOException e) {
-            LOGGER.warnf("Could not sweep expired export archives in %s: %s", archiveDir, e.getMessage());
+            LOGGER.warnf("Could not sweep expired export archives in %s: %s", directory, e.getMessage());
         }
     }
 
@@ -262,8 +288,19 @@ public class RestExportService extends AbstractBackupService implements IRestExp
             for (IResourceId resourceId : workflowConfigurations.keySet()) {
                 WorkflowConfiguration workflowConfig = workflowConfigurations.get(resourceId);
                 String workflowConfigString = jsonSerialization.serialize(workflowConfig);
-                // Workflow skeletons are always included (required)
-                Path workflowPath = writeDirAndDocument(resourceId.getId(), resourceId.getVersion(), workflowConfigString, agentPath, WORKFLOW_EXT);
+                // The workflow is archived exactly as this deployment has it, including
+                // the reference to a config the selection is about to leave out. It is
+                // the importer, the only side that knows the strategy, that decides what
+                // to do with a reference it cannot resolve: a merge answers it from the
+                // target's own copy, a create drops the step
+                // (RestImportService#withoutUnresolvableReferences).
+                //
+                // Pruning the step here instead made every selective archive a
+                // step-deletion on the promotion flow it exists for: strategy=merge PUTs
+                // the archived workflow over the target's, so the target's own LLM and
+                // output steps vanished when someone promoted just the behaviour rules.
+                Path workflowPath = writeDirAndDocument(resourceId.getId(), resourceId.getVersion(), workflowConfigString, agentPath,
+                        WORKFLOW_EXT);
                 writeDocumentDescriptor(workflowPath, resourceId.getId(), resourceId.getVersion());
 
                 Map<IResourceId, String> dictionaryConfigs = convertConfigsToString(
@@ -900,6 +937,11 @@ public class RestExportService extends AbstractBackupService implements IRestExp
         }
     }
 
+    /** A HITL approval-timeout schedule, which never belongs in an archive. */
+    private static boolean isHitlTimeout(ScheduleConfiguration schedule) {
+        return schedule != null && HitlSchedules.isHitlTimeout(schedule.getMetadata());
+    }
+
     /**
      * Lists the agent's scheduled triggers as deselectable preview rows. Failure to
      * read them is not failure to preview: the rest of the preview is still useful.
@@ -907,7 +949,7 @@ public class RestExportService extends AbstractBackupService implements IRestExp
     private void addScheduleResources(List<ExportableResource> resources, String agentId) {
         try {
             for (ScheduleConfiguration schedule : scheduleStore.readSchedulesByAgentId(agentId)) {
-                if (schedule == null || schedule.getId() == null) {
+                if (schedule == null || schedule.getId() == null || isHitlTimeout(schedule)) {
                     continue;
                 }
                 resources.add(new ExportableResource(schedule.getId(), null, SCHEDULE_EXT,
@@ -935,6 +977,14 @@ public class RestExportService extends AbstractBackupService implements IRestExp
             Path schedulesDir = Files.createDirectories(Paths.get(agentPath.toString(), SCHEDULES_DIR));
             int exported = 0;
             for (ScheduleConfiguration schedule : schedules) {
+                // A HITL approval timeout is a safety timer for one pending approval
+                // on THIS deployment, not part of the agent's configuration. The
+                // import surface refuses to mint one for anybody — including admins —
+                // so writing it into the archive only produced a backup that could
+                // not be restored.
+                if (isHitlTimeout(schedule)) {
+                    continue;
+                }
                 // When the caller expressed a schedule selection, only the ones it
                 // kept.
                 if (selectedScheduleIds != null && !selectedScheduleIds.contains(schedule.getId())) {

--- a/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
@@ -11,6 +11,7 @@ import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
 import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import ai.labs.eddi.backup.model.SyncMapping;
 import ai.labs.eddi.backup.model.SyncRequest;
+import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.configs.IRestVersionInfo;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
@@ -28,6 +29,9 @@ import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
+import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration.FireStatus;
 import ai.labs.eddi.engine.security.spaces.DescriptorAccess;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
@@ -55,14 +59,17 @@ import ai.labs.eddi.utils.LogSanitizer;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
-import ai.labs.eddi.engine.runtime.client.factory.RestInterfaceFactory;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import ai.labs.eddi.utils.FileUtilities;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
+import io.quarkus.runtime.LaunchMode;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.bson.Document;
 import org.jboss.logging.Logger;
@@ -88,8 +95,14 @@ import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
 public class RestImportService extends AbstractBackupService implements IRestImportService {
     private static final Pattern EDDI_URI_PATTERN = Pattern.compile("\"eddi://ai.labs..*?\"");
     private static final String AGENT_FILE_ENDING = ".agent.json";
+    /** EDDI 5.x named the agent file {@code <id>.bot.json}. */
+    private static final String LEGACY_AGENT_FILE_ENDING = ".bot.json";
+    private static final List<String> AGENT_FILE_ENDINGS = List.of(AGENT_FILE_ENDING, LEGACY_AGENT_FILE_ENDING);
     private static final String DESCRIPTOR_FILE_ENDING = ".descriptor.json";
+    private static final String STRATEGY_CREATE = "create";
     private static final String STRATEGY_MERGE = "merge";
+    private static final String STRATEGY_UPGRADE = "upgrade";
+    private static final Set<String> SUPPORTED_STRATEGIES = Set.of(STRATEGY_CREATE, STRATEGY_MERGE, STRATEGY_UPGRADE);
 
     private final Path tmpPath = Paths.get(FileUtilities.buildPath(System.getProperty("user.dir"), "tmp", "import"));
     private final IZipArchive zipArchive;
@@ -100,6 +113,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     private final TemplateSyntaxMigrator templateSyntaxMigrator;
     private final StructuralMatcher structuralMatcher;
     private final UpgradeExecutor upgradeExecutor;
+    private final IScheduleStore scheduleStore;
+    private final BackupMetrics metrics;
 
     private final ResourceAccessGuard resourceAccessGuard;
 
@@ -109,7 +124,9 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     public RestImportService(IZipArchive zipArchive, IJsonSerialization jsonSerialization,
             IMigrationManager migrationManager,
             IDocumentDescriptorStore documentDescriptorStore, TemplateSyntaxMigrator templateSyntaxMigrator,
-            StructuralMatcher structuralMatcher, UpgradeExecutor upgradeExecutor, ResourceAccessGuard resourceAccessGuard) {
+            StructuralMatcher structuralMatcher, UpgradeExecutor upgradeExecutor, IScheduleStore scheduleStore,
+            BackupMetrics metrics, ResourceAccessGuard resourceAccessGuard) {
+        this.metrics = metrics;
         this.resourceAccessGuard = resourceAccessGuard;
         this.zipArchive = zipArchive;
         this.jsonSerialization = jsonSerialization;
@@ -118,6 +135,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         this.templateSyntaxMigrator = templateSyntaxMigrator;
         this.structuralMatcher = structuralMatcher;
         this.upgradeExecutor = upgradeExecutor;
+        this.scheduleStore = scheduleStore;
     }
 
     // ==================== Preview ====================
@@ -134,50 +152,51 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             this.zipArchive.unzip(zippedAgentConfigFiles, targetDir);
             var targetDirPath = targetDir.getPath();
 
-            try (var directoryStream = Files.newDirectoryStream(Paths.get(targetDirPath), path -> path.toString().endsWith(AGENT_FILE_ENDING))) {
+            for (Path agentFilePath : singleAgentFileIn(Paths.get(targetDirPath))) {
+                String agentFileString = readFile(agentFilePath);
+                String agentOriginId = extractIdFromAgentFilename(agentFilePath);
+                String agentName = readNameFromDescriptor(Paths.get(targetDirPath), agentOriginId);
 
-                for (Path agentFilePath : directoryStream) {
-                    String agentFileString = readFile(agentFilePath);
-                    String agentOriginId = extractIdFromAgentFilename(agentFilePath);
-                    String agentName = readNameFromDescriptor(Paths.get(targetDirPath), agentOriginId);
+                List<ResourceDiff> diffs = new ArrayList<>();
 
-                    List<ResourceDiff> diffs = new ArrayList<>();
+                // Agent itself
+                diffs.add(buildResourceDiff(agentOriginId, "agent", agentName));
 
-                    // Agent itself
-                    diffs.add(buildResourceDiff(agentOriginId, "agent", agentName));
+                // Workflows & their extensions
+                AgentConfiguration agentConfig = jsonSerialization.deserialize(agentFileString, AgentConfiguration.class);
+                for (URI workflowUri : agentConfig.getWorkflows()) {
+                    IResourceId workflowResourceId = RestUtilities.extractResourceId(workflowUri);
+                    if (workflowResourceId == null)
+                        continue;
 
-                    // Workflows & their extensions
-                    AgentConfiguration agentConfig = jsonSerialization.deserialize(agentFileString, AgentConfiguration.class);
-                    for (URI workflowUri : agentConfig.getWorkflows()) {
-                        IResourceId workflowResourceId = RestUtilities.extractResourceId(workflowUri);
-                        if (workflowResourceId == null)
-                            continue;
+                    String workflowId = workflowResourceId.getId();
+                    String workflowVersion = String.valueOf(workflowResourceId.getVersion());
+                    String workflowName = readNameFromDescriptor(Paths.get(targetDirPath, workflowId, workflowVersion), workflowId);
+                    diffs.add(buildResourceDiff(workflowId, "workflow", workflowName));
 
-                        String workflowId = workflowResourceId.getId();
-                        String workflowVersion = String.valueOf(workflowResourceId.getVersion());
-                        String workflowName = readNameFromDescriptor(Paths.get(targetDirPath, workflowId, workflowVersion), workflowId);
-                        diffs.add(buildResourceDiff(workflowId, "workflow", workflowName));
-
-                        // Read workflow file to find extension URIs
-                        var dir = Paths.get(FileUtilities.buildPath(targetDirPath, workflowId, workflowVersion));
-                        try (var wfStream = Files.newDirectoryStream(dir,
-                                p -> p.toString().endsWith(".workflow.json") || p.toString().endsWith(".package.json"))) {
-                            for (Path workflowFilePath : wfStream) {
-                                String workflowFileString = readFile(workflowFilePath);
-                                // Normalize legacy URIs from v5 ZIPs
-                                workflowFileString = normalizeLegacyUris(workflowFileString);
-                                addExtensionDiffs(diffs, workflowFileString, dir);
-                            }
+                    // Read workflow file to find extension URIs
+                    var dir = Paths.get(FileUtilities.buildPath(targetDirPath, workflowId, workflowVersion));
+                    try (var wfStream = Files.newDirectoryStream(dir,
+                            p -> p.toString().endsWith(".workflow.json") || p.toString().endsWith(".package.json"))) {
+                        for (Path workflowFilePath : wfStream) {
+                            String workflowFileString = readFile(workflowFilePath);
+                            // Normalize legacy URIs from v5 ZIPs
+                            workflowFileString = normalizeLegacyUris(workflowFileString);
+                            addExtensionDiffs(diffs, workflowFileString, dir);
                         }
                     }
-                    // Snippets (global resources, not workflow-embedded)
-                    addSnippetDiffs(diffs, Paths.get(targetDirPath));
-
-                    return new ImportPreview(agentOriginId, agentName, null, null, diffs);
                 }
+                // Snippets (global resources, not workflow-embedded)
+                addSnippetDiffs(diffs, Paths.get(targetDirPath));
+                // Scheduled triggers, which the import recreates for the new agent
+                addScheduleDiffs(diffs, Paths.get(targetDirPath));
+
+                return new ImportPreview(agentOriginId, agentName, null, null, diffs);
             }
 
-            return new ImportPreview(null, null, null, null, List.of());
+            throw noAgentFileFound();
+        } catch (WebApplicationException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException("Preview failed: " + e.getMessage(), e);
@@ -258,6 +277,36 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         }
     }
 
+    /**
+     * Lists the archive's scheduled triggers. They are always CREATE: a schedule id
+     * belongs to the store that issued it, so there is nothing on this instance to
+     * match against, and the import repoints each one at the newly created agent.
+     */
+    private void addScheduleDiffs(List<ResourceDiff> diffs, Path targetDirPath) {
+        Path schedulesDir = findArchiveDir(targetDirPath, SCHEDULES_DIR);
+        if (schedulesDir == null) {
+            return;
+        }
+        try (var scheduleStream = Files.newDirectoryStream(schedulesDir,
+                p -> p.toString().endsWith("." + SCHEDULE_EXT + ".json"))) {
+            for (Path scheduleFilePath : scheduleStream) {
+                try {
+                    ScheduleConfiguration schedule = jsonSerialization.deserialize(
+                            readFile(scheduleFilePath), ScheduleConfiguration.class);
+                    if (schedule == null) {
+                        continue;
+                    }
+                    diffs.add(new ResourceDiff(schedule.getId(), SCHEDULE_EXT, schedule.getName(),
+                            DiffAction.CREATE, null, null, null, null, null, -1));
+                } catch (Exception e) {
+                    LOGGER.debugf("Could not preview schedule %s: %s", scheduleFilePath.getFileName(), e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debugf("Could not scan schedules for preview: %s", e.getMessage());
+        }
+    }
+
     private ResourceDiff buildResourceDiff(String originId, String resourceType, String name) {
         try {
             List<DocumentDescriptor> existing = documentDescriptorStore.findByOriginId(originId);
@@ -308,9 +357,52 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return null;
     }
 
+    /**
+     * Whether a file in the archive root is an agent config. EDDI 6 writes
+     * {@code <id>.agent.json}; a genuine 5.x export writes {@code <id>.bot.json}
+     * and is accepted too — the rest of the class already normalizes v5 URIs and
+     * accepts the v5 {@code .package.json} workflow file, so refusing the agent
+     * file alone made a v5 import a silent no-op that still answered 200.
+     */
+    private static boolean isAgentFile(Path path) {
+        String filename = path.toString();
+        return AGENT_FILE_ENDINGS.stream().anyMatch(filename::endsWith);
+    }
+
+    private static String agentFileEndingOf(Path path) {
+        String filename = path.toString();
+        return AGENT_FILE_ENDINGS.stream().filter(filename::endsWith).findFirst().orElse(AGENT_FILE_ENDING);
+    }
+
+    /**
+     * The one agent file in the archive root, as a single-element list, or an empty
+     * list when there is none.
+     * <p>
+     * More than one is rejected: the preview only ever described the first file it
+     * enumerated while the import created every one of them, so an operator
+     * approved an import of one agent and got several, with a Location header
+     * pointing at whichever happened to be enumerated last.
+     */
+    private List<Path> singleAgentFileIn(Path archiveRoot) throws IOException {
+        List<Path> agentFiles = new ArrayList<>();
+        try (var directoryStream = Files.newDirectoryStream(archiveRoot, RestImportService::isAgentFile)) {
+            directoryStream.forEach(agentFiles::add);
+        }
+        if (agentFiles.size() > 1) {
+            throw new BadRequestException("The archive contains " + agentFiles.size()
+                    + " agent configuration files. Import one agent per archive.");
+        }
+        return agentFiles;
+    }
+
+    private static BadRequestException noAgentFileFound() {
+        return new BadRequestException("The archive contains no agent configuration file: expected one of "
+                + String.join(", ", AGENT_FILE_ENDINGS) + " in the archive root.");
+    }
+
     private String extractIdFromAgentFilename(Path agentFilePath) {
         String filename = agentFilePath.getFileName().toString();
-        return filename.substring(0, filename.length() - AGENT_FILE_ENDING.length());
+        return filename.substring(0, filename.length() - agentFileEndingOf(agentFilePath).length());
     }
 
     // ==================== Import ====================
@@ -318,22 +410,42 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     @Override
     public Response importAgent(InputStream zippedAgentConfigFiles, String strategy, String selectedOriginIds,
                                 String targetAgentId, String workflowOrder) {
+        metrics.importAttempted();
         try {
+            String requestedStrategy = isNullOrEmpty(strategy) ? STRATEGY_CREATE : strategy.toLowerCase(Locale.ROOT);
+            if (!SUPPORTED_STRATEGIES.contains(requestedStrategy)) {
+                throw new BadRequestException("Unknown strategy '" + strategy + "'. Supported: "
+                        + String.join(", ", SUPPORTED_STRATEGIES) + ".");
+            }
+
             // "upgrade" strategy → use the new structural matcher + upgrade executor
-            if ("upgrade".equalsIgnoreCase(strategy) && targetAgentId != null) {
+            if (STRATEGY_UPGRADE.equals(requestedStrategy)) {
+                if (isNullOrEmpty(targetAgentId) || targetAgentId.isBlank()) {
+                    // Falling through to the create path here produced a brand-new
+                    // duplicate agent and reported 201, so a dropped query parameter
+                    // silently doubled the deployment's agent list.
+                    throw new BadRequestException("strategy=upgrade requires targetAgentId.");
+                }
                 return executeUpgradeFromZip(zippedAgentConfigFiles, targetAgentId, selectedOriginIds, workflowOrder);
             }
             File targetDir = new File(FileUtilities.buildPath(tmpPath.toString(), UUID.randomUUID().toString()));
 
             Set<String> selectedSet = parseSelectedResources(selectedOriginIds);
-            boolean isMerge = STRATEGY_MERGE.equalsIgnoreCase(strategy);
+            boolean isMerge = STRATEGY_MERGE.equals(requestedStrategy);
 
             return importAgentZipFile(zippedAgentConfigFiles, targetDir, isMerge, selectedSet);
+        } catch (WebApplicationException e) {
+            // 400/404 raised deliberately above (or by the upgrade path) must not be
+            // repackaged as a 500 by the catch-all below.
+            metrics.importFailed();
+            throw e;
         } catch (IllegalArgumentException e) {
             // Config validation failure (e.g. invalid hitlConfig) → 400 via the
             // IllegalArgumentExceptionMapper, not a 500.
+            metrics.importFailed();
             throw e;
         } catch (Exception e) {
+            metrics.importFailed();
             LOGGER.error(e.getLocalizedMessage(), e);
             throw new InternalServerErrorException(e.getMessage(), e);
         }
@@ -387,45 +499,48 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         importSnippets(Paths.get(targetDirPath), isMerge, transaction);
 
         URI lastAgentUri = null;
-        try (var directoryStream = Files.newDirectoryStream(Paths.get(targetDirPath), path -> path.toString().endsWith(AGENT_FILE_ENDING))) {
-            for (var agentFilePath : directoryStream) {
-                try {
-                    String agentOriginId = extractIdFromAgentFilename(agentFilePath);
-                    String agentFileString = readFile(agentFilePath);
+        for (var agentFilePath : singleAgentFileIn(Paths.get(targetDirPath))) {
+            try {
+                String agentOriginId = extractIdFromAgentFilename(agentFilePath);
+                String agentFileString = readFile(agentFilePath);
 
-                    // Normalize legacy eddi:// URIs from v5 ZIP exports to v6 canonical form
-                    agentFileString = normalizeLegacyUris(agentFileString);
-                    // Normalize legacy ${eddivault:...} → ${vault:...}
-                    agentFileString = normalizeVaultReferences(agentFileString);
+                // Normalize legacy eddi:// URIs from v5 ZIP exports to v6 canonical form
+                agentFileString = normalizeLegacyUris(agentFileString);
+                // Normalize legacy ${eddivault:...} → ${vault:...}
+                agentFileString = normalizeVaultReferences(agentFileString);
 
-                    AgentConfiguration agentConfig = jsonSerialization.deserialize(agentFileString, AgentConfiguration.class);
+                AgentConfiguration agentConfig = jsonSerialization.deserialize(agentFileString, AgentConfiguration.class);
 
-                    // Reject an invalid HITL config BEFORE importing workflows —
-                    // otherwise the store-level validation only fires at agent
-                    // creation, after all extensions already landed (partial
-                    // import), and surfaced as a 500 instead of a 400.
-                    HitlConfigValidation.validate(agentConfig.getHitlConfig());
+                // Reject an invalid HITL config BEFORE importing workflows —
+                // otherwise the store-level validation only fires at agent
+                // creation, after all extensions already landed (partial
+                // import), and surfaced as a 500 instead of a 400.
+                HitlConfigValidation.validate(agentConfig.getHitlConfig());
 
-                    agentConfig.getWorkflows()
-                            .forEach(workflowUri -> parseWorkflow(targetDirPath, workflowUri, agentConfig, isMerge, selectedSet, transaction));
+                agentConfig.getWorkflows()
+                        .forEach(workflowUri -> parseWorkflow(targetDirPath, workflowUri, agentConfig, isMerge, selectedSet, transaction));
 
-                    URI newAgentUri;
-                    if (isMerge && isSelected(selectedSet, agentOriginId)) {
-                        newAgentUri = createOrUpdateAgent(agentConfig, agentOriginId, transaction);
-                    } else {
-                        newAgentUri = createNewAgent(agentConfig, transaction);
-                    }
-
-                    updateDocumentDescriptor(Paths.get(targetDirPath), buildOldAgentUri(agentFilePath), newAgentUri);
-
-                    // Set originId on the new agent's descriptor
-                    setOriginIdOnDescriptor(newAgentUri, agentOriginId);
-
-                    lastAgentUri = newAgentUri;
-                } catch (IOException | RestInterfaceFactory.RestInterfaceFactoryException e) {
-                    LOGGER.error(e.getLocalizedMessage(), e);
-                    throw new InternalServerErrorException(e.getLocalizedMessage(), e);
+                URI newAgentUri;
+                if (isMerge && isSelected(selectedSet, agentOriginId)) {
+                    newAgentUri = createOrUpdateAgent(agentConfig, agentOriginId, transaction);
+                } else {
+                    newAgentUri = createNewAgent(agentConfig, transaction);
                 }
+
+                // Schedules carry the agent id they fire, so they can only be written
+                // once the agent exists — but before the descriptor bookkeeping, so a
+                // failure there still rolls them back.
+                importSchedules(Paths.get(targetDirPath), newAgentUri, transaction);
+
+                updateDocumentDescriptor(Paths.get(targetDirPath), buildOldAgentUri(agentFilePath), newAgentUri);
+
+                // Set originId on the new agent's descriptor
+                setOriginIdOnDescriptor(newAgentUri, agentOriginId);
+
+                lastAgentUri = newAgentUri;
+            } catch (IOException e) {
+                LOGGER.error(e.getLocalizedMessage(), e);
+                throw new InternalServerErrorException(e.getLocalizedMessage(), e);
             }
         }
         LOGGER.infof("Import complete: lastAgentUri=%s", lastAgentUri);
@@ -436,13 +551,15 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             return Response.status(Response.Status.CREATED)
                     .header("Location", lastAgentUri.toString()).build();
         }
-        return Response.ok(Map.of("resourceUri", "")).build();
+        // Nothing was imported. Answering 200 with an empty resourceUri is how a
+        // whole class of broken archives went unnoticed.
+        throw noAgentFileFound();
     }
 
     private URI buildOldAgentUri(Path agentPath) {
         String agentPathString = agentPath.toString();
         String oldAgentId = agentPathString.substring(agentPathString.lastIndexOf(File.separator) + 1,
-                agentPathString.lastIndexOf(AGENT_FILE_ENDING));
+                agentPathString.lastIndexOf(agentFileEndingOf(agentPath)));
 
         return URI.create(IRestAgentStore.resourceURI + oldAgentId + IRestAgentStore.versionQueryParam + "1");
     }
@@ -476,7 +593,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for dictionaries
                         List<URI> dictionaryUris = extractResourcesUris(workflowFileString, DICTIONARY_URI_PATTERN);
                         List<URI> newDictionaryUris = createOrUpdateResources(
-                                readResources(dictionaryUris, workflowPath, DICTIONARY_EXT, DictionaryConfiguration.class), dictionaryUris, isMerge,
+                                readResources(dictionaryUris, workflowPath, DICTIONARY_EXT, DictionaryConfiguration.class, isMerge, selectedSet),
+                                dictionaryUris, isMerge,
                                 selectedSet, this::createNewDictionaries, this::updateDictionary, transaction);
 
                         updateDocumentDescriptor(workflowPath, dictionaryUris, newDictionaryUris);
@@ -485,7 +603,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for behavior
                         List<URI> behaviorUris = extractResourcesUris(workflowFileString, BEHAVIOR_URI_PATTERN);
                         List<URI> newBehaviorUris = createOrUpdateResources(
-                                readResources(behaviorUris, workflowPath, BEHAVIOR_EXT, RuleSetConfiguration.class), behaviorUris, isMerge,
+                                readResources(behaviorUris, workflowPath, BEHAVIOR_EXT, RuleSetConfiguration.class, isMerge, selectedSet),
+                                behaviorUris, isMerge,
                                 selectedSet, this::createNewBehaviors, this::updateBehavior, transaction);
 
                         updateDocumentDescriptor(workflowPath, behaviorUris, newBehaviorUris);
@@ -494,7 +613,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for http calls
                         List<URI> httpCallsUris = extractResourcesUris(workflowFileString, HTTPCALLS_URI_PATTERN);
                         List<URI> newApiCallsUris = createOrUpdateResources(
-                                readResources(httpCallsUris, workflowPath, HTTPCALLS_EXT, ApiCallsConfiguration.class), httpCallsUris, isMerge,
+                                readResources(httpCallsUris, workflowPath, HTTPCALLS_EXT, ApiCallsConfiguration.class, isMerge, selectedSet),
+                                httpCallsUris, isMerge,
                                 selectedSet, this::createNewApiCalls, this::updateApiCalls, transaction);
 
                         updateDocumentDescriptor(workflowPath, httpCallsUris, newApiCallsUris);
@@ -503,7 +623,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for langchain
                         List<URI> langchainUris = extractResourcesUris(workflowFileString, LANGCHAIN_URI_PATTERN);
                         List<URI> newLangchainUris = createOrUpdateResources(
-                                readResources(langchainUris, workflowPath, LLM_EXT, LlmConfiguration.class), langchainUris, isMerge, selectedSet,
+                                readResources(langchainUris, workflowPath, LLM_EXT, LlmConfiguration.class, isMerge, selectedSet), langchainUris,
+                                isMerge, selectedSet,
                                 this::createNewLlm, this::updateLangchain, transaction);
 
                         updateDocumentDescriptor(workflowPath, langchainUris, newLangchainUris);
@@ -512,7 +633,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for property
                         List<URI> propertyUris = extractResourcesUris(workflowFileString, PROPERTY_URI_PATTERN);
                         List<URI> newPropertyUris = createOrUpdateResources(
-                                readResources(propertyUris, workflowPath, PROPERTY_EXT, PropertySetterConfiguration.class), propertyUris, isMerge,
+                                readResources(propertyUris, workflowPath, PROPERTY_EXT, PropertySetterConfiguration.class, isMerge, selectedSet),
+                                propertyUris, isMerge,
                                 selectedSet, this::createNewProperties, this::updateProperty, transaction);
 
                         updateDocumentDescriptor(workflowPath, propertyUris, newPropertyUris);
@@ -521,7 +643,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for output
                         List<URI> outputUris = extractResourcesUris(workflowFileString, OUTPUT_URI_PATTERN);
                         List<URI> newOutputUris = createOrUpdateResources(
-                                readResources(outputUris, workflowPath, OUTPUT_EXT, OutputConfigurationSet.class), outputUris, isMerge, selectedSet,
+                                readResources(outputUris, workflowPath, OUTPUT_EXT, OutputConfigurationSet.class, isMerge, selectedSet), outputUris,
+                                isMerge, selectedSet,
                                 this::createNewOutputs, this::updateOutput, transaction);
 
                         updateDocumentDescriptor(workflowPath, outputUris, newOutputUris);
@@ -530,7 +653,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for mcp calls
                         List<URI> mcpCallsUris = extractResourcesUris(workflowFileString, MCPCALLS_URI_PATTERN);
                         List<URI> newMcpCallsUris = createOrUpdateResources(
-                                readResources(mcpCallsUris, workflowPath, MCPCALLS_EXT, McpCallsConfiguration.class), mcpCallsUris, isMerge,
+                                readResources(mcpCallsUris, workflowPath, MCPCALLS_EXT, McpCallsConfiguration.class, isMerge, selectedSet),
+                                mcpCallsUris, isMerge,
                                 selectedSet, this::createNewMcpCalls, this::updateMcpCalls, transaction);
 
                         updateDocumentDescriptor(workflowPath, mcpCallsUris, newMcpCallsUris);
@@ -539,7 +663,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for rag
                         List<URI> ragUris = extractResourcesUris(workflowFileString, RAG_URI_PATTERN);
                         List<URI> newRagUris = createOrUpdateResources(
-                                readResources(ragUris, workflowPath, RAG_EXT, RagConfiguration.class), ragUris, isMerge, selectedSet,
+                                readResources(ragUris, workflowPath, RAG_EXT, RagConfiguration.class, isMerge, selectedSet), ragUris, isMerge,
+                                selectedSet,
                                 this::createNewRags, this::updateRag, transaction);
 
                         updateDocumentDescriptor(workflowPath, ragUris, newRagUris);
@@ -560,7 +685,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         agentConfig.setWorkflows(agentConfig.getWorkflows().stream().map(uri -> uri.equals(workflowUri) ? newWorkflowUri : uri)
                                 .collect(Collectors.toList()));
 
-                    } catch (IOException | RestInterfaceFactory.RestInterfaceFactoryException | CallbackMatcher.CallbackMatcherException e) {
+                    } catch (IOException | CallbackMatcher.CallbackMatcherException e) {
                         LOGGER.error(e.getLocalizedMessage(), e);
                         throw new InternalServerErrorException(e.getMessage(), e);
                     }
@@ -578,18 +703,16 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
     @FunctionalInterface
     private interface ResourceCreator<T> {
-        List<URI> create(List<T> configs, ImportTransaction transaction) throws RestInterfaceFactory.RestInterfaceFactoryException;
+        List<URI> create(List<T> configs, ImportTransaction transaction);
     }
 
     @FunctionalInterface
     private interface ResourceUpdater<T> {
-        URI update(T config, String localId, Integer localVersion, ImportTransaction transaction)
-                throws RestInterfaceFactory.RestInterfaceFactoryException;
+        URI update(T config, String localId, Integer localVersion, ImportTransaction transaction);
     }
 
     private <T> List<URI> createOrUpdateResources(List<T> configs, List<URI> originUris, boolean isMerge, Set<String> selectedSet,
-                                                  ResourceCreator<T> creator, ResourceUpdater<T> updater, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+                                                  ResourceCreator<T> creator, ResourceUpdater<T> updater, ImportTransaction transaction) {
 
         if (!isMerge) {
             // Original behavior: create everything new
@@ -616,9 +739,18 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
             String originId = origResId.getId();
             if (!isSelected(selectedSet, originId)) {
-                // Not selected — check if local exists, keep it; otherwise create
+                // Not selected — keep the local copy if this deployment has one.
                 URI existingUri = findLocalUriByOriginId(originId);
-                resultUris.add(existingUri != null ? existingUri : originUris.get(i));
+                if (existingUri == null) {
+                    // There is nothing to keep. Adding originUris.get(i) — the URI as
+                    // it appeared in the SOURCE deployment — stored a workflow step
+                    // pointing at a resource id that does not exist here, and the
+                    // failure only surfaced later, at deployment or first turn.
+                    throw new BadRequestException("Resource '" + originId + "' was excluded from the import,"
+                            + " but this deployment has no copy of it and the imported workflow references it."
+                            + " Include it in selectedResources, or remove its step from the workflow.");
+                }
+                resultUris.add(existingUri);
                 continue;
             }
 
@@ -672,8 +804,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return null;
     }
 
-    private URI createOrUpdateAgent(AgentConfiguration agentConfiguration, String agentOriginId, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+    private URI createOrUpdateAgent(AgentConfiguration agentConfiguration, String agentOriginId, ImportTransaction transaction) {
         URI existingUri = findLocalUriByOriginId(agentOriginId);
         if (existingUri != null) {
             IResourceId localResId = RestUtilities.extractResourceId(existingUri);
@@ -691,7 +822,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     }
 
     private URI createOrUpdateWorkflow(String workflowFileString, String workflowOriginId, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException, IOException {
+            throws IOException {
         URI existingUri = findLocalUriByOriginId(workflowOriginId);
         if (existingUri != null) {
             IResourceId localResId = RestUtilities.extractResourceId(existingUri);
@@ -810,8 +941,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
     // ==================== Resource Update (merge logic) ====================
 
-    private URI updateDictionary(DictionaryConfiguration config, String localId, Integer localVersion, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+    private URI updateDictionary(DictionaryConfiguration config, String localId, Integer localVersion, ImportTransaction transaction) {
         IRestDictionaryStore store = getRestResourceStore(IRestDictionaryStore.class);
         Response response = store.updateRegularDictionary(localId, localVersion, config);
         if (response.getStatus() == 200) {
@@ -820,8 +950,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return createResourceDirect(IDictionaryStore.class, config, IRestDictionaryStore.resourceURI, transaction);
     }
 
-    private URI updateBehavior(RuleSetConfiguration config, String localId, Integer localVersion, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+    private URI updateBehavior(RuleSetConfiguration config, String localId, Integer localVersion, ImportTransaction transaction) {
         IRestRuleSetStore store = getRestResourceStore(IRestRuleSetStore.class);
         Response response = store.updateRuleSet(localId, localVersion, config);
         if (response.getStatus() == 200) {
@@ -830,8 +959,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return createResourceDirect(IRuleSetStore.class, config, IRestRuleSetStore.resourceURI, transaction);
     }
 
-    private URI updateApiCalls(ApiCallsConfiguration config, String localId, Integer localVersion, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+    private URI updateApiCalls(ApiCallsConfiguration config, String localId, Integer localVersion, ImportTransaction transaction) {
         IRestApiCallsStore store = getRestResourceStore(IRestApiCallsStore.class);
         Response response = store.updateApiCalls(localId, localVersion, config);
         if (response.getStatus() == 200) {
@@ -840,8 +968,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return createResourceDirect(IApiCallsStore.class, config, IRestApiCallsStore.resourceURI, transaction);
     }
 
-    private URI updateLangchain(LlmConfiguration config, String localId, Integer localVersion, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+    private URI updateLangchain(LlmConfiguration config, String localId, Integer localVersion, ImportTransaction transaction) {
         IRestLlmStore store = getRestResourceStore(IRestLlmStore.class);
         Response response = store.updateLlm(localId, localVersion, config);
         if (response.getStatus() == 200) {
@@ -850,8 +977,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return createResourceDirect(ILlmStore.class, config, IRestLlmStore.resourceURI, transaction);
     }
 
-    private URI updateProperty(PropertySetterConfiguration config, String localId, Integer localVersion, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+    private URI updateProperty(PropertySetterConfiguration config, String localId, Integer localVersion, ImportTransaction transaction) {
         IRestPropertySetterStore store = getRestResourceStore(IRestPropertySetterStore.class);
         Response response = store.updatePropertySetter(localId, localVersion, config);
         if (response.getStatus() == 200) {
@@ -860,8 +986,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return createResourceDirect(IPropertySetterStore.class, config, IRestPropertySetterStore.resourceURI, transaction);
     }
 
-    private URI updateOutput(OutputConfigurationSet config, String localId, Integer localVersion, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+    private URI updateOutput(OutputConfigurationSet config, String localId, Integer localVersion, ImportTransaction transaction) {
         IRestOutputStore store = getRestResourceStore(IRestOutputStore.class);
         Response response = store.updateOutputSet(localId, localVersion, config);
         if (response.getStatus() == 200) {
@@ -874,8 +999,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return configs.stream().map(c -> createResourceDirect(IMcpCallsStore.class, c, IRestMcpCallsStore.resourceURI, transaction)).toList();
     }
 
-    private URI updateMcpCalls(McpCallsConfiguration config, String localId, Integer localVersion, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+    private URI updateMcpCalls(McpCallsConfiguration config, String localId, Integer localVersion, ImportTransaction transaction) {
         IRestMcpCallsStore store = getRestResourceStore(IRestMcpCallsStore.class);
         Response response = store.updateMcpCalls(localId, localVersion, config);
         if (response.getStatus() == 200) {
@@ -888,8 +1012,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return configs.stream().map(c -> createResourceDirect(IRagStore.class, c, IRestRagStore.resourceURI, transaction)).toList();
     }
 
-    private URI updateRag(RagConfiguration config, String localId, Integer localVersion, ImportTransaction transaction)
-            throws RestInterfaceFactory.RestInterfaceFactoryException {
+    private URI updateRag(RagConfiguration config, String localId, Integer localVersion, ImportTransaction transaction) {
         IRestRagStore store = getRestResourceStore(IRestRagStore.class);
         Response response = store.updateRag(localId, localVersion, config);
         if (response.getStatus() == 200) {
@@ -1033,8 +1156,17 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     }
 
     private Path findSnippetsDir(Path targetDirPath) {
+        return findArchiveDir(targetDirPath, "snippets");
+    }
+
+    /**
+     * Finds a top-level archive directory such as {@code snippets/} or
+     * {@code schedules/}, tolerating the extra {@code <agentId>/} and
+     * {@code <agentId>/<version>/} nesting a hand-built archive can have.
+     */
+    private Path findArchiveDir(Path targetDirPath, String dirName) {
         // Check directly under target dir
-        Path direct = Paths.get(targetDirPath.toString(), "snippets");
+        Path direct = Paths.get(targetDirPath.toString(), dirName);
         if (Files.exists(direct)) {
             return direct;
         }
@@ -1044,14 +1176,14 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         try (var dirStream = Files.newDirectoryStream(targetDirPath, Files::isDirectory)) {
             for (Path subDir : dirStream) {
                 // Look in agentId/ directory
-                Path nested = Paths.get(subDir.toString(), "snippets");
+                Path nested = Paths.get(subDir.toString(), dirName);
                 if (Files.exists(nested)) {
                     return nested;
                 }
                 // Look in agentId/version/ directories
                 try (var versionStream = Files.newDirectoryStream(subDir, Files::isDirectory)) {
                     for (Path versionDir : versionStream) {
-                        Path deepNested = Paths.get(versionDir.toString(), "snippets");
+                        Path deepNested = Paths.get(versionDir.toString(), dirName);
                         if (Files.exists(deepNested)) {
                             return deepNested;
                         }
@@ -1059,9 +1191,101 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 }
             }
         } catch (IOException e) {
-            LOGGER.debug("Error searching for snippets directory: " + e.getMessage());
+            LOGGER.debugf("Error searching for %s directory: %s", dirName, e.getMessage());
         }
         return null;
+    }
+
+    // ==================== Schedule Import ====================
+
+    /**
+     * Recreates the agent's scheduled triggers from the archive's
+     * {@code schedules/} directory.
+     * <p>
+     * Export has always written these files; nothing read them back, so restoring
+     * an agent from a backup brought up an agent whose nightly jobs and heartbeats
+     * had silently stopped — while the ZIP visibly contained them, which is what
+     * made the gap look like a success.
+     * <p>
+     * A schedule is always <em>created</em>, never merged: its id is the store's,
+     * not a portable resource id, and its {@code agentId} is repointed at the agent
+     * this import just created. Fire bookkeeping (claim state, retry counters, last
+     * fire) is reset so an imported schedule starts clean rather than inheriting
+     * another deployment's in-flight lease.
+     * <p>
+     * A schedule that cannot be created fails the whole import rather than being
+     * logged and skipped: the point of importing schedules at all is that an agent
+     * restored without its nightly job looks complete and is not.
+     */
+    private void importSchedules(Path targetDirPath, URI newAgentUri, ImportTransaction transaction) {
+        Path schedulesDir = findArchiveDir(targetDirPath, SCHEDULES_DIR);
+        if (schedulesDir == null) {
+            return;
+        }
+        IResourceId agentResourceId = RestUtilities.extractResourceId(newAgentUri);
+        if (agentResourceId == null || agentResourceId.getId() == null) {
+            throw new InternalServerErrorException(
+                    "The archive contains schedules but the imported agent URI " + newAgentUri + " carries no id.");
+        }
+
+        List<Path> scheduleFiles = new ArrayList<>();
+        try (var scheduleStream = Files.newDirectoryStream(schedulesDir,
+                p -> p.toString().endsWith("." + SCHEDULE_EXT + ".json"))) {
+            scheduleStream.forEach(scheduleFiles::add);
+        } catch (IOException e) {
+            throw new InternalServerErrorException("Could not read schedules from the archive: " + e.getMessage(), e);
+        }
+
+        int imported = 0;
+        for (Path scheduleFilePath : scheduleFiles) {
+            ScheduleConfiguration schedule;
+            try {
+                schedule = jsonSerialization.deserialize(readFile(scheduleFilePath), ScheduleConfiguration.class);
+            } catch (Exception e) {
+                throw new BadRequestException("Could not read '" + scheduleFilePath.getFileName()
+                        + "' from the archive: " + e.getMessage(), e);
+            }
+            if (schedule == null) {
+                continue;
+            }
+            prepareScheduleForImport(schedule, agentResourceId.getId());
+            try {
+                String scheduleId = scheduleStore.createSchedule(schedule);
+                transaction.recordCompensation(() -> deleteScheduleQuietly(scheduleId));
+            } catch (Exception e) {
+                throw new InternalServerErrorException("Could not create the schedule from '"
+                        + scheduleFilePath.getFileName() + "': " + e.getMessage(), e);
+            }
+            imported++;
+        }
+
+        if (imported > 0) {
+            LOGGER.infof("Schedules: imported %d for agent %s", imported, agentResourceId.getId());
+        }
+    }
+
+    /**
+     * Repoints a schedule at the imported agent and clears its fire bookkeeping.
+     */
+    private static void prepareScheduleForImport(ScheduleConfiguration schedule, String newAgentId) {
+        schedule.setId(null);
+        schedule.setAgentId(newAgentId);
+        schedule.setFireStatus(FireStatus.PENDING);
+        schedule.setClaimedBy(null);
+        schedule.setClaimedAt(null);
+        schedule.setFireId(null);
+        schedule.setFailCount(0);
+        schedule.setNextRetryAt(null);
+        schedule.setLastFired(null);
+    }
+
+    private void deleteScheduleQuietly(String scheduleId) {
+        try {
+            scheduleStore.deleteSchedule(scheduleId);
+        } catch (Exception e) {
+            LOGGER.warnf("Rollback could not delete schedule '%s': %s",
+                    LogSanitizer.sanitize(scheduleId), LogSanitizer.sanitize(e.getMessage()));
+        }
     }
 
     // ==================== Rollback of a partial import ====================
@@ -1082,6 +1306,13 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
         private final List<CreatedResource> created = new ArrayList<>();
 
+        /**
+         * Undo actions for things this import created that are not
+         * {@code IResourceStore} resources — a schedule, for instance, lives in
+         * {@link IScheduleStore} and has no version or descriptor.
+         */
+        private final List<Runnable> compensations = new ArrayList<>();
+
         void recordCreated(Class<?> storeClass, IResourceId resourceId) {
             if (storeClass == null || resourceId == null || resourceId.getId() == null) {
                 return;
@@ -1089,9 +1320,22 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             created.add(new CreatedResource(storeClass, resourceId.getId(), resourceId.getVersion()));
         }
 
+        void recordCompensation(Runnable undo) {
+            if (undo != null) {
+                compensations.add(undo);
+            }
+        }
+
         /** Newest first — compensating deletes undo creations in reverse order. */
         List<CreatedResource> createdNewestFirst() {
             List<CreatedResource> reversed = new ArrayList<>(created);
+            Collections.reverse(reversed);
+            return reversed;
+        }
+
+        /** Newest first, for the same reason. */
+        List<Runnable> compensationsNewestFirst() {
+            List<Runnable> reversed = new ArrayList<>(compensations);
             Collections.reverse(reversed);
             return reversed;
         }
@@ -1109,6 +1353,14 @@ public class RestImportService extends AbstractBackupService implements IRestImp
      * never mask the original error.
      */
     private void rollbackCreatedResources(ImportTransaction transaction) {
+        for (Runnable compensation : transaction.compensationsNewestFirst()) {
+            try {
+                compensation.run();
+            } catch (Exception e) {
+                LOGGER.warnf("Rollback compensation failed: %s", LogSanitizer.sanitize(e.getMessage()));
+            }
+        }
+
         List<ImportTransaction.CreatedResource> created = transaction.createdNewestFirst();
         if (created.isEmpty()) {
             return;
@@ -1262,63 +1514,108 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return ret;
     }
 
-    private <T> T getRestResourceStore(Class<T> clazz) throws RestInterfaceFactory.RestInterfaceFactoryException {
-        // Use direct CDI lookup instead of HTTP loopback proxy.
-        // The MP REST Client proxy strips response headers (Location, X-Resource-URI)
-        // and runs on the Vert.x IO event loop, causing deadlocks during import.
-        return jakarta.enterprise.inject.spi.CDI.current().select(clazz).get();
+    /**
+     * Looks up a REST store bean directly through CDI.
+     * <p>
+     * No REST proxy is involved despite the name: the MP REST Client proxy strips
+     * response headers (Location, X-Resource-URI) and runs on the Vert.x IO event
+     * loop, which deadlocks during import. It therefore cannot throw
+     * {@code RestInterfaceFactoryException} either — that checked exception used to
+     * be declared here and propagated through a dozen signatures, telling every
+     * reader a REST call was happening.
+     */
+    private <T> T getRestResourceStore(Class<T> clazz) {
+        return CDI.current().select(clazz).get();
+    }
+
+    /**
+     * Loads every config a workflow references from the unzipped archive.
+     * <p>
+     * A config that cannot be read fails the import with a 400 naming the file.
+     * Returning null instead put that null straight into the list handed to
+     * {@code store.create(...)}, so a selectively-exported ZIP — whose workflow
+     * still carries the URIs of the files the export left out — died with a bare
+     * NullPointerException surfaced as a 500 whose message was literally "null".
+     *
+     * @param isMerge
+     *            whether this is a merge import, where a resource the caller
+     *            excluded is answered from the local deployment instead of the
+     *            archive
+     * @param selectedSet
+     *            the caller's resource selection, or null for "everything"
+     */
+    private <T> List<T> readResources(List<URI> uris, Path workflowPath, String extension, Class<T> clazz,
+                                      boolean isMerge, Set<String> selectedSet) {
+        return uris.stream()
+                .map(uri -> readResource(uri, workflowPath, extension, clazz, isMerge, selectedSet))
+                .collect(Collectors.toList());
     }
 
     @SuppressWarnings("unchecked")
-    private <T> List<T> readResources(List<URI> uris, Path workflowPath, String extension, Class<T> clazz) {
-        return uris.stream().map(uri -> {
-            Path resourcePath = null;
-            String resourceContent = null;
-            try {
-                IResourceId resourceId = RestUtilities.extractResourceId(uri);
-                if (resourceId == null) {
-                    throw new IOException("resourceId was null");
-                }
-                resourceContent = readFile(createResourcePath(workflowPath, resourceId.getId(), extension));
-                if (uri.toString().startsWith(IRestPropertySetterStore.resourceBaseType)) {
-                    var resourceAsMap = jsonSerialization.deserialize(resourceContent, Map.class);
-                    var migratedPropertySetterDocument = migrationManager.migratePropertySetter().migrate(new Document(resourceAsMap));
+    private <T> T readResource(URI uri, Path workflowPath, String extension, Class<T> clazz,
+                               boolean isMerge, Set<String> selectedSet) {
+        IResourceId resourceId = RestUtilities.extractResourceId(uri);
+        if (resourceId == null || resourceId.getId() == null) {
+            throw new BadRequestException("The archive references '" + uri + "', which carries no resource id.");
+        }
 
-                    if (migratedPropertySetterDocument != null) {
-                        resourceContent = jsonSerialization.serialize(migratedPropertySetterDocument);
-                    }
-                } else if (uri.toString().startsWith(IRestApiCallsStore.resourceBaseType)) {
-                    var resourceAsMap = jsonSerialization.deserialize(resourceContent, Map.class);
-                    var migratedApiCallsDocument = migrationManager.migrateApiCalls().migrate(new Document(resourceAsMap));
-
-                    if (migratedApiCallsDocument != null) {
-                        resourceContent = jsonSerialization.serialize(migratedApiCallsDocument);
-                    }
-                } else if (uri.toString().startsWith(IRestOutputStore.resourceBaseType)) {
-                    var resourceAsMap = jsonSerialization.deserialize(resourceContent, Map.class);
-                    var migratedOutputDocument = migrationManager.migrateOutput().migrate(new Document(resourceAsMap));
-
-                    if (migratedOutputDocument != null) {
-                        resourceContent = jsonSerialization.serialize(migratedOutputDocument);
-                    }
-                }
-
-                // Normalize legacy ${eddivault:...} → ${vault:...}
-                resourceContent = normalizeVaultReferences(resourceContent);
-
-                // Final pass: migrate any remaining Thymeleaf template syntax to Qute
-                resourceContent = templateSyntaxMigrator.migrate(resourceContent);
-
-                return jsonSerialization.deserialize(resourceContent, clazz);
-            } catch (Exception e) {
-                LOGGER.error(e.getLocalizedMessage());
-                LOGGER.error(String.format("uri is: %s", uri));
-                LOGGER.error(String.format("workflowPath is: %s", workflowPath));
-                LOGGER.error(String.format("resourcePath is: %s", resourcePath));
-                LOGGER.error(String.format("resourceContent is:\n%s", resourceContent));
+        Path resourcePath = createResourcePath(workflowPath, resourceId.getId(), extension);
+        if (!Files.exists(resourcePath)) {
+            if (isMerge && !isSelected(selectedSet, resourceId.getId())) {
+                // A merge that deliberately excluded this resource never looks at its
+                // content — createOrUpdateResources answers it from the local copy, or
+                // fails naming it when there is none. EDDI's own selective export omits
+                // the file while leaving the reference in the workflow, so rejecting it
+                // here made the product refuse archives it had just written.
+                LOGGER.debugf("Archive omits %s for excluded resource %s — keeping the local copy",
+                        resourcePath.getFileName(), resourceId.getId());
                 return null;
             }
-        }).collect(Collectors.toList());
+            throw new BadRequestException("The archive references '" + uri + "' but does not contain '"
+                    + resourcePath.getFileName() + "'. A selective export that omits a configuration must also drop"
+                    + " its reference from the workflow it belongs to.");
+        }
+
+        String resourceContent;
+        try {
+            resourceContent = readFile(resourcePath);
+            if (uri.toString().startsWith(IRestPropertySetterStore.resourceBaseType)) {
+                var resourceAsMap = jsonSerialization.deserialize(resourceContent, Map.class);
+                var migratedPropertySetterDocument = migrationManager.migratePropertySetter().migrate(new Document(resourceAsMap));
+
+                if (migratedPropertySetterDocument != null) {
+                    resourceContent = jsonSerialization.serialize(migratedPropertySetterDocument);
+                }
+            } else if (uri.toString().startsWith(IRestApiCallsStore.resourceBaseType)) {
+                var resourceAsMap = jsonSerialization.deserialize(resourceContent, Map.class);
+                var migratedApiCallsDocument = migrationManager.migrateApiCalls().migrate(new Document(resourceAsMap));
+
+                if (migratedApiCallsDocument != null) {
+                    resourceContent = jsonSerialization.serialize(migratedApiCallsDocument);
+                }
+            } else if (uri.toString().startsWith(IRestOutputStore.resourceBaseType)) {
+                var resourceAsMap = jsonSerialization.deserialize(resourceContent, Map.class);
+                var migratedOutputDocument = migrationManager.migrateOutput().migrate(new Document(resourceAsMap));
+
+                if (migratedOutputDocument != null) {
+                    resourceContent = jsonSerialization.serialize(migratedOutputDocument);
+                }
+            }
+
+            // Normalize legacy ${eddivault:...} → ${vault:...}
+            resourceContent = normalizeVaultReferences(resourceContent);
+
+            // Final pass: migrate any remaining Thymeleaf template syntax to Qute
+            resourceContent = templateSyntaxMigrator.migrate(resourceContent);
+
+            return jsonSerialization.deserialize(resourceContent, clazz);
+        } catch (Exception e) {
+            // One line with the throwable attached, and no dump of the config body:
+            // the file name is the diagnostic that was missing, the body is not.
+            LOGGER.errorf(e, "Failed to read %s (referenced as %s)", resourcePath, uri);
+            throw new BadRequestException("Could not read '" + resourcePath.getFileName()
+                    + "' from the archive: " + e.getMessage(), e);
+        }
     }
 
     private Path createResourcePath(Path workflowPath, String resourceId, String extension) {
@@ -1348,39 +1645,79 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     // ==================== Upgrade (Structural) Flow ====================
 
     private ImportPreview previewUpgrade(InputStream zippedAgentConfigFiles, String targetAgentId) {
+        // Created before the try so the finally can remove it even when unzip itself
+        // fails: ZipResourceSource.close() is the only other thing that deletes the
+        // tree, and an unzip that throws never reaches it.
+        File targetDir = new File(FileUtilities.buildPath(tmpPath.toString(), UUID.randomUUID().toString()));
         try {
-            File targetDir = new File(FileUtilities.buildPath(tmpPath.toString(), UUID.randomUUID().toString()));
-            this.zipArchive.unzip(zippedAgentConfigFiles, targetDir);
-
             // try-with-resources: ZipResourceSource.close() removes the unzipped tree
             try (var source = new ZipResourceSource(targetDir.toPath(), jsonSerialization)) {
+                this.zipArchive.unzip(zippedAgentConfigFiles, targetDir);
                 return structuralMatcher.buildPreview(source, targetAgentId, true);
             }
+        } catch (WebApplicationException e) {
+            // A missing or unreadable target agent is a 404, not a server fault.
+            throw e;
         } catch (Exception e) {
             LOGGER.error("Upgrade preview failed: " + e.getMessage(), e);
             throw new InternalServerErrorException("Upgrade preview failed: " + e.getMessage(), e);
+        } finally {
+            deleteTempDirectoryQuietly(targetDir.toPath());
         }
     }
 
     private Response executeUpgradeFromZip(InputStream zippedAgentConfigFiles, String targetAgentId,
                                            String selectedOriginIds, String workflowOrderString) {
+        // See previewUpgrade: the tree must be removable even if unzip throws.
+        File targetDir = new File(FileUtilities.buildPath(tmpPath.toString(), UUID.randomUUID().toString()));
         try {
-            File targetDir = new File(FileUtilities.buildPath(tmpPath.toString(), UUID.randomUUID().toString()));
-            this.zipArchive.unzip(zippedAgentConfigFiles, targetDir);
-
             // try-with-resources: ZipResourceSource.close() removes the unzipped tree
             try (var source = new ZipResourceSource(targetDir.toPath(), jsonSerialization)) {
+                this.zipArchive.unzip(zippedAgentConfigFiles, targetDir);
                 Set<String> selectedSet = parseSelectedResources(selectedOriginIds);
                 List<String> workflowOrder = parseWorkflowOrder(workflowOrderString);
 
-                URI resultUri = upgradeExecutor.executeUpgrade(source, targetAgentId, selectedSet, workflowOrder);
-                return Response.status(Response.Status.CREATED)
-                        .header("Location", resultUri.toString()).build();
+                return upgradeResponse(upgradeExecutor.executeUpgrade(source, targetAgentId, selectedSet, workflowOrder));
             }
+        } catch (WebApplicationException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.error("Upgrade from ZIP failed: " + e.getMessage(), e);
             throw new InternalServerErrorException("Upgrade failed: " + e.getMessage(), e);
+        } finally {
+            deleteTempDirectoryQuietly(targetDir.toPath());
         }
+    }
+
+    /**
+     * Turns an upgrade outcome into a response the caller can act on.
+     * <ul>
+     * <li>207 Multi-Status - some resources failed; the body lists them. Every
+     * upgrade used to answer 201 regardless, so a half-applied sync looked
+     * identical to a clean one.</li>
+     * <li>201 Created - everything landed and something was written.</li>
+     * <li>200 OK - source and target were already identical; nothing was written
+     * and no agent version was burned.</li>
+     * </ul>
+     * The {@code Location} header is kept on every one of them, so clients that
+     * only read the header keep working.
+     */
+    private Response upgradeResponse(UpgradeResult result) {
+        Response.ResponseBuilder builder;
+        if (result.hasFailures()) {
+            LOGGER.warnf("Upgrade of %s completed with %d failed resource(s)",
+                    result.agentUri(), result.failures().size());
+            builder = Response.status(207, "Multi-Status");
+        } else {
+            builder = Response.status(result.wroteAnything() ? Response.Status.CREATED : Response.Status.OK);
+        }
+
+        // Use a manual Location header instead of Response.created(URI): the latter
+        // validates the URI scheme and may strip eddi:// URIs.
+        if (result.agentUri() != null) {
+            builder.header("Location", result.agentUri().toString());
+        }
+        return builder.entity(result).type(MediaType.APPLICATION_JSON).build();
     }
 
     private List<String> parseWorkflowOrder(String workflowOrderString) {
@@ -1396,10 +1733,17 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     /**
      * In development mode, allow HTTP for remote sync (easier local testing). In
      * production, enforce HTTPS to prevent credential leakage.
+     * <p>
+     * Read from the launch mode, not from the {@code quarkus.profile} <em>system
+     * property</em>: that property is only set when someone passed
+     * {@code -Dquarkus.profile=...} on the command line, so a container started the
+     * normal way with {@code QUARKUS_PROFILE=dev} looked like production and
+     * rejected every {@code http://} source with a message pointing at production
+     * configuration.
      */
-    private boolean isDevMode() {
-        String profile = System.getProperty("quarkus.profile", "prod");
-        return "dev".equalsIgnoreCase(profile) || "test".equalsIgnoreCase(profile);
+    boolean isDevMode() {
+        LaunchMode mode = LaunchMode.current();
+        return mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST;
     }
 
     private void validateSourceUrl(String sourceUrl) {
@@ -1423,8 +1767,11 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         validateSourceUrl(sourceUrl);
         try (var source = new RemoteApiResourceSource(sourceUrl, sourceAgentId, sourceVersion, sourceAuth, jsonSerialization)) {
             return structuralMatcher.buildPreview(source, targetAgentId, true);
+        } catch (WebApplicationException e) {
+            // An unreadable target agent is a 404 the operator can act on.
+            throw e;
         } catch (Exception e) {
-            LOGGER.errorf("Sync preview failed for agent %s from %s: %s", sourceAgentId, sourceUrl, e.getMessage());
+            LOGGER.errorf(e, "Sync preview failed for agent %s from %s", sourceAgentId, sourceUrl);
             throw new InternalServerErrorException("Sync preview failed: " + e.getMessage(), e);
         }
     }
@@ -1444,11 +1791,13 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 ImportPreview preview = structuralMatcher.buildPreview(source, mapping.targetAgentId(), true);
                 previews.add(preview);
             } catch (Exception e) {
-                LOGGER.warnf("Batch preview failed for agent %s: %s", mapping.sourceAgentId(), e.getMessage());
-                // Add a failed preview entry so the caller knows which agent failed
+                LOGGER.warnf(e, "Batch preview failed for agent %s", mapping.sourceAgentId());
+                // Report the failure in its own field. Prefixing the agent NAME with
+                // "Error: " made a client string-match to tell a failed row from a
+                // successful one, and rendered a remote exception where a name belongs.
                 previews.add(new ImportPreview(
-                        mapping.sourceAgentId(), "Error: " + e.getMessage(),
-                        mapping.targetAgentId(), null, List.of()));
+                        mapping.sourceAgentId(), null,
+                        mapping.targetAgentId(), null, List.of(), e.getMessage()));
             }
         }
         return previews;
@@ -1459,19 +1808,16 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                                 String targetAgentId, String selectedResources, String workflowOrder,
                                 String sourceAuth) {
         validateSourceUrl(sourceUrl);
-        try {
-            try (var source = new RemoteApiResourceSource(
-                    sourceUrl, sourceAgentId, sourceVersion, sourceAuth, jsonSerialization)) {
-                Set<String> selectedSet = parseSelectedResources(selectedResources);
-                List<String> wfOrder = parseWorkflowOrder(workflowOrder);
+        try (var source = new RemoteApiResourceSource(
+                sourceUrl, sourceAgentId, sourceVersion, sourceAuth, jsonSerialization)) {
+            Set<String> selectedSet = parseSelectedResources(selectedResources);
+            List<String> wfOrder = parseWorkflowOrder(workflowOrder);
 
-                URI resultUri = upgradeExecutor.executeUpgrade(source, targetAgentId, selectedSet, wfOrder);
-                return Response.status(Response.Status.CREATED)
-                        .header("Location", resultUri.toString()).build();
-            }
+            return upgradeResponse(upgradeExecutor.executeUpgrade(source, targetAgentId, selectedSet, wfOrder));
+        } catch (WebApplicationException e) {
+            throw e;
         } catch (Exception e) {
-            LOGGER.errorf("Sync execution failed for agent %s from %s: %s",
-                    sourceAgentId, sourceUrl, e.getMessage());
+            LOGGER.errorf(e, "Sync execution failed for agent %s from %s", sourceAgentId, sourceUrl);
             throw new InternalServerErrorException("Sync failed: " + e.getMessage(), e);
         }
     }
@@ -1479,28 +1825,64 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     @Override
     public Response executeSyncBatch(String sourceUrl, List<SyncRequest> requests, String sourceAuth) {
         validateSourceUrl(sourceUrl);
-        try {
-            List<URI> resultUris = new ArrayList<>();
-            for (SyncRequest request : requests) {
-                try (var source = new RemoteApiResourceSource(
-                        sourceUrl, request.sourceAgentId(), request.sourceAgentVersion(),
-                        sourceAuth, jsonSerialization)) {
-                    URI resultUri = upgradeExecutor.executeUpgrade(
-                            source, request.targetAgentId(),
-                            request.selectedResources(), request.workflowOrder());
-                    resultUris.add(resultUri);
-                } catch (Exception e) {
-                    LOGGER.warnf("Batch sync failed for agent %s→%s: %s",
-                            request.sourceAgentId(), request.targetAgentId(), e.getMessage());
-                    // Continue with remaining agents — partial success is better than total failure
-                }
-            }
-
-            return Response.ok(resultUris).build();
-        } catch (Exception e) {
-            LOGGER.errorf("Batch sync execution failed: %s", e.getMessage());
-            throw new InternalServerErrorException("Batch sync failed: " + e.getMessage(), e);
+        if (requests == null || requests.isEmpty()) {
+            return Response.ok(List.of()).build();
         }
+
+        // One entry per request, in request order, whether it succeeded or not. The
+        // endpoint used to answer 200 with a list of the URIs that happened to work,
+        // so a batch in which every single agent failed was indistinguishable from a
+        // batch with nothing to do.
+        List<BatchSyncResult> results = new ArrayList<>();
+        int failed = 0;
+        for (SyncRequest request : requests) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InternalServerErrorException("Batch sync was interrupted after "
+                        + results.size() + " of " + requests.size() + " agent(s).");
+            }
+            try (var source = new RemoteApiResourceSource(
+                    sourceUrl, request.sourceAgentId(), request.sourceAgentVersion(),
+                    sourceAuth, jsonSerialization)) {
+                UpgradeResult result = upgradeExecutor.executeUpgrade(
+                        source, request.targetAgentId(),
+                        request.selectedResources(), request.workflowOrder());
+                if (result.hasFailures()) {
+                    failed++;
+                }
+                results.add(new BatchSyncResult(request.sourceAgentId(), request.targetAgentId(), result, null));
+            } catch (Exception e) {
+                LOGGER.warnf(e, "Batch sync failed for agent %s to %s",
+                        request.sourceAgentId(), request.targetAgentId());
+                // Continue with the remaining agents, but keep the failure visible.
+                failed++;
+                results.add(new BatchSyncResult(request.sourceAgentId(), request.targetAgentId(), null, e.getMessage()));
+            }
+        }
+
+        if (failed == results.size()) {
+            LOGGER.errorf("Batch sync failed for all %d agent(s) from %s", failed, sourceUrl);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(results).type(MediaType.APPLICATION_JSON).build();
+        }
+        if (failed > 0) {
+            return Response.status(207, "Multi-Status").entity(results).type(MediaType.APPLICATION_JSON).build();
+        }
+        return Response.ok(results).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /**
+     * One agent's outcome inside a batch sync.
+     *
+     * @param sourceAgentId
+     *            the agent that was read from the remote instance
+     * @param targetAgentId
+     *            the local agent it was synced into
+     * @param result
+     *            what the upgrade did, or null when it could not run at all
+     * @param error
+     *            why it could not run, or null on success
+     */
+    public record BatchSyncResult(String sourceAgentId, String targetAgentId, UpgradeResult result, String error) {
     }
 
 }

--- a/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
@@ -29,11 +29,14 @@ import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.engine.schedule.IRestScheduleStore;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration.FireStatus;
+import ai.labs.eddi.engine.hitl.HitlSchedules;
 import ai.labs.eddi.engine.security.spaces.DescriptorAccess;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
 import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
 import ai.labs.eddi.configs.llm.IRestLlmStore;
@@ -66,6 +69,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.security.ForbiddenException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.WebApplicationException;
@@ -103,6 +107,11 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     private static final String STRATEGY_MERGE = "merge";
     private static final String STRATEGY_UPGRADE = "upgrade";
     private static final Set<String> SUPPORTED_STRATEGIES = Set.of(STRATEGY_CREATE, STRATEGY_MERGE, STRATEGY_UPGRADE);
+    /**
+     * How many of the archive's schedules {@code selectedResources} left out.
+     * Absent when it left out none, which is every import that does not filter.
+     */
+    static final String HEADER_SCHEDULES_SKIPPED = "X-Schedules-Skipped";
 
     private final Path tmpPath = Paths.get(FileUtilities.buildPath(System.getProperty("user.dir"), "tmp", "import"));
     private final IZipArchive zipArchive;
@@ -117,6 +126,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     private final BackupMetrics metrics;
 
     private final ResourceAccessGuard resourceAccessGuard;
+    private final SpaceContext spaceContext;
 
     private static final Logger LOGGER = Logger.getLogger(RestImportService.class);
 
@@ -125,9 +135,10 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             IMigrationManager migrationManager,
             IDocumentDescriptorStore documentDescriptorStore, TemplateSyntaxMigrator templateSyntaxMigrator,
             StructuralMatcher structuralMatcher, UpgradeExecutor upgradeExecutor, IScheduleStore scheduleStore,
-            BackupMetrics metrics, ResourceAccessGuard resourceAccessGuard) {
+            BackupMetrics metrics, ResourceAccessGuard resourceAccessGuard, SpaceContext spaceContext) {
         this.metrics = metrics;
         this.resourceAccessGuard = resourceAccessGuard;
+        this.spaceContext = spaceContext;
         this.zipArchive = zipArchive;
         this.jsonSerialization = jsonSerialization;
         this.migrationManager = migrationManager;
@@ -160,7 +171,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 List<ResourceDiff> diffs = new ArrayList<>();
 
                 // Agent itself
-                diffs.add(buildResourceDiff(agentOriginId, "agent", agentName));
+                ResourceDiff agentDiff = buildResourceDiff(agentOriginId, "agent", agentName);
+                diffs.add(agentDiff);
 
                 // Workflows & their extensions
                 AgentConfiguration agentConfig = jsonSerialization.deserialize(agentFileString, AgentConfiguration.class);
@@ -188,8 +200,10 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 }
                 // Snippets (global resources, not workflow-embedded)
                 addSnippetDiffs(diffs, Paths.get(targetDirPath));
-                // Scheduled triggers, which the import recreates for the new agent
-                addScheduleDiffs(diffs, Paths.get(targetDirPath));
+                // Scheduled triggers. The agent row's targetId is the agent a merge
+                // would write into, and therefore the one whose schedules an archived
+                // schedule can be matched against by name.
+                addScheduleDiffs(diffs, Paths.get(targetDirPath), agentDiff.targetId());
 
                 return new ImportPreview(agentOriginId, agentName, null, null, diffs);
             }
@@ -227,7 +241,24 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             if (resourceId == null)
                 continue;
             String name = readNameFromDescriptor(workflowDir, resourceId.getId());
-            diffs.add(buildResourceDiff(resourceId.getId(), ext, name));
+            ResourceDiff diff = buildResourceDiff(resourceId.getId(), ext, name);
+            if (diff.action() == DiffAction.UPDATE
+                    && !Files.exists(createResourcePath(workflowDir, resourceId.getId(), ext))) {
+                // A selective archive names this config and does not carry it, and the
+                // target has its own copy. The import writes nothing to it — it answers
+                // the reference from that copy — so promising an UPDATE described a
+                // write that never happens. Ticking or unticking the row changes
+                // nothing either way; readResource keeps the local copy on a merge
+                // whether or not the id is named.
+                //
+                // A row that matched nothing locally is left as it is: the import will
+                // refuse that archive, and dressing it up as SKIP would claim the
+                // reference is satisfied.
+                diff = new ResourceDiff(diff.sourceId(), diff.resourceType(), diff.name(), DiffAction.SKIP,
+                        diff.targetId(), diff.targetVersion(), diff.matchStrategy(), diff.sourceContent(),
+                        diff.targetContent(), diff.workflowIndex());
+            }
+            diffs.add(diff);
         }
     }
 
@@ -278,15 +309,32 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     }
 
     /**
-     * Lists the archive's scheduled triggers. They are always CREATE: a schedule id
-     * belongs to the store that issued it, so there is nothing on this instance to
-     * match against, and the import repoints each one at the newly created agent.
+     * Lists the archive's scheduled triggers.
+     * <p>
+     * A schedule id belongs to the store that issued it, so it cannot be matched
+     * on. What a merge does match on is the <b>name</b>, against the schedules of
+     * the agent it writes into ({@link #existingScheduleIdsByName}), and it
+     * overwrites what it finds — so a row promising CREATE told the operator a
+     * nightly job would be added while the import was about to replace theirs. Rows
+     * are therefore UPDATE where that same name lookup finds a target, with the
+     * target's id, and CREATE where it does not.
+     * <p>
+     * Matches are consumed exactly as the import consumes them, so a second
+     * archived schedule of the same name is previewed as the CREATE it will be
+     * rather than as a second UPDATE onto the one target.
+     *
+     * @param targetAgentId
+     *            the agent a merge would write into, or null when nothing on this
+     *            instance matches the archived agent — then every schedule is new
      */
-    private void addScheduleDiffs(List<ResourceDiff> diffs, Path targetDirPath) {
+    private void addScheduleDiffs(List<ResourceDiff> diffs, Path targetDirPath, String targetAgentId) {
         Path schedulesDir = findArchiveDir(targetDirPath, SCHEDULES_DIR);
         if (schedulesDir == null) {
             return;
         }
+        Map<String, String> existingByName = targetAgentId != null
+                ? existingScheduleIdsByName(targetAgentId)
+                : new LinkedHashMap<>();
         try (var scheduleStream = Files.newDirectoryStream(schedulesDir,
                 p -> p.toString().endsWith("." + SCHEDULE_EXT + ".json"))) {
             for (Path scheduleFilePath : scheduleStream) {
@@ -296,8 +344,12 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                     if (schedule == null) {
                         continue;
                     }
-                    diffs.add(new ResourceDiff(schedule.getId(), SCHEDULE_EXT, schedule.getName(),
-                            DiffAction.CREATE, null, null, null, null, null, -1));
+                    String matchedId = existingByName.remove(schedule.getName());
+                    diffs.add(matchedId != null
+                            ? new ResourceDiff(schedule.getId(), SCHEDULE_EXT, schedule.getName(),
+                                    DiffAction.UPDATE, matchedId, null, "name", null, null, -1)
+                            : new ResourceDiff(schedule.getId(), SCHEDULE_EXT, schedule.getName(),
+                                    DiffAction.CREATE, null, null, null, null, null, -1));
                 } catch (Exception e) {
                     LOGGER.debugf("Could not preview schedule %s: %s", scheduleFilePath.getFileName(), e.getMessage());
                 }
@@ -439,6 +491,12 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             // repackaged as a 500 by the catch-all below.
             metrics.importFailed();
             throw e;
+        } catch (ForbiddenException e) {
+            // A schedule in the archive that names an agent this caller may not use
+            // is a 403 they can act on. The catch-all below would report the
+            // platform's own authorization refusal as a server fault.
+            metrics.importFailed();
+            throw e;
         } catch (IllegalArgumentException e) {
             // Config validation failure (e.g. invalid hitlConfig) → 400 via the
             // IllegalArgumentExceptionMapper, not a 500.
@@ -499,6 +557,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         importSnippets(Paths.get(targetDirPath), isMerge, transaction);
 
         URI lastAgentUri = null;
+        int schedulesNotImported = 0;
         for (var agentFilePath : singleAgentFileIn(Paths.get(targetDirPath))) {
             try {
                 String agentOriginId = extractIdFromAgentFilename(agentFilePath);
@@ -530,7 +589,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 // Schedules carry the agent id they fire, so they can only be written
                 // once the agent exists — but before the descriptor bookkeeping, so a
                 // failure there still rolls them back.
-                importSchedules(Paths.get(targetDirPath), newAgentUri, transaction);
+                schedulesNotImported += importSchedules(Paths.get(targetDirPath), newAgentUri, isMerge, selectedSet,
+                        transaction);
 
                 updateDocumentDescriptor(Paths.get(targetDirPath), buildOldAgentUri(agentFilePath), newAgentUri);
 
@@ -543,13 +603,21 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 throw new InternalServerErrorException(e.getLocalizedMessage(), e);
             }
         }
-        LOGGER.infof("Import complete: lastAgentUri=%s", lastAgentUri);
+        LOGGER.infof("Import complete: lastAgentUri=%s", LogSanitizer.sanitize(String.valueOf(lastAgentUri)));
         if (lastAgentUri != null) {
             // Use manual .header("Location", ...) instead of Response.created(URI)
             // because Response.created() validates the URI scheme and may strip eddi://
             // URIs
-            return Response.status(Response.Status.CREATED)
-                    .header("Location", lastAgentUri.toString()).build();
+            var created = Response.status(Response.Status.CREATED)
+                    .header("Location", lastAgentUri.toString());
+            if (schedulesNotImported > 0) {
+                // selectedResources is one flat list over every preview row, so naming
+                // extension ids alone silently deselects every schedule in the archive.
+                // A script that restores an agent has no reason to read this instance's
+                // log, so the count travels with the answer it gets.
+                created.header(HEADER_SCHEDULES_SKIPPED, schedulesNotImported);
+            }
+            return created.build();
         }
         // Nothing was imported. Answering 200 with an empty resourceUri is how a
         // whole class of broken archives went unnoticed.
@@ -587,13 +655,21 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // Normalize legacy ${eddivault:...} → ${vault:...}
                         workflowFileString = normalizeVaultReferences(workflowFileString);
 
+                        // A selective archive names configs it does not carry. A merge
+                        // answers those from this deployment's own copy and needs the
+                        // reference to do it, so this only ever runs on a create — where
+                        // there is nothing to answer them with.
+                        if (!isMerge) {
+                            workflowFileString = withoutUnresolvableReferences(workflowFileString, workflowPath);
+                        }
+
                         // loading old resources, creating/updating them,
                         // updating document descriptor and replacing references in workflow config
 
                         // ... for dictionaries
                         List<URI> dictionaryUris = extractResourcesUris(workflowFileString, DICTIONARY_URI_PATTERN);
                         List<URI> newDictionaryUris = createOrUpdateResources(
-                                readResources(dictionaryUris, workflowPath, DICTIONARY_EXT, DictionaryConfiguration.class, isMerge, selectedSet),
+                                readResources(dictionaryUris, workflowPath, DICTIONARY_EXT, DictionaryConfiguration.class, isMerge),
                                 dictionaryUris, isMerge,
                                 selectedSet, this::createNewDictionaries, this::updateDictionary, transaction);
 
@@ -603,7 +679,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for behavior
                         List<URI> behaviorUris = extractResourcesUris(workflowFileString, BEHAVIOR_URI_PATTERN);
                         List<URI> newBehaviorUris = createOrUpdateResources(
-                                readResources(behaviorUris, workflowPath, BEHAVIOR_EXT, RuleSetConfiguration.class, isMerge, selectedSet),
+                                readResources(behaviorUris, workflowPath, BEHAVIOR_EXT, RuleSetConfiguration.class, isMerge),
                                 behaviorUris, isMerge,
                                 selectedSet, this::createNewBehaviors, this::updateBehavior, transaction);
 
@@ -613,7 +689,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for http calls
                         List<URI> httpCallsUris = extractResourcesUris(workflowFileString, HTTPCALLS_URI_PATTERN);
                         List<URI> newApiCallsUris = createOrUpdateResources(
-                                readResources(httpCallsUris, workflowPath, HTTPCALLS_EXT, ApiCallsConfiguration.class, isMerge, selectedSet),
+                                readResources(httpCallsUris, workflowPath, HTTPCALLS_EXT, ApiCallsConfiguration.class, isMerge),
                                 httpCallsUris, isMerge,
                                 selectedSet, this::createNewApiCalls, this::updateApiCalls, transaction);
 
@@ -623,7 +699,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for langchain
                         List<URI> langchainUris = extractResourcesUris(workflowFileString, LANGCHAIN_URI_PATTERN);
                         List<URI> newLangchainUris = createOrUpdateResources(
-                                readResources(langchainUris, workflowPath, LLM_EXT, LlmConfiguration.class, isMerge, selectedSet), langchainUris,
+                                readResources(langchainUris, workflowPath, LLM_EXT, LlmConfiguration.class, isMerge), langchainUris,
                                 isMerge, selectedSet,
                                 this::createNewLlm, this::updateLangchain, transaction);
 
@@ -633,7 +709,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for property
                         List<URI> propertyUris = extractResourcesUris(workflowFileString, PROPERTY_URI_PATTERN);
                         List<URI> newPropertyUris = createOrUpdateResources(
-                                readResources(propertyUris, workflowPath, PROPERTY_EXT, PropertySetterConfiguration.class, isMerge, selectedSet),
+                                readResources(propertyUris, workflowPath, PROPERTY_EXT, PropertySetterConfiguration.class, isMerge),
                                 propertyUris, isMerge,
                                 selectedSet, this::createNewProperties, this::updateProperty, transaction);
 
@@ -643,7 +719,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for output
                         List<URI> outputUris = extractResourcesUris(workflowFileString, OUTPUT_URI_PATTERN);
                         List<URI> newOutputUris = createOrUpdateResources(
-                                readResources(outputUris, workflowPath, OUTPUT_EXT, OutputConfigurationSet.class, isMerge, selectedSet), outputUris,
+                                readResources(outputUris, workflowPath, OUTPUT_EXT, OutputConfigurationSet.class, isMerge), outputUris,
                                 isMerge, selectedSet,
                                 this::createNewOutputs, this::updateOutput, transaction);
 
@@ -653,7 +729,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for mcp calls
                         List<URI> mcpCallsUris = extractResourcesUris(workflowFileString, MCPCALLS_URI_PATTERN);
                         List<URI> newMcpCallsUris = createOrUpdateResources(
-                                readResources(mcpCallsUris, workflowPath, MCPCALLS_EXT, McpCallsConfiguration.class, isMerge, selectedSet),
+                                readResources(mcpCallsUris, workflowPath, MCPCALLS_EXT, McpCallsConfiguration.class, isMerge),
                                 mcpCallsUris, isMerge,
                                 selectedSet, this::createNewMcpCalls, this::updateMcpCalls, transaction);
 
@@ -663,7 +739,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                         // ... for rag
                         List<URI> ragUris = extractResourcesUris(workflowFileString, RAG_URI_PATTERN);
                         List<URI> newRagUris = createOrUpdateResources(
-                                readResources(ragUris, workflowPath, RAG_EXT, RagConfiguration.class, isMerge, selectedSet), ragUris, isMerge,
+                                readResources(ragUris, workflowPath, RAG_EXT, RagConfiguration.class, isMerge), ragUris, isMerge,
                                 selectedSet,
                                 this::createNewRags, this::updateRag, transaction);
 
@@ -738,17 +814,23 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             }
 
             String originId = origResId.getId();
-            if (!isSelected(selectedSet, originId)) {
-                // Not selected — keep the local copy if this deployment has one.
+            // Either the caller excluded it, or the archive simply does not carry it
+            // (config == null, see readResource) — a selective export writes exactly
+            // that. Both mean the same thing here: keep the local copy, write nothing.
+            if (config == null || !isSelected(selectedSet, originId)) {
                 URI existingUri = findLocalUriByOriginId(originId);
                 if (existingUri == null) {
                     // There is nothing to keep. Adding originUris.get(i) — the URI as
                     // it appeared in the SOURCE deployment — stored a workflow step
                     // pointing at a resource id that does not exist here, and the
                     // failure only surfaced later, at deployment or first turn.
-                    throw new BadRequestException("Resource '" + originId + "' was excluded from the import,"
-                            + " but this deployment has no copy of it and the imported workflow references it."
-                            + " Include it in selectedResources, or remove its step from the workflow.");
+                    throw new BadRequestException("The imported workflow references resource '" + originId
+                            + "', which this import does not write — "
+                            + (config == null
+                                    ? "the archive does not carry it"
+                                    : "it was left out of selectedResources")
+                            + " — and this deployment has no copy of it to answer the reference with."
+                            + " Include it in the import, or remove its step from the workflow.");
                 }
                 resultUris.add(existingUri);
                 continue;
@@ -1207,20 +1289,50 @@ public class RestImportService extends AbstractBackupService implements IRestImp
      * had silently stopped — while the ZIP visibly contained them, which is what
      * made the gap look like a success.
      * <p>
-     * A schedule is always <em>created</em>, never merged: its id is the store's,
-     * not a portable resource id, and its {@code agentId} is repointed at the agent
-     * this import just created. Fire bookkeeping (claim state, retry counters, last
-     * fire) is reset so an imported schedule starts clean rather than inheriting
-     * another deployment's in-flight lease.
+     * <b>Every write goes through {@link IRestScheduleStore}</b>, never through
+     * {@link IScheduleStore} directly. That REST bean is where the platform's
+     * schedule rules live: a schedule may not run as another user unless an
+     * administrator says so, a body marked as a HITL approval timeout is refused
+     * for everyone, the agent's USE gate is checked, the cron expression is
+     * validated and {@code nextFire} is computed. Calling the raw store meant a ZIP
+     * could mint a schedule that fires conversations as any user it named, or forge
+     * the very HITL timer the REST surface exists to protect — a privilege
+     * escalation reachable by anyone allowed to POST an archive.
      * <p>
-     * A schedule that cannot be created fails the whole import rather than being
+     * {@code agentId} is repointed at the agent this import just wrote. Fire
+     * bookkeeping (claim state, retry counters, last fire), {@code nextFire},
+     * {@code agentVersion} and the source deployment's tenant and persistent
+     * conversation are all reset: an archived {@code nextFire} is either long past
+     * (so the schedule fires during the import) or absent (so it never fires at
+     * all), and a pinned {@code agentVersion} names a version the freshly created
+     * agent does not have.
+     * <p>
+     * On a <b>merge</b> the agent is updated in place, so a schedule is matched
+     * against the agent's existing schedules by name and updated rather than added.
+     * Creating unconditionally meant every re-import added another copy of every
+     * schedule, and a nightly consolidation ran N times per night after N
+     * promotions.
+     * <p>
+     * A schedule that cannot be written fails the whole import rather than being
      * logged and skipped: the point of importing schedules at all is that an agent
      * restored without its nightly job looks complete and is not.
+     *
+     * @param selectedSet
+     *            the caller's resource selection, or null for "everything" — the
+     *            preview renders every schedule as a deselectable row, and ignoring
+     *            the selection here created schedules the operator had explicitly
+     *            unticked. It is one flat list across every row type, so a caller
+     *            who names extension ids only — which is what the selective-merge
+     *            examples in the docs do — excludes every schedule in the archive
+     * @return how many of the archive's schedules the selection left out, so the
+     *         caller can say so instead of answering a bare 201 for an agent whose
+     *         nightly job is missing
      */
-    private void importSchedules(Path targetDirPath, URI newAgentUri, ImportTransaction transaction) {
+    private int importSchedules(Path targetDirPath, URI newAgentUri, boolean isMerge,
+                                Set<String> selectedSet, ImportTransaction transaction) {
         Path schedulesDir = findArchiveDir(targetDirPath, SCHEDULES_DIR);
         if (schedulesDir == null) {
-            return;
+            return 0;
         }
         IResourceId agentResourceId = RestUtilities.extractResourceId(newAgentUri);
         if (agentResourceId == null || agentResourceId.getId() == null) {
@@ -1235,8 +1347,18 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         } catch (IOException e) {
             throw new InternalServerErrorException("Could not read schedules from the archive: " + e.getMessage(), e);
         }
+        if (scheduleFiles.isEmpty()) {
+            return 0;
+        }
+
+        String agentId = agentResourceId.getId();
+        IRestScheduleStore restScheduleStore = getRestResourceStore(IRestScheduleStore.class);
+        // Mutable on purpose: a matched target id is consumed below so a second
+        // archived schedule of the same name cannot land on it too.
+        Map<String, String> existingByName = isMerge ? existingScheduleIdsByName(agentId) : new LinkedHashMap<>();
 
         int imported = 0;
+        int excluded = 0;
         for (Path scheduleFilePath : scheduleFiles) {
             ScheduleConfiguration schedule;
             try {
@@ -1248,28 +1370,153 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             if (schedule == null) {
                 continue;
             }
-            prepareScheduleForImport(schedule, agentResourceId.getId());
-            try {
-                String scheduleId = scheduleStore.createSchedule(schedule);
-                transaction.recordCompensation(() -> deleteScheduleQuietly(scheduleId));
-            } catch (Exception e) {
-                throw new InternalServerErrorException("Could not create the schedule from '"
-                        + scheduleFilePath.getFileName() + "': " + e.getMessage(), e);
+            if (!isSelected(selectedSet, schedule.getId())) {
+                LOGGER.debugf("Schedule '%s' was excluded from the import", LogSanitizer.sanitize(schedule.getId()));
+                excluded++;
+                continue;
+            }
+
+            prepareScheduleForImport(schedule, agentId, spaceContext.currentPrincipal());
+
+            // A merge overwrites the matched schedule in place, which is destructive
+            // and — unlike a create — cannot be undone by deleting anything. Snapshot
+            // it first and register the snapshot as this import's compensation, or
+            // the rollback promised at the call site would restore the agent while
+            // leaving the operator's live cron replaced by the archive's.
+            //
+            // remove, not get: schedule names are not unique per agent, and an archive
+            // holding two schedules called "heartbeat" would otherwise PUT both onto
+            // the same target schedule — last write wins, the other target left stale,
+            // and a 201 saying it all landed. Consuming the match sends the second one
+            // down the create path instead, where nothing existing is touched.
+            String matchedId = existingByName.remove(schedule.getName());
+            ScheduleConfiguration overwritten = matchedId != null ? readScheduleForRollback(matchedId) : null;
+            if (matchedId != null && overwritten != null) {
+                final String existingId = matchedId;
+                schedule.setId(existingId);
+                keepOwnerOfOverwrittenSchedule(schedule, overwritten);
+                requireScheduleWritten(restScheduleStore.updateSchedule(existingId, schedule), 200, scheduleFilePath);
+                transaction.recordCompensation(() -> restoreScheduleQuietly(existingId, overwritten));
+            } else {
+                requireScheduleWritten(restScheduleStore.createSchedule(schedule), 201, scheduleFilePath);
+                // createSchedule stamps the generated id onto the body it was given.
+                String createdId = schedule.getId();
+                if (createdId != null) {
+                    transaction.recordCompensation(() -> deleteScheduleQuietly(createdId));
+                }
             }
             imported++;
         }
 
         if (imported > 0) {
-            LOGGER.infof("Schedules: imported %d for agent %s", imported, agentResourceId.getId());
+            LOGGER.infof("Schedules: imported %d for agent %s", imported, LogSanitizer.sanitize(agentId));
         }
+        if (excluded > 0) {
+            // Loud on purpose, and reported back to the caller as well. selectedResources
+            // is one flat list covering every kind of row the preview emits, so a caller
+            // who names extension ids only — which is what the selective-merge examples
+            // in the docs do — deselects every schedule in the archive by omission.
+            // Restoring an agent whose nightly job is silently missing is the failure
+            // this import exists to remove, so neither DEBUG nor a bare 201 will do.
+            LOGGER.infof("Schedules: %d of %d in the archive were not named in selectedResources and were not"
+                    + " imported for agent %s — name their ids too if you want them",
+                    excluded, scheduleFiles.size(), LogSanitizer.sanitize(agentId));
+        }
+        return excluded;
     }
 
     /**
-     * Repoints a schedule at the imported agent and clears its fire bookkeeping.
+     * The agent's existing schedules, keyed by name — the only stable identity a
+     * schedule has across deployments. Its id belongs to the store that issued it,
+     * so it cannot be matched on.
+     * <p>
+     * HITL approval timeouts are left out, mirroring the export side: they are
+     * safety timers for one pending approval on this deployment, named after its
+     * conversation, and never part of an agent's configuration. Listed here, an
+     * archive carrying a plain schedule with that name would match one and — for an
+     * admin, whom {@code requireAdminForHitl} lets through — PUT over it, dropping
+     * the {@code hitlType} marker and the deadline and silently disarming the
+     * pending approval's ABORT/AUTO_REJECT policy. Excluded, such a name falls
+     * through to the create path instead, where nothing existing is touched.
+     * <p>
+     * A name the agent uses twice is left out for the same reason: nothing makes a
+     * schedule name unique — {@code RestScheduleStore.createSchedule} validates the
+     * body, never the name — so picking one of them to overwrite would be picking
+     * at random, and the loser's settings would be gone with the import still
+     * answering 201.
      */
-    private static void prepareScheduleForImport(ScheduleConfiguration schedule, String newAgentId) {
+    private Map<String, String> existingScheduleIdsByName(String agentId) {
+        Map<String, String> byName = new LinkedHashMap<>();
+        Set<String> ambiguousNames = new LinkedHashSet<>();
+        try {
+            for (ScheduleConfiguration existing : scheduleStore.readSchedulesByAgentId(agentId)) {
+                if (existing != null && existing.getName() != null && existing.getId() != null
+                        && !HitlSchedules.isHitlTimeout(existing.getMetadata())) {
+                    if (byName.putIfAbsent(existing.getName(), existing.getId()) != null) {
+                        ambiguousNames.add(existing.getName());
+                    }
+                }
+            }
+            for (String ambiguous : ambiguousNames) {
+                byName.remove(ambiguous);
+                LOGGER.warnf("Agent %s has more than one schedule named '%s' — an archived schedule with that"
+                        + " name is imported as a new one rather than overwriting an arbitrary existing one",
+                        LogSanitizer.sanitize(agentId), LogSanitizer.sanitize(ambiguous));
+            }
+        } catch (Exception e) {
+            // Failing closed here would refuse a merge because the store hiccuped;
+            // failing open re-creates a schedule the agent already has. Neither is
+            // good, but a duplicate is visible and deletable while a refused restore
+            // is not, so the merge continues and says so.
+            LOGGER.warnf("Could not list existing schedules of agent %s — imported schedules may duplicate"
+                    + " ones already present: %s", LogSanitizer.sanitize(agentId), LogSanitizer.sanitize(e.getMessage()));
+        }
+        return byName;
+    }
+
+    /**
+     * Turns the schedule REST bean's answer into an import failure, preserving its
+     * status so a refusal reaches the caller as the 400/403 it is instead of a 500.
+     */
+    private static void requireScheduleWritten(Response response, int expectedStatus, Path scheduleFilePath) {
+        if (response != null && response.getStatus() == expectedStatus) {
+            return;
+        }
+        int status = response != null ? response.getStatus() : 500;
+        Object entity = response != null ? response.getEntity() : null;
+        throw new WebApplicationException("Could not restore the schedule from '"
+                + scheduleFilePath.getFileName() + "': "
+                + (entity != null ? entity : "the schedule store answered " + status), status);
+    }
+
+    /**
+     * Repoints a schedule at the imported agent and clears everything that belonged
+     * to the deployment it came from.
+     * <p>
+     * {@code nextFire} is cleared rather than carried over so that the REST bean
+     * recomputes it from the cron expression: an archived value is either in the
+     * past (the schedule fires the moment it is imported — a customer-facing
+     * message, or a cost-bearing Dream consolidation, during the restore) or absent
+     * (the due filter never matches and it silently never fires).
+     * {@code agentVersion} goes back to 0, "latest deployed", because a version
+     * pinned on the source does not exist on a freshly created agent: a Dream
+     * schedule reads its agent at exactly that version
+     * ({@code ScheduleFireExecutor} → {@code DreamService.processScheduledFire},
+     * which only falls back to the current version when the field is 0), so every
+     * fire would be rejected, retried and eventually dead-lettered.
+     *
+     * @param importerPrincipal
+     *            the authenticated importer, or {@code null} when there is none —
+     *            see {@link #userIdForImport}
+     */
+    private static void prepareScheduleForImport(ScheduleConfiguration schedule, String newAgentId, String importerPrincipal) {
         schedule.setId(null);
         schedule.setAgentId(newAgentId);
+        schedule.setAgentVersion(0);
+        schedule.setNextFire(null);
+        schedule.setTenantId(null);
+        schedule.setUserId(userIdForImport(schedule.getUserId(), importerPrincipal));
+        schedule.setPersistentConversationId(null);
         schedule.setFireStatus(FireStatus.PENDING);
         schedule.setClaimedBy(null);
         schedule.setClaimedAt(null);
@@ -1277,6 +1524,114 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         schedule.setFailCount(0);
         schedule.setNextRetryAt(null);
         schedule.setLastFired(null);
+    }
+
+    /**
+     * The identity an imported schedule is allowed to run as.
+     * <p>
+     * A schedule's {@code userId} is the identity every fire ACTS AS: it owns the
+     * conversation the fire starts, and for a Dream consolidation it is the user
+     * whose persistent memories are pruned, rewritten and deleted. That makes it
+     * source-deployment state exactly like {@code tenantId} — an id minted by
+     * whichever identity provider the source used, which on the target names
+     * nobody, or names somebody else entirely.
+     * <p>
+     * It is therefore kept only when it already names the importing caller — the
+     * common case, and the only one where the value is known to be right — and
+     * cleared otherwise, so {@code RestScheduleStore.applyDefaults} files it under
+     * the system scheduler until an operator assigns the real owner. Two deliberate
+     * consequences: a non-admin can import somebody else's archive at all
+     * ({@code requireOwnUserId} 403s a schedule running as another user, which made
+     * every user-bound schedule un-importable for them), and a Dream schedule
+     * arrives ownerless rather than bound to a stranger — it says so loudly on its
+     * first fire, naming the field to set, instead of quietly consolidating the
+     * memories of whoever holds that id here. Rewriting it to the importer instead
+     * was rejected for the reason {@code requireOwnUserId} gives for refusing
+     * rather than rewriting: a schedule that silently does something other than
+     * what it says is worse than one that asks to be configured.
+     * <p>
+     * With no authenticated caller (authorization disabled) there is nothing to
+     * compare against and none of the schedule guards apply either, so the archived
+     * value is left untouched.
+     *
+     * @param archivedUserId
+     *            the identity the archive says the schedule ran as
+     * @param importerPrincipal
+     *            the authenticated importer, or {@code null} when there is none
+     * @return the identity to store, or {@code null} to let the schedule surface
+     *         default it
+     */
+    private static String userIdForImport(String archivedUserId, String importerPrincipal) {
+        if (archivedUserId == null || archivedUserId.isBlank()) {
+            return archivedUserId; // no identity to carry over in the first place
+        }
+        if (importerPrincipal == null || archivedUserId.equals(importerPrincipal)) {
+            return archivedUserId;
+        }
+        return null;
+    }
+
+    /**
+     * Carries the owner of the schedule a merge is about to overwrite onto the
+     * schedule replacing it, when {@link #userIdForImport} left the archived one
+     * without an identity to run as.
+     * <p>
+     * The update is a full replace: {@code RestScheduleStore.applyDefaults} files a
+     * schedule that arrives without a {@code userId} under the system scheduler, so
+     * without this a re-promotion of the same agent stripped the owner an operator
+     * had assigned on the target after the first import — every time. Two things
+     * broke silently: Dream consolidation refuses to run as the system placeholder,
+     * so the nightly job stopped after each promotion; and the placeholder is
+     * exempt from the store's ownership guard, so a schedule that was
+     * owner-protected became writable by every editor.
+     * <p>
+     * A merge updates what a schedule <em>does</em> — cron, message, agent — and
+     * has no business changing who it runs as: that identity is target-deployment
+     * state, assigned there, and the archive's own value has already been rejected
+     * as foreign. The store's stored-owner guard runs inside the
+     * {@code updateSchedule} call that follows this one, so a caller who may not
+     * act on that identity is refused there, not here.
+     */
+    private static void keepOwnerOfOverwrittenSchedule(ScheduleConfiguration schedule, ScheduleConfiguration overwritten) {
+        if (schedule.getUserId() == null || schedule.getUserId().isBlank()) {
+            schedule.setUserId(overwritten.getUserId());
+        }
+    }
+
+    /**
+     * The stored schedule a merge is about to overwrite, so the import can put it
+     * back when a later step fails.
+     * <p>
+     * {@code null} when it cannot be read — the caller then creates instead of
+     * updating, because a schedule this import could not restore is one it must not
+     * overwrite. That mirrors {@link #existingScheduleIdsByName}: a visible
+     * duplicate beats an unrecoverable overwrite.
+     */
+    private ScheduleConfiguration readScheduleForRollback(String scheduleId) {
+        try {
+            return scheduleStore.readSchedule(scheduleId);
+        } catch (Exception e) {
+            LOGGER.warnf("Could not snapshot schedule '%s' before a merge would overwrite it — importing it as a new"
+                    + " schedule instead: %s", LogSanitizer.sanitize(scheduleId), LogSanitizer.sanitize(e.getMessage()));
+            return null;
+        }
+    }
+
+    /**
+     * Puts an overwritten schedule back exactly as it was.
+     * <p>
+     * Deliberately through {@link IScheduleStore} rather than the REST bean the
+     * import writes with: this is not a new write to be validated but the undo of
+     * one. The bean would re-apply defaults and recompute {@code nextFire},
+     * restoring something subtly different from what it replaced.
+     */
+    private void restoreScheduleQuietly(String scheduleId, ScheduleConfiguration previous) {
+        try {
+            scheduleStore.updateSchedule(scheduleId, previous);
+        } catch (Exception e) {
+            LOGGER.warnf("Rollback could not restore schedule '%s': %s",
+                    LogSanitizer.sanitize(scheduleId), LogSanitizer.sanitize(e.getMessage()));
+        }
     }
 
     private void deleteScheduleQuietly(String scheduleId) {
@@ -1528,6 +1883,141 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         return CDI.current().select(clazz).get();
     }
 
+    /** Guards against a pathological (or cyclic-looking) nested step config. */
+    private static final int MAX_PRUNE_DEPTH = 10;
+
+    /**
+     * The archived workflow with every reference this archive cannot satisfy
+     * removed — for the <em>create</em> strategy only.
+     * <p>
+     * A selective export writes the workflow whole, references to the configs it
+     * left out included, because that is what {@code strategy=merge} needs: it
+     * answers such a reference from this deployment's own copy
+     * ({@link #readResource} → {@link #createOrUpdateResources}), and a workflow
+     * arriving without the step would instead <em>delete</em> that step from the
+     * live target the merge writes to. A create has no such copy to fall back on,
+     * so the step cannot be honoured and used to fail the whole import with "The
+     * archive references … but does not contain …" — an instruction the operator
+     * could not act on, because the product had written the archive.
+     * <p>
+     * Dropping it here rather than pruning on export keeps the two strategies
+     * honest about their own needs, and matches what {@link ZipResourceSource}
+     * already does on the upgrade path (a referenced file the archive lacks is
+     * skipped, not fatal). A step whose own {@code config.uri} is missing is
+     * dropped entirely; a nested reference — a parser's regular dictionaries, say —
+     * has just its list entry removed, so the step itself survives. It is logged at
+     * WARN, so an archive that is incomplete for any other reason says so instead
+     * of quietly producing a smaller agent.
+     *
+     * @return the serialized workflow, and the string unchanged when nothing had to
+     *         be dropped
+     */
+    private String withoutUnresolvableReferences(String workflowFileString, Path workflowPath) throws IOException {
+        WorkflowConfiguration workflow = jsonSerialization.deserialize(workflowFileString, WorkflowConfiguration.class);
+        if (workflow == null || workflow.getWorkflowSteps() == null) {
+            return workflowFileString;
+        }
+
+        List<WorkflowConfiguration.WorkflowStep> kept = new ArrayList<>();
+        boolean dropped = false;
+        for (WorkflowConfiguration.WorkflowStep step : workflow.getWorkflowSteps()) {
+            if (step == null) {
+                continue;
+            }
+            if (referencesMissingFile(step.getConfig(), workflowPath, 0)) {
+                LOGGER.warnf("Import drops the '%s' step: the archive references a configuration it does not contain",
+                        LogSanitizer.sanitize(String.valueOf(step.getType())));
+                dropped = true;
+                continue;
+            }
+            dropped |= pruneMissingEntries(step.getExtensions(), workflowPath, 0);
+            kept.add(step);
+        }
+
+        if (!dropped) {
+            // Serializing a workflow nothing was dropped from would rewrite every
+            // archived workflow through this deployment's model on every import.
+            return workflowFileString;
+        }
+        workflow.setWorkflowSteps(kept);
+        return jsonSerialization.serialize(workflow);
+    }
+
+    /**
+     * True when this node, or anything nested in it, names a file the archive
+     * lacks.
+     */
+    private boolean referencesMissingFile(Object node, Path workflowPath, int depth) {
+        if (node == null || depth > MAX_PRUNE_DEPTH) {
+            return false;
+        }
+        if (node instanceof Map<?, ?> map) {
+            if (map.get(WorkflowExtensions.KEY_URI) instanceof String uriString
+                    && isMissingFromArchive(uriString, workflowPath)) {
+                return true;
+            }
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (!WorkflowExtensions.KEY_URI.equals(entry.getKey())
+                        && referencesMissingFile(entry.getValue(), workflowPath, depth + 1)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (node instanceof List<?> list) {
+            for (Object element : list) {
+                if (referencesMissingFile(element, workflowPath, depth + 1)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Removes nested list entries naming a file the archive lacks; true if any
+     * went.
+     */
+    private boolean pruneMissingEntries(Object node, Path workflowPath, int depth) {
+        if (node == null || depth > MAX_PRUNE_DEPTH) {
+            return false;
+        }
+        boolean pruned = false;
+        if (node instanceof Map<?, ?> map) {
+            for (Object value : map.values()) {
+                pruned |= pruneMissingEntries(value, workflowPath, depth + 1);
+            }
+        } else if (node instanceof List<?> list) {
+            pruned = list.removeIf(element -> referencesMissingFile(element, workflowPath, 0));
+            for (Object element : list) {
+                pruned |= pruneMissingEntries(element, workflowPath, depth + 1);
+            }
+        }
+        return pruned;
+    }
+
+    /**
+     * Whether a URI names an extension config the archive does not carry. Anything
+     * that is not an extension resource — a parser dictionary type, say — is never
+     * dropped, and neither is a URI {@link #readResource} would reject on its own
+     * account.
+     */
+    private boolean isMissingFromArchive(String uriString, Path workflowPath) {
+        URI uri;
+        IResourceId resourceId;
+        try {
+            uri = URI.create(uriString);
+            resourceId = RestUtilities.extractResourceId(uri);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+        WorkflowExtensions.ExtensionType type = WorkflowExtensions.typeOf(uri);
+        if (type == null || resourceId == null || resourceId.getId() == null) {
+            return false;
+        }
+        return !Files.exists(createResourcePath(workflowPath, resourceId.getId(), type.fileExtension()));
+    }
+
     /**
      * Loads every config a workflow references from the unzipped archive.
      * <p>
@@ -1538,22 +2028,18 @@ public class RestImportService extends AbstractBackupService implements IRestImp
      * NullPointerException surfaced as a 500 whose message was literally "null".
      *
      * @param isMerge
-     *            whether this is a merge import, where a resource the caller
-     *            excluded is answered from the local deployment instead of the
-     *            archive
-     * @param selectedSet
-     *            the caller's resource selection, or null for "everything"
+     *            whether this is a merge import, where a resource the archive does
+     *            not carry is answered from the local deployment instead
      */
     private <T> List<T> readResources(List<URI> uris, Path workflowPath, String extension, Class<T> clazz,
-                                      boolean isMerge, Set<String> selectedSet) {
+                                      boolean isMerge) {
         return uris.stream()
-                .map(uri -> readResource(uri, workflowPath, extension, clazz, isMerge, selectedSet))
+                .map(uri -> readResource(uri, workflowPath, extension, clazz, isMerge))
                 .collect(Collectors.toList());
     }
 
     @SuppressWarnings("unchecked")
-    private <T> T readResource(URI uri, Path workflowPath, String extension, Class<T> clazz,
-                               boolean isMerge, Set<String> selectedSet) {
+    private <T> T readResource(URI uri, Path workflowPath, String extension, Class<T> clazz, boolean isMerge) {
         IResourceId resourceId = RestUtilities.extractResourceId(uri);
         if (resourceId == null || resourceId.getId() == null) {
             throw new BadRequestException("The archive references '" + uri + "', which carries no resource id.");
@@ -1561,19 +2047,27 @@ public class RestImportService extends AbstractBackupService implements IRestImp
 
         Path resourcePath = createResourcePath(workflowPath, resourceId.getId(), extension);
         if (!Files.exists(resourcePath)) {
-            if (isMerge && !isSelected(selectedSet, resourceId.getId())) {
-                // A merge that deliberately excluded this resource never looks at its
-                // content — createOrUpdateResources answers it from the local copy, or
+            if (isMerge) {
+                // A merge never needs the content of a resource the archive left out:
+                // createOrUpdateResources answers the reference from the local copy, or
                 // fails naming it when there is none. EDDI's own selective export omits
                 // the file while leaving the reference in the workflow, so rejecting it
                 // here made the product refuse archives it had just written.
-                LOGGER.debugf("Archive omits %s for excluded resource %s — keeping the local copy",
+                //
+                // Whether the caller happened to name the id makes no difference. The
+                // preview lists that reference as a row, the Manager's wizard ticks
+                // every row it is given and posts them all back as selectedResources,
+                // so treating a named id as proof of a broken archive answered 400 to
+                // the product's own default selection — while the one case that really
+                // is broken, a reference nothing can answer, is caught downstream with
+                // a message naming the resource.
+                LOGGER.debugf("Archive omits %s for resource %s — keeping this deployment's copy",
                         resourcePath.getFileName(), resourceId.getId());
                 return null;
             }
             throw new BadRequestException("The archive references '" + uri + "' but does not contain '"
-                    + resourcePath.getFileName() + "'. A selective export that omits a configuration must also drop"
-                    + " its reference from the workflow it belongs to.");
+                    + resourcePath.getFileName() + "'. Import it with strategy=merge to answer that"
+                    + " reference from this deployment's own copy, or export the resource into the archive.");
         }
 
         String resourceContent;
@@ -1706,7 +2200,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         Response.ResponseBuilder builder;
         if (result.hasFailures()) {
             LOGGER.warnf("Upgrade of %s completed with %d failed resource(s)",
-                    result.agentUri(), result.failures().size());
+                    LogSanitizer.sanitize(String.valueOf(result.agentUri())), result.failures().size());
             builder = Response.status(207, "Multi-Status");
         } else {
             builder = Response.status(result.wroteAnything() ? Response.Status.CREATED : Response.Status.OK);
@@ -1756,7 +2250,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         try {
             return RemoteApiResourceSource.listRemoteAgentDescriptors(sourceUrl, sourceAuth, jsonSerialization);
         } catch (Exception e) {
-            LOGGER.errorf("Failed to list remote agents from %s: %s", sourceUrl, e.getMessage());
+            LOGGER.errorf("Failed to list remote agents from %s: %s",
+                    LogSanitizer.sanitize(sourceUrl), LogSanitizer.sanitize(e.getMessage()));
             throw new InternalServerErrorException("Failed to connect to remote instance: " + e.getMessage(), e);
         }
     }
@@ -1771,7 +2266,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
             // An unreadable target agent is a 404 the operator can act on.
             throw e;
         } catch (Exception e) {
-            LOGGER.errorf(e, "Sync preview failed for agent %s from %s", sourceAgentId, sourceUrl);
+            LOGGER.errorf(e, "Sync preview failed for agent %s from %s",
+                    LogSanitizer.sanitize(sourceAgentId), LogSanitizer.sanitize(sourceUrl));
             throw new InternalServerErrorException("Sync preview failed: " + e.getMessage(), e);
         }
     }
@@ -1791,7 +2287,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 ImportPreview preview = structuralMatcher.buildPreview(source, mapping.targetAgentId(), true);
                 previews.add(preview);
             } catch (Exception e) {
-                LOGGER.warnf(e, "Batch preview failed for agent %s", mapping.sourceAgentId());
+                LOGGER.warnf(e, "Batch preview failed for agent %s", LogSanitizer.sanitize(mapping.sourceAgentId()));
                 // Report the failure in its own field. Prefixing the agent NAME with
                 // "Error: " made a client string-match to tell a failed row from a
                 // successful one, and rendered a remote exception where a name belongs.
@@ -1817,7 +2313,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         } catch (WebApplicationException e) {
             throw e;
         } catch (Exception e) {
-            LOGGER.errorf(e, "Sync execution failed for agent %s from %s", sourceAgentId, sourceUrl);
+            LOGGER.errorf(e, "Sync execution failed for agent %s from %s",
+                    LogSanitizer.sanitize(sourceAgentId), LogSanitizer.sanitize(sourceUrl));
             throw new InternalServerErrorException("Sync failed: " + e.getMessage(), e);
         }
     }
@@ -1852,7 +2349,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 results.add(new BatchSyncResult(request.sourceAgentId(), request.targetAgentId(), result, null));
             } catch (Exception e) {
                 LOGGER.warnf(e, "Batch sync failed for agent %s to %s",
-                        request.sourceAgentId(), request.targetAgentId());
+                        LogSanitizer.sanitize(request.sourceAgentId()), LogSanitizer.sanitize(request.targetAgentId()));
                 // Continue with the remaining agents, but keep the failure visible.
                 failed++;
                 results.add(new BatchSyncResult(request.sourceAgentId(), request.targetAgentId(), null, e.getMessage()));
@@ -1860,7 +2357,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         }
 
         if (failed == results.size()) {
-            LOGGER.errorf("Batch sync failed for all %d agent(s) from %s", failed, sourceUrl);
+            LOGGER.errorf("Batch sync failed for all %d agent(s) from %s", failed, LogSanitizer.sanitize(sourceUrl));
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                     .entity(results).type(MediaType.APPLICATION_JSON).build();
         }

--- a/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
@@ -327,6 +327,31 @@ public class RestImportService extends AbstractBackupService implements IRestImp
      *            the agent a merge would write into, or null when nothing on this
      *            instance matches the archived agent — then every schedule is new
      */
+    /**
+     * The archive's schedule files, in a stable order.
+     * <p>
+     * {@link Files#newDirectoryStream} yields entries in whatever order the
+     * filesystem hands back, which is unspecified and differs between platforms. It
+     * matters here because a name match is <em>consumed</em>: when an archive
+     * carries two schedules of the same name and the target agent runs one, the
+     * first file read takes the UPDATE and the second becomes a CREATE. Left to the
+     * filesystem, which of the two overwrites the live schedule depends on the
+     * machine the import happens to run on, and {@code previewImport} can promise
+     * an outcome that {@code importAgent} then does not perform - the preview
+     * exists precisely so an operator can refuse an overwrite before it happens.
+     * Sorting by file name makes both passes agree and makes the same archive
+     * import the same way everywhere.
+     */
+    private static List<Path> archivedScheduleFiles(Path schedulesDir) throws IOException {
+        List<Path> files = new ArrayList<>();
+        try (var scheduleStream = Files.newDirectoryStream(schedulesDir,
+                p -> p.toString().endsWith("." + SCHEDULE_EXT + ".json"))) {
+            scheduleStream.forEach(files::add);
+        }
+        files.sort(Comparator.comparing(p -> p.getFileName().toString()));
+        return files;
+    }
+
     private void addScheduleDiffs(List<ResourceDiff> diffs, Path targetDirPath, String targetAgentId) {
         Path schedulesDir = findArchiveDir(targetDirPath, SCHEDULES_DIR);
         if (schedulesDir == null) {
@@ -335,9 +360,8 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         Map<String, String> existingByName = targetAgentId != null
                 ? existingScheduleIdsByName(targetAgentId)
                 : new LinkedHashMap<>();
-        try (var scheduleStream = Files.newDirectoryStream(schedulesDir,
-                p -> p.toString().endsWith("." + SCHEDULE_EXT + ".json"))) {
-            for (Path scheduleFilePath : scheduleStream) {
+        try {
+            for (Path scheduleFilePath : archivedScheduleFiles(schedulesDir)) {
                 try {
                     ScheduleConfiguration schedule = jsonSerialization.deserialize(
                             readFile(scheduleFilePath), ScheduleConfiguration.class);
@@ -1340,10 +1364,9 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                     "The archive contains schedules but the imported agent URI " + newAgentUri + " carries no id.");
         }
 
-        List<Path> scheduleFiles = new ArrayList<>();
-        try (var scheduleStream = Files.newDirectoryStream(schedulesDir,
-                p -> p.toString().endsWith("." + SCHEDULE_EXT + ".json"))) {
-            scheduleStream.forEach(scheduleFiles::add);
+        List<Path> scheduleFiles;
+        try {
+            scheduleFiles = archivedScheduleFiles(schedulesDir);
         } catch (IOException e) {
             throw new InternalServerErrorException("Could not read schedules from the archive: " + e.getMessage(), e);
         }

--- a/src/main/java/ai/labs/eddi/backup/impl/ScrubbedSecrets.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/ScrubbedSecrets.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Puts a target's own secret values back into source content that the export's
@@ -32,6 +33,13 @@ final class ScrubbedSecrets {
     /** The marker {@link SecretScrubber} writes in place of a secret value. */
     static final String PLACEHOLDER = SecretScrubber.REDACTED;
 
+    /**
+     * Fields that identify one element of a JSON array across a reorder, in
+     * priority order. {@code ApiCall.name}, {@code LlmConfiguration.Task.id} and
+     * {@code RagConfiguration.name} are the shapes this actually meets.
+     */
+    private static final List<String> IDENTITY_FIELDS = List.of("name", "id", "key");
+
     private ScrubbedSecrets() {
     }
 
@@ -41,8 +49,11 @@ final class ScrubbedSecrets {
     }
 
     /**
-     * The source content with every scrubbed leaf replaced by the target's value at
-     * the same position.
+     * The source content with every scrubbed leaf replaced by the target's own
+     * value for that leaf. Object fields are bound by key; array elements by a
+     * stable identity where they carry one, and otherwise only by a position the
+     * surrounding content proves — see {@link #counterpartOf}. A leaf with no
+     * provable counterpart keeps its placeholder.
      *
      * @return the merged JSON
      * @throws Exception
@@ -59,7 +70,7 @@ final class ScrubbedSecrets {
 
     /**
      * Walks two parsed configs in parallel and returns the source with every
-     * scrubbed leaf replaced by the target's value at the same position.
+     * scrubbed leaf replaced by the target's value for the same leaf.
      */
     private static Object merge(Object sourceNode, Object targetNode) {
         if (sourceNode instanceof String text) {
@@ -81,10 +92,141 @@ final class ScrubbedSecrets {
             List<?> targetList = targetNode instanceof List<?> list ? list : List.of();
             List<Object> merged = new ArrayList<>(sourceList.size());
             for (int i = 0; i < sourceList.size(); i++) {
-                merged.add(merge(sourceList.get(i), i < targetList.size() ? targetList.get(i) : null));
+                Object sourceElement = sourceList.get(i);
+                // An element with nothing scrubbed in it needs no counterpart at all,
+                // so it never risks being paired with the wrong one.
+                Object counterpart = containsPlaceholder(sourceElement)
+                        ? counterpartOf(sourceElement, i, sourceList, targetList)
+                        : null;
+                merged.add(merge(sourceElement, counterpart));
             }
             return merged;
         }
         return sourceNode;
+    }
+
+    /**
+     * The target element a scrubbed source element may take its value from, or
+     * {@code null} when there is no element the pairing can be proven against.
+     * <p>
+     * Pairing array elements by position alone was a credential disclosure, not
+     * only a lost secret: an httpCalls config whose entries were reordered or had
+     * one inserted kept each source entry's own endpoint while taking the value at
+     * that index from the target, so one endpoint's live {@code Authorization}
+     * header was written into the configuration that calls a different host. The
+     * two ways out are to bind by something stable or to refuse; refusing costs an
+     * operator one re-entered key, guessing wrong hands a credential to whoever is
+     * at the other endpoint.
+     * <ul>
+     * <li>An element carrying one of {@link #IDENTITY_FIELDS} is bound by that
+     * value, wherever in the target list it sits. Two target elements sharing the
+     * identity are ambiguous, so neither is used.</li>
+     * <li>An element with no identity — a bare string in an array, an anonymous
+     * object — falls back to its position, and only when the lists are the same
+     * length and the two elements are identical in everything the scrubber did not
+     * replace. That is what makes them demonstrably the same entry.</li>
+     * </ul>
+     */
+    private static Object counterpartOf(Object sourceElement, int index,
+                                        List<?> sourceList, List<?> targetList) {
+        String identityField = identityFieldOf(sourceElement);
+        if (identityField != null) {
+            Object identity = ((Map<?, ?>) sourceElement).get(identityField);
+            Object match = null;
+            for (Object candidate : targetList) {
+                if (candidate instanceof Map<?, ?> candidateMap
+                        && Objects.equals(identity, candidateMap.get(identityField))) {
+                    if (match != null) {
+                        return null;
+                    }
+                    match = candidate;
+                }
+            }
+            return match;
+        }
+
+        if (sourceList.size() != targetList.size() || index >= targetList.size()) {
+            return null;
+        }
+        Object targetElement = targetList.get(index);
+        return equalApartFromPlaceholders(sourceElement, targetElement) ? targetElement : null;
+    }
+
+    /**
+     * The name of the field that identifies this element, or {@code null} when it
+     * carries none. Only scalar values count — an object or array under
+     * {@code name} is not a natural key.
+     */
+    private static String identityFieldOf(Object node) {
+        if (!(node instanceof Map<?, ?> map)) {
+            return null;
+        }
+        for (String field : IDENTITY_FIELDS) {
+            Object value = map.get(field);
+            if (value != null && !(value instanceof Map) && !(value instanceof List)) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether the two nodes agree everywhere the source is not a scrubbed value —
+     * that is, whether the target is what the source looked like before the export
+     * redacted it.
+     */
+    private static boolean equalApartFromPlaceholders(Object sourceNode, Object targetNode) {
+        if (sourceNode instanceof String text) {
+            return text.contains(PLACEHOLDER) || text.equals(targetNode);
+        }
+        if (sourceNode instanceof Map<?, ?> sourceMap) {
+            if (!(targetNode instanceof Map<?, ?> targetMap) || sourceMap.size() != targetMap.size()) {
+                return false;
+            }
+            for (Map.Entry<?, ?> entry : sourceMap.entrySet()) {
+                String key = String.valueOf(entry.getKey());
+                if (!targetMap.containsKey(key)
+                        || !equalApartFromPlaceholders(entry.getValue(), targetMap.get(key))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (sourceNode instanceof List<?> sourceList) {
+            if (!(targetNode instanceof List<?> targetList) || sourceList.size() != targetList.size()) {
+                return false;
+            }
+            for (int i = 0; i < sourceList.size(); i++) {
+                if (!equalApartFromPlaceholders(sourceList.get(i), targetList.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return Objects.equals(sourceNode, targetNode);
+    }
+
+    /** Whether anything anywhere below this parsed node was scrubbed. */
+    private static boolean containsPlaceholder(Object node) {
+        if (node instanceof String text) {
+            return text.contains(PLACEHOLDER);
+        }
+        if (node instanceof Map<?, ?> map) {
+            for (Object value : map.values()) {
+                if (containsPlaceholder(value)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (node instanceof List<?> list) {
+            for (Object element : list) {
+                if (containsPlaceholder(element)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return false;
     }
 }

--- a/src/main/java/ai/labs/eddi/backup/impl/ScrubbedSecrets.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/ScrubbedSecrets.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.secrets.sanitize.SecretScrubber;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Puts a target's own secret values back into source content that the export's
+ * {@link SecretScrubber} redacted.
+ * <p>
+ * Shared by {@link StructuralMatcher} and {@link UpgradeExecutor} on purpose.
+ * Everything in an export ZIP (and everything a remote instance hands out) has
+ * been through the scrubber, so an LLM or httpCalls config holding an API key
+ * arrives as {@code ${vault:REDACTED}} while the target still carries the live
+ * value. Restoring only on the execute side left the two disagreeing: the
+ * matcher compared a placeholder against a real credential, so <em>every</em>
+ * agent with a credential compared unequal, could never SKIP, and burned a
+ * resource and agent version on every sync that changed nothing.
+ *
+ * @since 6.0.0
+ */
+final class ScrubbedSecrets {
+
+    /** The marker {@link SecretScrubber} writes in place of a secret value. */
+    static final String PLACEHOLDER = SecretScrubber.REDACTED;
+
+    private ScrubbedSecrets() {
+    }
+
+    /** Whether this content carries at least one scrubbed value. */
+    static boolean carriesPlaceholder(String json) {
+        return json != null && json.contains(PLACEHOLDER);
+    }
+
+    /**
+     * The source content with every scrubbed leaf replaced by the target's value at
+     * the same position.
+     *
+     * @return the merged JSON
+     * @throws Exception
+     *             when either side cannot be parsed or the merge cannot be
+     *             serialized — the caller decides what to do with the unmerged
+     *             source
+     */
+    static String restore(String sourceJson, String targetJson, IJsonSerialization jsonSerialization)
+            throws Exception {
+        Object sourceTree = jsonSerialization.deserialize(sourceJson);
+        Object targetTree = jsonSerialization.deserialize(targetJson);
+        return jsonSerialization.serialize(merge(sourceTree, targetTree));
+    }
+
+    /**
+     * Walks two parsed configs in parallel and returns the source with every
+     * scrubbed leaf replaced by the target's value at the same position.
+     */
+    private static Object merge(Object sourceNode, Object targetNode) {
+        if (sourceNode instanceof String text) {
+            if (text.contains(PLACEHOLDER) && targetNode instanceof String targetText) {
+                return targetText;
+            }
+            return text;
+        }
+        if (sourceNode instanceof Map<?, ?> sourceMap) {
+            Map<?, ?> targetMap = targetNode instanceof Map<?, ?> map ? map : Map.of();
+            Map<String, Object> merged = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : sourceMap.entrySet()) {
+                String key = String.valueOf(entry.getKey());
+                merged.put(key, merge(entry.getValue(), targetMap.get(key)));
+            }
+            return merged;
+        }
+        if (sourceNode instanceof List<?> sourceList) {
+            List<?> targetList = targetNode instanceof List<?> list ? list : List.of();
+            List<Object> merged = new ArrayList<>(sourceList.size());
+            for (int i = 0; i < sourceList.size(); i++) {
+                merged.add(merge(sourceList.get(i), i < targetList.size() ? targetList.get(i) : null));
+            }
+            return merged;
+        }
+        return sourceNode;
+    }
+}

--- a/src/main/java/ai/labs/eddi/backup/impl/SourceUrlValidator.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/SourceUrlValidator.java
@@ -5,6 +5,8 @@
 package ai.labs.eddi.backup.impl;
 
 import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
+
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 import org.jboss.logging.Logger;
 
 import java.net.InetAddress;
@@ -76,7 +78,7 @@ public final class SourceUrlValidator {
             throw new IllegalArgumentException("Source URL must not point to a private IP address: " + sourceUrl);
         }
 
-        LOGGER.debugf("Source URL validated: %s", sourceUrl);
+        LOGGER.debugf("Source URL validated: %s", sanitize(sourceUrl));
     }
 
     private static boolean isLoopback(String host) {
@@ -118,7 +120,7 @@ public final class SourceUrlValidator {
             return false;
         } catch (UnknownHostException e) {
             // DNS resolution failed — fail closed to prevent DNS rebinding attacks
-            LOGGER.debugf("Could not resolve host %s — rejecting source URL", host);
+            LOGGER.debugf("Could not resolve host %s — rejecting source URL", sanitize(host));
             throw new IllegalArgumentException("Source URL host could not be resolved: " + host, e);
         }
     }

--- a/src/main/java/ai/labs/eddi/backup/impl/StructuralMatcher.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/StructuralMatcher.java
@@ -31,6 +31,7 @@ import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
 import org.jboss.logging.Logger;
 
 import java.net.URI;
@@ -46,8 +47,10 @@ import java.util.*;
  * <li><b>Agent</b> — matched directly by {@code targetAgentId} parameter</li>
  * <li><b>Workflows</b> — matched by position (index in agent's workflow
  * list)</li>
- * <li><b>Extensions</b> — matched by {@code WorkflowStep.type} URI
- * (deterministic: each type appears at most once per workflow)</li>
+ * <li><b>Extensions</b> — matched by the canonical
+ * {@link WorkflowExtensions#scan(WorkflowConfiguration) extension key}: the
+ * workflow step's {@code type} URI plus that type's occurrence ordinal within
+ * the workflow</li>
  * <li><b>Snippets</b> — matched by {@code PromptSnippet.name} (natural
  * key)</li>
  * </ol>
@@ -55,6 +58,13 @@ import java.util.*;
  * This is the core matching engine shared by all import/sync flows. It is
  * stateless — all state comes from the {@link IResourceSource} and the target
  * agent's existing configuration.
+ * <p>
+ * <b>Content is always loaded when there is a target.</b>
+ * {@code includeContent} decides only whether the source/target JSON is
+ * <em>returned</em> for the diff view — never whether it is read. Deciding the
+ * {@link DiffAction} from content that was not loaded made every matched
+ * resource compare equal, so {@link UpgradeExecutor} skipped all of them and a
+ * sync silently updated nothing.
  *
  * @since 6.0.0
  */
@@ -94,8 +104,12 @@ public class StructuralMatcher {
      *            if non-null, match against this agent's resource tree (upgrade
      *            strategy). If null, all resources are CREATE.
      * @param includeContent
-     *            if true, populate sourceContent/targetContent for diff view
+     *            if true, populate sourceContent/targetContent for the diff view.
+     *            Does not affect which {@link DiffAction} is computed — content is
+     *            always loaded when {@code targetAgentId} is given.
      * @return the preview with all resource diffs
+     * @throws jakarta.ws.rs.NotFoundException
+     *             if {@code targetAgentId} was given but could not be read
      */
     public ImportPreview buildPreview(IResourceSource source,
                                       String targetAgentId,
@@ -109,14 +123,12 @@ public class StructuralMatcher {
         List<ResourceDiff> diffs = new ArrayList<>();
 
         if (targetAgentId != null) {
-            try {
-                targetConfig = readTargetAgent(targetAgentId);
-                targetAgentName = readDescriptorName(targetAgentId);
-            } catch (Exception e) {
-                LOGGER.warnf("Could not load target agent %s: %s", targetAgentId, e.getMessage());
-                // Proceed without target — all resources will be CREATE
-                targetAgentId = null;
-            }
+            // Deliberately not caught: the caller explicitly named a target, so a
+            // target that cannot be read is a 404 — not a silent switch to "create
+            // everything", which previewed an upgrade as a full duplicate of the
+            // agent and gave the operator nothing to distinguish the two.
+            targetConfig = readTargetAgent(targetAgentId);
+            targetAgentName = readDescriptorName(targetAgentId);
         }
 
         // 1. Agent-level diff
@@ -163,10 +175,10 @@ public class StructuralMatcher {
                     null, -1);
         }
 
-        String sourceJson = includeContent ? serializeSafe(sourceAgent.config()) : null;
-        String targetJson = includeContent ? serializeSafe(targetConfig) : null;
+        String sourceJson = serializeSafe(sourceAgent.config());
+        String targetJson = serializeSafe(targetConfig);
 
-        DiffAction action = Objects.equals(sourceJson, targetJson)
+        DiffAction action = contentEquals(sourceJson, targetJson)
                 ? DiffAction.SKIP
                 : DiffAction.UPDATE;
 
@@ -175,7 +187,8 @@ public class StructuralMatcher {
         return new ResourceDiff(
                 sourceAgent.sourceId(), "agent", sourceAgent.name(),
                 action, targetAgentId, targetVersion, "targetAgent",
-                sourceJson, targetJson, -1);
+                includeContent ? sourceJson : null,
+                includeContent ? targetJson : null, -1);
     }
 
     // ==================== Workflow Diffs ====================
@@ -196,9 +209,9 @@ public class StructuralMatcher {
         String targetName = readDescriptorName(targetId);
 
         // Workflow-level diff
-        String sourceJson = includeContent ? serializeSafe(sourceWf.config()) : null;
-        String targetJson = includeContent ? readTargetWorkflowJson(targetId, targetVersion) : null;
-        DiffAction wfAction = Objects.equals(sourceJson, targetJson)
+        String sourceJson = serializeSafe(sourceWf.config());
+        String targetJson = readTargetWorkflowJson(targetId, targetVersion);
+        DiffAction wfAction = contentEquals(sourceJson, targetJson)
                 ? DiffAction.SKIP
                 : DiffAction.UPDATE;
 
@@ -206,29 +219,32 @@ public class StructuralMatcher {
                 sourceWf.sourceId(), "workflow",
                 sourceWf.name() != null ? sourceWf.name() : targetName,
                 wfAction, targetId, targetVersion, "position",
-                sourceJson, targetJson, sourceWf.positionIndex()));
+                includeContent ? sourceJson : null,
+                includeContent ? targetJson : null, sourceWf.positionIndex()));
 
-        // Extension diffs within this workflow — match by step type
+        // Extension diffs within this workflow — matched by the canonical
+        // WorkflowExtensions key, which both sides derive the same way.
         Map<String, ExtensionSourceData> sourceExtensions = sourceWf.extensions();
         Map<String, TargetExtension> targetExtensions = readTargetExtensions(targetId, targetVersion);
 
         for (Map.Entry<String, ExtensionSourceData> entry : sourceExtensions.entrySet()) {
-            String stepType = entry.getKey();
+            String extensionKey = entry.getKey();
             ExtensionSourceData sourceExt = entry.getValue();
-            TargetExtension targetExt = targetExtensions.get(stepType);
+            TargetExtension targetExt = targetExtensions.get(extensionKey);
 
             if (targetExt != null) {
-                // Matched by type
-                String srcContent = includeContent ? sourceExt.contentJson() : null;
-                String tgtContent = includeContent ? targetExt.contentJson : null;
-                DiffAction extAction = Objects.equals(srcContent, tgtContent)
+                // Matched by step type + occurrence
+                String srcContent = sourceExt.contentJson();
+                String tgtContent = targetExt.contentJson;
+                DiffAction extAction = contentEquals(srcContent, tgtContent)
                         ? DiffAction.SKIP
                         : DiffAction.UPDATE;
 
                 diffs.add(new ResourceDiff(
                         sourceExt.sourceId(), sourceExt.type(), sourceExt.name(),
                         extAction, targetExt.id, targetExt.version, "type",
-                        srcContent, tgtContent, -1));
+                        includeContent ? srcContent : null,
+                        includeContent ? tgtContent : null, -1));
             } else {
                 // No match — new extension type in this workflow
                 diffs.add(new ResourceDiff(
@@ -270,16 +286,17 @@ public class StructuralMatcher {
         IResourceId existing = existingByName.get(sourceSnippet.name());
 
         if (existing != null) {
-            String sourceJson = includeContent ? serializeSafe(sourceSnippet.snippet()) : null;
-            String targetJson = includeContent ? readTargetSnippetJson(existing.getId(), existing.getVersion()) : null;
-            DiffAction action = Objects.equals(sourceJson, targetJson)
+            String sourceJson = serializeSafe(sourceSnippet.snippet());
+            String targetJson = readTargetSnippetJson(existing.getId(), existing.getVersion());
+            DiffAction action = contentEquals(sourceJson, targetJson)
                     ? DiffAction.SKIP
                     : DiffAction.UPDATE;
 
             return new ResourceDiff(
                     sourceSnippet.sourceId(), "snippet", sourceSnippet.name(),
                     action, existing.getId(), existing.getVersion(), "name",
-                    sourceJson, targetJson, -1);
+                    includeContent ? sourceJson : null,
+                    includeContent ? targetJson : null, -1);
         }
 
         return new ResourceDiff(
@@ -292,12 +309,19 @@ public class StructuralMatcher {
     // ==================== Target Reading Helpers ====================
 
     private AgentConfiguration readTargetAgent(String agentId) {
+        AgentConfiguration config;
         try {
             int version = readLatestVersionOrDefault(agentId, 1);
-            return agentStore.readAgent(agentId, version);
+            config = agentStore.readAgent(agentId, version);
+        } catch (NotFoundException e) {
+            throw e;
         } catch (Exception e) {
-            throw new RuntimeException("Failed to read target agent " + agentId, e);
+            throw new NotFoundException("Could not read target agent " + agentId + ": " + e.getMessage(), e);
         }
+        if (config == null) {
+            throw new NotFoundException("Target agent " + agentId + " does not exist.");
+        }
+        return config;
     }
 
     private String readTargetWorkflowJson(String workflowId, int version) {
@@ -305,7 +329,7 @@ public class StructuralMatcher {
             WorkflowConfiguration config = workflowStore.readWorkflow(workflowId, version);
             return serializeSafe(config);
         } catch (Exception e) {
-            LOGGER.debugf("Could not read target workflow %s v%d: %s", workflowId, version, e.getMessage());
+            LOGGER.warnf(e, "Could not read target workflow %s v%d", workflowId, version);
             return null;
         }
     }
@@ -314,56 +338,53 @@ public class StructuralMatcher {
     }
 
     /**
-     * Reads all extensions from a target workflow by parsing its config and loading
-     * each referenced resource via the correct typed store.
+     * Reads all extensions a target workflow references, keyed by the canonical
+     * {@link WorkflowExtensions} key. The URI of each extension is read from the
+     * step's {@code config} map, which is where the engine itself looks — reading
+     * it from {@code extensions} found nothing on any real workflow, so every
+     * source extension was reported as CREATE and a sync duplicated the lot.
      */
     private Map<String, TargetExtension> readTargetExtensions(String workflowId, int version) {
         Map<String, TargetExtension> result = new LinkedHashMap<>();
 
+        WorkflowConfiguration wfConfig;
         try {
-            WorkflowConfiguration wfConfig = workflowStore.readWorkflow(workflowId, version);
-
-            for (WorkflowConfiguration.WorkflowStep step : wfConfig.getWorkflowSteps()) {
-                URI stepType = step.getType();
-                if (stepType == null)
-                    continue;
-
-                Object uriObj = step.getExtensions().get("uri");
-                if (uriObj == null)
-                    continue;
-
-                URI extUri = URI.create(uriObj.toString());
-                IResourceId extResId = RestUtilities.extractResourceId(extUri);
-                if (extResId == null)
-                    continue;
-
-                try {
-                    Object extConfig = readTypedExtension(extUri, stepType.toString());
-                    String json = serializeSafe(extConfig);
-                    result.put(stepType.toString(), new TargetExtension(
-                            extResId.getId(), extResId.getVersion(), json));
-                } catch (Exception e) {
-                    LOGGER.debugf("Could not read target extension %s: %s", extUri, e.getMessage());
-                }
-            }
+            wfConfig = workflowStore.readWorkflow(workflowId, version);
         } catch (Exception e) {
-            LOGGER.debugf("Could not read target workflow config %s v%d: %s", workflowId, version, e.getMessage());
+            LOGGER.warnf(e, "Could not read target workflow config %s v%d", workflowId, version);
+            return result;
+        }
+
+        for (WorkflowExtensions.ExtensionRef ref : WorkflowExtensions.scan(wfConfig)) {
+            try {
+                Object extConfig = readTypedExtension(ref);
+                String json = serializeSafe(extConfig);
+                result.put(ref.key(), new TargetExtension(
+                        ref.resourceId().getId(), ref.resourceId().getVersion(), json));
+            } catch (Exception e) {
+                LOGGER.warnf(e, "Could not read target extension %s", ref.extensionUri());
+            }
         }
 
         return result;
     }
 
     /**
-     * Reads a typed extension config from the correct store based on the step type.
-     * This produces deterministic JSON serialization (matching what UpgradeExecutor
-     * would write), unlike deserializing as {@code Object.class}.
+     * Reads a typed extension config from the correct store, chosen by the
+     * authority of the resource URI itself ({@code ai.labs.rules},
+     * {@code ai.labs.llm}, …) rather than by the workflow step type
+     * ({@code eddi://ai.labs.behavior}) — the two are different names for the same
+     * thing, and matching on the wrong one resolved every extension to "unknown".
+     * <p>
+     * The {@code default} branch is unreachable: {@link WorkflowExtensions#scan}
+     * only produces references for registered authorities. It throws rather than
+     * returning null so that adding a type to the registry without adding it here
+     * fails loudly.
      */
-    private Object readTypedExtension(URI extUri, String stepType) throws Exception {
-        IResourceId resId = RestUtilities.extractResourceId(extUri);
-        if (resId == null)
-            return null;
+    private Object readTypedExtension(WorkflowExtensions.ExtensionRef ref) throws Exception {
+        IResourceId resId = ref.resourceId();
 
-        return switch (stepType) {
+        return switch (ref.type().resourceAuthority()) {
             case "ai.labs.dictionary" -> restInterfaceFactory.get(
                     IRestDictionaryStore.class)
                     .readRegularDictionary(resId.getId(), resId.getVersion(), "", "", 0, 0);
@@ -388,10 +409,8 @@ public class StructuralMatcher {
             case "ai.labs.rag" -> restInterfaceFactory.get(
                     IRestRagStore.class)
                     .readRag(resId.getId(), resId.getVersion());
-            default -> {
-                LOGGER.debugf("Unknown step type for typed read: %s", stepType);
-                yield null;
-            }
+            default -> throw new IllegalStateException(
+                    "No typed store read is registered for extension type " + ref.type().resourceAuthority());
         };
     }
 
@@ -476,6 +495,68 @@ public class StructuralMatcher {
         } catch (Exception e) {
             LOGGER.debugf("Serialization failed: %s", e.getMessage());
             return null;
+        }
+    }
+
+    /**
+     * Compares two configs for equality of <em>content</em>, not of text.
+     * <p>
+     * The two sides are produced by different pipelines: source content is the
+     * verbatim file text from a ZIP or the verbatim HTTP body from another
+     * instance, while target content is a fresh serialization of a deserialized
+     * object. Comparing them as strings made whitespace or field-ordering
+     * differences look like changes, so SKIP effectively never fired and every
+     * resource showed as modified.
+     */
+    private boolean contentEquals(String sourceJson, String targetJson) {
+        if (Objects.equals(sourceJson, targetJson)) {
+            return true;
+        }
+        if (sourceJson == null || targetJson == null) {
+            return false;
+        }
+        return Objects.equals(canonicalJson(sourceJson), canonicalJson(targetJson));
+    }
+
+    /**
+     * Re-serializes JSON with object keys sorted, so two renderings of the same
+     * document compare equal. Returns the input unchanged when it cannot be parsed
+     * — a comparison on raw text is still better than treating unparseable content
+     * as equal.
+     */
+    private String canonicalJson(String json) {
+        try {
+            Object tree = jsonSerialization.deserialize(json);
+            if (tree == null) {
+                return json;
+            }
+            String canonical = jsonSerialization.serialize(sortKeys(tree));
+            return canonical != null ? canonical : json;
+        } catch (Exception e) {
+            LOGGER.debugf("Could not canonicalize JSON for comparison: %s", e.getMessage());
+            return json;
+        }
+    }
+
+    private static Object sortKeys(Object node) {
+        switch (node) {
+            case Map<?, ?> map -> {
+                Map<String, Object> sorted = new TreeMap<>();
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    sorted.put(String.valueOf(entry.getKey()), sortKeys(entry.getValue()));
+                }
+                return sorted;
+            }
+            case List<?> list -> {
+                List<Object> mapped = new ArrayList<>(list.size());
+                for (Object element : list) {
+                    mapped.add(sortKeys(element));
+                }
+                return mapped;
+            }
+            case null, default -> {
+                return node;
+            }
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/backup/impl/StructuralMatcher.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/StructuralMatcher.java
@@ -25,12 +25,14 @@ import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
 import ai.labs.eddi.configs.snippets.model.PromptSnippet;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import org.jboss.logging.Logger;
 
@@ -109,7 +111,9 @@ public class StructuralMatcher {
      *            always loaded when {@code targetAgentId} is given.
      * @return the preview with all resource diffs
      * @throws jakarta.ws.rs.NotFoundException
-     *             if {@code targetAgentId} was given but could not be read
+     *             if {@code targetAgentId} was given but no such agent exists
+     * @throws jakarta.ws.rs.InternalServerErrorException
+     *             if the target agent exists but could not be read
      */
     public ImportPreview buildPreview(IResourceSource source,
                                       String targetAgentId,
@@ -124,9 +128,10 @@ public class StructuralMatcher {
 
         if (targetAgentId != null) {
             // Deliberately not caught: the caller explicitly named a target, so a
-            // target that cannot be read is a 404 — not a silent switch to "create
-            // everything", which previewed an upgrade as a full duplicate of the
-            // agent and gave the operator nothing to distinguish the two.
+            // target that cannot be read is an error the operator can act on — not a
+            // silent switch to "create everything", which previewed an upgrade as a
+            // full duplicate of the agent and gave the operator nothing to
+            // distinguish the two. See readTargetAgent for 404 vs 5xx.
             targetConfig = readTargetAgent(targetAgentId);
             targetAgentName = readDescriptorName(targetAgentId);
         }
@@ -236,7 +241,7 @@ public class StructuralMatcher {
                 // Matched by step type + occurrence
                 String srcContent = sourceExt.contentJson();
                 String tgtContent = targetExt.contentJson;
-                DiffAction extAction = contentEquals(srcContent, tgtContent)
+                DiffAction extAction = contentEquals(secretNeutral(srcContent, tgtContent), tgtContent)
                         ? DiffAction.SKIP
                         : DiffAction.UPDATE;
 
@@ -308,6 +313,17 @@ public class StructuralMatcher {
 
     // ==================== Target Reading Helpers ====================
 
+    /**
+     * Reads the agent the caller named as the sync target.
+     * <p>
+     * A missing agent is a 404 — the operator mistyped an id, or the agent was
+     * deleted. Everything else is a 5xx: reporting a datastore outage as "target
+     * agent not found" sends the operator to look for a resource that is there, and
+     * a client that retries a 404 by creating the agent would duplicate it. The two
+     * are distinguished by the store's own contract, which separates
+     * {@link IResourceStore.ResourceNotFoundException} from
+     * {@link IResourceStore.ResourceStoreException}.
+     */
     private AgentConfiguration readTargetAgent(String agentId) {
         AgentConfiguration config;
         try {
@@ -316,7 +332,15 @@ public class StructuralMatcher {
         } catch (NotFoundException e) {
             throw e;
         } catch (Exception e) {
-            throw new NotFoundException("Could not read target agent " + agentId + ": " + e.getMessage(), e);
+            // instanceof rather than a second catch clause: the store's checked
+            // exceptions reach this frame through SneakyThrow (see
+            // RestVersionInfo.read), so the compiler does not believe they can be
+            // thrown here and refuses to let them be caught by type.
+            if (e instanceof IResourceStore.ResourceNotFoundException) {
+                throw new NotFoundException("Target agent " + agentId + " does not exist: " + e.getMessage(), e);
+            }
+            throw new InternalServerErrorException(
+                    "Could not read target agent " + agentId + ": " + e.getMessage(), e);
         }
         if (config == null) {
             throw new NotFoundException("Target agent " + agentId + " does not exist.");
@@ -495,6 +519,34 @@ public class StructuralMatcher {
         } catch (Exception e) {
             LOGGER.debugf("Serialization failed: %s", e.getMessage());
             return null;
+        }
+    }
+
+    /**
+     * The source content as {@link UpgradeExecutor} would actually write it: with
+     * the target's own values put back wherever the export's secret scrubber left a
+     * placeholder.
+     * <p>
+     * Comparing the raw source against the target instead made every configuration
+     * holding a credential — an LLM's apiKey, an httpCalls authorization header —
+     * differ by the placeholder alone. Such a resource could never SKIP, so a sync
+     * that changed nothing still wrote the resource, bumped its version, repointed
+     * the workflow and bumped the agent version, for exactly the agents that matter
+     * most.
+     *
+     * @return the source content, unchanged when it carries no placeholder or the
+     *         target could not be read
+     */
+    private String secretNeutral(String sourceJson, String targetJson) {
+        if (targetJson == null || !ScrubbedSecrets.carriesPlaceholder(sourceJson)) {
+            return sourceJson;
+        }
+        try {
+            String restored = ScrubbedSecrets.restore(sourceJson, targetJson, jsonSerialization);
+            return restored != null ? restored : sourceJson;
+        } catch (Exception e) {
+            LOGGER.debugf("Could not neutralize scrubbed secrets before comparing: %s", e.getMessage());
+            return sourceJson;
         }
     }
 

--- a/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
@@ -10,6 +10,8 @@ import ai.labs.eddi.backup.IResourceSource.*;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
 import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
+import ai.labs.eddi.backup.model.UpgradeResult;
+import ai.labs.eddi.backup.model.UpgradeResult.ResourceFailure;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
@@ -45,10 +47,12 @@ import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.secrets.sanitize.SecretScrubber;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
@@ -66,8 +70,9 @@ import static ai.labs.eddi.configs.descriptors.ResourceUtilities.createDocumentD
  * The target agent's URI structure stays unchanged — only content is updated
  * and version numbers incremented.
  * <p>
- * Extension type dispatch is handled via {@link ExtensionStoreRegistry} to
- * avoid duplicated switch blocks.
+ * Adding an extension type takes two edits: register the resource authority in
+ * {@link WorkflowExtensions} (file extension + remote REST path) and add its
+ * store operations to {@link #resolveExtensionOps(String)}.
  *
  * @since 6.0.0
  */
@@ -82,6 +87,7 @@ public class UpgradeExecutor {
     private final IJsonSerialization jsonSerialization;
     private final StructuralMatcher structuralMatcher;
     private final IDocumentDescriptorStore documentDescriptorStore;
+    private final BackupMetrics metrics;
 
     private final ResourceAccessGuard resourceAccessGuard;
 
@@ -92,7 +98,9 @@ public class UpgradeExecutor {
             IJsonSerialization jsonSerialization,
             StructuralMatcher structuralMatcher,
             IDocumentDescriptorStore documentDescriptorStore,
+            BackupMetrics metrics,
             ResourceAccessGuard resourceAccessGuard) {
+        this.metrics = metrics;
         this.resourceAccessGuard = resourceAccessGuard;
         this.agentStore = agentStore;
         this.workflowStore = workflowStore;
@@ -113,15 +121,20 @@ public class UpgradeExecutor {
      *            source resource IDs to process (null = all)
      * @param workflowOrder
      *            desired final workflow order (null = append new ones at end)
-     * @return URI of the updated agent
+     * @return what actually happened, per resource — see {@link UpgradeResult}
      */
-    public URI executeUpgrade(IResourceSource source,
-                              String targetAgentId,
-                              Set<String> selectedSourceIds,
-                              List<String> workflowOrder) {
+    public UpgradeResult executeUpgrade(IResourceSource source,
+                                        String targetAgentId,
+                                        Set<String> selectedSourceIds,
+                                        List<String> workflowOrder) {
+        var outcome = new Outcome();
+        metrics.upgradeAttempted();
         try {
-            // 1. Build the preview to get the match map
-            ImportPreview preview = structuralMatcher.buildPreview(source, targetAgentId, false);
+            // 1. Build the preview to get the match map. Content is requested because
+            // the target's current JSON is needed to put back values the export's
+            // secret scrubber replaced with ${vault:REDACTED} — see
+            // restoreRedactedSecrets.
+            ImportPreview preview = structuralMatcher.buildPreview(source, targetAgentId, true);
 
             List<WorkflowSourceData> sourceWorkflows = source.readWorkflows();
             List<SnippetSourceData> sourceSnippets = source.readSnippets();
@@ -136,7 +149,7 @@ public class UpgradeExecutor {
                 ResourceDiff diff = diffMap.get(snippet.sourceId());
                 if (diff == null || !isSelected(selectedSourceIds, snippet.sourceId()))
                     continue;
-                processSnippet(snippet, diff);
+                processSnippet(snippet, diff, outcome);
             }
 
             // 3. Process each workflow's extensions
@@ -152,53 +165,117 @@ public class UpgradeExecutor {
                 if (wfDiff.action() == DiffAction.CREATE) {
                     // New workflow — create it if selected
                     if (isSelected(selectedSourceIds, sourceWf.sourceId())) {
-                        URI newUri = createNewWorkflow(sourceWf);
+                        URI newUri = createNewWorkflow(sourceWf, outcome);
                         if (newUri != null) {
                             newWorkflowUris.add(newUri);
+                            outcome.created++;
                         }
                     }
                 } else if (wfDiff.action() == DiffAction.UPDATE) {
                     // Matched workflow — process extensions
                     Map<String, URI> extensionUpdates = processWorkflowExtensions(
-                            sourceWf, diffMap, selectedSourceIds);
+                            sourceWf, diffMap, selectedSourceIds, outcome);
 
                     // Update the workflow config with new extension version URIs
                     if (!extensionUpdates.isEmpty()) {
                         URI updatedUri = updateWorkflowExtensionUris(
-                                wfDiff.targetId(), wfDiff.targetVersion(), extensionUpdates);
+                                wfDiff.targetId(), wfDiff.targetVersion(), extensionUpdates, outcome);
                         if (updatedUri != null) {
                             updatedWorkflowUris.put(wfDiff.targetId(), updatedUri);
+                            outcome.updated++;
                         }
                     }
+                } else {
+                    outcome.skipped++;
                 }
             }
 
-            // 4. Update the agent config with new workflow version URIs
-            return updateAgentConfig(targetAgentId, updatedWorkflowUris,
-                    newWorkflowUris, workflowOrder);
+            // 4. Update the agent config with new workflow version URIs — but only
+            // when there is something to write. An unconditional update wrote a
+            // byte-identical agent configuration and bumped its version, so a CI job
+            // that syncs on every build inflated the version history forever and
+            // 'v14' said nothing about whether anything had changed.
+            boolean agentNeedsUpdate = !updatedWorkflowUris.isEmpty()
+                    || !newWorkflowUris.isEmpty()
+                    || (workflowOrder != null && !workflowOrder.isEmpty());
 
+            URI agentUri = agentNeedsUpdate
+                    ? updateAgentConfig(targetAgentId, updatedWorkflowUris, newWorkflowUris, workflowOrder)
+                    : currentAgentUri(targetAgentId);
+
+            if (!agentNeedsUpdate) {
+                LOGGER.infof("Agent '%s' upgrade wrote no workflow changes — agent version left at %s",
+                        targetAgentId, agentUri);
+            }
+
+            UpgradeResult result = outcome.toResult(agentUri, agentNeedsUpdate);
+            metrics.upgradeCompleted(result.updated(), result.created(), result.skipped(),
+                    result.failures().size());
+            return result;
+
+        } catch (WebApplicationException e) {
+            // A target agent that cannot be read is a 404 the operator can act on.
+            // Wrapping it turned the one actionable failure of a sync into a 500.
+            metrics.upgradeFailed();
+            LOGGER.errorf(e, "Upgrade failed for target agent %s", targetAgentId);
+            throw e;
         } catch (Exception e) {
-            LOGGER.errorf("Upgrade failed for target agent %s: %s", targetAgentId, e.getMessage());
+            metrics.upgradeFailed();
+            LOGGER.errorf(e, "Upgrade failed for target agent %s", targetAgentId);
             throw new RuntimeException("Upgrade failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Mutable tally of what an upgrade did, turned into an immutable
+     * {@link UpgradeResult} at the end.
+     * <p>
+     * One instance belongs to exactly one {@code executeUpgrade} call and never
+     * escapes it, so the bean itself stays stateless.
+     */
+    private static final class Outcome {
+        private int updated;
+        private int created;
+        private int skipped;
+        private final List<ResourceFailure> failures = new ArrayList<>();
+
+        void failed(String sourceId, String resourceType, String name, Throwable cause) {
+            String reason = cause.getMessage() != null
+                    ? cause.getClass().getSimpleName() + ": " + cause.getMessage()
+                    : cause.getClass().getSimpleName();
+            failures.add(new ResourceFailure(sourceId, resourceType, name, reason));
+        }
+
+        void failed(String sourceId, String resourceType, String name, String reason) {
+            failures.add(new ResourceFailure(sourceId, resourceType, name, reason));
+        }
+
+        UpgradeResult toResult(URI agentUri, boolean agentUpdated) {
+            return new UpgradeResult(agentUri, agentUpdated, updated, created, skipped, List.copyOf(failures));
         }
     }
 
     // ==================== Snippet Processing ====================
 
-    private void processSnippet(SnippetSourceData sourceSnippet, ResourceDiff diff) {
+    private void processSnippet(SnippetSourceData sourceSnippet, ResourceDiff diff, Outcome outcome) {
         try {
             if (diff.action() == DiffAction.UPDATE && diff.targetId() != null) {
                 // Update existing snippet
                 snippetStore.updateSnippet(diff.targetId(), diff.targetVersion(), sourceSnippet.snippet());
+                outcome.updated++;
                 LOGGER.infof("Updated snippet '%s' (target=%s, v%d→v%d)",
                         sourceSnippet.name(), diff.targetId(), diff.targetVersion(), diff.targetVersion() + 1);
             } else if (diff.action() == DiffAction.CREATE) {
                 // Create new snippet
                 snippetStore.createSnippet(sourceSnippet.snippet());
+                outcome.created++;
                 LOGGER.infof("Created snippet '%s'", sourceSnippet.name());
+            } else {
+                outcome.skipped++;
             }
         } catch (Exception e) {
-            LOGGER.warnf("Failed to process snippet '%s': %s", sourceSnippet.name(), e.getMessage());
+            LOGGER.warnf(e, "Failed to process snippet '%s'", sourceSnippet.name());
+            outcome.failed(sourceSnippet.sourceId(), "snippet", sourceSnippet.name(), e);
         }
     }
 
@@ -208,44 +285,59 @@ public class UpgradeExecutor {
      * For each extension in a matched workflow, update the target extension with
      * the source content.
      *
-     * @return map of stepType → updated extension URI (with new version)
+     * @return map of canonical extension key → updated extension URI (with new
+     *         version)
      */
     private Map<String, URI> processWorkflowExtensions(
                                                        WorkflowSourceData sourceWf,
                                                        Map<String, ResourceDiff> diffMap,
-                                                       Set<String> selectedSourceIds) {
+                                                       Set<String> selectedSourceIds,
+                                                       Outcome outcome) {
 
         Map<String, URI> updates = new LinkedHashMap<>();
 
         for (Map.Entry<String, ExtensionSourceData> entry : sourceWf.extensions().entrySet()) {
-            String stepType = entry.getKey();
+            String extensionKey = entry.getKey();
             ExtensionSourceData sourceExt = entry.getValue();
             ResourceDiff extDiff = diffMap.get(sourceExt.sourceId());
 
-            if (extDiff == null || extDiff.action() == DiffAction.SKIP)
+            if (extDiff == null)
                 continue;
             if (!isSelected(selectedSourceIds, sourceExt.sourceId()))
                 continue;
+            if (extDiff.action() == DiffAction.SKIP) {
+                outcome.skipped++;
+                continue;
+            }
 
             try {
                 if (extDiff.action() == DiffAction.UPDATE && extDiff.targetId() != null) {
-                    URI updatedUri = updateExtension(sourceExt, extDiff.targetId(), extDiff.targetVersion());
+                    URI updatedUri = updateExtension(sourceExt, extDiff.targetId(), extDiff.targetVersion(),
+                            extDiff.targetContent());
                     if (updatedUri != null) {
-                        updates.put(stepType, updatedUri);
+                        updates.put(extensionKey, updatedUri);
+                        outcome.updated++;
                         LOGGER.infof("Updated %s '%s' (target=%s, v%d→v%d)",
                                 sourceExt.type(), sourceExt.name(),
                                 extDiff.targetId(), extDiff.targetVersion(), extDiff.targetVersion() + 1);
+                    } else {
+                        outcome.failed(sourceExt.sourceId(), sourceExt.type(), sourceExt.name(),
+                                "the store did not accept the update");
                     }
                 } else if (extDiff.action() == DiffAction.CREATE) {
                     URI newUri = createExtension(sourceExt);
                     if (newUri != null) {
-                        updates.put(stepType, newUri);
+                        updates.put(extensionKey, newUri);
+                        outcome.created++;
                         LOGGER.infof("Created %s '%s'", sourceExt.type(), sourceExt.name());
+                    } else {
+                        outcome.failed(sourceExt.sourceId(), sourceExt.type(), sourceExt.name(),
+                                "the store did not accept the create");
                     }
                 }
             } catch (Exception e) {
-                LOGGER.warnf("Failed to process extension %s '%s': %s",
-                        sourceExt.type(), sourceExt.name(), e.getMessage());
+                LOGGER.warnf(e, "Failed to process extension %s '%s'", sourceExt.type(), sourceExt.name());
+                outcome.failed(sourceExt.sourceId(), sourceExt.type(), sourceExt.name(), e);
             }
         }
 
@@ -255,74 +347,90 @@ public class UpgradeExecutor {
     // ==================== Extension Store Registry ====================
 
     /**
-     * Central registry mapping extension type names to their configuration class
-     * and store operations. Adding a new extension type requires only one new entry
-     * here — no switch blocks to maintain.
+     * Maps an extension's file-extension label ({@code behavior},
+     * {@code langchain}, …) to its configuration class and store operations. This
+     * is the only place in the upgrade path that knows about concrete stores; the
+     * matching side derives everything else from {@link WorkflowExtensions}.
      */
     @SuppressWarnings("unchecked")
     private <T> ExtensionStoreOps<T> resolveExtensionOps(String extensionType) {
         return (ExtensionStoreOps<T>) switch (extensionType) {
             case "regulardictionary" -> new ExtensionStoreOps<>(
                     DictionaryConfiguration.class,
-                    getStore(IRestDictionaryStore.class),
+                    (id, version, config) -> getStore(IRestDictionaryStore.class).updateRegularDictionary(id, version, config),
                     IRestDictionaryStore.resourceURI,
                     IRestDictionaryStore.versionQueryParam,
                     IDictionaryStore.class);
             case "behavior" -> new ExtensionStoreOps<>(
                     RuleSetConfiguration.class,
-                    getStore(IRestRuleSetStore.class),
+                    (id, version, config) -> getStore(IRestRuleSetStore.class).updateRuleSet(id, version, config),
                     IRestRuleSetStore.resourceURI,
                     IRestRuleSetStore.versionQueryParam,
                     IRuleSetStore.class);
             case "httpcalls" -> new ExtensionStoreOps<>(
                     ApiCallsConfiguration.class,
-                    getStore(IRestApiCallsStore.class),
+                    (id, version, config) -> getStore(IRestApiCallsStore.class).updateApiCalls(id, version, config),
                     IRestApiCallsStore.resourceURI,
                     IRestApiCallsStore.versionQueryParam,
                     IApiCallsStore.class);
             case "langchain" -> new ExtensionStoreOps<>(
                     LlmConfiguration.class,
-                    getStore(IRestLlmStore.class),
+                    (id, version, config) -> getStore(IRestLlmStore.class).updateLlm(id, version, config),
                     IRestLlmStore.resourceURI,
                     IRestLlmStore.versionQueryParam,
                     ILlmStore.class);
             case "property" -> new ExtensionStoreOps<>(
                     PropertySetterConfiguration.class,
-                    getStore(IRestPropertySetterStore.class),
+                    (id, version, config) -> getStore(IRestPropertySetterStore.class).updatePropertySetter(id, version, config),
                     IRestPropertySetterStore.resourceURI,
                     IRestPropertySetterStore.versionQueryParam,
                     IPropertySetterStore.class);
             case "output" -> new ExtensionStoreOps<>(
                     OutputConfigurationSet.class,
-                    getStore(IRestOutputStore.class),
+                    (id, version, config) -> getStore(IRestOutputStore.class).updateOutputSet(id, version, config),
                     IRestOutputStore.resourceURI,
                     IRestOutputStore.versionQueryParam,
                     IOutputStore.class);
             case "mcpcalls" -> new ExtensionStoreOps<>(
                     McpCallsConfiguration.class,
-                    getStore(IRestMcpCallsStore.class),
+                    (id, version, config) -> getStore(IRestMcpCallsStore.class).updateMcpCalls(id, version, config),
                     IRestMcpCallsStore.resourceURI,
                     IRestMcpCallsStore.versionQueryParam,
                     IMcpCallsStore.class);
             case "rag" -> new ExtensionStoreOps<>(
                     RagConfiguration.class,
-                    getStore(IRestRagStore.class),
+                    (id, version, config) -> getStore(IRestRagStore.class).updateRag(id, version, config),
                     IRestRagStore.resourceURI,
                     IRestRagStore.versionQueryParam,
                     IRagStore.class);
-            default -> null;
+            // Loud, not silent: a type registered in WorkflowExtensions but missing
+            // here used to return null, which every caller turned into "the store
+            // did not accept it" — a wrong diagnosis for a wiring mistake.
+            default -> throw new IllegalArgumentException(
+                    "No store operations are registered for extension type '" + extensionType + "'.");
         };
     }
 
+    /** Applies the source content to an existing resource in its own store. */
+    @FunctionalInterface
+    private interface ExtensionUpdate<T> {
+        Response apply(String targetId, Integer targetVersion, T config);
+    }
+
     /**
-     * Holds the configuration class, store reference, URI pattern, and direct store
-     * class for a single extension type. The {@code directStoreClass} is used by
-     * {@link #dispatchCreateDirect} to bypass Response.getLocation() which fails
-     * for eddi:// scheme URIs.
+     * Holds the configuration class, its store's update call, the URI pattern, and
+     * the direct store class for a single extension type. The
+     * {@code directStoreClass} is used by {@link #dispatchCreateDirect} to bypass
+     * Response.getLocation() which fails for eddi:// scheme URIs.
+     * <p>
+     * The update call is a typed lambda so that dispatch happens here, in the one
+     * table, instead of a second switch on the config class's <em>simple name</em>
+     * — a string comparison that a class rename would have broken with no compile
+     * error.
      */
     private record ExtensionStoreOps<T>(
             Class<T> configClass,
-            Object store,
+            ExtensionUpdate<T> update,
             String resourceUri,
             String versionQueryParam,
             Class<?> directStoreClass) {
@@ -333,21 +441,28 @@ public class UpgradeExecutor {
     /**
      * Updates a target extension resource with content from the source. Dispatches
      * to the correct store via {@link #resolveExtensionOps}.
+     *
+     * @param targetContentJson
+     *            the target's current config as JSON, used to put back values the
+     *            export scrubbed — may be null when the target could not be read
+     * @throws IllegalArgumentException
+     *             if no store is registered for the source's extension type. That
+     *             is a wiring mistake, not a store rejection, and is deliberately
+     *             not caught here: swallowing it reported "the store did not accept
+     *             the update" to the operator, which sends them to look at the
+     *             wrong thing entirely.
      */
-    private URI updateExtension(ExtensionSourceData source, String targetId, Integer targetVersion) {
+    private URI updateExtension(ExtensionSourceData source, String targetId, Integer targetVersion,
+                                String targetContentJson) {
+        ExtensionStoreOps<?> ops = resolveExtensionOps(source.type());
         try {
-            ExtensionStoreOps<?> ops = resolveExtensionOps(source.type());
-            if (ops == null) {
-                LOGGER.warnf("Unknown extension type: %s", source.type());
-                return null;
-            }
-            Response resp = dispatchUpdate(ops, source.contentJson(), targetId, targetVersion);
+            String contentJson = restoreRedactedSecrets(source, source.contentJson(), targetContentJson);
+            Response resp = dispatchUpdate(ops, contentJson, targetId, targetVersion);
             return resp != null && resp.getStatus() == 200
                     ? URI.create(ops.resourceUri() + targetId + ops.versionQueryParam() + (targetVersion + 1))
                     : null;
         } catch (Exception e) {
-            LOGGER.warnf("Failed to update %s '%s' (target=%s): %s",
-                    source.type(), source.name(), targetId, e.getMessage());
+            LOGGER.warnf(e, "Failed to update %s '%s' (target=%s)", source.type(), source.name(), targetId);
             return null;
         }
     }
@@ -355,44 +470,111 @@ public class UpgradeExecutor {
     /**
      * Creates a new extension resource from the source content. Uses direct store
      * create to bypass Response.getLocation() which fails for eddi:// URIs.
+     *
+     * @throws IllegalArgumentException
+     *             if no store is registered for the source's extension type — see
+     *             {@link #updateExtension} for why that one is not caught here
      */
     private URI createExtension(ExtensionSourceData source) {
+        ExtensionStoreOps<?> ops = resolveExtensionOps(source.type());
         try {
-            ExtensionStoreOps<?> ops = resolveExtensionOps(source.type());
-            if (ops == null) {
-                LOGGER.warnf("Unknown extension type for create: %s", source.type());
-                return null;
-            }
             return dispatchCreateDirect(ops, source.contentJson());
         } catch (Exception e) {
-            LOGGER.warnf("Failed to create %s '%s': %s", source.type(), source.name(), e.getMessage());
+            LOGGER.warnf(e, "Failed to create %s '%s'", source.type(), source.name());
             return null;
         }
     }
 
     /**
-     * Deserializes JSON and calls the store's update method via reflection-free
-     * type-safe dispatch.
+     * The marker {@link SecretScrubber} writes in place of a secret value.
+     * <p>
+     * Referenced, not re-typed: as a bare literal the two copies could drift, and
+     * the drift would be silent — {@link #restoreRedactedSecrets} would simply stop
+     * matching and write placeholders over a production agent's live API keys.
+     */
+    private static final String SCRUBBED_SECRET = SecretScrubber.REDACTED;
+
+    /**
+     * Puts the target's own value back wherever the source content carries a
+     * scrubbed secret.
+     * <p>
+     * Everything in an export ZIP has been through the secret scrubber, which
+     * replaces live credentials with {@value #SCRUBBED_SECRET}. Writing that
+     * straight into the target replaced a production agent's working API keys with
+     * placeholders — an upgrade from an export silently broke the agent it was
+     * meant to update. A placeholder with no counterpart in the target is left
+     * alone and reported, because there is nothing to preserve and the operator has
+     * to supply the value.
+     *
+     * @return the source JSON, with scrubbed leaves replaced by the target's values
+     */
+    private String restoreRedactedSecrets(ExtensionSourceData source, String sourceJson, String targetJson) {
+        if (sourceJson == null || !sourceJson.contains(SCRUBBED_SECRET)) {
+            return sourceJson;
+        }
+        if (targetJson == null) {
+            LOGGER.warnf("%s '%s' carries scrubbed secrets and the target's current config could not be read —"
+                    + " the placeholders will be written as-is and must be replaced by hand",
+                    source.type(), source.name());
+            return sourceJson;
+        }
+        try {
+            Object sourceTree = jsonSerialization.deserialize(sourceJson);
+            Object targetTree = jsonSerialization.deserialize(targetJson);
+            Object merged = mergeScrubbedValues(sourceTree, targetTree);
+            String mergedJson = jsonSerialization.serialize(merged);
+            if (mergedJson != null && mergedJson.contains(SCRUBBED_SECRET)) {
+                LOGGER.warnf("%s '%s' still carries scrubbed secrets the target has no value for —"
+                        + " they must be replaced by hand", source.type(), source.name());
+            }
+            return mergedJson != null ? mergedJson : sourceJson;
+        } catch (Exception e) {
+            LOGGER.warnf(e, "Could not restore scrubbed secrets for %s '%s' — writing the source content as-is",
+                    source.type(), source.name());
+            return sourceJson;
+        }
+    }
+
+    /**
+     * Walks two parsed configs in parallel and returns the source with every
+     * scrubbed leaf replaced by the target's value at the same position.
+     */
+    private static Object mergeScrubbedValues(Object sourceNode, Object targetNode) {
+        if (sourceNode instanceof String text) {
+            if (text.contains(SCRUBBED_SECRET) && targetNode instanceof String targetText) {
+                return targetText;
+            }
+            return text;
+        }
+        if (sourceNode instanceof Map<?, ?> sourceMap) {
+            Map<?, ?> targetMap = targetNode instanceof Map<?, ?> map ? map : Map.of();
+            Map<String, Object> merged = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : sourceMap.entrySet()) {
+                String key = String.valueOf(entry.getKey());
+                merged.put(key, mergeScrubbedValues(entry.getValue(), targetMap.get(key)));
+            }
+            return merged;
+        }
+        if (sourceNode instanceof List<?> sourceList) {
+            List<?> targetList = targetNode instanceof List<?> list ? list : List.of();
+            List<Object> merged = new ArrayList<>(sourceList.size());
+            for (int i = 0; i < sourceList.size(); i++) {
+                merged.add(mergeScrubbedValues(sourceList.get(i), i < targetList.size() ? targetList.get(i) : null));
+            }
+            return merged;
+        }
+        return sourceNode;
+    }
+
+    /**
+     * Deserializes JSON and calls the store's update method through the typed
+     * lambda held by {@link #resolveExtensionOps}.
      */
     private <T> Response dispatchUpdate(ExtensionStoreOps<T> ops, String json,
                                         String targetId, Integer targetVersion)
             throws Exception {
         T config = jsonSerialization.deserialize(json, ops.configClass());
-        Object store = ops.store();
-        // Type-safe dispatch — each store has a different update method name
-        return switch (ops.configClass().getSimpleName()) {
-            case "DictionaryConfiguration" ->
-                ((IRestDictionaryStore) store).updateRegularDictionary(targetId, targetVersion, (DictionaryConfiguration) config);
-            case "RuleSetConfiguration" -> ((IRestRuleSetStore) store).updateRuleSet(targetId, targetVersion, (RuleSetConfiguration) config);
-            case "ApiCallsConfiguration" -> ((IRestApiCallsStore) store).updateApiCalls(targetId, targetVersion, (ApiCallsConfiguration) config);
-            case "LlmConfiguration" -> ((IRestLlmStore) store).updateLlm(targetId, targetVersion, (LlmConfiguration) config);
-            case "PropertySetterConfiguration" ->
-                ((IRestPropertySetterStore) store).updatePropertySetter(targetId, targetVersion, (PropertySetterConfiguration) config);
-            case "OutputConfigurationSet" -> ((IRestOutputStore) store).updateOutputSet(targetId, targetVersion, (OutputConfigurationSet) config);
-            case "McpCallsConfiguration" -> ((IRestMcpCallsStore) store).updateMcpCalls(targetId, targetVersion, (McpCallsConfiguration) config);
-            case "RagConfiguration" -> ((IRestRagStore) store).updateRag(targetId, targetVersion, (RagConfiguration) config);
-            default -> throw new IllegalArgumentException("Unsupported config class: " + ops.configClass().getSimpleName());
-        };
+        return ops.update().apply(targetId, targetVersion, config);
     }
 
     /**
@@ -421,7 +603,7 @@ public class UpgradeExecutor {
      * Creates a new workflow using direct store access, bypassing
      * Response.getLocation() which fails for eddi:// scheme URIs.
      */
-    private URI createNewWorkflow(WorkflowSourceData sourceWf) {
+    private URI createNewWorkflow(WorkflowSourceData sourceWf, Outcome outcome) {
         try {
             IWorkflowStore store = CDI.current().select(IWorkflowStore.class).get();
             IResourceId resourceId = store.create(sourceWf.config());
@@ -435,7 +617,8 @@ public class UpgradeExecutor {
 
             return createdUri;
         } catch (Exception e) {
-            LOGGER.warnf("Failed to create workflow '%s': %s", sourceWf.name(), e.getMessage());
+            LOGGER.warnf(e, "Failed to create workflow '%s'", sourceWf.name());
+            outcome.failed(sourceWf.sourceId(), "workflow", sourceWf.name(), e);
             return null;
         }
     }
@@ -444,35 +627,41 @@ public class UpgradeExecutor {
      * Updates the extension URIs within a target workflow's config. When an
      * extension was updated (version incremented), the workflow config needs to
      * point to the new version.
+     * <p>
+     * The new URI is written into the step's {@code config} map — the one the
+     * engine reads. Writing it into {@code extensions} left the deployed pipeline
+     * loading the OLD extension version while the agent version was bumped, and
+     * left a stray {@code extensions.uri} that reference scans do not count, so the
+     * resource it named looked orphaned.
      */
     private URI updateWorkflowExtensionUris(String workflowId, Integer workflowVersion,
-                                            Map<String, URI> extensionUpdates) {
+                                            Map<String, URI> extensionUpdates, Outcome outcome) {
         try {
             WorkflowConfiguration wfConfig = workflowStore.readWorkflow(workflowId, workflowVersion);
 
             boolean changed = false;
-            for (WorkflowConfiguration.WorkflowStep step : wfConfig.getWorkflowSteps()) {
-                if (step.getType() == null)
-                    continue;
-                String stepType = step.getType().toString();
-                URI newExtUri = extensionUpdates.get(stepType);
+            for (WorkflowExtensions.ExtensionRef ref : WorkflowExtensions.scan(wfConfig)) {
+                URI newExtUri = extensionUpdates.get(ref.key());
                 if (newExtUri != null) {
-                    step.getExtensions().put("uri", newExtUri.toString());
+                    ref.repointTo(newExtUri);
                     changed = true;
                 }
             }
 
             if (changed) {
                 Response resp = workflowStore.updateWorkflow(workflowId, workflowVersion, wfConfig);
-                if (resp.getStatus() == 200) {
+                if (resp != null && resp.getStatus() == 200) {
                     return URI.create(IRestWorkflowStore.resourceURI + workflowId
                             + IRestWorkflowStore.versionQueryParam + (workflowVersion + 1));
                 }
+                outcome.failed(workflowId, "workflow", null,
+                        "the workflow store did not accept the updated extension URIs");
             }
 
             return null;
         } catch (Exception e) {
-            LOGGER.warnf("Failed to update workflow URIs %s: %s", workflowId, e.getMessage());
+            LOGGER.warnf(e, "Failed to update workflow URIs %s", workflowId);
+            outcome.failed(workflowId, "workflow", null, e);
             return null;
         }
     }
@@ -524,15 +713,46 @@ public class UpgradeExecutor {
 
             return null;
         } catch (Exception e) {
-            LOGGER.errorf("Failed to update agent config %s: %s", agentId, e.getMessage());
+            LOGGER.errorf(e, "Failed to update agent config %s", agentId);
             throw new RuntimeException("Agent config update failed: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * The agent's current URI, for an upgrade that had nothing to write.
+     * <p>
+     * This one does not fall back to version 1. {@link #readLatestVersion} swallows
+     * every descriptor failure and answers 1, which on this path handed the caller
+     * {@code ?version=1} for an agent that may well be at v14 — a wrong version
+     * number reported as the outcome of a successful no-op sync. When the version
+     * cannot be established the URI is returned without a {@code ?version=}
+     * parameter instead, which is this codebase's "unspecified, i.e. latest" form
+     * and states no number the deployment might not agree with.
+     */
+    private URI currentAgentUri(String agentId) {
+        Integer currentVersion = resolveLatestVersion(agentId);
+        if (currentVersion == null) {
+            LOGGER.warnf("Could not establish the current version of agent %s — reporting its URI without one"
+                    + " rather than guessing", agentId);
+            return URI.create(IRestAgentStore.resourceURI + agentId);
+        }
+        return URI.create(IRestAgentStore.resourceURI + agentId + "?version=" + currentVersion);
     }
 
     /**
      * Reads the latest version of a resource via its descriptor.
      */
     private int readLatestVersion(String resourceId) {
+        Integer version = resolveLatestVersion(resourceId);
+        return version != null ? version : 1;
+    }
+
+    /**
+     * The latest version of a resource per its descriptor, or {@code null} when
+     * that cannot be established — an unreadable descriptor, one with no resource
+     * URI, or one whose URI carries no resource id.
+     */
+    private Integer resolveLatestVersion(String resourceId) {
         try {
             DocumentDescriptor desc = documentDescriptorStore.readDescriptor(resourceId, null);
             if (desc != null && desc.getResource() != null) {
@@ -541,9 +761,9 @@ public class UpgradeExecutor {
                     return resId.getVersion();
             }
         } catch (Exception e) {
-            LOGGER.debugf("Could not find latest version for %s, using 1", resourceId);
+            LOGGER.debugf(e, "Could not find latest version for %s", resourceId);
         }
-        return 1;
+        return null;
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
@@ -176,16 +176,23 @@ public class UpgradeExecutor {
                     Map<String, URI> extensionUpdates = processWorkflowExtensions(
                             sourceWf, diffMap, selectedSourceIds, outcome);
 
-                    // Update the workflow config with new extension version URIs
-                    if (extensionUpdates.isEmpty()) {
+                    // The workflow document itself changed — reordered steps, a
+                    // changed step config, a condition — and the preview said so.
+                    // Counting that as "skipped" and writing nothing told the
+                    // operator the sync was a no-op while their edit was dropped.
+                    boolean adoptSourceConfig = wfDiff.action() == DiffAction.UPDATE
+                            && isSelected(selectedSourceIds, sourceWf.sourceId());
+
+                    int failuresBefore = outcome.failures.size();
+                    URI updatedUri = extensionUpdates.isEmpty() && !adoptSourceConfig
+                            ? null
+                            : updateMatchedWorkflow(sourceWf, wfDiff, extensionUpdates,
+                                    adoptSourceConfig, outcome);
+                    if (updatedUri != null) {
+                        updatedWorkflowUris.put(wfDiff.targetId(), updatedUri);
+                        outcome.updated++;
+                    } else if (extensionUpdates.isEmpty() && outcome.failures.size() == failuresBefore) {
                         outcome.skipped++;
-                    } else {
-                        URI updatedUri = updateWorkflowExtensionUris(
-                                wfDiff.targetId(), wfDiff.targetVersion(), extensionUpdates, outcome);
-                        if (updatedUri != null) {
-                            updatedWorkflowUris.put(wfDiff.targetId(), updatedUri);
-                            outcome.updated++;
-                        }
                     }
                 }
             }
@@ -264,17 +271,18 @@ public class UpgradeExecutor {
                 snippetStore.updateSnippet(diff.targetId(), diff.targetVersion(), sourceSnippet.snippet());
                 outcome.updated++;
                 LOGGER.infof("Updated snippet '%s' (target=%s, v%d→v%d)",
-                        sourceSnippet.name(), diff.targetId(), diff.targetVersion(), diff.targetVersion() + 1);
+                        LogSanitizer.sanitize(sourceSnippet.name()), LogSanitizer.sanitize(diff.targetId()), diff.targetVersion(),
+                        diff.targetVersion() + 1);
             } else if (diff.action() == DiffAction.CREATE) {
                 // Create new snippet
                 snippetStore.createSnippet(sourceSnippet.snippet());
                 outcome.created++;
-                LOGGER.infof("Created snippet '%s'", sourceSnippet.name());
+                LOGGER.infof("Created snippet '%s'", LogSanitizer.sanitize(sourceSnippet.name()));
             } else {
                 outcome.skipped++;
             }
         } catch (Exception e) {
-            LOGGER.warnf(e, "Failed to process snippet '%s'", sourceSnippet.name());
+            LOGGER.warnf(e, "Failed to process snippet '%s'", LogSanitizer.sanitize(sourceSnippet.name()));
             outcome.failed(sourceSnippet.sourceId(), "snippet", sourceSnippet.name(), e);
         }
     }
@@ -318,8 +326,8 @@ public class UpgradeExecutor {
                         updates.put(extensionKey, updatedUri);
                         outcome.updated++;
                         LOGGER.infof("Updated %s '%s' (target=%s, v%d→v%d)",
-                                sourceExt.type(), sourceExt.name(),
-                                extDiff.targetId(), extDiff.targetVersion(), extDiff.targetVersion() + 1);
+                                LogSanitizer.sanitize(sourceExt.type()), LogSanitizer.sanitize(sourceExt.name()),
+                                LogSanitizer.sanitize(extDiff.targetId()), extDiff.targetVersion(), extDiff.targetVersion() + 1);
                     } else {
                         outcome.failed(sourceExt.sourceId(), sourceExt.type(), sourceExt.name(),
                                 "the store did not accept the update");
@@ -347,7 +355,8 @@ public class UpgradeExecutor {
                             LogSanitizer.sanitize(sourceExt.type()), LogSanitizer.sanitize(sourceExt.name()));
                 }
             } catch (Exception e) {
-                LOGGER.warnf(e, "Failed to process extension %s '%s'", sourceExt.type(), sourceExt.name());
+                LOGGER.warnf(e, "Failed to process extension %s '%s'", LogSanitizer.sanitize(sourceExt.type()),
+                        LogSanitizer.sanitize(sourceExt.name()));
                 outcome.failed(sourceExt.sourceId(), sourceExt.type(), sourceExt.name(), e);
             }
         }
@@ -462,7 +471,8 @@ public class UpgradeExecutor {
                     ? URI.create(ops.resourceUri() + targetId + ops.versionQueryParam() + (targetVersion + 1))
                     : null;
         } catch (Exception e) {
-            LOGGER.warnf(e, "Failed to update %s '%s' (target=%s)", source.type(), source.name(), targetId);
+            LOGGER.warnf(e, "Failed to update %s '%s' (target=%s)", LogSanitizer.sanitize(source.type()), LogSanitizer.sanitize(source.name()),
+                    LogSanitizer.sanitize(targetId));
             return null;
         }
     }
@@ -541,16 +551,16 @@ public class UpgradeExecutor {
 
             return createdUri;
         } catch (Exception e) {
-            LOGGER.warnf(e, "Failed to create workflow '%s'", sourceWf.name());
+            LOGGER.warnf(e, "Failed to create workflow '%s'", LogSanitizer.sanitize(sourceWf.name()));
             outcome.failed(sourceWf.sourceId(), "workflow", sourceWf.name(), e);
             return null;
         }
     }
 
     /**
-     * Updates the extension URIs within a target workflow's config. When an
-     * extension was updated (version incremented), the workflow config needs to
-     * point to the new version.
+     * Writes the target workflow: its own document when the source workflow changed
+     * and can be adopted, plus the extension URIs of everything this run
+     * re-versioned.
      * <p>
      * The new URI is written into the step's {@code config} map — the one the
      * engine reads. Writing it into {@code extensions} left the deployed pipeline
@@ -561,19 +571,53 @@ public class UpgradeExecutor {
      * Any key this method cannot place is reported as a failure rather than
      * dropped. A written resource whose URI nothing consumes is an orphan the
      * operator is never told about, and the run would still answer success.
+     *
+     * @param adoptSourceConfig
+     *            whether the preview said the workflow document itself changed, so
+     *            the source's steps replace the target's. Honoured only when the
+     *            two workflows wire up the same extensions — see
+     *            {@link #adoptableSourceConfig}
+     * @return the workflow's new version URI, or null when nothing was written
      */
-    private URI updateWorkflowExtensionUris(String workflowId, Integer workflowVersion,
-                                            Map<String, URI> extensionUpdates, Outcome outcome) {
+    private URI updateMatchedWorkflow(WorkflowSourceData sourceWf, ResourceDiff wfDiff,
+                                      Map<String, URI> extensionUpdates,
+                                      boolean adoptSourceConfig, Outcome outcome) {
+        String workflowId = wfDiff.targetId();
+        Integer workflowVersion = wfDiff.targetVersion();
         try {
-            WorkflowConfiguration wfConfig = workflowStore.readWorkflow(workflowId, workflowVersion);
+            WorkflowConfiguration targetConfig = workflowStore.readWorkflow(workflowId, workflowVersion);
 
-            boolean changed = false;
+            // Where the target currently points, so an adopted source config can be
+            // rewritten onto the target's own resources instead of the source
+            // instance's ids, which do not exist here.
+            Map<String, URI> targetRefs = new LinkedHashMap<>();
+            for (WorkflowExtensions.ExtensionRef ref : WorkflowExtensions.scan(targetConfig)) {
+                targetRefs.put(ref.key(), ref.extensionUri());
+            }
+
+            String refusedAdoption = null;
+            WorkflowConfiguration configToWrite = targetConfig;
+            if (adoptSourceConfig && targetConfig == null) {
+                LOGGER.warnf("Workflow %s changed in the source but its current version could not be read —"
+                        + " its steps are left as they are", LogSanitizer.sanitize(workflowId));
+            } else if (adoptSourceConfig && hasSteps(sourceWf.config())) {
+                refusedAdoption = adoptableSourceConfig(sourceWf.config(), targetRefs);
+                if (refusedAdoption == null) {
+                    configToWrite = sourceWf.config();
+                }
+            }
+
+            boolean changed = configToWrite != null && configToWrite != targetConfig;
             Set<String> unconsumed = new LinkedHashSet<>(extensionUpdates.keySet());
-            for (WorkflowExtensions.ExtensionRef ref : WorkflowExtensions.scan(wfConfig)) {
+            for (WorkflowExtensions.ExtensionRef ref : WorkflowExtensions.scan(configToWrite)) {
                 URI newExtUri = extensionUpdates.get(ref.key());
                 if (newExtUri != null) {
-                    ref.repointTo(newExtUri);
                     unconsumed.remove(ref.key());
+                } else if (configToWrite != targetConfig) {
+                    newExtUri = targetRefs.get(ref.key());
+                }
+                if (newExtUri != null && !newExtUri.equals(ref.extensionUri())) {
+                    ref.repointTo(newExtUri);
                     changed = true;
                 }
             }
@@ -583,23 +627,109 @@ public class UpgradeExecutor {
                         "the target workflow has no reference at '" + key + "' for "
                                 + extensionUpdates.get(key) + ", so the updated resource is not deployed");
             }
+            if (refusedAdoption != null) {
+                outcome.failed(workflowId, "workflow", sourceWf.name(), refusedAdoption);
+            }
+
+            // Adopting a config that repoints to exactly what the target already has
+            // is the cross-instance no-op: same steps, different resource ids. Writing
+            // it would burn a workflow and an agent version to change nothing.
+            if (changed && configToWrite != targetConfig && sameSteps(configToWrite, targetConfig)) {
+                changed = false;
+            }
 
             if (changed) {
-                Response resp = workflowStore.updateWorkflow(workflowId, workflowVersion, wfConfig);
+                Response resp = workflowStore.updateWorkflow(workflowId, workflowVersion, configToWrite);
                 if (resp != null && resp.getStatus() == 200) {
                     return URI.create(IRestWorkflowStore.resourceURI + workflowId
                             + IRestWorkflowStore.versionQueryParam + (workflowVersion + 1));
                 }
                 outcome.failed(workflowId, "workflow", null,
-                        "the workflow store did not accept the updated extension URIs");
+                        "the workflow store did not accept the updated workflow");
             }
 
             return null;
         } catch (Exception e) {
-            LOGGER.warnf(e, "Failed to update workflow URIs %s", workflowId);
+            LOGGER.warnf(e, "Failed to update workflow %s", LogSanitizer.sanitize(workflowId));
             outcome.failed(workflowId, "workflow", null, e);
             return null;
         }
+    }
+
+    /**
+     * Whether the source workflow's steps may replace the target's, or the reason
+     * they may not.
+     * <p>
+     * Only when both sides wire up the same extensions. A source step referencing
+     * something the target workflow does not have would be written pointing at a
+     * resource id from the other instance — a pipeline step loading a config that
+     * is not in this database. That is the same refusal
+     * {@link #processWorkflowExtensions} makes for a CREATE extension, applied to
+     * the step that would reference it.
+     *
+     * @return null when the source config can be adopted, otherwise the reason for
+     *         the operator
+     */
+    private String adoptableSourceConfig(WorkflowConfiguration sourceConfig, Map<String, URI> targetRefs) {
+        for (WorkflowExtensions.ExtensionRef ref : WorkflowExtensions.scan(sourceConfig)) {
+            if (!targetRefs.containsKey(ref.key())) {
+                return "the source workflow's steps were not applied: it references a " + ref.fileExtension()
+                        + " at '" + ref.key() + "' that the target workflow does not have"
+                        + " — add the step to the target workflow, or import the source workflow as a new one";
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether a source workflow carries a pipeline to apply at all.
+     * <p>
+     * A source with no steps is left alone rather than adopted. A workflow with
+     * zero steps deploys an agent that runs no lifecycle task and answers nothing
+     * (see {@link WorkflowConfiguration#setWorkflowSteps}), so emptying a live
+     * pipeline is never what a sync is for — and it is what an unparsed or
+     * partially read source workflow looks like.
+     */
+    private static boolean hasSteps(WorkflowConfiguration config) {
+        return config != null && config.getWorkflowSteps() != null && !config.getWorkflowSteps().isEmpty();
+    }
+
+    /**
+     * Whether two workflow documents describe the same pipeline.
+     * {@link WorkflowConfiguration} has no {@code equals}, and the comparison has
+     * to hold without a serializer so that it cannot itself fail.
+     */
+    private static boolean sameSteps(WorkflowConfiguration left, WorkflowConfiguration right) {
+        if (left == right) {
+            return true;
+        }
+        if (left == null || right == null) {
+            return false;
+        }
+        List<WorkflowConfiguration.WorkflowStep> leftSteps = left.getWorkflowSteps();
+        List<WorkflowConfiguration.WorkflowStep> rightSteps = right.getWorkflowSteps();
+        if (leftSteps == null || rightSteps == null) {
+            return leftSteps == rightSteps;
+        }
+        if (leftSteps.size() != rightSteps.size()) {
+            return false;
+        }
+        for (int i = 0; i < leftSteps.size(); i++) {
+            WorkflowConfiguration.WorkflowStep leftStep = leftSteps.get(i);
+            WorkflowConfiguration.WorkflowStep rightStep = rightSteps.get(i);
+            if (leftStep == null || rightStep == null) {
+                if (leftStep != rightStep) {
+                    return false;
+                }
+                continue;
+            }
+            if (!Objects.equals(leftStep.getType(), rightStep.getType())
+                    || !Objects.equals(leftStep.getConfig(), rightStep.getConfig())
+                    || !Objects.equals(leftStep.getExtensions(), rightStep.getExtensions())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     // ==================== Agent Config Update ====================
@@ -643,7 +773,8 @@ public class UpgradeExecutor {
             Response resp = agentStore.updateAgent(agentId, currentVersion, agentConfig);
             if (resp.getStatus() == 200) {
                 URI updatedUri = URI.create(IRestAgentStore.resourceURI + agentId + "?version=" + (currentVersion + 1));
-                LOGGER.infof("Agent '%s' upgraded successfully (v%d→v%d)", agentId, currentVersion, currentVersion + 1);
+                LOGGER.infof("Agent '%s' upgraded successfully (v%d→v%d)", LogSanitizer.sanitize(agentId), currentVersion,
+                        currentVersion + 1);
                 return updatedUri;
             }
 

--- a/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/UpgradeExecutor.java
@@ -14,40 +14,31 @@ import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.backup.model.UpgradeResult.ResourceFailure;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
-import ai.labs.eddi.configs.apicalls.IApiCallsStore;
 import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
 import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
-import ai.labs.eddi.configs.dictionary.IDictionaryStore;
 import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
 import ai.labs.eddi.configs.dictionary.model.DictionaryConfiguration;
-import ai.labs.eddi.configs.llm.ILlmStore;
 import ai.labs.eddi.configs.llm.IRestLlmStore;
-import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
 import ai.labs.eddi.configs.mcpcalls.IRestMcpCallsStore;
 import ai.labs.eddi.configs.mcpcalls.model.McpCallsConfiguration;
-import ai.labs.eddi.configs.output.IOutputStore;
 import ai.labs.eddi.configs.output.IRestOutputStore;
 import ai.labs.eddi.configs.output.model.OutputConfigurationSet;
-import ai.labs.eddi.configs.propertysetter.IPropertySetterStore;
 import ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore;
 import ai.labs.eddi.configs.propertysetter.model.PropertySetterConfiguration;
-import ai.labs.eddi.configs.rag.IRagStore;
 import ai.labs.eddi.configs.rag.IRestRagStore;
 import ai.labs.eddi.configs.rag.model.RagConfiguration;
-import ai.labs.eddi.configs.rules.IRuleSetStore;
 import ai.labs.eddi.configs.rules.IRestRuleSetStore;
 import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
-import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
-import ai.labs.eddi.secrets.sanitize.SecretScrubber;
+import ai.labs.eddi.utils.LogSanitizer;
 import ai.labs.eddi.utils.RestUtilities;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.CDI;
@@ -171,13 +162,24 @@ public class UpgradeExecutor {
                             outcome.created++;
                         }
                     }
-                } else if (wfDiff.action() == DiffAction.UPDATE) {
-                    // Matched workflow — process extensions
+                } else {
+                    // Matched workflow — process its extensions whatever the
+                    // workflow-level action says.
+                    //
+                    // The action is decided from the workflow JSON alone, and on the
+                    // most natural sync path — export an agent, edit one extension in
+                    // the ZIP, upgrade the same agent — that JSON is byte-identical on
+                    // both sides, so the workflow came back SKIP. Reading the extension
+                    // diffs only inside the UPDATE branch therefore threw away every
+                    // extension change the preview had just shown the operator, and the
+                    // response still said 200 OK.
                     Map<String, URI> extensionUpdates = processWorkflowExtensions(
                             sourceWf, diffMap, selectedSourceIds, outcome);
 
                     // Update the workflow config with new extension version URIs
-                    if (!extensionUpdates.isEmpty()) {
+                    if (extensionUpdates.isEmpty()) {
+                        outcome.skipped++;
+                    } else {
                         URI updatedUri = updateWorkflowExtensionUris(
                                 wfDiff.targetId(), wfDiff.targetVersion(), extensionUpdates, outcome);
                         if (updatedUri != null) {
@@ -185,8 +187,6 @@ public class UpgradeExecutor {
                             outcome.updated++;
                         }
                     }
-                } else {
-                    outcome.skipped++;
                 }
             }
 
@@ -205,7 +205,7 @@ public class UpgradeExecutor {
 
             if (!agentNeedsUpdate) {
                 LOGGER.infof("Agent '%s' upgrade wrote no workflow changes — agent version left at %s",
-                        targetAgentId, agentUri);
+                        LogSanitizer.sanitize(targetAgentId), LogSanitizer.sanitize(String.valueOf(agentUri)));
             }
 
             UpgradeResult result = outcome.toResult(agentUri, agentNeedsUpdate);
@@ -217,11 +217,11 @@ public class UpgradeExecutor {
             // A target agent that cannot be read is a 404 the operator can act on.
             // Wrapping it turned the one actionable failure of a sync into a 500.
             metrics.upgradeFailed();
-            LOGGER.errorf(e, "Upgrade failed for target agent %s", targetAgentId);
+            LOGGER.errorf(e, "Upgrade failed for target agent %s", LogSanitizer.sanitize(targetAgentId));
             throw e;
         } catch (Exception e) {
             metrics.upgradeFailed();
-            LOGGER.errorf(e, "Upgrade failed for target agent %s", targetAgentId);
+            LOGGER.errorf(e, "Upgrade failed for target agent %s", LogSanitizer.sanitize(targetAgentId));
             throw new RuntimeException("Upgrade failed: " + e.getMessage(), e);
         }
     }
@@ -325,15 +325,26 @@ public class UpgradeExecutor {
                                 "the store did not accept the update");
                     }
                 } else if (extDiff.action() == DiffAction.CREATE) {
-                    URI newUri = createExtension(sourceExt);
-                    if (newUri != null) {
-                        updates.put(extensionKey, newUri);
-                        outcome.created++;
-                        LOGGER.infof("Created %s '%s'", sourceExt.type(), sourceExt.name());
-                    } else {
-                        outcome.failed(sourceExt.sourceId(), sourceExt.type(), sourceExt.name(),
-                                "the store did not accept the create");
-                    }
+                    // Deliberately NOT created. The only thing that would consume the
+                    // new URI is updateWorkflowExtensionUris, which can repoint a
+                    // reference the target workflow already has — and CREATE means, by
+                    // definition, that it has none. Creating the resource anyway left
+                    // it in the store with nothing pointing at it, counted it as
+                    // created, answered 201, changed the agent's behaviour not at all,
+                    // and previewed the same CREATE again on the next sync, so every
+                    // run added another unreferenced copy.
+                    //
+                    // Cloning the source's step into the target workflow instead was
+                    // considered and rejected: the preview has no row for "a step will
+                    // be added to your existing pipeline", so it would reshape a live
+                    // agent's pipeline off the back of a resource row the operator
+                    // approved as a config change.
+                    outcome.failed(sourceExt.sourceId(), sourceExt.type(), sourceExt.name(),
+                            "the target workflow has no step referencing this " + sourceExt.type()
+                                    + " — add the step to the target workflow, or import the source"
+                                    + " workflow as a new one, then sync again");
+                    LOGGER.warnf("Skipped %s '%s': the target workflow has no step to reference it",
+                            LogSanitizer.sanitize(sourceExt.type()), LogSanitizer.sanitize(sourceExt.name()));
                 }
             } catch (Exception e) {
                 LOGGER.warnf(e, "Failed to process extension %s '%s'", sourceExt.type(), sourceExt.name());
@@ -359,50 +370,42 @@ public class UpgradeExecutor {
                     DictionaryConfiguration.class,
                     (id, version, config) -> getStore(IRestDictionaryStore.class).updateRegularDictionary(id, version, config),
                     IRestDictionaryStore.resourceURI,
-                    IRestDictionaryStore.versionQueryParam,
-                    IDictionaryStore.class);
+                    IRestDictionaryStore.versionQueryParam);
             case "behavior" -> new ExtensionStoreOps<>(
                     RuleSetConfiguration.class,
                     (id, version, config) -> getStore(IRestRuleSetStore.class).updateRuleSet(id, version, config),
                     IRestRuleSetStore.resourceURI,
-                    IRestRuleSetStore.versionQueryParam,
-                    IRuleSetStore.class);
+                    IRestRuleSetStore.versionQueryParam);
             case "httpcalls" -> new ExtensionStoreOps<>(
                     ApiCallsConfiguration.class,
                     (id, version, config) -> getStore(IRestApiCallsStore.class).updateApiCalls(id, version, config),
                     IRestApiCallsStore.resourceURI,
-                    IRestApiCallsStore.versionQueryParam,
-                    IApiCallsStore.class);
+                    IRestApiCallsStore.versionQueryParam);
             case "langchain" -> new ExtensionStoreOps<>(
                     LlmConfiguration.class,
                     (id, version, config) -> getStore(IRestLlmStore.class).updateLlm(id, version, config),
                     IRestLlmStore.resourceURI,
-                    IRestLlmStore.versionQueryParam,
-                    ILlmStore.class);
+                    IRestLlmStore.versionQueryParam);
             case "property" -> new ExtensionStoreOps<>(
                     PropertySetterConfiguration.class,
                     (id, version, config) -> getStore(IRestPropertySetterStore.class).updatePropertySetter(id, version, config),
                     IRestPropertySetterStore.resourceURI,
-                    IRestPropertySetterStore.versionQueryParam,
-                    IPropertySetterStore.class);
+                    IRestPropertySetterStore.versionQueryParam);
             case "output" -> new ExtensionStoreOps<>(
                     OutputConfigurationSet.class,
                     (id, version, config) -> getStore(IRestOutputStore.class).updateOutputSet(id, version, config),
                     IRestOutputStore.resourceURI,
-                    IRestOutputStore.versionQueryParam,
-                    IOutputStore.class);
+                    IRestOutputStore.versionQueryParam);
             case "mcpcalls" -> new ExtensionStoreOps<>(
                     McpCallsConfiguration.class,
                     (id, version, config) -> getStore(IRestMcpCallsStore.class).updateMcpCalls(id, version, config),
                     IRestMcpCallsStore.resourceURI,
-                    IRestMcpCallsStore.versionQueryParam,
-                    IMcpCallsStore.class);
+                    IRestMcpCallsStore.versionQueryParam);
             case "rag" -> new ExtensionStoreOps<>(
                     RagConfiguration.class,
                     (id, version, config) -> getStore(IRestRagStore.class).updateRag(id, version, config),
                     IRestRagStore.resourceURI,
-                    IRestRagStore.versionQueryParam,
-                    IRagStore.class);
+                    IRestRagStore.versionQueryParam);
             // Loud, not silent: a type registered in WorkflowExtensions but missing
             // here used to return null, which every caller turned into "the store
             // did not accept it" — a wrong diagnosis for a wiring mistake.
@@ -418,10 +421,8 @@ public class UpgradeExecutor {
     }
 
     /**
-     * Holds the configuration class, its store's update call, the URI pattern, and
-     * the direct store class for a single extension type. The
-     * {@code directStoreClass} is used by {@link #dispatchCreateDirect} to bypass
-     * Response.getLocation() which fails for eddi:// scheme URIs.
+     * Holds the configuration class, its store's update call and the URI pattern
+     * for a single extension type.
      * <p>
      * The update call is a typed lambda so that dispatch happens here, in the one
      * table, instead of a second switch on the config class's <em>simple name</em>
@@ -432,8 +433,7 @@ public class UpgradeExecutor {
             Class<T> configClass,
             ExtensionUpdate<T> update,
             String resourceUri,
-            String versionQueryParam,
-            Class<?> directStoreClass) {
+            String versionQueryParam) {
     }
 
     // ==================== Extension Update/Create (Unified) ====================
@@ -468,102 +468,46 @@ public class UpgradeExecutor {
     }
 
     /**
-     * Creates a new extension resource from the source content. Uses direct store
-     * create to bypass Response.getLocation() which fails for eddi:// URIs.
-     *
-     * @throws IllegalArgumentException
-     *             if no store is registered for the source's extension type — see
-     *             {@link #updateExtension} for why that one is not caught here
-     */
-    private URI createExtension(ExtensionSourceData source) {
-        ExtensionStoreOps<?> ops = resolveExtensionOps(source.type());
-        try {
-            return dispatchCreateDirect(ops, source.contentJson());
-        } catch (Exception e) {
-            LOGGER.warnf(e, "Failed to create %s '%s'", source.type(), source.name());
-            return null;
-        }
-    }
-
-    /**
-     * The marker {@link SecretScrubber} writes in place of a secret value.
-     * <p>
-     * Referenced, not re-typed: as a bare literal the two copies could drift, and
-     * the drift would be silent — {@link #restoreRedactedSecrets} would simply stop
-     * matching and write placeholders over a production agent's live API keys.
-     */
-    private static final String SCRUBBED_SECRET = SecretScrubber.REDACTED;
-
-    /**
      * Puts the target's own value back wherever the source content carries a
      * scrubbed secret.
      * <p>
      * Everything in an export ZIP has been through the secret scrubber, which
-     * replaces live credentials with {@value #SCRUBBED_SECRET}. Writing that
-     * straight into the target replaced a production agent's working API keys with
-     * placeholders — an upgrade from an export silently broke the agent it was
-     * meant to update. A placeholder with no counterpart in the target is left
-     * alone and reported, because there is nothing to preserve and the operator has
-     * to supply the value.
+     * replaces live credentials with a placeholder. Writing that straight into the
+     * target replaced a production agent's working API keys with placeholders — an
+     * upgrade from an export silently broke the agent it was meant to update. A
+     * placeholder with no counterpart in the target is left alone and reported,
+     * because there is nothing to preserve and the operator has to supply the
+     * value.
+     * <p>
+     * The merge itself lives in {@link ScrubbedSecrets} so that
+     * {@link StructuralMatcher} decides its {@link DiffAction} on exactly the
+     * content this method is about to write.
      *
      * @return the source JSON, with scrubbed leaves replaced by the target's values
      */
     private String restoreRedactedSecrets(ExtensionSourceData source, String sourceJson, String targetJson) {
-        if (sourceJson == null || !sourceJson.contains(SCRUBBED_SECRET)) {
+        if (!ScrubbedSecrets.carriesPlaceholder(sourceJson)) {
             return sourceJson;
         }
         if (targetJson == null) {
             LOGGER.warnf("%s '%s' carries scrubbed secrets and the target's current config could not be read —"
                     + " the placeholders will be written as-is and must be replaced by hand",
-                    source.type(), source.name());
+                    LogSanitizer.sanitize(source.type()), LogSanitizer.sanitize(source.name()));
             return sourceJson;
         }
         try {
-            Object sourceTree = jsonSerialization.deserialize(sourceJson);
-            Object targetTree = jsonSerialization.deserialize(targetJson);
-            Object merged = mergeScrubbedValues(sourceTree, targetTree);
-            String mergedJson = jsonSerialization.serialize(merged);
-            if (mergedJson != null && mergedJson.contains(SCRUBBED_SECRET)) {
+            String mergedJson = ScrubbedSecrets.restore(sourceJson, targetJson, jsonSerialization);
+            if (ScrubbedSecrets.carriesPlaceholder(mergedJson)) {
                 LOGGER.warnf("%s '%s' still carries scrubbed secrets the target has no value for —"
-                        + " they must be replaced by hand", source.type(), source.name());
+                        + " they must be replaced by hand",
+                        LogSanitizer.sanitize(source.type()), LogSanitizer.sanitize(source.name()));
             }
             return mergedJson != null ? mergedJson : sourceJson;
         } catch (Exception e) {
             LOGGER.warnf(e, "Could not restore scrubbed secrets for %s '%s' — writing the source content as-is",
-                    source.type(), source.name());
+                    LogSanitizer.sanitize(source.type()), LogSanitizer.sanitize(source.name()));
             return sourceJson;
         }
-    }
-
-    /**
-     * Walks two parsed configs in parallel and returns the source with every
-     * scrubbed leaf replaced by the target's value at the same position.
-     */
-    private static Object mergeScrubbedValues(Object sourceNode, Object targetNode) {
-        if (sourceNode instanceof String text) {
-            if (text.contains(SCRUBBED_SECRET) && targetNode instanceof String targetText) {
-                return targetText;
-            }
-            return text;
-        }
-        if (sourceNode instanceof Map<?, ?> sourceMap) {
-            Map<?, ?> targetMap = targetNode instanceof Map<?, ?> map ? map : Map.of();
-            Map<String, Object> merged = new LinkedHashMap<>();
-            for (Map.Entry<?, ?> entry : sourceMap.entrySet()) {
-                String key = String.valueOf(entry.getKey());
-                merged.put(key, mergeScrubbedValues(entry.getValue(), targetMap.get(key)));
-            }
-            return merged;
-        }
-        if (sourceNode instanceof List<?> sourceList) {
-            List<?> targetList = targetNode instanceof List<?> list ? list : List.of();
-            List<Object> merged = new ArrayList<>(sourceList.size());
-            for (int i = 0; i < sourceList.size(); i++) {
-                merged.add(mergeScrubbedValues(sourceList.get(i), i < targetList.size() ? targetList.get(i) : null));
-            }
-            return merged;
-        }
-        return sourceNode;
     }
 
     /**
@@ -575,26 +519,6 @@ public class UpgradeExecutor {
             throws Exception {
         T config = jsonSerialization.deserialize(json, ops.configClass());
         return ops.update().apply(targetId, targetVersion, config);
-    }
-
-    /**
-     * Deserializes JSON and creates the resource directly via the underlying
-     * I*Store, bypassing the REST layer and Response.getLocation() entirely.
-     */
-    @SuppressWarnings("unchecked")
-    private <T> URI dispatchCreateDirect(ExtensionStoreOps<T> ops, String json) throws Exception {
-        T config = jsonSerialization.deserialize(json, ops.configClass());
-        IResourceStore<T> store = (IResourceStore<T>) CDI.current().select(ops.directStoreClass()).get();
-        IResourceId resourceId = store.create(config);
-        URI createdUri = RestUtilities.createURI(ops.resourceUri(), resourceId.getId(), ops.versionQueryParam(), resourceId.getVersion());
-
-        // Create the DocumentDescriptor that the DocumentDescriptorFilter would
-        // normally create on a 201 response — including the ownership stamp, or a
-        // resource created by an upgrade would be unowned and unlistable.
-        documentDescriptorStore.createDescriptor(resourceId.getId(), resourceId.getVersion(),
-                resourceAccessGuard.stampNewDescriptor(createDocumentDescriptor(createdUri)));
-
-        return createdUri;
     }
 
     // ==================== Workflow Updates ====================
@@ -633,6 +557,10 @@ public class UpgradeExecutor {
      * loading the OLD extension version while the agent version was bumped, and
      * left a stray {@code extensions.uri} that reference scans do not count, so the
      * resource it named looked orphaned.
+     * <p>
+     * Any key this method cannot place is reported as a failure rather than
+     * dropped. A written resource whose URI nothing consumes is an orphan the
+     * operator is never told about, and the run would still answer success.
      */
     private URI updateWorkflowExtensionUris(String workflowId, Integer workflowVersion,
                                             Map<String, URI> extensionUpdates, Outcome outcome) {
@@ -640,12 +568,20 @@ public class UpgradeExecutor {
             WorkflowConfiguration wfConfig = workflowStore.readWorkflow(workflowId, workflowVersion);
 
             boolean changed = false;
+            Set<String> unconsumed = new LinkedHashSet<>(extensionUpdates.keySet());
             for (WorkflowExtensions.ExtensionRef ref : WorkflowExtensions.scan(wfConfig)) {
                 URI newExtUri = extensionUpdates.get(ref.key());
                 if (newExtUri != null) {
                     ref.repointTo(newExtUri);
+                    unconsumed.remove(ref.key());
                     changed = true;
                 }
+            }
+
+            for (String key : unconsumed) {
+                outcome.failed(workflowId, "workflow", null,
+                        "the target workflow has no reference at '" + key + "' for "
+                                + extensionUpdates.get(key) + ", so the updated resource is not deployed");
             }
 
             if (changed) {
@@ -713,7 +649,7 @@ public class UpgradeExecutor {
 
             return null;
         } catch (Exception e) {
-            LOGGER.errorf(e, "Failed to update agent config %s", agentId);
+            LOGGER.errorf(e, "Failed to update agent config %s", LogSanitizer.sanitize(agentId));
             throw new RuntimeException("Agent config update failed: " + e.getMessage(), e);
         }
     }
@@ -733,7 +669,7 @@ public class UpgradeExecutor {
         Integer currentVersion = resolveLatestVersion(agentId);
         if (currentVersion == null) {
             LOGGER.warnf("Could not establish the current version of agent %s — reporting its URI without one"
-                    + " rather than guessing", agentId);
+                    + " rather than guessing", LogSanitizer.sanitize(agentId));
             return URI.create(IRestAgentStore.resourceURI + agentId);
         }
         return URI.create(IRestAgentStore.resourceURI + agentId + "?version=" + currentVersion);
@@ -761,7 +697,7 @@ public class UpgradeExecutor {
                     return resId.getVersion();
             }
         } catch (Exception e) {
-            LOGGER.debugf(e, "Could not find latest version for %s", resourceId);
+            LOGGER.debugf(e, "Could not find latest version for %s", LogSanitizer.sanitize(resourceId));
         }
         return null;
     }

--- a/src/main/java/ai/labs/eddi/backup/impl/WorkflowExtensions.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/WorkflowExtensions.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.utils.RestUtilities;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static ai.labs.eddi.backup.impl.AbstractBackupService.BEHAVIOR_EXT;
+import static ai.labs.eddi.backup.impl.AbstractBackupService.DICTIONARY_EXT;
+import static ai.labs.eddi.backup.impl.AbstractBackupService.HTTPCALLS_EXT;
+import static ai.labs.eddi.backup.impl.AbstractBackupService.LLM_EXT;
+import static ai.labs.eddi.backup.impl.AbstractBackupService.MCPCALLS_EXT;
+import static ai.labs.eddi.backup.impl.AbstractBackupService.OUTPUT_EXT;
+import static ai.labs.eddi.backup.impl.AbstractBackupService.PROPERTY_EXT;
+import static ai.labs.eddi.backup.impl.AbstractBackupService.RAG_EXT;
+
+/**
+ * Single source of truth for <em>how a workflow points at its extension
+ * configs</em> and for the per-type metadata the backup package needs.
+ * <p>
+ * Every producer and consumer of
+ * {@link ai.labs.eddi.backup.IResourceSource.WorkflowSourceData#extensions()}
+ * derives its map keys from {@link #scan(WorkflowConfiguration)}, so source
+ * (ZIP or remote instance) and target (local store) keys are guaranteed to
+ * join. Before this class existed the ZIP side keyed the map by resource-store
+ * authority ({@code ai.labs.rules}) while the target side keyed it by the
+ * workflow step type URI ({@code eddi://ai.labs.behavior}), so no extension
+ * could ever match and every sync reported CREATE.
+ *
+ * <h3>Where the URI actually lives</h3> A workflow step keeps its extension
+ * reference in the step's {@code config} map — {@code config.uri} — not in its
+ * {@code extensions} map; {@code extensions} carries nested things such as the
+ * parser's {@code dictionaries} list, where each entry has a {@code config.uri}
+ * of its own. {@link #scan(WorkflowConfiguration)} walks both, so a parser's
+ * regular dictionaries are found alongside the top-level references.
+ *
+ * <h3>Key shape</h3> {@code <stepType>#<occurrence>/<path>}, e.g.
+ * {@code eddi://ai.labs.behavior#0/config} or
+ * {@code eddi://ai.labs.parser#0/extensions/dictionaries/0/config}. The
+ * occurrence ordinal counts steps of the same type within the workflow, so a
+ * workflow with two {@code eddi://ai.labs.httpcalls} steps keeps both instead
+ * of collapsing them onto one key.
+ *
+ * @since 6.0.0
+ */
+final class WorkflowExtensions {
+
+    /** The map key under which a workflow step stores its extension URI. */
+    static final String KEY_URI = "uri";
+
+    /** Guards against a pathological (or cyclic-looking) nested config. */
+    private static final int MAX_DEPTH = 10;
+
+    private WorkflowExtensions() {
+    }
+
+    /**
+     * Per extension type: the authority of its resource URI (the key), the file
+     * extension used inside an export ZIP, and the REST path on a remote EDDI
+     * instance.
+     *
+     * @param resourceAuthority
+     *            authority of the {@code eddi://} resource URI, e.g.
+     *            {@code ai.labs.rules}
+     * @param fileExtension
+     *            file extension inside an export ZIP, e.g. {@code behavior} — also
+     *            the value carried as
+     *            {@link ai.labs.eddi.backup.IResourceSource.ExtensionSourceData#type()}
+     * @param restPath
+     *            store path on a remote instance, e.g. {@code /rulestore/rulesets/}
+     */
+    record ExtensionType(String resourceAuthority, String fileExtension, String restPath) {
+    }
+
+    private static final Map<String, ExtensionType> BY_AUTHORITY = new LinkedHashMap<>();
+
+    static {
+        register("ai.labs.dictionary", DICTIONARY_EXT, "/dictionarystore/dictionaries/");
+        register("ai.labs.rules", BEHAVIOR_EXT, "/rulestore/rulesets/");
+        register("ai.labs.apicalls", HTTPCALLS_EXT, "/apicallstore/apicalls/");
+        register("ai.labs.llm", LLM_EXT, "/llmstore/llms/");
+        register("ai.labs.property", PROPERTY_EXT, "/propertysetterstore/propertysetters/");
+        register("ai.labs.output", OUTPUT_EXT, "/outputstore/outputsets/");
+        register("ai.labs.mcpcalls", MCPCALLS_EXT, "/mcpcallsstore/mcpcalls/");
+        register("ai.labs.rag", RAG_EXT, "/ragstore/rags/");
+    }
+
+    private static void register(String authority, String fileExtension, String restPath) {
+        BY_AUTHORITY.put(authority, new ExtensionType(authority, fileExtension, restPath));
+    }
+
+    /**
+     * A single extension reference found in a workflow.
+     *
+     * @param key
+     *            canonical map key, stable across source and target
+     * @param stepIndex
+     *            0-based index of the workflow step the reference was found in
+     * @param stepType
+     *            the step's {@code type} URI as stored, e.g.
+     *            {@code eddi://ai.labs.behavior}
+     * @param container
+     *            the live map that holds the {@code uri} entry — writing to it
+     *            repoints the workflow at another version
+     * @param extensionUri
+     *            the referenced resource URI
+     * @param resourceId
+     *            id + version extracted from {@code extensionUri}
+     * @param type
+     *            the extension type metadata; never null (unregistered authorities
+     *            do not produce a reference)
+     */
+    record ExtensionRef(String key,
+            int stepIndex,
+            String stepType,
+            Map<String, Object> container,
+            URI extensionUri,
+            IResourceId resourceId,
+            ExtensionType type) {
+
+        String fileExtension() {
+            return type.fileExtension();
+        }
+
+        /** Repoints this reference at a new version of the same resource. */
+        void repointTo(URI newExtensionUri) {
+            container.put(KEY_URI, newExtensionUri.toString());
+        }
+    }
+
+    /** Metadata for the type of resource a URI addresses, or null if unknown. */
+    static ExtensionType typeOf(URI resourceUri) {
+        if (resourceUri == null) {
+            return null;
+        }
+        String authority = resourceUri.getHost() != null ? resourceUri.getHost() : resourceUri.getAuthority();
+        return authority != null ? BY_AUTHORITY.get(authority) : null;
+    }
+
+    /**
+     * All extension references a workflow carries, in step order. Null-safe: a
+     * config, step list, step, or map that is null simply contributes nothing.
+     */
+    static List<ExtensionRef> scan(WorkflowConfiguration config) {
+        List<ExtensionRef> refs = new ArrayList<>();
+        if (config == null || config.getWorkflowSteps() == null) {
+            return refs;
+        }
+
+        Map<String, Integer> occurrences = new HashMap<>();
+        List<WorkflowConfiguration.WorkflowStep> steps = config.getWorkflowSteps();
+        for (int i = 0; i < steps.size(); i++) {
+            WorkflowConfiguration.WorkflowStep step = steps.get(i);
+            if (step == null || step.getType() == null) {
+                continue;
+            }
+            String stepType = step.getType().toString();
+            int occurrence = occurrences.merge(stepType, 1, Integer::sum) - 1;
+            String base = stepType + "#" + occurrence;
+
+            collect(refs, step.getConfig(), base + "/config", i, stepType, 0);
+            collect(refs, step.getExtensions(), base + "/extensions", i, stepType, 0);
+        }
+        return refs;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void collect(List<ExtensionRef> refs, Object node, String path,
+                                int stepIndex, String stepType, int depth) {
+        if (node == null || depth > MAX_DEPTH) {
+            return;
+        }
+
+        if (node instanceof Map<?, ?> map) {
+            Object uriValue = map.get(KEY_URI);
+            if (uriValue instanceof String uriString && !uriString.isBlank()) {
+                addRef(refs, (Map<String, Object>) map, uriString, path, stepIndex, stepType);
+            }
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (KEY_URI.equals(entry.getKey())) {
+                    continue;
+                }
+                collect(refs, entry.getValue(), path + "/" + entry.getKey(), stepIndex, stepType, depth + 1);
+            }
+        } else if (node instanceof List<?> list) {
+            for (int i = 0; i < list.size(); i++) {
+                collect(refs, list.get(i), path + "/" + i, stepIndex, stepType, depth + 1);
+            }
+        }
+    }
+
+    private static void addRef(List<ExtensionRef> refs, Map<String, Object> container, String uriString,
+                               String path, int stepIndex, String stepType) {
+        URI extensionUri;
+        try {
+            extensionUri = URI.create(uriString);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+
+        ExtensionType type = typeOf(extensionUri);
+        if (type == null) {
+            // Not a resource type the backup package knows how to move (e.g. a
+            // parser config). Leaving it out keeps the key space identical on
+            // both sides, which is what makes source and target join at all.
+            return;
+        }
+
+        IResourceId resourceId;
+        try {
+            resourceId = RestUtilities.extractResourceId(extensionUri);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+        if (resourceId == null || resourceId.getId() == null) {
+            return;
+        }
+
+        refs.add(new ExtensionRef(path, stepIndex, stepType, container, extensionUri, resourceId, type));
+    }
+}

--- a/src/main/java/ai/labs/eddi/backup/impl/ZipArchive.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/ZipArchive.java
@@ -24,11 +24,6 @@ public class ZipArchive implements IZipArchive {
     private static final int BUFFER_SIZE = 4096;
 
     @Override
-    public void createZip(String sourceDirPath, String targetZipPath) throws IOException {
-        createZip(sourceDirPath, targetZipPath, Path.of(System.getProperty("user.dir")));
-    }
-
-    @Override
     public void createZip(String sourceDirPath, String targetZipPath, Path allowedBaseDir) throws IOException {
         File directoryToZip = new File(sourceDirPath);
 

--- a/src/main/java/ai/labs/eddi/backup/impl/ZipResourceSource.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/ZipResourceSource.java
@@ -23,9 +23,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.regex.Pattern;
 
-import static ai.labs.eddi.backup.impl.AbstractBackupService.*;
+import static ai.labs.eddi.backup.impl.AbstractBackupService.SNIPPET_EXT;
 
 /**
  * Reads agent resource data from an unzipped directory (the result of unzipping
@@ -37,22 +36,29 @@ import static ai.labs.eddi.backup.impl.AbstractBackupService.*;
  * the unzipped directory. Implements {@link AutoCloseable} to allow cleanup of
  * temporary files.
  *
- * <h3>Expected ZIP directory structure</h3>
+ * <h3>Expected ZIP directory structure</h3> This is the layout
+ * {@link RestExportService} actually produces: it zips from
+ * {@code <scratch>/<agentId>/<version>/}, so that directory <em>is</em> the
+ * archive root — there is no {@code <agentId>/} wrapper inside.
  *
  * <pre>
  * &lt;rootDir&gt;/
- *   &lt;agentId&gt;/
- *     &lt;agentId&gt;.agent.json
- *     &lt;agentId&gt;.descriptor.json
- *     &lt;workflowId&gt;/
- *       &lt;version&gt;/
- *         &lt;workflowId&gt;.workflow.json        (or .package.json for legacy)
- *         &lt;workflowId&gt;.descriptor.json
- *         &lt;extId&gt;.&lt;type&gt;.json              (e.g., abc123.langchain.json)
- *         &lt;extId&gt;.descriptor.json
- *     snippets/                              (may be at root, agent, or version level)
- *       &lt;snippetId&gt;.snippet.json
+ *   &lt;agentId&gt;.agent.json
+ *   &lt;agentId&gt;.descriptor.json
+ *   &lt;workflowId&gt;/
+ *     &lt;version&gt;/
+ *       &lt;workflowId&gt;.workflow.json        (or .package.json for legacy)
+ *       &lt;workflowId&gt;.descriptor.json
+ *       &lt;extId&gt;.&lt;type&gt;.json              (e.g., abc123.langchain.json)
+ *       &lt;extId&gt;.descriptor.json
+ *   snippets/
+ *     &lt;snippetId&gt;.snippet.json
  * </pre>
+ *
+ * {@link #findVersionDir(String, String)} and {@link #findSnippetsDir()} also
+ * accept an extra {@code <agentId>/} level above the workflow directories: that
+ * is the shape a hand-built archive (or a differently-rooted ZIP) can have, and
+ * accepting it costs one directory listing.
  *
  * @since 6.0.0
  */
@@ -60,21 +66,8 @@ public class ZipResourceSource implements IResourceSource {
 
     private static final Logger LOGGER = Logger.getLogger(ZipResourceSource.class);
 
-    /** Map from URI pattern authority to [file extension, step type label]. */
-    private static final Map<Pattern, String[]> EXTENSION_TYPE_MAP = new LinkedHashMap<>();
-
-    static {
-        EXTENSION_TYPE_MAP.put(DICTIONARY_URI_PATTERN, new String[]{DICTIONARY_EXT, "ai.labs.dictionary"});
-        EXTENSION_TYPE_MAP.put(BEHAVIOR_URI_PATTERN, new String[]{BEHAVIOR_EXT, "ai.labs.rules"});
-        EXTENSION_TYPE_MAP.put(HTTPCALLS_URI_PATTERN, new String[]{HTTPCALLS_EXT, "ai.labs.apicalls"});
-        EXTENSION_TYPE_MAP.put(LANGCHAIN_URI_PATTERN, new String[]{LLM_EXT, "ai.labs.llm"});
-        EXTENSION_TYPE_MAP.put(PROPERTY_URI_PATTERN, new String[]{PROPERTY_EXT, "ai.labs.property"});
-        EXTENSION_TYPE_MAP.put(OUTPUT_URI_PATTERN, new String[]{OUTPUT_EXT, "ai.labs.output"});
-        EXTENSION_TYPE_MAP.put(MCPCALLS_URI_PATTERN, new String[]{MCPCALLS_EXT, "ai.labs.mcpcalls"});
-        EXTENSION_TYPE_MAP.put(RAG_URI_PATTERN, new String[]{RAG_EXT, "ai.labs.rag"});
-    }
-
     private static final String AGENT_FILE_ENDING = ".agent.json";
+    private static final String LEGACY_AGENT_FILE_ENDING = ".bot.json";
     private static final String DESCRIPTOR_FILE_ENDING = ".descriptor.json";
 
     private final Path rootDir;
@@ -96,12 +89,19 @@ public class ZipResourceSource implements IResourceSource {
             return agentData;
 
         try {
+            String suffix = AGENT_FILE_ENDING;
             Path agentFilePath = findFileWithSuffix(rootDir, AGENT_FILE_ENDING);
             if (agentFilePath == null) {
-                throw new RuntimeException("No agent file found in ZIP at " + rootDir);
+                // A genuine EDDI 5.x export names the agent file <id>.bot.json.
+                suffix = LEGACY_AGENT_FILE_ENDING;
+                agentFilePath = findFileWithSuffix(rootDir, LEGACY_AGENT_FILE_ENDING);
+            }
+            if (agentFilePath == null) {
+                throw new RuntimeException("No agent file (" + AGENT_FILE_ENDING + " or "
+                        + LEGACY_AGENT_FILE_ENDING + ") found in ZIP at " + rootDir);
             }
 
-            String agentId = extractIdFromFilename(agentFilePath, AGENT_FILE_ENDING);
+            String agentId = extractIdFromFilename(agentFilePath, suffix);
             String agentJson = readFile(agentFilePath);
             agentJson = AbstractBackupService.normalizeLegacyUris(agentJson);
             AgentConfiguration config = jsonSerialization.deserialize(agentJson, AgentConfiguration.class);
@@ -214,68 +214,47 @@ public class ZipResourceSource implements IResourceSource {
         String name = readNameFromDescriptor(versionDir, workflowId);
 
         // Read all extension configs from the workflow directory
-        Map<String, ExtensionSourceData> extensions = readExtensions(versionDir, workflowJson);
+        Map<String, ExtensionSourceData> extensions = readExtensions(versionDir, config);
 
         return new WorkflowSourceData(workflowId, name, positionIndex, config, extensions);
     }
 
     /**
-     * Reads all extension configs for a workflow by scanning the workflow JSON for
-     * URI references, then reading the corresponding files from disk.
+     * Reads all extension configs a workflow references, keyed by the canonical
+     * {@link WorkflowExtensions} key so the map joins with the one
+     * {@link StructuralMatcher} builds from the target workflow.
+     * <p>
+     * The references come from the parsed workflow steps rather than a regex sweep
+     * of the file, so the key can carry the step type and its occurrence ordinal —
+     * a workflow with two steps of the same type keeps both.
      */
-    private Map<String, ExtensionSourceData> readExtensions(Path workflowDir, String workflowJson) {
+    private Map<String, ExtensionSourceData> readExtensions(Path workflowDir, WorkflowConfiguration config) {
         Map<String, ExtensionSourceData> extensions = new LinkedHashMap<>();
 
-        for (Map.Entry<Pattern, String[]> entry : EXTENSION_TYPE_MAP.entrySet()) {
-            Pattern uriPattern = entry.getKey();
-            String fileExtension = entry.getValue()[0];
-            String stepType = entry.getValue()[1];
-
+        for (WorkflowExtensions.ExtensionRef ref : WorkflowExtensions.scan(config)) {
             try {
-                List<URI> uris = extractResourcesUris(workflowJson, uriPattern);
-                for (URI uri : uris) {
-                    IResourceId resId = RestUtilities.extractResourceId(uri);
-                    if (resId == null)
-                        continue;
+                String fileExtension = ref.fileExtension();
+                Path resourcePath = Paths.get(FileUtilities.buildPath(
+                        workflowDir.toString(),
+                        ref.resourceId().getId() + "." + fileExtension + ".json"));
 
-                    Path resourcePath = Paths.get(FileUtilities.buildPath(
-                            workflowDir.toString(),
-                            resId.getId() + "." + fileExtension + ".json"));
-
-                    if (!Files.exists(resourcePath))
-                        continue;
-
-                    String contentJson = readFile(resourcePath);
-                    String name = readNameFromDescriptor(workflowDir, resId.getId());
-
-                    extensions.put(stepType, new ExtensionSourceData(
-                            resId.getId(), name, fileExtension, stepType, contentJson));
+                if (!Files.exists(resourcePath)) {
+                    LOGGER.debugf("Workflow references %s but the archive does not contain %s",
+                            ref.extensionUri(), resourcePath.getFileName());
+                    continue;
                 }
+
+                String contentJson = readFile(resourcePath);
+                String name = readNameFromDescriptor(workflowDir, ref.resourceId().getId());
+
+                extensions.put(ref.key(), new ExtensionSourceData(
+                        ref.resourceId().getId(), name, fileExtension, ref.stepType(), contentJson));
             } catch (Exception e) {
-                LOGGER.debugf("Failed to read %s extensions: %s", fileExtension, e.getMessage());
+                LOGGER.debugf("Failed to read extension %s: %s", ref.extensionUri(), e.getMessage());
             }
         }
 
         return extensions;
-    }
-
-    /**
-     * Extracts resource URIs from a JSON string using the given pattern.
-     */
-    private List<URI> extractResourcesUris(String json, Pattern uriPattern) {
-        List<URI> uris = new ArrayList<>();
-        try {
-            var matcher = uriPattern.matcher(json);
-            while (matcher.find()) {
-                String match = matcher.group();
-                // Remove surrounding quotes
-                String uri = match.substring(1, match.length() - 1);
-                uris.add(URI.create(uri));
-            }
-        } catch (Exception e) {
-            LOGGER.debugf("URI extraction failed: %s", e.getMessage());
-        }
-        return uris;
     }
 
     private Path findVersionDir(String workflowId, String version) {

--- a/src/main/java/ai/labs/eddi/backup/model/ImportPreview.java
+++ b/src/main/java/ai/labs/eddi/backup/model/ImportPreview.java
@@ -18,6 +18,21 @@ import java.util.List;
  * <p>
  * Returned by POST /backup/import/preview and POST /backup/import/sync/preview.
  *
+ * @param sourceAgentId
+ *            the agent's id in the source system
+ * @param sourceAgentName
+ *            the agent's human-readable name in the source system
+ * @param targetAgentId
+ *            the local agent being matched against, or null in create mode
+ * @param targetAgentName
+ *            the local agent's name, or null in create mode
+ * @param resources
+ *            one diff per resource
+ * @param error
+ *            why this preview could not be produced; null on success. Only a
+ *            batch preview fills it — a single preview reports failure with an
+ *            HTTP status. It exists so a failed row in a batch is a real field
+ *            rather than an {@code "Error: ..."} prefix smuggled into the name
  * @since 6.0.0
  */
 public record ImportPreview(
@@ -25,7 +40,18 @@ public record ImportPreview(
         String sourceAgentName,
         String targetAgentId,
         String targetAgentName,
-        List<ResourceDiff> resources) {
+        List<ResourceDiff> resources,
+        String error) {
+
+    /** A preview that was produced successfully — {@code error} is null. */
+    public ImportPreview(String sourceAgentId,
+            String sourceAgentName,
+            String targetAgentId,
+            String targetAgentName,
+            List<ResourceDiff> resources) {
+        this(sourceAgentId, sourceAgentName, targetAgentId, targetAgentName, resources, null);
+    }
+
     /**
      * Diff for a single resource in the import/sync preview.
      *
@@ -34,7 +60,7 @@ public record ImportPreview(
      * @param resourceType
      *            type identifier: "agent", "workflow", "langchain", "httpcalls",
      *            "behavior", "regulardictionary", "property", "output", "mcpcalls",
-     *            "rag", "snippet"
+     *            "rag", "snippet", "schedule"
      * @param name
      *            human-readable name from DocumentDescriptor or snippet.name
      * @param action

--- a/src/main/java/ai/labs/eddi/backup/model/UpgradeResult.java
+++ b/src/main/java/ai/labs/eddi/backup/model/UpgradeResult.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.model;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Outcome of an upgrade/sync run, returned in the body of
+ * {@code POST /backup/import?strategy=upgrade},
+ * {@code POST /backup/import/sync} and each entry of
+ * {@code POST /backup/import/sync/batch}.
+ * <p>
+ * Per-resource failures used to be logged at WARN and then discarded: the agent
+ * version was bumped anyway and the caller got 201 CREATED, so a half-applied
+ * sync was indistinguishable from a clean one. Anything that did not land is
+ * listed in {@link #failures()} and the endpoint answers 207 Multi-Status.
+ *
+ * @param agentUri
+ *            the resulting agent URI — the new version when the agent config
+ *            was rewritten, otherwise the version that was already there
+ * @param agentUpdated
+ *            whether the agent configuration itself was rewritten (a new agent
+ *            version). False when nothing referenced by the agent changed
+ * @param updated
+ *            number of existing resources updated in place
+ * @param created
+ *            number of resources created in the target
+ * @param skipped
+ *            number of matched resources whose content was already identical
+ * @param failures
+ *            resources that could not be processed, with the reason
+ * @since 6.0.0
+ */
+public record UpgradeResult(
+        URI agentUri,
+        boolean agentUpdated,
+        int updated,
+        int created,
+        int skipped,
+        List<ResourceFailure> failures) {
+
+    /**
+     * A resource the upgrade could not process.
+     *
+     * @param sourceId
+     *            the resource's id in the source system
+     * @param resourceType
+     *            "workflow", "langchain", "snippet", …
+     * @param name
+     *            human-readable name, when the source knew one
+     * @param reason
+     *            why it failed
+     */
+    public record ResourceFailure(
+            String sourceId,
+            String resourceType,
+            String name,
+            String reason) {
+    }
+
+    public boolean hasFailures() {
+        return failures != null && !failures.isEmpty();
+    }
+
+    /** Whether anything at all was written to the target. */
+    public boolean wroteAnything() {
+        return agentUpdated || updated > 0 || created > 0;
+    }
+}

--- a/src/main/java/ai/labs/eddi/configs/workflows/model/WorkflowConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/model/WorkflowConfiguration.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.configs.workflows.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+
 import java.net.URI;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -54,11 +56,14 @@ public class WorkflowConfiguration {
         return workflowSteps;
     }
 
-    // Note: Alias required for backward compatibility with v5 exported agent
-    // schemas (ZIP files / MongoDB)
-    // where the property was natively named "workflowExtensions" instead of
-    // "workflowSteps".
-    @com.fasterxml.jackson.annotation.JsonAlias("workflowExtensions")
+    // Aliases required for backward compatibility with v5 exported agent schemas
+    // (ZIP files / MongoDB), where this property was named "workflowExtensions"
+    // or — in a genuine 5.x <id>.package.json — "packageExtensions". Without the
+    // latter, importing a real 5.x archive deserialized the workflow into an EMPTY
+    // step list (FAIL_ON_UNKNOWN_PROPERTIES is off), stored it, and answered 201:
+    // an agent that deploys and answers nothing, with every extension resource
+    // created alongside it as an orphan.
+    @JsonAlias({"workflowExtensions", "packageExtensions"})
     public void setWorkflowSteps(List<WorkflowStep> workflowSteps) {
         this.workflowSteps = workflowSteps;
     }

--- a/src/main/java/ai/labs/eddi/secrets/sanitize/SecretScrubber.java
+++ b/src/main/java/ai/labs/eddi/secrets/sanitize/SecretScrubber.java
@@ -44,7 +44,18 @@ import java.util.regex.Pattern;
 public class SecretScrubber {
 
     private static final Logger LOGGER = Logger.getLogger(SecretScrubber.class);
-    private static final String REDACTED = "${vault:REDACTED}";
+
+    /**
+     * The marker written in place of a secret value.
+     * <p>
+     * Public because readers of scrubbed content have to recognise it: the upgrade
+     * path puts the target's own value back wherever the source carries this
+     * placeholder, and it used to compare against its own copy of the literal — so
+     * changing the marker here would have silently stopped that matching and
+     * overwritten a production agent's live credentials with placeholders, with no
+     * compile error and no failing test.
+     */
+    public static final String REDACTED = "${vault:REDACTED}";
 
     /**
      * Minimum length for entropy analysis (short strings are less likely to be

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,14 @@ eddi.compliance.audit-signing-required=false
 eddi.migration.skipConversationMemories=false
 eddi.migration.v6-qute.enabled=false
 
+# Backup — how long a finished export archive stays downloadable.
+# POST /backup/export/{agentId} writes a ZIP under tmp/archives/ and answers with
+# a Location header; the client then GETs it. Nothing else deletes those files, so
+# every export first sweeps archives older than this window. Raise it if a client
+# may take longer than this between the POST and the GET; lower it to bound disk
+# use on an instance that exports on a cron.
+eddi.backup.export.retention-minutes=60
+
 # Qute — template engine (replaces Thymeleaf for native image support)
 # Strict rendering is deliberately OFF in EVERY profile — do NOT add a %prod
 # override. Templates are agent *data* loaded from the database, so a missing

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,10 @@ eddi.migration.v6-qute.enabled=false
 # may take longer than this between the POST and the GET; lower it to bound disk
 # use on an instance that exports on a cron.
 eddi.backup.export.retention-minutes=60
+# How often that sweep runs on its own. Sweeping only from the export path left
+# the last archives an instance produced on disk until its next export, which on
+# a deployment that exports occasionally is indefinitely.
+eddi.backup.export.sweep-interval=15m
 
 # Qute — template engine (replaces Thymeleaf for native image support)
 # Strict rendering is deliberately OFF in EVERY profile — do NOT add a %prod

--- a/src/test/java/ai/labs/eddi/backup/impl/BackupMetricsTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/BackupMetricsTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The counters an operator alerts on when an export or a sync "did nothing".
+ * <p>
+ * Two things are asserted here and nowhere else: that each method moves the
+ * meter with the exact name the dashboards and {@code docs/metrics.md} query —
+ * a renamed or mistyped meter is invisible until an alert fails to fire — and
+ * that a {@code BackupMetrics} whose {@code @PostConstruct} never ran (every
+ * unit test that builds the backup services directly) records nothing instead
+ * of throwing, because metrics must never be the reason a backup fails.
+ */
+@DisplayName("BackupMetrics")
+class BackupMetricsTest {
+
+    private MeterRegistry registry;
+    private BackupMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        metrics = new BackupMetrics(registry);
+        metrics.initMetrics();
+    }
+
+    private double count(String name) {
+        var counter = registry.find(name).counter();
+        return counter == null ? -1d : counter.count();
+    }
+
+    @Nested
+    @DisplayName("with the registry wired up")
+    class Wired {
+
+        /**
+         * Export attempts and failures are separate meters, each counted once per call.
+         */
+        @Test
+        @DisplayName("export attempts and failures land on their own meters")
+        void exportCounters() {
+            metrics.exportAttempted();
+            metrics.exportAttempted();
+            metrics.exportFailed();
+
+            assertEquals(2.0, count("eddi.backup.export.count"));
+            assertEquals(1.0, count("eddi.backup.export.failure.count"));
+        }
+
+        /**
+         * Import attempts and failures are separate meters, each counted once per call.
+         */
+        @Test
+        @DisplayName("import attempts and failures land on their own meters")
+        void importCounters() {
+            metrics.importAttempted();
+            metrics.importFailed();
+            metrics.importFailed();
+
+            assertEquals(1.0, count("eddi.backup.import.count"));
+            assertEquals(2.0, count("eddi.backup.import.failure.count"));
+        }
+
+        /**
+         * Upgrade attempts and failures are separate meters, each counted once per
+         * call.
+         */
+        @Test
+        @DisplayName("upgrade attempts and failures land on their own meters")
+        void upgradeCounters() {
+            metrics.upgradeAttempted();
+            metrics.upgradeFailed();
+
+            assertEquals(1.0, count("eddi.backup.upgrade.count"));
+            assertEquals(1.0, count("eddi.backup.upgrade.failure.count"));
+        }
+
+        /**
+         * The per-resource tally is what answers "the sync did nothing" — each of the
+         * four outcomes must move its own meter by its own amount, never by one.
+         */
+        @Test
+        @DisplayName("upgradeCompleted adds each per-resource tally to its own meter")
+        void upgradeCompletedTallies() {
+            metrics.upgradeCompleted(3, 2, 5, 1);
+
+            assertEquals(3.0, count("eddi.backup.upgrade.resource.updated.count"));
+            assertEquals(2.0, count("eddi.backup.upgrade.resource.created.count"));
+            assertEquals(5.0, count("eddi.backup.upgrade.resource.skipped.count"));
+            assertEquals(1.0, count("eddi.backup.upgrade.resource.failure.count"));
+        }
+
+        /**
+         * A run that skipped everything must not touch the other three meters at all.
+         * <p>
+         * Reading the count back cannot show this — {@code increment(0)} and no call
+         * leave a counter reading 0.0 alike — so the increments themselves are
+         * recorded, and the assertion is on the call, not on the total. What it
+         * protects is the meter's own semantics: Micrometer counters are monotonic and
+         * a registry backend is entitled to reject or to emit a sample for any
+         * increment it is handed, so "nothing happened" has to mean no increment
+         * reached the registry.
+         */
+        @Test
+        @DisplayName("a zero tally never reaches its counter")
+        void upgradeCompletedIgnoresZeroTallies() {
+            var recordingRegistry = new RecordingRegistry();
+            var recordingMetrics = new BackupMetrics(recordingRegistry);
+            recordingMetrics.initMetrics();
+
+            recordingMetrics.upgradeCompleted(0, 0, 4, 0);
+
+            assertEquals(List.of(4.0), recordingRegistry.incrementsOf("eddi.backup.upgrade.resource.skipped.count"));
+            assertEquals(List.of(), recordingRegistry.incrementsOf("eddi.backup.upgrade.resource.updated.count"));
+            assertEquals(List.of(), recordingRegistry.incrementsOf("eddi.backup.upgrade.resource.created.count"));
+            assertEquals(List.of(), recordingRegistry.incrementsOf("eddi.backup.upgrade.resource.failure.count"));
+        }
+
+        /**
+         * A negative tally cannot happen through {@code UpgradeResult}, but Micrometer
+         * counters are monotonic and would reject one — the guard keeps that from
+         * reaching the registry.
+         */
+        @Test
+        @DisplayName("a negative tally is dropped rather than rejected by the registry")
+        void upgradeCompletedIgnoresNegativeTallies() {
+            metrics.upgradeCompleted(-5, 0, 0, 0);
+
+            assertEquals(0.0, count("eddi.backup.upgrade.resource.updated.count"));
+        }
+    }
+
+    @Nested
+    @DisplayName("before @PostConstruct has run")
+    class Uninitialized {
+
+        /**
+         * Every unit test in this package builds the backup services with a
+         * {@code BackupMetrics} CDI never initialized. Each counter method must be a
+         * no-op then, not a NullPointerException that fails the operation it measures.
+         */
+        @Test
+        @DisplayName("every counter method is a silent no-op")
+        void uninitializedCountersDoNotThrow() {
+            var uninitialized = new BackupMetrics(new SimpleMeterRegistry());
+
+            assertDoesNotThrow(() -> {
+                uninitialized.exportAttempted();
+                uninitialized.exportFailed();
+                uninitialized.importAttempted();
+                uninitialized.importFailed();
+                uninitialized.upgradeAttempted();
+                uninitialized.upgradeFailed();
+                uninitialized.upgradeCompleted(1, 1, 1, 1);
+            });
+        }
+
+        /**
+         * Nothing was registered either — the meters only exist once initMetrics ran.
+         */
+        @Test
+        @DisplayName("registers no meters")
+        void uninitializedRegistersNothing() {
+            var ownRegistry = new SimpleMeterRegistry();
+            var uninitialized = new BackupMetrics(ownRegistry);
+
+            uninitialized.exportAttempted();
+
+            assertNull(ownRegistry.find("eddi.backup.export.count").counter());
+        }
+    }
+
+    // ==================== Helpers ====================
+
+    /**
+     * A real registry that also remembers every increment its counters were handed.
+     * <p>
+     * The hook is the registry's own counter factory rather than
+     * {@code MeterRegistry.counter(String)}, so it keeps working whichever idiom
+     * registers the meter — the one-arg call, a tagged {@code counter(name, tags)},
+     * or {@code Counter.builder(name).register(registry)}. A mock registry stubbed
+     * for one overload would quietly record nothing after such a refactor and turn
+     * the assertions below into no-ops.
+     */
+    private static final class RecordingRegistry extends SimpleMeterRegistry {
+
+        private final Map<String, List<Double>> increments = new LinkedHashMap<>();
+
+        @Override
+        protected Counter newCounter(Meter.Id id) {
+            Counter delegate = super.newCounter(id);
+            List<Double> recorded = increments.computeIfAbsent(id.getName(), name -> new ArrayList<>());
+            return new Counter() {
+                @Override
+                public void increment(double amount) {
+                    recorded.add(amount);
+                    delegate.increment(amount);
+                }
+
+                @Override
+                public double count() {
+                    return delegate.count();
+                }
+
+                @Override
+                public Id getId() {
+                    return id;
+                }
+            };
+        }
+
+        /** Every amount that reached the named counter, in order. */
+        List<Double> incrementsOf(String meterName) {
+            List<Double> recorded = increments.get(meterName);
+            assertNotNull(recorded, "no counter named '" + meterName
+                    + "' was ever registered, only: " + increments.keySet());
+            return recorded;
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/ExtensionSourceKeyContractTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/ExtensionSourceKeyContractTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IResourceSource;
+import ai.labs.eddi.backup.IResourceSource.ExtensionSourceData;
+import ai.labs.eddi.backup.IResourceSource.WorkflowSourceData;
+import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
+import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
+import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.apicalls.IRestApiCallsStore;
+import ai.labs.eddi.configs.apicalls.model.ApiCallsConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.llm.IRestLlmStore;
+import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The claim this branch is built around, tested against the two <em>real</em>
+ * producers rather than a hand-built fixture.
+ * <p>
+ * {@link StructuralMatcherRealWorkflowTest} proves the matcher joins, but it
+ * builds its {@link IResourceSource} by hand and derives the key by calling
+ * {@link WorkflowExtensions#scan} itself — so it cannot catch a producer-side
+ * mistake (the wrong file-extension lookup, the wrong resource id, the silent
+ * {@code continue} when an archive file is missing). The only assertions on
+ * {@code WorkflowSourceData.extensions()} anywhere else in the backup tree
+ * assert the map is empty.
+ * <p>
+ * A regression in either producer reproduces the original defect exactly —
+ * every extension reported CREATE, the whole configuration tree duplicated on
+ * each sync — with the rest of the suite still green.
+ * <p>
+ * The fixture carries <em>two</em> steps of the same type on purpose: keying by
+ * type alone silently kept only the last of them, and repointing then aimed
+ * both steps at the same resource.
+ */
+@DisplayName("ZIP and remote sources produce extension keys the matcher joins on")
+class ExtensionSourceKeyContractTest {
+
+    private static final String SOURCE_AGENT_ID = "aaaa11112222333344445555";
+    private static final String SOURCE_WF_ID = "bbbb11112222333344445555";
+    private static final String SOURCE_LLM_ID = "cccc11112222333344445555";
+    private static final String SOURCE_API_1_ID = "dddd11112222333344445555";
+    private static final String SOURCE_API_2_ID = "eeee11112222333344445555";
+
+    private static final String TARGET_AGENT_ID = "1111aaaabbbbccccdddd2222";
+    private static final String TARGET_WF_ID = "2222aaaabbbbccccdddd3333";
+    private static final String TARGET_LLM_ID = "3333aaaabbbbccccdddd4444";
+    private static final String TARGET_API_1_ID = "4444aaaabbbbccccdddd5555";
+    private static final String TARGET_API_2_ID = "5555aaaabbbbccccdddd6666";
+
+    /** The canonical keys the fixture must produce, on both sides. */
+    private static final List<String> EXPECTED_KEYS = List.of(
+            "eddi://ai.labs.httpcalls#0/config",
+            "eddi://ai.labs.llm#0/config",
+            "eddi://ai.labs.httpcalls#1/config");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final IJsonSerialization jsonSerialization = new JacksonJsonSerialization();
+
+    private Path zipRoot;
+
+    private IRestAgentStore targetAgentStore;
+    private IRestWorkflowStore targetWorkflowStore;
+    private IDocumentDescriptorStore descriptorStore;
+    private StructuralMatcher matcher;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        zipRoot = Files.createTempDirectory("extension-key-contract");
+        writeArchive(zipRoot);
+
+        targetAgentStore = mock(IRestAgentStore.class);
+        targetWorkflowStore = mock(IRestWorkflowStore.class);
+        descriptorStore = mock(IDocumentDescriptorStore.class);
+        var snippetStore = mock(IRestPromptSnippetStore.class);
+        var restInterfaceFactory = mock(IRestInterfaceFactory.class);
+
+        matcher = new StructuralMatcher(targetAgentStore, descriptorStore, snippetStore,
+                targetWorkflowStore, restInterfaceFactory, jsonSerialization);
+
+        doReturn(Collections.emptyList()).when(snippetStore).readSnippetDescriptors(anyString(), anyInt(), anyInt());
+
+        // The target agent: one workflow, shaped exactly like the source's.
+        var targetAgent = new AgentConfiguration();
+        targetAgent.setWorkflows(List.of(URI.create(
+                "eddi://ai.labs.workflow/workflowstore/workflows/" + TARGET_WF_ID + "?version=1")));
+        doReturn(targetAgent).when(targetAgentStore).readAgent(TARGET_AGENT_ID, 1);
+        stubDescriptor(TARGET_AGENT_ID, "eddi://ai.labs.agent/agentstore/agents/" + TARGET_AGENT_ID + "?version=1");
+        stubDescriptor(TARGET_WF_ID, "eddi://ai.labs.workflow/workflowstore/workflows/" + TARGET_WF_ID + "?version=1");
+
+        doReturn(MAPPER.readValue(workflowJson(TARGET_API_1_ID, TARGET_LLM_ID, TARGET_API_2_ID),
+                WorkflowConfiguration.class))
+                .when(targetWorkflowStore).readWorkflow(TARGET_WF_ID, 1);
+
+        var llmStore = mock(IRestLlmStore.class);
+        var apiCallsStore = mock(IRestApiCallsStore.class);
+        doReturn(llmStore).when(restInterfaceFactory).get(IRestLlmStore.class);
+        doReturn(apiCallsStore).when(restInterfaceFactory).get(IRestApiCallsStore.class);
+        doReturn(llm("target prompt")).when(llmStore).readLlm(TARGET_LLM_ID, 1);
+        doReturn(apiCalls("https://target.example.com")).when(apiCallsStore).readApiCalls(TARGET_API_1_ID, 1);
+        doReturn(apiCalls("https://target.example.com")).when(apiCallsStore).readApiCalls(TARGET_API_2_ID, 1);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        deleteRecursively(zipRoot);
+    }
+
+    @Test
+    @DisplayName("a ZIP source's extensions carry the canonical key, one entry per reference")
+    void zipSourceEmitsCanonicalKeys() {
+        try (var source = new ZipResourceSource(zipRoot, jsonSerialization)) {
+            Map<String, ExtensionSourceData> extensions = onlyWorkflow(source).extensions();
+
+            assertEquals(EXPECTED_KEYS, List.copyOf(extensions.keySet()),
+                    "the ZIP side used to key by resource-store authority (ai.labs.apicalls), "
+                            + "which the target map never contains");
+            assertEquals(SOURCE_API_1_ID, extensions.get(EXPECTED_KEYS.get(0)).sourceId());
+            assertEquals(SOURCE_LLM_ID, extensions.get(EXPECTED_KEYS.get(1)).sourceId());
+            assertEquals(SOURCE_API_2_ID, extensions.get(EXPECTED_KEYS.get(2)).sourceId(),
+                    "two steps of one type must both survive, not collapse onto one key");
+
+            // The file-extension label decides which store the executor writes to.
+            assertEquals("httpcalls", extensions.get(EXPECTED_KEYS.get(0)).type());
+            assertEquals("langchain", extensions.get(EXPECTED_KEYS.get(1)).type());
+            // The content is the archive's own bytes, not a placeholder.
+            assertTrue(extensions.get(EXPECTED_KEYS.get(1)).contentJson().contains("source prompt"),
+                    extensions.get(EXPECTED_KEYS.get(1)).contentJson());
+        }
+    }
+
+    @Test
+    @DisplayName("a remote source's extensions carry the same keys as the ZIP source's")
+    void remoteSourceEmitsTheSameKeys() throws Exception {
+        try (var remote = remoteSource();
+                var zip = new ZipResourceSource(zipRoot, jsonSerialization)) {
+
+            Map<String, ExtensionSourceData> remoteExtensions = onlyWorkflow(remote).extensions();
+
+            assertEquals(EXPECTED_KEYS, List.copyOf(remoteExtensions.keySet()));
+            assertEquals(List.copyOf(onlyWorkflow(zip).extensions().keySet()),
+                    List.copyOf(remoteExtensions.keySet()),
+                    "the two producers must agree, or a sync works from a ZIP and not from an instance");
+            assertEquals(SOURCE_API_2_ID, remoteExtensions.get(EXPECTED_KEYS.get(2)).sourceId());
+            assertTrue(remoteExtensions.get(EXPECTED_KEYS.get(1)).contentJson().contains("source prompt"));
+        }
+    }
+
+    @Test
+    @DisplayName("every extension read from a ZIP matches a target extension instead of being CREATEd")
+    void zipSourceJoinsWithTheTarget() {
+        try (var source = new ZipResourceSource(zipRoot, jsonSerialization)) {
+            assertJoins(matcher.buildPreview(source, TARGET_AGENT_ID, true));
+        }
+    }
+
+    @Test
+    @DisplayName("every extension read from a remote instance matches a target extension too")
+    void remoteSourceJoinsWithTheTarget() throws Exception {
+        try (var source = remoteSource()) {
+            assertJoins(matcher.buildPreview(source, TARGET_AGENT_ID, true));
+        }
+    }
+
+    /**
+     * Each source extension has to land on its own target extension. CREATE here
+     * means {@code UpgradeExecutor} calls {@code createExtension} for every one of
+     * them, duplicating the configuration tree on every sync.
+     */
+    private void assertJoins(ImportPreview preview) {
+        assertEquals(TARGET_API_1_ID, matchedTargetId(preview, SOURCE_API_1_ID));
+        assertEquals(TARGET_LLM_ID, matchedTargetId(preview, SOURCE_LLM_ID));
+        assertEquals(TARGET_API_2_ID, matchedTargetId(preview, SOURCE_API_2_ID),
+                "the second step of a repeated type must match its own target, not the first one's");
+    }
+
+    private String matchedTargetId(ImportPreview preview, String sourceId) {
+        ResourceDiff diff = preview.resources().stream()
+                .filter(d -> sourceId.equals(d.sourceId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "no diff for source resource " + sourceId + " in " + preview.resources()));
+        assertNotEquals(DiffAction.CREATE, diff.action(),
+                "CREATE means source and target keys did not join: " + diff);
+        assertEquals("type", diff.matchStrategy(), diff.toString());
+        return diff.targetId();
+    }
+
+    // ==================== Fixtures ====================
+
+    private static WorkflowSourceData onlyWorkflow(IResourceSource source) {
+        List<WorkflowSourceData> workflows = source.readWorkflows();
+        assertEquals(1, workflows.size(), "the fixture agent has exactly one workflow: " + workflows);
+        return workflows.getFirst();
+    }
+
+    /**
+     * The shape {@code AgentSetupService} writes and the shipped reference config
+     * uses: an {@code eddi://} step type, and the extension reference in
+     * {@code config.uri}.
+     */
+    private static String workflowJson(String apiCalls1Id, String llmId, String apiCalls2Id) {
+        return """
+                {"workflowSteps":[
+                  {"type":"eddi://ai.labs.httpcalls","extensions":{},
+                   "config":{"uri":"eddi://ai.labs.apicalls/apicallstore/apicalls/%s?version=1"}},
+                  {"type":"eddi://ai.labs.llm","extensions":{},
+                   "config":{"uri":"eddi://ai.labs.llm/llmstore/llms/%s?version=1"}},
+                  {"type":"eddi://ai.labs.httpcalls","extensions":{},
+                   "config":{"uri":"eddi://ai.labs.apicalls/apicallstore/apicalls/%s?version=1"}}
+                ]}""".formatted(apiCalls1Id, llmId, apiCalls2Id);
+    }
+
+    /** An export archive, in the layout {@code RestExportService} produces. */
+    private void writeArchive(Path root) throws IOException {
+        Files.writeString(root.resolve(SOURCE_AGENT_ID + ".agent.json"),
+                "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                        + SOURCE_WF_ID + "?version=1\"]}");
+        Files.writeString(root.resolve(SOURCE_AGENT_ID + ".descriptor.json"), "{\"name\":\"Source Agent\"}");
+
+        Path versionDir = Files.createDirectories(root.resolve(SOURCE_WF_ID).resolve("1"));
+        Files.writeString(versionDir.resolve(SOURCE_WF_ID + ".workflow.json"),
+                workflowJson(SOURCE_API_1_ID, SOURCE_LLM_ID, SOURCE_API_2_ID));
+        Files.writeString(versionDir.resolve(SOURCE_API_1_ID + ".httpcalls.json"), apiCallsJson());
+        Files.writeString(versionDir.resolve(SOURCE_API_2_ID + ".httpcalls.json"), apiCallsJson());
+        Files.writeString(versionDir.resolve(SOURCE_LLM_ID + ".langchain.json"), llmJson());
+    }
+
+    private static String apiCallsJson() {
+        return "{\"targetServerUrl\":\"https://source.example.com\",\"httpCalls\":[]}";
+    }
+
+    private static String llmJson() {
+        return "{\"tasks\":[{\"id\":\"main\",\"type\":\"llm\",\"description\":\"source prompt\"}]}";
+    }
+
+    private static LlmConfiguration llm(String description) {
+        var task = new LlmConfiguration.Task();
+        task.setId("main");
+        task.setType("llm");
+        task.setDescription(description);
+        return new LlmConfiguration(new ArrayList<>(List.of(task)));
+    }
+
+    private static ApiCallsConfiguration apiCalls(String targetServerUrl) {
+        var config = new ApiCallsConfiguration();
+        config.setTargetServerUrl(targetServerUrl);
+        config.setHttpCalls(new ArrayList<>());
+        return config;
+    }
+
+    /**
+     * A {@link RemoteApiResourceSource} over a stubbed HTTP client that answers the
+     * same documents the archive holds.
+     */
+    @SuppressWarnings("unchecked")
+    private RemoteApiResourceSource remoteSource() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        Mockito.doAnswer(invocation -> {
+            HttpRequest request = invocation.getArgument(0);
+            return response(bodyFor(request.uri().toString()));
+        }).when(httpClient).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+
+        return new RemoteApiResourceSource("https://source.example.com", SOURCE_AGENT_ID, 1,
+                "Bearer token", jsonSerialization, httpClient);
+    }
+
+    private static String bodyFor(String uri) {
+        if (uri.contains("/descriptors")) {
+            return "[]";
+        }
+        if (uri.contains("/agentstore/agents/")) {
+            return "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                    + SOURCE_WF_ID + "?version=1\"]}";
+        }
+        if (uri.contains("/workflowstore/workflows/")) {
+            return workflowJson(SOURCE_API_1_ID, SOURCE_LLM_ID, SOURCE_API_2_ID);
+        }
+        if (uri.contains("/apicallstore/apicalls/")) {
+            return apiCallsJson();
+        }
+        if (uri.contains("/llmstore/llms/")) {
+            return llmJson();
+        }
+        throw new AssertionError("the fixture does not serve " + uri);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static HttpResponse<String> response(String body) {
+        HttpResponse<String> response = mock(HttpResponse.class);
+        doReturn(200).when(response).statusCode();
+        doReturn(body).when(response).body();
+        return response;
+    }
+
+    private void stubDescriptor(String id, String resourceUri) throws Exception {
+        var descriptor = new DocumentDescriptor();
+        descriptor.setName("Target " + id);
+        descriptor.setResource(URI.create(resourceUri));
+        doReturn(descriptor).when(descriptorStore).readDescriptor(eq(id), isNull());
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (root == null || !Files.exists(root)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                    // best effort
+                }
+            });
+        }
+    }
+
+    /** A real serializer — what is under test is JSON handling, not a mock. */
+    private static final class JacksonJsonSerialization implements IJsonSerialization {
+        @Override
+        public String serialize(Object model) throws IOException {
+            return MAPPER.writeValueAsString(model);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(String json) throws IOException {
+            return (T) MAPPER.readValue(json, Object.class);
+        }
+
+        @Override
+        public <T> T deserialize(String json, Class<T> type) throws IOException {
+            return MAPPER.readValue(json, type);
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceDeepCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceDeepCoverageTest.java
@@ -227,7 +227,7 @@ class RemoteApiResourceSourceDeepCoverageTest {
     @DisplayName("readExtensionsFromWorkflow — null stepType skipped; unknown stepType skipped")
     void readExtensionsFromWorkflowSkips() throws Exception {
         AgentConfiguration agentConfig = new AgentConfiguration();
-        URI wfUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf1?version=1");
+        URI wfUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/aaaaaaaaaaaaaaaaaaaaaaaa?version=1");
         agentConfig.setWorkflows(List.of(wfUri));
         doReturn(agentConfig).when(jsonSerialization).deserialize(anyString(), eq(AgentConfiguration.class));
 
@@ -260,8 +260,12 @@ class RemoteApiResourceSourceDeepCoverageTest {
     @DisplayName("resolveLatestAgentVersion")
     class ResolveVersion {
 
+        // A version that cannot be resolved is an error, not a reason to guess:
+        // "fall back to 1" silently synced an arbitrarily old configuration into the
+        // target and left only a DEBUG line behind.
+
         @Test
-        @DisplayName("null descriptors → defaults to version 1")
+        @DisplayName("null descriptors → error, not a guess at version 1")
         void nullDescriptors() throws Exception {
             doReturn(null).when(jsonSerialization).deserialize(anyString(), eq(DocumentDescriptor[].class));
 
@@ -273,16 +277,15 @@ class RemoteApiResourceSourceDeepCoverageTest {
             RemoteApiResourceSource source = new RemoteApiResourceSource(
                     "http://127.0.0.1:1", "agent1", null, null, jsonSerialization, httpClient);
 
-            // readAgent triggers resolveLatestAgentVersion which falls back to 1
-            var agentData = source.readAgent();
-            assertNotNull(agentData);
+            var ex = assertThrows(RuntimeException.class, source::readAgent);
+            assertTrue(ex.getMessage().contains("latest version"), ex.getMessage());
         }
 
         @Test
-        @DisplayName("no matching descriptor → defaults to version 1")
+        @DisplayName("no matching descriptor → error, not a guess at version 1")
         void noMatchingDescriptor() throws Exception {
             DocumentDescriptor desc = new DocumentDescriptor();
-            desc.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/other?version=3"));
+            desc.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/bbbbbbbbbbbbbbbbbbbbbbbb?version=3"));
             DocumentDescriptor[] descs = new DocumentDescriptor[]{desc};
 
             // First call: resolve version (descriptors), second call: read agent
@@ -294,10 +297,31 @@ class RemoteApiResourceSourceDeepCoverageTest {
             doReturn(config).when(jsonSerialization).deserialize(eq("{}"), eq(AgentConfiguration.class));
 
             RemoteApiResourceSource source = new RemoteApiResourceSource(
-                    "http://127.0.0.1:1", "agent1", null, null, jsonSerialization, httpClient);
+                    "http://127.0.0.1:1", "aaaaaaaaaaaaaaaaaaaaaaaa", null, null, jsonSerialization, httpClient);
 
-            var agentData = source.readAgent();
-            assertNotNull(agentData);
+            var ex = assertThrows(RuntimeException.class, source::readAgent);
+            assertTrue(ex.getMessage().contains("latest version"), ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("matching descriptor → its version is used")
+        void matchingDescriptorResolvesVersion() throws Exception {
+            String agentId = "aaaaaaaaaaaaaaaaaaaaaaaa";
+            DocumentDescriptor desc = new DocumentDescriptor();
+            desc.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + agentId + "?version=7"));
+
+            doReturn("[]").doReturn("{}").doReturn("[]").when(mockResponse).body();
+            doReturn(new DocumentDescriptor[]{desc}).when(jsonSerialization)
+                    .deserialize(eq("[]"), eq(DocumentDescriptor[].class));
+
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(List.of());
+            doReturn(config).when(jsonSerialization).deserialize(eq("{}"), eq(AgentConfiguration.class));
+
+            RemoteApiResourceSource source = new RemoteApiResourceSource(
+                    "http://127.0.0.1:1", agentId, null, null, jsonSerialization, httpClient);
+
+            assertNotNull(source.readAgent());
         }
     }
 
@@ -310,14 +334,14 @@ class RemoteApiResourceSourceDeepCoverageTest {
         // The STEP_TYPE_TO_REST_PATH values end with "/" which tryReadDescriptorName
         // trims
         AgentConfiguration agentConfig = new AgentConfiguration();
-        URI wfUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf1?version=1");
+        URI wfUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/aaaaaaaaaaaaaaaaaaaaaaaa?version=1");
         agentConfig.setWorkflows(List.of(wfUri));
         doReturn(agentConfig).when(jsonSerialization).deserialize(anyString(), eq(AgentConfiguration.class));
 
         WorkflowConfiguration wfConfig = new WorkflowConfiguration();
         WorkflowConfiguration.WorkflowStep step = new WorkflowConfiguration.WorkflowStep();
-        step.setType(URI.create("ai.labs.llm"));
-        step.setExtensions(new HashMap<>(Map.<String, Object>of("uri", "eddi://ai.labs.llm/llmstore/llms/llm1?version=1")));
+        step.setType(URI.create("eddi://ai.labs.llm"));
+        step.setExtensions(new HashMap<>(Map.<String, Object>of("uri", "eddi://ai.labs.llm/llmstore/llms/bbbbbbbbbbbbbbbbbbbbbbbb?version=1")));
         wfConfig.setWorkflowSteps(List.of(step));
         doReturn(wfConfig).when(jsonSerialization).deserialize(anyString(), eq(WorkflowConfiguration.class));
         doReturn(null).when(jsonSerialization).deserialize(anyString(), eq(DocumentDescriptor[].class));

--- a/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceDeepCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceDeepCoverageTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.net.URI;
@@ -44,6 +45,50 @@ class RemoteApiResourceSourceDeepCoverageTest {
         doReturn(200).when(mockResponse).statusCode();
         doReturn("{}").when(mockResponse).body();
         doReturn(mockResponse).when(httpClient).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    // ==================== redirects ====================
+
+    @Nested
+    @DisplayName("redirects")
+    class Redirects {
+
+        @Test
+        @DisplayName("a 3xx is refused, not followed with the caller's bearer token attached")
+        void redirectIsRefused() throws Exception {
+            // The remote answers "go to the cloud metadata endpoint instead".
+            doReturn(302).when(mockResponse).statusCode();
+            doReturn("").when(mockResponse).body();
+
+            RemoteApiResourceSource source = new RemoteApiResourceSource(
+                    "http://127.0.0.1:1", "aaaaaaaaaaaaaaaaaaaaaaaa", 1,
+                    "Bearer secret-token", jsonSerialization, httpClient);
+
+            // The remote instance is user-supplied, so a compromised or hostile one
+            // could answer a read with a redirect to an internal address. The client
+            // never follows one: the hop surfaces as a non-200 status and the read
+            // fails, so the X-Source-Authorization bearer is never re-sent anywhere.
+            var ex = assertThrows(RuntimeException.class, source::readAgent);
+            assertTrue(ex.getMessage().contains("302"),
+                    "a redirect must surface as its status, got: " + ex.getMessage());
+
+            var sent = ArgumentCaptor.forClass(HttpRequest.class);
+            verify(httpClient, atLeastOnce()).send(sent.capture(), any(HttpResponse.BodyHandler.class));
+            assertTrue(sent.getAllValues().stream()
+                    .noneMatch(request -> "169.254.169.254".equals(request.uri().getHost())),
+                    "the redirect target must never be requested, requests were: " + sent.getAllValues());
+
+            // Everything above runs on a client this test handed in, and a mock
+            // follows nothing whatever the production code asks for — so on its own it
+            // pins the non-200 handling and says nothing about redirects. The actual
+            // guarantee is the policy the clients this class OWNS are built with, and
+            // that is what the assertion below reads. It cannot build one to look at:
+            // HttpClient.build() opens a selector, and a sandboxed build has no
+            // loopback socket for it.
+            HttpClient.Builder ownBuilder = mock(HttpClient.Builder.class, RETURNS_SELF);
+            RemoteApiResourceSource.configure(ownBuilder);
+            verify(ownBuilder).followRedirects(HttpClient.Redirect.NEVER);
+        }
     }
 
     // ==================== normalizeBaseUrl ====================
@@ -322,6 +367,16 @@ class RemoteApiResourceSourceDeepCoverageTest {
                     "http://127.0.0.1:1", agentId, null, null, jsonSerialization, httpClient);
 
             assertNotNull(source.readAgent());
+
+            // assertNotNull alone cannot tell the resolved version from the
+            // version-1 fallback this branch removed — both answer non-null. The
+            // requested URI is what actually distinguishes them.
+            var sent = ArgumentCaptor.forClass(HttpRequest.class);
+            verify(httpClient, atLeastOnce()).send(sent.capture(), any(HttpResponse.BodyHandler.class));
+            assertTrue(sent.getAllValues().stream()
+                    .anyMatch(request -> request.uri().toString().endsWith("/" + agentId + "?version=7")),
+                    "the agent must be read at the version its descriptor names, requests were: "
+                            + sent.getAllValues());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceExtendedTest.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -63,15 +65,26 @@ class RemoteApiResourceSourceExtendedTest {
         }
 
         @Test
-        @DisplayName("InterruptedException is wrapped in RuntimeException")
+        @DisplayName("InterruptedException is wrapped AND the interrupt flag is restored")
         @SuppressWarnings("unchecked")
         void interruptedException() throws Exception {
             when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
                     .thenThrow(new InterruptedException("interrupted"));
 
             var source = createSource(AGENT_ID, 1);
-            var ex = assertThrows(RuntimeException.class, source::readAgent);
-            assertTrue(ex.getMessage().contains("interrupted") || ex.getCause() instanceof InterruptedException);
+            try {
+                var ex = assertThrows(RuntimeException.class, source::readAgent);
+                assertTrue(ex.getMessage().contains("Interrupted"), ex.getMessage());
+
+                // readWorkflows tolerates per-workflow failures and carries on, so a
+                // swallowed interrupt meant a cancelled or shutting-down batch sync kept
+                // issuing HTTP calls to the remote instance.
+                assertTrue(Thread.currentThread().isInterrupted(),
+                        "the interrupt flag must be restored before unwinding");
+            } finally {
+                // Clear it again so the flag does not leak into the next test.
+                Thread.interrupted();
+            }
         }
     }
 
@@ -280,11 +293,41 @@ class RemoteApiResourceSourceExtendedTest {
     @DisplayName("AutoCloseable behavior")
     class CloseableTests {
 
+        /**
+         * The client this class builds for itself owns a selector thread and an
+         * executor. Callers already wrap every source in try-with-resources, so
+         * inheriting {@link IResourceSource}'s no-op {@code close()} left one live
+         * client per agent behind on every batch sync.
+         * <p>
+         * This replaces a test whose only assertion was
+         * {@code assertDoesNotThrow(source::close)} driven through the
+         * <em>borrowed</em>-client constructor — a guaranteed no-op that passed just as
+         * happily with the whole override deleted.
+         */
         @Test
-        @DisplayName("close() does not throw")
-        void closeDoesNotThrow() {
+        @DisplayName("close() shuts down the HTTP client this source created")
+        void closeShutsDownTheClientItCreated() throws Exception {
+            // The ownership flag is what the public constructor sets; it is passed
+            // explicitly here because building a real client opens a selector, and
+            // that needs a loopback socket a sandboxed build does not have.
+            var source = new RemoteApiResourceSource(
+                    BASE_URL, AGENT_ID, 1, "Bearer test-token", jsonSerialization, mockHttpClient, true);
+
+            source.close();
+
+            verify(mockHttpClient).close();
+        }
+
+        @Test
+        @DisplayName("close() leaves a client it was handed alone")
+        void closeLeavesABorrowedClientOpen() throws Exception {
             var source = createSource(AGENT_ID, 1);
-            assertDoesNotThrow(source::close);
+
+            source.close();
+
+            // Closing a client this instance did not create would take the caller's
+            // own client down with it.
+            verify(mockHttpClient, never()).close();
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceFailurePathTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceFailurePathTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IResourceSource.ExtensionSourceData;
+import ai.labs.eddi.backup.IResourceSource.WorkflowSourceData;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * What a live sync reads from a remote instance when part of that instance does
+ * not answer.
+ * <p>
+ * The split matters: a missing <em>version</em> is fatal, because guessing one
+ * would sync an arbitrarily old configuration into the target, while a missing
+ * <em>name</em> or a single unreadable extension is not — the preview is still
+ * worth showing, and the sync's own diff decides what to write.
+ */
+@DisplayName("RemoteApiResourceSource — partial remote failures")
+@SuppressWarnings("unchecked")
+class RemoteApiResourceSourceFailurePathTest {
+
+    private static final String BASE_URL = "http://remote.invalid:7070";
+    private static final String AGENT_ID = "aabbccddeeff112233445566";
+    private static final String WORKFLOW_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String LLM_ID = "cccccccccccccccccccccccc";
+    private static final String READABLE_LLM_ID = "dddddddddddddddddddddddd";
+
+    private IJsonSerialization jsonSerialization;
+    private HttpClient httpClient;
+    /**
+     * path suffix → status; anything not listed answers 200 with
+     * {@link #bodyByPath}.
+     */
+    private final Map<String, Integer> statusByPath = new HashMap<>();
+    private final Map<String, String> bodyByPath = new HashMap<>();
+    /** Every path this source asked the remote instance for, in order. */
+    private final List<String> requestedPaths = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jsonSerialization = mock(IJsonSerialization.class);
+        httpClient = mock(HttpClient.class);
+
+        doAnswer(invocation -> {
+            HttpRequest request = invocation.getArgument(0);
+            String path = request.uri().getPath() + (request.uri().getQuery() == null
+                    ? ""
+                    : "?" + request.uri().getQuery());
+            requestedPaths.add(path);
+            HttpResponse<String> response = mock(HttpResponse.class);
+            int status = statusByPath.entrySet().stream()
+                    .filter(entry -> path.contains(entry.getKey()))
+                    .map(Map.Entry::getValue)
+                    .findFirst()
+                    .orElse(200);
+            when(response.statusCode()).thenReturn(status);
+            when(response.body()).thenReturn(bodyByPath.entrySet().stream()
+                    .filter(entry -> path.contains(entry.getKey()))
+                    .map(Map.Entry::getValue)
+                    .findFirst()
+                    .orElse("{}"));
+            return response;
+        }).when(httpClient).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    /**
+     * Falling back to version 1 silently synced an arbitrarily old configuration
+     * into the target whenever the descriptor listing was paginated, access-scoped,
+     * or briefly unavailable. Failing loudly is the point.
+     */
+    @Test
+    @DisplayName("an unresolvable agent version fails the read instead of guessing one")
+    void unresolvableAgentVersionFails() {
+        statusByPath.put("/agentstore/agents/descriptors", 503);
+
+        var source = new RemoteApiResourceSource(BASE_URL, AGENT_ID, null, null, jsonSerialization, httpClient);
+
+        var thrown = assertThrows(RuntimeException.class, source::readAgent);
+
+        assertTrue(thrown.getMessage().contains(AGENT_ID), thrown.getMessage());
+        Throwable cause = thrown.getCause();
+        assertTrue(cause != null && cause.getMessage().contains("latest version"),
+                "the reason must name the version lookup, was: " + cause);
+    }
+
+    /**
+     * A descriptor listing that does not answer costs the human-readable name and
+     * nothing else. The sync joins on ids, so an unnamed row is still a usable row.
+     */
+    @Test
+    @DisplayName("an unreadable descriptor listing costs the name, not the agent")
+    void unreadableDescriptorListingCostsOnlyTheName() throws Exception {
+        statusByPath.put("/agentstore/agents/descriptors", 500);
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of());
+        when(jsonSerialization.deserialize(anyString(), eq(AgentConfiguration.class))).thenReturn(agentConfig);
+
+        var source = new RemoteApiResourceSource(BASE_URL, AGENT_ID, 3, null, jsonSerialization, httpClient);
+        var agent = source.readAgent();
+
+        assertEquals(AGENT_ID, agent.sourceId());
+        assertNull(agent.name(), "an unnamed row is still a row the sync can join on");
+    }
+
+    /**
+     * Snippets are a bonus, not a precondition: a remote instance that will not
+     * list them must not stop the agent and its workflows from being previewed.
+     */
+    @Test
+    @DisplayName("a snippet listing that fails yields no snippets rather than failing the read")
+    void unreadableSnippetListingYieldsNoSnippets() {
+        statusByPath.put("/snippetstore/snippets/descriptors", 502);
+
+        var source = new RemoteApiResourceSource(BASE_URL, AGENT_ID, 1, null, jsonSerialization, httpClient);
+
+        assertTrue(source.readSnippets().isEmpty());
+    }
+
+    /**
+     * One extension the remote will not hand over must not cost the workflow it
+     * belongs to — nor the other extensions of that same workflow.
+     * <p>
+     * The surviving one is asserted by its <em>key</em>, not merely by its
+     * presence, because the key is the join: {@code StructuralMatcher} builds the
+     * same key from the local target workflow, and when the two sides disagreed
+     * every extension read as CREATE and every sync duplicated the lot. The
+     * occurrence ordinal is part of it, so two steps of the same type stay two
+     * entries instead of collapsing onto one.
+     */
+    @Test
+    @DisplayName("an extension the remote refuses is left out; the workflow and its other extensions are still read")
+    void unreadableExtensionLeavesTheWorkflowIntact() throws Exception {
+        statusByPath.put("/llmstore/llms/" + LLM_ID, 500);
+        bodyByPath.put("/llmstore/llms/" + READABLE_LLM_ID, "{\"model\":\"gpt\"}");
+        stubAgentWithOneWorkflow();
+        stubWorkflowWithTwoLlmSteps();
+        when(jsonSerialization.deserialize(anyString(), eq(DocumentDescriptor[].class)))
+                .thenReturn(new DocumentDescriptor[0]);
+
+        var source = new RemoteApiResourceSource(BASE_URL, AGENT_ID, 1, null, jsonSerialization, httpClient);
+        List<WorkflowSourceData> workflows = source.readWorkflows();
+
+        assertEquals(1, workflows.size(), "the workflow itself must survive an unreadable extension");
+        Map<String, ExtensionSourceData> extensions = workflows.getFirst().extensions();
+        assertEquals(Set.of("eddi://ai.labs.llm#1/config"), extensions.keySet(),
+                "the readable extension must be keyed the way the matcher keys the target's own copy");
+
+        ExtensionSourceData readable = extensions.get("eddi://ai.labs.llm#1/config");
+        assertEquals(READABLE_LLM_ID, readable.sourceId());
+        assertEquals("langchain", readable.type());
+        assertEquals("{\"model\":\"gpt\"}", readable.contentJson(),
+                "the config the remote did hand over has to arrive intact");
+    }
+
+    /**
+     * A descriptor listing is unpaged: it returns every descriptor of that type in
+     * the whole remote deployment. Fetching it once per workflow and once per
+     * extension — purely to fill in a display name — turned a single preview of a
+     * modest agent into dozens of full downloads from the remote instance, which is
+     * what made a sync preview time out against a real deployment.
+     */
+    @Test
+    @DisplayName("a store's descriptor listing is downloaded once per sync, not once per extension")
+    void descriptorListingsAreFetchedOncePerStore() throws Exception {
+        bodyByPath.put("/llmstore/llms/" + LLM_ID, "{\"model\":\"a\"}");
+        bodyByPath.put("/llmstore/llms/" + READABLE_LLM_ID, "{\"model\":\"b\"}");
+        stubAgentWithOneWorkflow();
+        stubWorkflowWithTwoLlmSteps();
+        when(jsonSerialization.deserialize(anyString(), eq(DocumentDescriptor[].class)))
+                .thenReturn(new DocumentDescriptor[0]);
+
+        var source = new RemoteApiResourceSource(BASE_URL, AGENT_ID, 1, null, jsonSerialization, httpClient);
+        List<WorkflowSourceData> workflows = source.readWorkflows();
+
+        assertEquals(2, workflows.getFirst().extensions().size(), "both extensions were read");
+        assertEquals(1, requestCount("/llmstore/llms/descriptors"),
+                "the LLM descriptor listing must be downloaded once, was: " + requestedPaths);
+        assertEquals(1, requestCount("/workflowstore/workflows/descriptors"),
+                "and the workflow listing likewise, was: " + requestedPaths);
+    }
+
+    // ==================== Helpers ====================
+
+    private void stubAgentWithOneWorkflow() throws Exception {
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of(URI.create(
+                "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1")));
+        when(jsonSerialization.deserialize(anyString(), eq(AgentConfiguration.class))).thenReturn(agentConfig);
+    }
+
+    /**
+     * Two steps of the same type, so the occurrence ordinal in the extension key is
+     * load-bearing: {@code #0} is the one the remote refuses, {@code #1} the one it
+     * hands over.
+     */
+    private void stubWorkflowWithTwoLlmSteps() throws Exception {
+        var workflowConfig = new WorkflowConfiguration();
+        workflowConfig.setWorkflowSteps(new ArrayList<>(List.of(
+                llmStep(LLM_ID), llmStep(READABLE_LLM_ID))));
+        when(jsonSerialization.deserialize(anyString(), eq(WorkflowConfiguration.class))).thenReturn(workflowConfig);
+    }
+
+    private static WorkflowConfiguration.WorkflowStep llmStep(String llmId) {
+        var step = new WorkflowConfiguration.WorkflowStep();
+        step.setType(URI.create("eddi://ai.labs.llm"));
+        step.setConfig(new HashMap<>(Map.of("uri",
+                "eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1")));
+        step.setExtensions(new HashMap<>());
+        return step;
+    }
+
+    private long requestCount(String pathFragment) {
+        return requestedPaths.stream().filter(path -> path.contains(pathFragment)).count();
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceMissedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceMissedBranchTest.java
@@ -204,7 +204,7 @@ class RemoteApiResourceSourceMissedBranchTest {
                     .when(httpClient).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
 
             AgentConfiguration agentConfig = new AgentConfiguration();
-            URI wfUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf1?version=1");
+            URI wfUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/aaaaaaaaaaaaaaaaaaaaaaaa?version=1");
             agentConfig.setWorkflows(List.of(wfUri));
             doReturn("{}").when(okResponse).body();
             doReturn(agentConfig).when(jsonSerialization).deserialize(eq("{}"), eq(AgentConfiguration.class));
@@ -224,13 +224,13 @@ class RemoteApiResourceSourceMissedBranchTest {
     @DisplayName("step with null uri extension — skipped")
     void nullUriExtension() throws Exception {
         AgentConfiguration agentConfig = new AgentConfiguration();
-        URI wfUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/wf1?version=1");
+        URI wfUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/aaaaaaaaaaaaaaaaaaaaaaaa?version=1");
         agentConfig.setWorkflows(List.of(wfUri));
         doReturn(agentConfig).when(jsonSerialization).deserialize(anyString(), eq(AgentConfiguration.class));
 
         WorkflowConfiguration wfConfig = new WorkflowConfiguration();
         WorkflowConfiguration.WorkflowStep step = new WorkflowConfiguration.WorkflowStep();
-        step.setType(URI.create("ai.labs.llm"));
+        step.setType(URI.create("eddi://ai.labs.llm"));
         // uri key is missing from extensions
         step.setExtensions(new HashMap<>(Map.of("other", "value")));
         wfConfig.setWorkflowSteps(List.of(step));
@@ -254,8 +254,12 @@ class RemoteApiResourceSourceMissedBranchTest {
         @Test
         @DisplayName("matching descriptor — returns its version")
         void matchingDescriptor() throws Exception {
+            // A real resource id: RestUtilities.extractResourceId only accepts ids of
+            // at least 18 hex characters, so the old "agent1" fixture resolved to a
+            // null id and this case silently exercised the fallback instead.
+            String agentId = "aaaaaaaaaaaaaaaaaaaaaaaa";
             DocumentDescriptor desc = new DocumentDescriptor();
-            desc.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/agent1?version=5"));
+            desc.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + agentId + "?version=5"));
             DocumentDescriptor[] descs = new DocumentDescriptor[]{desc};
 
             doReturn("[]").doReturn("{}").doReturn("[]").when(mockResponse).body();
@@ -266,10 +270,27 @@ class RemoteApiResourceSourceMissedBranchTest {
             doReturn(config).when(jsonSerialization).deserialize(eq("{}"), eq(AgentConfiguration.class));
 
             RemoteApiResourceSource source = new RemoteApiResourceSource(
-                    "http://127.0.0.1:1", "agent1", null, null, jsonSerialization, httpClient);
+                    "http://127.0.0.1:1", agentId, null, null, jsonSerialization, httpClient);
 
             var agentData = source.readAgent();
             assertNotNull(agentData);
+        }
+
+        @Test
+        @DisplayName("agent not listed — fails loudly instead of guessing version 1")
+        void unlistedAgentIsAnError() throws Exception {
+            doReturn("[]").when(mockResponse).body();
+            doReturn(new DocumentDescriptor[0]).when(jsonSerialization)
+                    .deserialize(eq("[]"), eq(DocumentDescriptor[].class));
+
+            RemoteApiResourceSource source = new RemoteApiResourceSource(
+                    "http://127.0.0.1:1", "aaaaaaaaaaaaaaaaaaaaaaaa", null, null, jsonSerialization, httpClient);
+
+            // Falling back to version 1 silently synced an arbitrarily old
+            // configuration into the target whenever the listing was paginated,
+            // access-scoped, or briefly unavailable.
+            var ex = assertThrows(RuntimeException.class, source::readAgent);
+            assertTrue(ex.getMessage().contains("latest version"), ex.getMessage());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceMissedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceMissedBranchTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.net.URI;
@@ -274,6 +275,15 @@ class RemoteApiResourceSourceMissedBranchTest {
 
             var agentData = source.readAgent();
             assertNotNull(agentData);
+
+            // Non-null is also what the removed version-1 fallback answered, so it
+            // proves nothing on its own: pin the version that was actually requested.
+            var sent = ArgumentCaptor.forClass(HttpRequest.class);
+            verify(httpClient, atLeastOnce()).send(sent.capture(), any(HttpResponse.BodyHandler.class));
+            assertTrue(sent.getAllValues().stream()
+                    .anyMatch(request -> request.uri().toString().endsWith("/" + agentId + "?version=5")),
+                    "the agent must be read at the version its descriptor names, requests were: "
+                            + sent.getAllValues());
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceOwnedClientTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceOwnedClientTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The two paths that build their own {@link HttpClient} rather than being
+ * handed one: the public constructor a sync endpoint uses, and the static agent
+ * listing behind the "connect to a remote instance" screen.
+ * <p>
+ * Neither can be reached with a real client here — {@code HttpClient.build()}
+ * opens a selector, which needs a loopback socket a sandboxed build does not
+ * have — so {@code HttpClient.newBuilder()} is stubbed and the assertions are
+ * on what the code asks the builder and the client for. That is the right level
+ * anyway: the guarantees are that a client this class owns is configured (and
+ * closed) by this class, and that a listing which did not come back 200 is
+ * never mistaken for an empty deployment.
+ */
+@DisplayName("RemoteApiResourceSource — the clients it builds itself")
+class RemoteApiResourceSourceOwnedClientTest {
+
+    private static final String BASE_URL = "https://203.0.113.10";
+    private static final String AGENT_ID = "aabbccddeeff112233445566";
+
+    private IJsonSerialization jsonSerialization;
+    private HttpClient.Builder builder;
+    private HttpClient builtClient;
+    private MockedStatic<HttpClient> httpClientStatics;
+
+    @BeforeEach
+    void setUp() {
+        jsonSerialization = mock(IJsonSerialization.class);
+        builder = mock(HttpClient.Builder.class, RETURNS_SELF);
+        builtClient = mock(HttpClient.class);
+        when(builder.build()).thenReturn(builtClient);
+        httpClientStatics = mockStatic(HttpClient.class);
+        httpClientStatics.when(HttpClient::newBuilder).thenReturn(builder);
+    }
+
+    @AfterEach
+    void tearDown() {
+        httpClientStatics.close();
+        // A test that asserts the interrupt flag must not hand it to the next one.
+        Thread.interrupted();
+    }
+
+    /**
+     * A source built through the public constructor owns its client, so it applies
+     * the class's own policy to it — never following a redirect, because a hostile
+     * remote instance answering 3xx must not be able to bounce the caller's bearer
+     * token at an address of its choosing.
+     * <p>
+     * The connect timeout is asserted as "set", not as a number: the policy this
+     * test names is the redirect one, and the duration is a tunable an operator may
+     * want changed without a test standing in the way. Dropping it entirely — and
+     * letting a build hang on an unreachable host — still fails here.
+     */
+    @Test
+    @DisplayName("the public constructor configures the client it builds")
+    void publicConstructorConfiguresItsOwnClient() {
+        new RemoteApiResourceSource(BASE_URL, AGENT_ID, 1, "Bearer t", jsonSerialization);
+
+        verify(builder).followRedirects(HttpClient.Redirect.NEVER);
+        verify(builder).connectTimeout(any(Duration.class));
+    }
+
+    /**
+     * ...and it closes that client again. Callers already wrap every source in
+     * try-with-resources; before this override they inherited a no-op, so a batch
+     * sync over N agents left N clients — each with a selector thread and an
+     * executor — alive until GC.
+     */
+    @Test
+    @DisplayName("closing a source closes the client it built")
+    void closingASourceClosesTheClientItBuilt() {
+        var source = new RemoteApiResourceSource(BASE_URL, AGENT_ID, 1, null, jsonSerialization);
+
+        source.close();
+
+        verify(builtClient).close();
+    }
+
+    /**
+     * The mirror image, and the reason ownership is tracked at all: a client handed
+     * in by the caller belongs to the caller. Closing it would take down a client
+     * the caller is still using — for the very next agent of the same batch, say.
+     */
+    @Test
+    @DisplayName("closing a source never closes a client it was handed")
+    void closingASourceLeavesABorrowedClientAlone() {
+        var borrowed = mock(HttpClient.class);
+        var source = new RemoteApiResourceSource(BASE_URL, AGENT_ID, 1, null, jsonSerialization, borrowed);
+
+        source.close();
+
+        verify(borrowed, never()).close();
+    }
+
+    /**
+     * The agent listing: it asks the remote instance for every agent descriptor in
+     * one unpaged call, sends the caller's own bearer token, and hands back what
+     * the remote deserialized to. The URL and the {@code limit=0} matter — a paged
+     * listing would show the operator a truncated agent list and let them "not
+     * find" the agent they meant to sync.
+     */
+    @Test
+    @DisplayName("the agent listing asks for every descriptor in one unpaged, authenticated call")
+    void listRemoteAgentDescriptorsReadsTheWholeListing() throws Exception {
+        var descriptor = new DocumentDescriptor();
+        descriptor.setName("Support Bot");
+        stubResponse(200, "[{\"name\":\"Support Bot\"}]");
+        when(jsonSerialization.deserialize(anyString(), eq(DocumentDescriptor[].class)))
+                .thenReturn(new DocumentDescriptor[]{descriptor});
+
+        List<DocumentDescriptor> descriptors = RemoteApiResourceSource.listRemoteAgentDescriptors(
+                BASE_URL + "/", "Bearer source-token", jsonSerialization);
+
+        assertEquals(List.of(descriptor), descriptors);
+
+        var sent = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(builtClient).send(sent.capture(), any(HttpResponse.BodyHandler.class));
+        assertEquals(URI.create(BASE_URL + "/agentstore/agents/descriptors?index=0&limit=0"),
+                sent.getValue().uri());
+        assertEquals("Bearer source-token", sent.getValue().headers().firstValue("Authorization").orElse(null));
+        // The client is this method's own, so this method has to close it.
+        verify(builtClient).close();
+    }
+
+    /**
+     * A remote instance that deserializes to nothing is an empty list, not a null
+     * the caller has to guard.
+     */
+    @Test
+    @DisplayName("a listing that deserializes to null is an empty list")
+    void nullDeserializationIsAnEmptyList() throws Exception {
+        stubResponse(200, "null");
+        when(jsonSerialization.deserialize(anyString(), eq(DocumentDescriptor[].class))).thenReturn(null);
+
+        assertTrue(RemoteApiResourceSource.listRemoteAgentDescriptors(BASE_URL, null, jsonSerialization).isEmpty());
+    }
+
+    /**
+     * A status other than 200 is a failure, never an empty deployment — the whole
+     * point of the screen this feeds is telling "that instance has no agents" apart
+     * from "that instance would not talk to us", and the status has to be in the
+     * message for the operator to tell an expired token from a wrong URL.
+     */
+    @Test
+    @DisplayName("a non-200 listing fails and names the status, rather than reading as no agents")
+    void nonOkListingFails() throws Exception {
+        stubResponse(401, "");
+
+        var thrown = assertThrows(RuntimeException.class,
+                () -> RemoteApiResourceSource.listRemoteAgentDescriptors(BASE_URL, "Bearer stale", jsonSerialization));
+
+        assertTrue(thrown.getMessage().contains("401"),
+                "the operator needs the status to tell a stale token from a wrong URL, was: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains(BASE_URL), thrown.getMessage());
+        verify(builtClient).close();
+    }
+
+    /**
+     * An interrupt is never swallowed. The caller — or the container shutting down
+     * — asked this thread to stop, and a lost flag means the next blocking call
+     * simply carries on, which for a batch sync means going on hammering a remote
+     * instance nobody is waiting for any more.
+     */
+    @Test
+    @DisplayName("an interrupted listing restores the flag and says it was interrupted")
+    void interruptedListingRestoresTheFlag() throws Exception {
+        var interrupted = new InterruptedException("shutting down");
+        when(builtClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenThrow(interrupted);
+
+        var thrown = assertThrows(RuntimeException.class,
+                () -> RemoteApiResourceSource.listRemoteAgentDescriptors(BASE_URL, null, jsonSerialization));
+
+        assertTrue(Thread.currentThread().isInterrupted(),
+                "the interrupt flag must be restored before unwinding");
+        assertTrue(thrown.getMessage().contains("Interrupted"), thrown.getMessage());
+        assertSame(interrupted, thrown.getCause());
+    }
+
+    /**
+     * A base URL that is not addressable is rejected before any client is built —
+     * building one and then throwing would leak a selector thread per bad request.
+     */
+    @Test
+    @DisplayName("a non-HTTP base URL is refused before a client is built")
+    void nonHttpBaseUrlIsRefusedBeforeBuilding() {
+        assertThrows(IllegalArgumentException.class,
+                () -> RemoteApiResourceSource.listRemoteAgentDescriptors("ftp://203.0.113.10", null, jsonSerialization));
+
+        verify(builder, never()).build();
+    }
+
+    // ==================== Helpers ====================
+
+    @SuppressWarnings("unchecked")
+    private void stubResponse(int status, String body) throws Exception {
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(status);
+        when(response.body()).thenReturn(body);
+        when(builtClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+        assertFalse(Thread.currentThread().isInterrupted(), "a leaked interrupt flag would corrupt this test");
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RemoteApiResourceSourceTest.java
@@ -353,26 +353,22 @@ class RemoteApiResourceSourceTest {
         }
 
         @Test
-        @DisplayName("should fallback to version=1 when descriptor lookup fails")
-        void fallbacksToVersion1() throws Exception {
-            var agentConfig = new AgentConfiguration();
-            agentConfig.setWorkflows(new ArrayList<>());
-
+        @DisplayName("should fail loudly when the latest version cannot be resolved")
+        void unresolvableVersionIsAnError() throws Exception {
             // Descriptors return empty (no matching agent)
             mockHttpResponse("/agentstore/agents/descriptors?index=0&limit=0", "[]");
             when(jsonSerialization.deserialize("[]", DocumentDescriptor[].class))
                     .thenReturn(new DocumentDescriptor[0]);
 
-            // Should fallback to version=1
-            mockHttpResponse("/agentstore/agents/" + AGENT_ID + "?version=1", "{agentJson}");
-            when(jsonSerialization.deserialize("{agentJson}", AgentConfiguration.class))
-                    .thenReturn(agentConfig);
-
             try (var source = new RemoteApiResourceSource(
                     BASE_URL, AGENT_ID, null, "Bearer test-token", jsonSerialization, mockHttpClient)) {
-                AgentSourceData result = source.readAgent();
 
-                assertNotNull(result);
+                // "null version = latest" is the documented contract. Falling back to
+                // version 1 met it by reading an arbitrarily old configuration and
+                // writing it into the target as if it were the newest, leaving only a
+                // DEBUG line behind.
+                var ex = assertThrows(RuntimeException.class, source::readAgent);
+                assertTrue(ex.getMessage().contains("latest version"), ex.getMessage());
             }
         }
     }

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceBranchTest.java
@@ -94,7 +94,7 @@ class RestExportServiceBranchTest {
                 dictionaryStore, ruleSetStore, apiCallsStore, llmStore,
                 propertySetterStore, outputStore, mcpCallsStore, ragStore,
                 snippetStore, jsonSerialization, zipArchive, secretScrubber,
-                scheduleStore, mock(ResourceAccessGuard.class));
+                scheduleStore, mock(ResourceAccessGuard.class), mock(BackupMetrics.class));
     }
 
     // =========================================================
@@ -406,21 +406,21 @@ class RestExportServiceBranchTest {
         @DisplayName("agentId with .. throws BadRequestException")
         void agentIdPathTraversal() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent("../etc", 1, null));
+                    () -> exportService.exportAgent("../etc", 1, null, null, null));
         }
 
         @Test
         @DisplayName("null agentId throws BadRequestException")
         void nullAgentId() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent(null, 1, null));
+                    () -> exportService.exportAgent(null, 1, null, null, null));
         }
 
         @Test
         @DisplayName("agentId with slash throws BadRequestException")
         void agentIdWithSlash() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent("agent/id", 1, null));
+                    () -> exportService.exportAgent("agent/id", 1, null, null, null));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceCleanupTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceCleanupTest.java
@@ -36,6 +36,9 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -90,7 +93,7 @@ class RestExportServiceCleanupTest {
                 mock(IDictionaryStore.class), mock(IRuleSetStore.class), mock(IApiCallsStore.class),
                 mock(ILlmStore.class), mock(IPropertySetterStore.class), mock(IOutputStore.class),
                 mock(IMcpCallsStore.class), mock(IRagStore.class), mock(IPromptSnippetStore.class),
-                jsonSerialization, zipArchive, secretScrubber, scheduleStore, mock(ResourceAccessGuard.class));
+                jsonSerialization, zipArchive, secretScrubber, scheduleStore, mock(ResourceAccessGuard.class), mock(BackupMetrics.class));
 
         tmpDir = Paths.get(FileUtilities.buildPath(System.getProperty("user.dir"), "tmp"));
         exportRoot = tmpDir.resolve("export");
@@ -116,6 +119,7 @@ class RestExportServiceCleanupTest {
         // Belt and braces: if an assertion fails mid-test, do not leave the repo dirty.
         deleteRecursively(exportRoot);
         deleteRecursively(legacyScratchDir);
+        deleteRecursively(tmpDir.resolve("archives"));
     }
 
     @Test
@@ -134,7 +138,7 @@ class RestExportServiceCleanupTest {
             return null;
         }).when(zipArchive).createZip(anyString(), anyString(), any());
 
-        exportService.exportAgent(AGENT_ID, 1, null);
+        exportService.exportAgent(AGENT_ID, 1, null, null, null);
 
         assertEquals(1, zippedSources.size());
         Path zippedSource = zippedSources.get(0).toAbsolutePath().normalize();
@@ -160,6 +164,44 @@ class RestExportServiceCleanupTest {
     }
 
     @Test
+    @DisplayName("finished archives land in tmp/archives/ and expire, instead of accumulating forever")
+    void finishedArchivesExpire() throws Exception {
+        List<Path> archiveTargets = new ArrayList<>();
+        doAnswer(inv -> {
+            Path target = Paths.get(inv.getArgument(1, String.class)).toAbsolutePath().normalize();
+            archiveTargets.add(target);
+            Files.createDirectories(target.getParent());
+            Files.writeString(target, "zip-bytes");
+            return null;
+        }).when(zipArchive).createZip(anyString(), anyString(), any());
+
+        exportService.exportAgent(AGENT_ID, 1, null, null, null);
+
+        assertEquals(1, archiveTargets.size());
+        Path archive = archiveTargets.getFirst();
+        Path archiveRoot = tmpDir.resolve("archives").toAbsolutePath().normalize();
+        // Their own directory is what lets the sweep delete by age without ever
+        // looking at the export scratch tree or the import staging root.
+        assertEquals(archiveRoot, archive.getParent(),
+                "the finished ZIP must live in tmp/archives/, not loose in tmp/");
+        assertTrue(Files.exists(archive));
+
+        // Nothing deleted these before: the scratch tree was cleaned up but the ZIP
+        // itself stayed in tmp/ forever, so every export permanently consumed disk.
+        Path stale = archiveRoot.resolve("stale-download-1.zip");
+        Files.writeString(stale, "zip-bytes");
+        Files.setLastModifiedTime(stale, FileTime.from(Instant.now().minus(Duration.ofDays(1))));
+
+        Path fresh = archiveRoot.resolve("fresh-download-1.zip");
+        Files.writeString(fresh, "zip-bytes");
+
+        exportService.exportAgent(AGENT_ID, 1, null, null, null);
+
+        assertFalse(Files.exists(stale), "an expired archive must be swept: " + stale);
+        assertTrue(Files.exists(fresh), "an archive inside the retention window must be kept: " + fresh);
+    }
+
+    @Test
     @DisplayName("a failing export still deletes its scratch tree")
     void failedExportLeavesNoResidue() throws Exception {
         List<Path> zippedSources = new ArrayList<>();
@@ -168,7 +210,7 @@ class RestExportServiceCleanupTest {
             throw new IOException("disk full");
         }).when(zipArchive).createZip(anyString(), anyString(), any());
 
-        assertThrows(IOException.class, () -> exportService.exportAgent(AGENT_ID, 1, null));
+        assertThrows(IOException.class, () -> exportService.exportAgent(AGENT_ID, 1, null, null, null));
 
         assertEquals(1, zippedSources.size());
         Path perRequestRoot = zippedSources.get(0).toAbsolutePath().normalize().getParent().getParent();
@@ -189,13 +231,13 @@ class RestExportServiceCleanupTest {
             if (nestedExportStarted.compareAndSet(false, true)) {
                 // A second export of the same agent (same version, even) starts and
                 // finishes — including its cleanup — while this one is mid-flight.
-                exportService.exportAgent(AGENT_ID, 1, null);
+                exportService.exportAgent(AGENT_ID, 1, null, null, null);
                 ownFilesSurvivedOverlap.set(Files.exists(source.resolve(AGENT_ID + ".agent.json")));
             }
             return null;
         }).when(zipArchive).createZip(anyString(), anyString(), any());
 
-        exportService.exportAgent(AGENT_ID, 1, null);
+        exportService.exportAgent(AGENT_ID, 1, null, null, null);
 
         assertEquals(2, zippedSources.size(), "both the outer and the nested export must have been zipped");
         assertNotEquals(zippedSources.get(0), zippedSources.get(1),
@@ -222,9 +264,9 @@ class RestExportServiceCleanupTest {
                     .thenThrow(new IResourceStore.ResourceNotFoundException("no such agent"));
 
             assertThrows(IResourceStore.ResourceNotFoundException.class,
-                    () -> exportService.exportAgent("import", 1, null));
+                    () -> exportService.exportAgent("import", 1, null, null, null));
             assertThrows(IResourceStore.ResourceNotFoundException.class,
-                    () -> exportService.exportAgent("d12pendingdownload-1.zip", 1, null));
+                    () -> exportService.exportAgent("d12pendingdownload-1.zip", 1, null, null, null));
 
             assertTrue(Files.exists(importStagingMarker),
                     "exporting an agent named 'import' wiped the import staging tree: " + importStagingMarker);

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceCleanupTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceCleanupTest.java
@@ -202,6 +202,45 @@ class RestExportServiceCleanupTest {
     }
 
     @Test
+    @DisplayName("archives leaked into tmp/ by earlier releases are swept too")
+    void legacyLooseArchivesAreReclaimed() throws Exception {
+        doAnswer(inv -> {
+            Path target = Paths.get(inv.getArgument(1, String.class)).toAbsolutePath().normalize();
+            Files.createDirectories(target.getParent());
+            Files.writeString(target, "zip-bytes");
+            return null;
+        }).when(zipArchive).createZip(anyString(), anyString(), any());
+
+        // Before this branch archives were written straight into tmp/. Nothing ever
+        // deleted them, and getAgentZipArchive now resolves only under tmp/archives,
+        // so an instance upgraded in place would keep every historical export forever
+        // while being unable to serve any of them.
+        Path legacyStale = tmpDir.resolve("d12-legacy-export-1.zip");
+        Files.createDirectories(tmpDir);
+        Files.writeString(legacyStale, "zip-bytes");
+        Files.setLastModifiedTime(legacyStale, FileTime.from(Instant.now().minus(Duration.ofDays(1))));
+
+        Path legacyFresh = tmpDir.resolve("d12-legacy-export-2.zip");
+        Files.writeString(legacyFresh, "zip-bytes");
+
+        Path notAnArchive = tmpDir.resolve("d12-legacy-notes.txt");
+        Files.writeString(notAnArchive, "keep me");
+        Files.setLastModifiedTime(notAnArchive, FileTime.from(Instant.now().minus(Duration.ofDays(1))));
+
+        try {
+            exportService.exportAgent(AGENT_ID, 1, null, null, null);
+
+            assertFalse(Files.exists(legacyStale), "an expired legacy archive must be reclaimed: " + legacyStale);
+            assertTrue(Files.exists(legacyFresh), "a legacy archive inside the retention window must be kept");
+            assertTrue(Files.exists(notAnArchive), "the sweep must only ever delete .zip files");
+        } finally {
+            Files.deleteIfExists(legacyStale);
+            Files.deleteIfExists(legacyFresh);
+            Files.deleteIfExists(notAnArchive);
+        }
+    }
+
+    @Test
     @DisplayName("a failing export still deletes its scratch tree")
     void failedExportLeavesNoResidue() throws Exception {
         List<Path> zippedSources = new ArrayList<>();

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedBranchTest.java
@@ -29,6 +29,8 @@ import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.secrets.sanitize.SecretScrubber;
 import ai.labs.eddi.backup.model.ExportPreview;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,10 +38,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -97,7 +101,7 @@ class RestExportServiceExtendedBranchTest {
                 dictionaryStore, ruleSetStore, apiCallsStore, llmStore,
                 propertySetterStore, outputStore, mcpCallsStore, ragStore,
                 snippetStore, jsonSerialization, zipArchive, secretScrubber,
-                scheduleStore, mock(ResourceAccessGuard.class));
+                scheduleStore, mock(ResourceAccessGuard.class), mock(BackupMetrics.class));
     }
 
     // =========================================================
@@ -112,18 +116,26 @@ class RestExportServiceExtendedBranchTest {
         @DisplayName("empty referenced names — returns early")
         void emptyReferencedNames() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class, Set.class);
             method.setAccessible(true);
-            // Should not throw; no snippets directory creation attempted
-            method.invoke(exportService, Files.createTempDirectory("test-snippets"), new LinkedHashSet<>());
-            verify(documentDescriptorStore, never()).readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean());
+
+            Path agentPath = Files.createTempDirectory("test-snippets");
+            method.invoke(exportService, agentPath, new LinkedHashSet<>(), null);
+
+            // The 6-argument overload is the one production calls — it carries the
+            // access scope. Verifying the 5-argument one, as this test used to,
+            // could never fail no matter what exportSnippets did.
+            verify(documentDescriptorStore, never())
+                    .readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean(), any());
+            assertFalse(Files.exists(agentPath.resolve("snippets")),
+                    "an early return must not leave an empty snippets directory behind");
         }
 
         @Test
         @DisplayName("null descriptors from store — returns early")
         void nullDescriptors() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class, Set.class);
             method.setAccessible(true);
 
             when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
@@ -131,14 +143,18 @@ class RestExportServiceExtendedBranchTest {
 
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting");
-            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
+            Path agentPath = Files.createTempDirectory("test-snippets");
+            method.invoke(exportService, agentPath, names, null);
+
+            assertFalse(Files.exists(agentPath.resolve("snippets")),
+                    "nothing to export means nothing written");
         }
 
         @Test
         @DisplayName("empty descriptors from store — returns early")
         void emptyDescriptors() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class, Set.class);
             method.setAccessible(true);
 
             when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
@@ -146,56 +162,70 @@ class RestExportServiceExtendedBranchTest {
 
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting");
-            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
+            Path agentPath = Files.createTempDirectory("test-snippets");
+            method.invoke(exportService, agentPath, names, null);
+
+            assertFalse(Files.exists(agentPath.resolve("snippets")),
+                    "nothing to export means nothing written");
         }
 
         @Test
         @DisplayName("snippet with null name is skipped")
         void snippetWithNullNameSkipped() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class, Set.class);
             method.setAccessible(true);
 
+            String snippetId = "aabbccddeeff112233445566";
             DocumentDescriptor desc = new DocumentDescriptor();
-            desc.setResource(URI.create("eddi://ai.labs.snippet/snippetstore/snippets/aabbccddeeff112233445566?version=1"));
+            desc.setResource(URI.create("eddi://ai.labs.snippet/snippetstore/snippets/" + snippetId + "?version=1"));
             when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
                     .thenReturn(List.of(desc));
 
             PromptSnippet snippet = new PromptSnippet();
             snippet.setName(null); // null name → skip
-            when(snippetStore.read("aabbccddeeff112233445566", 1)).thenReturn(snippet);
+            when(snippetStore.read(snippetId, 1)).thenReturn(snippet);
 
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting");
-            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
+            Path agentPath = Files.createTempDirectory("test-snippets");
+            method.invoke(exportService, agentPath, names, null);
+
+            assertFalse(Files.exists(agentPath.resolve("snippets").resolve(snippetId + ".snippet.json")),
+                    "a nameless snippet cannot be matched against the referenced set, so it must not be written");
         }
 
         @Test
         @DisplayName("snippet not in referenced set is skipped")
         void snippetNotReferencedSkipped() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class, Set.class);
             method.setAccessible(true);
 
+            String snippetId = "aabbccddeeff112233445566";
             DocumentDescriptor desc = new DocumentDescriptor();
-            desc.setResource(URI.create("eddi://ai.labs.snippet/snippetstore/snippets/aabbccddeeff112233445566?version=1"));
+            desc.setResource(URI.create("eddi://ai.labs.snippet/snippetstore/snippets/" + snippetId + "?version=1"));
             when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
                     .thenReturn(List.of(desc));
 
             PromptSnippet snippet = new PromptSnippet();
             snippet.setName("farewell"); // not in referenced set
-            when(snippetStore.read("aabbccddeeff112233445566", 1)).thenReturn(snippet);
+            when(snippetStore.read(snippetId, 1)).thenReturn(snippet);
 
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting"); // only "greeting" is referenced
-            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
+            Path agentPath = Files.createTempDirectory("test-snippets");
+            method.invoke(exportService, agentPath, names, null);
+
+            assertFalse(Files.exists(agentPath.resolve("snippets").resolve(snippetId + ".snippet.json")),
+                    "a snippet this agent never references must stay out of the archive");
         }
 
         @Test
         @DisplayName("ResourceNotFoundException on snippet read is handled gracefully")
         void snippetResourceNotFound() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSnippets", Path.class, Set.class);
+                    "exportSnippets", Path.class, Set.class, Set.class);
             method.setAccessible(true);
 
             DocumentDescriptor desc = new DocumentDescriptor();
@@ -208,7 +238,41 @@ class RestExportServiceExtendedBranchTest {
             Set<String> names = new LinkedHashSet<>();
             names.add("greeting");
             // Should not throw
-            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names);
+            method.invoke(exportService, Files.createTempDirectory("test-snippets"), names, null);
+        }
+
+        @Test
+        @DisplayName("a deselected snippet is not written into the archive")
+        void deselectedSnippetSkipped() throws Exception {
+            Method method = RestExportService.class.getDeclaredMethod(
+                    "exportSnippets", Path.class, Set.class, Set.class);
+            method.setAccessible(true);
+
+            String snippetId = "aabbccddeeff112233445566";
+            DocumentDescriptor desc = new DocumentDescriptor();
+            desc.setResource(URI.create("eddi://ai.labs.snippet/snippetstore/snippets/" + snippetId + "?version=1"));
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(), eq(false), any()))
+                    .thenReturn(List.of(desc));
+
+            PromptSnippet snippet = new PromptSnippet();
+            snippet.setName("greeting");
+            when(snippetStore.read(snippetId, 1)).thenReturn(snippet);
+            when(jsonSerialization.serialize(any())).thenReturn("{}");
+            when(secretScrubber.scrubJson(anyString())).thenReturn("{}");
+
+            Set<String> names = new LinkedHashSet<>();
+            names.add("greeting");
+
+            Path agentPath = Files.createTempDirectory("test-snippets");
+            // The preview renders snippet rows as deselectable; ignoring the selection
+            // here put back exactly the deployment-specific prompt text a user unticked.
+            method.invoke(exportService, agentPath, names, Set.of("some-other-id"));
+
+            assertFalse(Files.exists(agentPath.resolve("snippets").resolve(snippetId + ".snippet.json")));
+
+            // ...and a selected one is still written.
+            method.invoke(exportService, agentPath, names, Set.of(snippetId));
+            assertTrue(Files.exists(agentPath.resolve("snippets").resolve(snippetId + ".snippet.json")));
         }
     }
 
@@ -224,12 +288,12 @@ class RestExportServiceExtendedBranchTest {
         @DisplayName("empty schedules — returns early")
         void emptySchedules() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSchedules", String.class, Path.class);
+                    "exportSchedules", String.class, Path.class, Set.class);
             method.setAccessible(true);
 
             when(scheduleStore.readSchedulesByAgentId("agent1")).thenReturn(Collections.emptyList());
 
-            method.invoke(exportService, "agent1", Files.createTempDirectory("test-sched"));
+            method.invoke(exportService, "agent1", Files.createTempDirectory("test-sched"), null);
             // No files should be written
         }
 
@@ -237,7 +301,7 @@ class RestExportServiceExtendedBranchTest {
         @DisplayName("schedule export exception is handled gracefully")
         void scheduleExportException() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
-                    "exportSchedules", String.class, Path.class);
+                    "exportSchedules", String.class, Path.class, Set.class);
             method.setAccessible(true);
 
             when(scheduleStore.readSchedulesByAgentId("agent1"))
@@ -245,7 +309,32 @@ class RestExportServiceExtendedBranchTest {
 
             // Should not throw
             assertDoesNotThrow(() -> method.invoke(exportService, "agent1",
-                    Files.createTempDirectory("test-sched")));
+                    Files.createTempDirectory("test-sched"), null));
+        }
+
+        @Test
+        @DisplayName("a deselected schedule is not written into the archive")
+        void deselectedScheduleSkipped() throws Exception {
+            Method method = RestExportService.class.getDeclaredMethod(
+                    "exportSchedules", String.class, Path.class, Set.class);
+            method.setAccessible(true);
+
+            var kept = new ScheduleConfiguration();
+            kept.setId("aabbccddeeff112233445566");
+            kept.setName("nightly");
+            var dropped = new ScheduleConfiguration();
+            dropped.setId("bbccddeeff11223344556677");
+            dropped.setName("hourly");
+            when(scheduleStore.readSchedulesByAgentId("agent1")).thenReturn(List.of(kept, dropped));
+            when(jsonSerialization.serialize(any())).thenReturn("{}");
+            when(secretScrubber.scrubJson(anyString())).thenReturn("{}");
+
+            Path agentPath = Files.createTempDirectory("test-sched");
+            method.invoke(exportService, "agent1", agentPath, Set.of(kept.getId()));
+
+            Path schedulesDir = agentPath.resolve("schedules");
+            assertTrue(Files.exists(schedulesDir.resolve(kept.getId() + ".schedule.json")));
+            assertFalse(Files.exists(schedulesDir.resolve(dropped.getId() + ".schedule.json")));
         }
     }
 
@@ -258,7 +347,7 @@ class RestExportServiceExtendedBranchTest {
     class PrepareZipFilenameTests {
 
         @Test
-        @DisplayName("non-empty descriptor name is URL-encoded in filename")
+        @DisplayName("non-empty descriptor name is slugified into the filename")
         void nonEmptyName() throws Exception {
             Method method = RestExportService.class.getDeclaredMethod(
                     "prepareZipFilename", DocumentDescriptor.class, String.class, Integer.class);
@@ -268,7 +357,27 @@ class RestExportServiceExtendedBranchTest {
             descriptor.setName("My Agent");
             String result = (String) method.invoke(exportService, descriptor, "id123", 2);
 
-            assertTrue(result.contains("My+Agent-"));
+            assertTrue(result.startsWith("My-Agent-"), result);
+            assertTrue(result.endsWith("id123-2.zip"));
+        }
+
+        @Test
+        @DisplayName("a non-ASCII name produces a downloadable filename")
+        void nonAsciiNameIsDownloadable() throws Exception {
+            Method method = RestExportService.class.getDeclaredMethod(
+                    "prepareZipFilename", DocumentDescriptor.class, String.class, Integer.class);
+            method.setAccessible(true);
+
+            DocumentDescriptor descriptor = new DocumentDescriptor();
+            descriptor.setName("Müller Bot");
+            String result = (String) method.invoke(exportService, descriptor, "id123", 2);
+
+            // URLEncoder produced "M%C3%BCller+Bot-…", JAX-RS decoded the path
+            // parameter back on the way in, and the download endpoint's character
+            // class then rejected both the decoded "ü" and the literal "%" — so the
+            // export succeeded into an archive that could never be downloaded.
+            assertTrue(result.matches("^[a-zA-Z0-9_.+\\-]+$"), result);
+            assertTrue(result.startsWith("Muller-Bot-"), result);
             assertTrue(result.endsWith("id123-2.zip"));
         }
 
@@ -348,6 +457,162 @@ class RestExportServiceExtendedBranchTest {
         void backslashInAgentId() {
             assertThrows(BadRequestException.class,
                     () -> exportService.previewExport("agent\\id", 1));
+        }
+    }
+
+    // =========================================================
+    // previewExport — what a client echoes back as a selection
+    // =========================================================
+
+    @Nested
+    @DisplayName("previewExport row keys")
+    class PreviewRowKeyTests {
+
+        private static final String PREVIEW_AGENT_ID = "previewAgent";
+        private static final String PREVIEW_WF_ID = "aaaa11112222333344445555";
+        private static final String SNIPPET_ID = "bbbb11112222333344445555";
+        private static final String SCHEDULE_ID = "cccc11112222333344445555";
+
+        @BeforeEach
+        void stubOneWorkflowReferencingOneSnippet() throws Exception {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(List.of(URI.create(
+                    "eddi://ai.labs.workflow/workflowstore/workflows/" + PREVIEW_WF_ID + "?version=1")));
+            when(agentStore.read(PREVIEW_AGENT_ID, 1)).thenReturn(config);
+            when(workflowStore.read(PREVIEW_WF_ID, 1)).thenReturn(new WorkflowConfiguration());
+
+            DocumentDescriptor agentDescriptor = new DocumentDescriptor();
+            agentDescriptor.setName("Preview Agent");
+            when(documentDescriptorStore.readDescriptor(PREVIEW_AGENT_ID, 1)).thenReturn(agentDescriptor);
+
+            // The workflow's own JSON is enough to carry a snippet reference.
+            when(jsonSerialization.serialize(any()))
+                    .thenReturn("{\"workflowSteps\":[{\"systemMessage\":\"{snippets.greeting}\"}]}");
+        }
+
+        private void stubSnippetDescriptorSweep(List<DocumentDescriptor> descriptors) throws Exception {
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(),
+                    eq(false), any())).thenReturn(descriptors);
+        }
+
+        private ExportPreview.ExportableResource rowOfType(ExportPreview preview, String type) {
+            return preview.resources().stream()
+                    .filter(r -> type.equals(r.resourceType()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                            "no '" + type + "' row in preview: " + preview.resources()));
+        }
+
+        @Test
+        @DisplayName("a snippet row carries the snippet's resource id, like every other row")
+        void snippetRowIsKeyedByResourceId() throws Exception {
+            DocumentDescriptor snippetDescriptor = new DocumentDescriptor();
+            snippetDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.snippet/snippetstore/snippets/" + SNIPPET_ID + "?version=1"));
+            stubSnippetDescriptorSweep(List.of(snippetDescriptor));
+
+            PromptSnippet snippet = new PromptSnippet();
+            snippet.setName("greeting");
+            when(snippetStore.read(SNIPPET_ID, 1)).thenReturn(snippet);
+
+            ExportPreview preview = exportService.previewExport(PREVIEW_AGENT_ID, 1);
+
+            var row = rowOfType(preview, "snippet");
+            // exportSnippets filters on resourceId. A row keyed by the snippet's NAME
+            // could never be matched by a client echoing it back, so the snippet was
+            // silently dropped from the archive.
+            assertEquals(SNIPPET_ID, row.resourceId());
+            assertEquals("greeting", row.name(), "the name is still what the operator reads");
+            assertEquals(Integer.valueOf(1), row.resourceVersion());
+        }
+
+        @Test
+        @DisplayName("a snippet whose id cannot be resolved falls back to its name rather than vanishing")
+        void snippetRowFallsBackToName() throws Exception {
+            // Access-scoped listing, or a descriptor read that failed: both are caught
+            // and logged at debug inside resolveSnippetIdsByName.
+            stubSnippetDescriptorSweep(List.of());
+
+            ExportPreview preview = exportService.previewExport(PREVIEW_AGENT_ID, 1);
+
+            var row = rowOfType(preview, "snippet");
+            assertEquals("greeting", row.resourceId(),
+                    "an unresolvable snippet must still be listed, so the operator sees it exists");
+            assertNull(row.resourceVersion());
+        }
+
+        @Test
+        @DisplayName("the agent's schedules are listed as deselectable rows")
+        void schedulesAppearInPreview() throws Exception {
+            stubSnippetDescriptorSweep(List.of());
+
+            ScheduleConfiguration schedule = new ScheduleConfiguration();
+            schedule.setId(SCHEDULE_ID);
+            schedule.setName("nightly consolidation");
+            when(scheduleStore.readSchedulesByAgentId(PREVIEW_AGENT_ID)).thenReturn(List.of(schedule));
+
+            ExportPreview preview = exportService.previewExport(PREVIEW_AGENT_ID, 1);
+
+            // Schedules are written into every archive but appeared in no preview, so
+            // an operator could neither see what a restore would bring back nor build a
+            // correct selectedSchedules set from what they were shown.
+            var row = rowOfType(preview, "schedule");
+            assertEquals(SCHEDULE_ID, row.resourceId());
+            assertEquals("nightly consolidation", row.name());
+            assertFalse(row.required(), "a schedule must be deselectable");
+        }
+    }
+
+    // =========================================================
+    // getAgentZipArchive — the download contract
+    // =========================================================
+
+    @Nested
+    @DisplayName("getAgentZipArchive")
+    class DownloadContractTests {
+
+        private Path archiveDir;
+
+        @BeforeEach
+        void createArchiveDir() throws Exception {
+            archiveDir = Paths.get(System.getProperty("user.dir"), "tmp", "archives");
+            Files.createDirectories(archiveDir);
+        }
+
+        @Test
+        @DisplayName("serves the archive as an attachment named after the file")
+        void servesAsAttachment() throws Exception {
+            Path archive = archiveDir.resolve("My-Agent-aaaa11112222333344445555-1.zip");
+            Files.write(archive, new byte[]{0x50, 0x4b, 0x03, 0x04});
+            Response response = null;
+            try {
+                response = exportService.getAgentZipArchive(archive.getFileName().toString());
+
+                assertEquals(200, response.getStatus());
+                // Without this the browser renders the ZIP inline (or saves it under
+                // the endpoint's last path segment) instead of offering it by name.
+                assertEquals("attachment; filename=\"" + archive.getFileName() + "\"",
+                        response.getHeaderString("Content-Disposition"));
+            } finally {
+                // The entity is an open stream on the file, and Windows will not
+                // delete a file while a handle is held.
+                if (response != null && response.getEntity() instanceof InputStream stream) {
+                    stream.close();
+                }
+                Files.deleteIfExists(archive);
+            }
+        }
+
+        @Test
+        @DisplayName("a missing archive is a 404 that quotes the retention window")
+        void missingArchiveIsNotFound() {
+            var ex = assertThrows(NotFoundException.class,
+                    () -> exportService.getAgentZipArchive("never-written-aaaa1111-1.zip"));
+
+            assertTrue(ex.getMessage().contains("never-written-aaaa1111-1.zip"), ex.getMessage());
+            // The message used to claim archives "are not kept indefinitely" while
+            // nothing deleted them at all; now it names the window that does.
+            assertTrue(ex.getMessage().contains("60 minutes"), ex.getMessage());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedBranchTest.java
@@ -24,10 +24,13 @@ import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.hitl.HitlSchedules;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.secrets.sanitize.SecretScrubber;
+import ai.labs.eddi.utils.FileUtilities;
 import ai.labs.eddi.backup.model.ExportPreview;
+import io.quarkus.scheduler.Scheduled;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
@@ -44,6 +47,9 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -239,6 +245,34 @@ class RestExportServiceExtendedBranchTest {
             names.add("greeting");
             // Should not throw
             method.invoke(exportService, Files.createTempDirectory("test-snippets"), names, null);
+        }
+
+        /**
+         * The listing itself failing is the wider case: a snippet store that will not
+         * answer at all costs the snippets and nothing else. The export the operator
+         * asked for is an agent, and it still has to produce one — and no half-built
+         * {@code snippets/} directory to make the archive look like it carried some.
+         */
+        @Test
+        @DisplayName("a snippet listing that will not answer costs the snippets, not the export")
+        void snippetListingFailureIsNotFatal() throws Exception {
+            Method method = RestExportService.class.getDeclaredMethod(
+                    "exportSnippets", Path.class, Set.class, Set.class);
+            method.setAccessible(true);
+
+            doAnswer(invocation -> {
+                throw new IResourceStore.ResourceStoreException("snippet descriptors unavailable");
+            }).when(documentDescriptorStore).readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(),
+                    eq(false), any());
+
+            Set<String> names = new LinkedHashSet<>();
+            names.add("greeting");
+            Path agentPath = Files.createTempDirectory("test-snippets");
+
+            method.invoke(exportService, agentPath, names, null);
+
+            assertFalse(Files.exists(agentPath.resolve("snippets")),
+                    "a listing that never answered must not leave a snippets directory suggesting it did");
         }
 
         @Test
@@ -644,6 +678,150 @@ class RestExportServiceExtendedBranchTest {
             // Should call writeConfigs with filtered configs
             method.invoke(exportService, Files.createTempDirectory("test"),
                     Collections.emptyMap(), "ext", Set.of("r1"));
+        }
+    }
+
+    // =========================================================
+    // HITL approval timeouts are never archived
+    // =========================================================
+
+    /**
+     * A HITL approval timeout is a safety timer for one pending approval on this
+     * deployment, named after its conversation — not part of the agent's
+     * configuration. The import surface refuses to mint one for anybody, including
+     * administrators, so archiving it only produced a backup that could not be
+     * restored, and previewing it offered the operator a row that could never land.
+     */
+    @Nested
+    @DisplayName("HITL approval timeouts are never archived")
+    class HitlTimeoutSchedules {
+
+        @Test
+        @DisplayName("exportSchedules writes the agent's own schedules and skips its HITL timers")
+        void hitlTimerIsNotWritten() throws Exception {
+            Method method = RestExportService.class.getDeclaredMethod(
+                    "exportSchedules", String.class, Path.class, Set.class);
+            method.setAccessible(true);
+
+            var nightly = new ScheduleConfiguration();
+            nightly.setId("aabbccddeeff112233445566");
+            nightly.setName("nightly");
+            var hitlTimer = new ScheduleConfiguration();
+            hitlTimer.setId("bbccddeeff11223344556677");
+            hitlTimer.setName(HitlSchedules.regularTimeoutScheduleName("conv-1"));
+            hitlTimer.setMetadata(Map.of(HitlSchedules.METADATA_TYPE_KEY, HitlSchedules.METADATA_TYPE_TIMEOUT));
+
+            when(scheduleStore.readSchedulesByAgentId("agent1")).thenReturn(List.of(nightly, hitlTimer));
+            when(jsonSerialization.serialize(any())).thenReturn("{}");
+            when(secretScrubber.scrubJson(anyString())).thenReturn("{}");
+
+            Path agentPath = Files.createTempDirectory("test-hitl-sched");
+            method.invoke(exportService, "agent1", agentPath, null);
+
+            Path schedulesDir = agentPath.resolve("schedules");
+            assertTrue(Files.exists(schedulesDir.resolve(nightly.getId() + ".schedule.json")),
+                    "an ordinary schedule must still be archived");
+            assertFalse(Files.exists(schedulesDir.resolve(hitlTimer.getId() + ".schedule.json")),
+                    "an approval timer must never reach the archive — the import refuses to restore it");
+        }
+
+        @Test
+        @DisplayName("the preview offers no row for a HITL timer, nor for a schedule with no id")
+        void hitlTimerIsNotPreviewed() throws Exception {
+            var nightly = new ScheduleConfiguration();
+            nightly.setId("aabbccddeeff112233445566");
+            nightly.setName("nightly");
+            var hitlTimer = new ScheduleConfiguration();
+            hitlTimer.setId("bbccddeeff11223344556677");
+            hitlTimer.setName(HitlSchedules.regularTimeoutScheduleName("conv-1"));
+            hitlTimer.setMetadata(Map.of(HitlSchedules.METADATA_TYPE_KEY, HitlSchedules.METADATA_TYPE_TIMEOUT));
+            var idless = new ScheduleConfiguration();
+            idless.setName("half-written");
+
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(new ArrayList<>());
+            when(agentStore.read("previewAgent", 1)).thenReturn(config);
+            when(jsonSerialization.serialize(any())).thenReturn("{}");
+            when(scheduleStore.readSchedulesByAgentId("previewAgent"))
+                    .thenReturn(Arrays.asList(nightly, hitlTimer, idless, null));
+
+            ExportPreview preview = exportService.previewExport("previewAgent", 1);
+
+            List<String> scheduleRowIds = preview.resources().stream()
+                    .filter(resource -> "schedule".equals(resource.resourceType()))
+                    .map(ExportPreview.ExportableResource::resourceId)
+                    .toList();
+            assertEquals(List.of(nightly.getId()), scheduleRowIds,
+                    "only the agent's own, fully-formed schedules are deselectable rows");
+        }
+    }
+
+    // =========================================================
+    // Retention sweep on the timer
+    // =========================================================
+
+    /**
+     * Sweeping only from the export path left the last archives an instance
+     * produced on disk until its next export — which on a deployment that exports
+     * occasionally is indefinitely. The timer is what bounds an idle instance, so
+     * it has to sweep the same two directories the export path does.
+     */
+    @Nested
+    @DisplayName("Retention sweep on the timer")
+    class ScheduledRetentionSweep {
+
+        @Test
+        @DisplayName("the scheduled sweep deletes expired archives in tmp/archives and tmp/, and only those")
+        void scheduledSweepReclaimsWhatTheInstanceWrote() throws Exception {
+            Path tmpDir = Paths.get(FileUtilities.buildPath(System.getProperty("user.dir"), "tmp"));
+            Path archiveDir = Files.createDirectories(tmpDir.resolve("archives"));
+
+            Path expiredArchive = archiveDir.resolve("sweep-expired.zip");
+            Path freshArchive = archiveDir.resolve("sweep-fresh.zip");
+            Path legacyExpired = tmpDir.resolve("sweep-legacy-expired.zip");
+            Path notAnArchive = archiveDir.resolve("sweep-keep-me.txt");
+            for (Path path : List.of(expiredArchive, freshArchive, legacyExpired, notAnArchive)) {
+                Files.writeString(path, "zip-bytes");
+            }
+            var longExpired = FileTime.from(Instant.now().minus(Duration.ofDays(30)));
+            Files.setLastModifiedTime(expiredArchive, longExpired);
+            Files.setLastModifiedTime(legacyExpired, longExpired);
+            Files.setLastModifiedTime(notAnArchive, longExpired);
+
+            try {
+                exportService.sweepExpiredArchivesOnSchedule();
+
+                assertFalse(Files.exists(expiredArchive), "an expired archive must be reclaimed by the timer");
+                assertFalse(Files.exists(legacyExpired),
+                        "archives leaked into tmp/ by earlier releases must be reclaimed too");
+                assertTrue(Files.exists(freshArchive), "an archive still inside the retention window must survive");
+                assertTrue(Files.exists(notAnArchive), "the sweep must only ever delete .zip files");
+            } finally {
+                Files.deleteIfExists(expiredArchive);
+                Files.deleteIfExists(freshArchive);
+                Files.deleteIfExists(legacyExpired);
+                Files.deleteIfExists(notAnArchive);
+            }
+        }
+
+        /**
+         * The test above calls the sweep by hand, so it passes just as well on a method
+         * nothing ever fires — which is precisely the defect reported: an instance that
+         * stops exporting never reclaims what it already wrote. What makes the sweep
+         * independent of {@code exportAgent} is the annotation, so that is what this
+         * pins.
+         */
+        @Test
+        @DisplayName("the sweep is fired by the scheduler, not only from the export path")
+        void sweepIsScheduledIndependentlyOfExports() throws Exception {
+            Method scheduled = RestExportService.class.getDeclaredMethod("sweepExpiredArchivesOnSchedule");
+            Scheduled annotation = scheduled.getAnnotation(Scheduled.class);
+
+            assertNotNull(annotation, "the retention sweep must run on a timer, not only when an export happens");
+            assertEquals("${eddi.backup.export.sweep-interval:15m}", annotation.every(),
+                    "the sweep cadence must stay operator-configurable");
+            assertEquals("backup-export-archive-retention", annotation.identity(),
+                    "the job needs a stable identity so operators can see and pause it by name");
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceExtendedTest.java
@@ -88,7 +88,7 @@ class RestExportServiceExtendedTest {
                 dictionaryStore, behaviorStore, httpCallsStore, llmStore,
                 propertySetterStore, outputStore, mcpCallsStore, ragStore,
                 snippetStore, jsonSerialization, zipArchive, secretScrubber,
-                scheduleStore, mock(ResourceAccessGuard.class));
+                scheduleStore, mock(ResourceAccessGuard.class), mock(BackupMetrics.class));
     }
 
     // ─── sanitizePathComponent ─────────────────────────────────
@@ -101,21 +101,21 @@ class RestExportServiceExtendedTest {
         @DisplayName("should reject double-dot path traversal")
         void doubleDotTraversal() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent("agent..id", 1, null));
+                    () -> exportService.exportAgent("agent..id", 1, null, null, null));
         }
 
         @Test
         @DisplayName("should reject absolute path in agentId")
         void absolutePathLinux() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent("/etc/passwd", 1, null));
+                    () -> exportService.exportAgent("/etc/passwd", 1, null, null, null));
         }
 
         @Test
         @DisplayName("should reject backslash in agentId")
         void backslash() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent("agent\\id", 1, null));
+                    () -> exportService.exportAgent("agent\\id", 1, null, null, null));
         }
     }
 
@@ -158,7 +158,7 @@ class RestExportServiceExtendedTest {
             when(secretScrubber.scrubJson(anyString())).thenAnswer(inv -> inv.getArgument(0));
             when(scheduleStore.readSchedulesByAgentId(agentId)).thenReturn(List.of());
 
-            Response response = exportService.exportAgent(agentId, agentVersion, null);
+            Response response = exportService.exportAgent(agentId, agentVersion, null, null, null);
 
             assertNotNull(response);
             assertEquals(200, response.getStatus());
@@ -266,7 +266,7 @@ class RestExportServiceExtendedTest {
             schedule.setId("schedule-1");
             when(scheduleStore.readSchedulesByAgentId(agentId)).thenReturn(List.of(schedule));
 
-            Response response = exportService.exportAgent(agentId, 1, null);
+            Response response = exportService.exportAgent(agentId, 1, null, null, null);
 
             assertNotNull(response);
             assertEquals(200, response.getStatus());
@@ -291,7 +291,7 @@ class RestExportServiceExtendedTest {
             when(secretScrubber.scrubJson(anyString())).thenAnswer(inv -> inv.getArgument(0));
             when(scheduleStore.readSchedulesByAgentId(agentId)).thenReturn(List.of());
 
-            Response response = exportService.exportAgent(agentId, 1, null);
+            Response response = exportService.exportAgent(agentId, 1, null, null, null);
 
             assertNotNull(response);
             assertEquals(200, response.getStatus());
@@ -322,7 +322,7 @@ class RestExportServiceExtendedTest {
             when(secretScrubber.scrubJson(anyString())).thenAnswer(inv -> inv.getArgument(0));
             when(scheduleStore.readSchedulesByAgentId(agentId)).thenReturn(List.of());
 
-            Response response = exportService.exportAgent(agentId, 1, "res1,res2");
+            Response response = exportService.exportAgent(agentId, 1, "res1,res2", null, null);
 
             assertNotNull(response);
             assertEquals(200, response.getStatus());

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServicePreviewResilienceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServicePreviewResilienceTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IZipArchive;
+import ai.labs.eddi.backup.model.ExportPreview;
+import ai.labs.eddi.backup.model.ExportPreview.ExportableResource;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.apicalls.IApiCallsStore;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.dictionary.IDictionaryStore;
+import ai.labs.eddi.configs.llm.ILlmStore;
+import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
+import ai.labs.eddi.configs.output.IOutputStore;
+import ai.labs.eddi.configs.propertysetter.IPropertySetterStore;
+import ai.labs.eddi.configs.rag.IRagStore;
+import ai.labs.eddi.configs.rules.IRuleSetStore;
+import ai.labs.eddi.configs.snippets.IPromptSnippetStore;
+import ai.labs.eddi.configs.snippets.model.PromptSnippet;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.secrets.sanitize.SecretScrubber;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The export preview is what the wizard renders before anyone commits to a
+ * download, and every row in it is stitched together from a different store.
+ * <p>
+ * That makes it the one screen where a single unavailable collaborator must
+ * never be fatal: an agent the operator can still export is worth more than a
+ * complete row set. Each store below is failed in turn, and the assertion is
+ * always the same shape — the preview still comes back, the rows that do not
+ * depend on the broken store are unchanged, and the row that does degrades in a
+ * stated way rather than vanishing or carrying a lie.
+ */
+@DisplayName("RestExportService — a preview built from stores that fail")
+class RestExportServicePreviewResilienceTest {
+
+    private static final String AGENT_ID = "aabbccddeeff112233445566";
+    private static final String WORKFLOW_ID = "bbbbccddeeff112233445566";
+    private static final String LLM_ID = "ccccccddeeff112233445566";
+    private static final String SNIPPET_ID = "ddddccddeeff112233445566";
+    /** A second snippet document, so "one descriptor drops out" is observable. */
+    private static final String SECOND_SNIPPET_ID = "eeeeccddeeff112233445566";
+
+    private static final String LLM_URI = "eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=1";
+
+    private IDocumentDescriptorStore documentDescriptorStore;
+    private IAgentStore agentStore;
+    private IWorkflowStore workflowStore;
+    private ILlmStore llmStore;
+    private IPromptSnippetStore snippetStore;
+    private IJsonSerialization jsonSerialization;
+    private RestExportService exportService;
+
+    /** The workflow JSON every test starts from: one LLM step, one snippet ref. */
+    private String workflowJson = """
+            {"workflowSteps":[{"type":"eddi://ai.labs.llm","config":{"uri":"%s"}}],
+             "systemPrompt":"{snippets.cautious_mode}"}
+            """.formatted(LLM_URI);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        agentStore = mock(IAgentStore.class);
+        workflowStore = mock(IWorkflowStore.class);
+        llmStore = mock(ILlmStore.class);
+        snippetStore = mock(IPromptSnippetStore.class);
+        jsonSerialization = mock(IJsonSerialization.class);
+
+        exportService = new RestExportService(
+                documentDescriptorStore, agentStore, workflowStore,
+                mock(IDictionaryStore.class), mock(IRuleSetStore.class), mock(IApiCallsStore.class), llmStore,
+                mock(IPropertySetterStore.class), mock(IOutputStore.class), mock(IMcpCallsStore.class),
+                mock(IRagStore.class), snippetStore, jsonSerialization, mock(IZipArchive.class),
+                mock(SecretScrubber.class), mock(IScheduleStore.class), mock(ResourceAccessGuard.class),
+                mock(BackupMetrics.class));
+
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of(URI.create(
+                "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1")));
+        when(agentStore.read(AGENT_ID, 1)).thenReturn(agentConfig);
+
+        when(workflowStore.read(WORKFLOW_ID, 1)).thenReturn(new WorkflowConfiguration());
+        when(jsonSerialization.serialize(any())).thenAnswer(invocation -> workflowJson);
+        when(documentDescriptorStore.readDescriptor(AGENT_ID, 1)).thenReturn(descriptorNamed("Support Bot"));
+        when(documentDescriptorStore.readDescriptor(WORKFLOW_ID, 1)).thenReturn(descriptorNamed("Main workflow"));
+    }
+
+    /**
+     * The baseline every degradation below is measured against: with every store
+     * answering, the LLM row carries its descriptor name and the snippet row
+     * carries the snippet's real resource id and version — the id the selection
+     * filter compares against, which is why a row keyed by the name could never be
+     * ticked off by a client echoing it back.
+     */
+    @Test
+    @DisplayName("with every store answering, rows carry their names and their real ids")
+    void fullyResolvedPreview() throws Exception {
+        when(documentDescriptorStore.readDescriptor(LLM_ID, 1)).thenReturn(descriptorNamed("GPT config"));
+        stubSnippetLookup();
+
+        ExportPreview preview = exportService.previewExport(AGENT_ID, 1);
+
+        ExportableResource llmRow = rowOfType(preview, "langchain");
+        assertEquals(LLM_ID, llmRow.resourceId());
+        assertEquals("GPT config", llmRow.name());
+
+        ExportableResource snippetRow = rowOfType(preview, "snippet");
+        assertEquals(SNIPPET_ID, snippetRow.resourceId(), "the row has to carry the id the selection filter compares");
+        assertEquals(1, snippetRow.resourceVersion());
+        assertEquals("cautious_mode", snippetRow.name());
+    }
+
+    /**
+     * A descriptor read that throws costs the human-readable name of that one row.
+     * The row itself stays: the archive is assembled from ids, so an unnamed row is
+     * still an exportable row, and dropping it would silently shrink the archive.
+     */
+    @Test
+    @DisplayName("a descriptor read that throws costs the row's name, not the row")
+    void unreadableExtensionDescriptorCostsOnlyTheName() throws Exception {
+        doAnswer(invocation -> {
+            throw new IResourceStore.ResourceStoreException("descriptor store is down");
+        }).when(documentDescriptorStore).readDescriptor(LLM_ID, 1);
+        stubSnippetLookup();
+
+        ExportPreview preview = exportService.previewExport(AGENT_ID, 1);
+
+        ExportableResource llmRow = rowOfType(preview, "langchain");
+        assertEquals(LLM_ID, llmRow.resourceId(), "the row is what the export needs; the name is decoration");
+        assertNull(llmRow.name());
+        assertEquals(SNIPPET_ID, rowOfType(preview, "snippet").resourceId(),
+                "one broken descriptor must not disturb the rest of the preview");
+    }
+
+    /**
+     * A workflow carrying an extension URI that is not a URI at all costs that one
+     * extension type and nothing else. The agent and workflow rows — and the other
+     * seven extension types — are still listed, so the operator can see and export
+     * everything that is intact.
+     */
+    @Test
+    @DisplayName("an unparseable extension URI costs that extension type, not the preview")
+    void unparseableExtensionUriCostsOnlyThatType() throws Exception {
+        workflowJson = """
+                {"workflowSteps":[{"type":"eddi://ai.labs.llm","config":{"uri":"eddi://ai.labs.llm/llmstore/llms/not a uri?version=1"}}],
+                 "systemPrompt":"{snippets.cautious_mode}"}
+                """;
+        stubSnippetLookup();
+
+        ExportPreview preview = exportService.previewExport(AGENT_ID, 1);
+
+        assertNotNull(rowOfType(preview, "agent"));
+        assertNotNull(rowOfType(preview, "workflow"));
+        assertTrue(preview.resources().stream().noneMatch(r -> "langchain".equals(r.resourceType())),
+                "the malformed reference cannot become a row: " + preview.resources());
+        assertEquals(SNIPPET_ID, rowOfType(preview, "snippet").resourceId());
+    }
+
+    /**
+     * The snippet scan reads every extension config a second time to look for
+     * {@code {snippets.x}} references inside them. A store that refuses that read
+     * costs only the references it would have found — here the workflow's own
+     * reference is still picked up, so the snippet row survives.
+     */
+    @Test
+    @DisplayName("an extension store that will not read still leaves the workflow's own snippet refs")
+    void unreadableExtensionContentStillFindsWorkflowSnippetRefs() throws Exception {
+        doAnswer(invocation -> {
+            throw new IResourceStore.ResourceStoreException("llm store is down");
+        }).when(llmStore).read(LLM_ID, 1);
+        stubSnippetLookup();
+
+        ExportPreview preview = exportService.previewExport(AGENT_ID, 1);
+
+        assertEquals(SNIPPET_ID, rowOfType(preview, "snippet").resourceId());
+        assertEquals(LLM_ID, rowOfType(preview, "langchain").resourceId(),
+                "the row comes from the workflow's reference, not from reading the config");
+    }
+
+    /**
+     * When the snippet's own id cannot be resolved the row falls back to the name
+     * in both fields, with no version. It is a degraded row and it says so — a row
+     * that claimed an id it had not verified would be ticked off against a snippet
+     * that is not the one the agent references.
+     * <p>
+     * <strong>What this test does not pin.</strong> The contract asserted here is
+     * real and reachable, but the {@code if (descriptors == null) return byName;}
+     * guard in {@code resolveSnippetIdsByName} is <em>not</em> observable from
+     * outside: delete it and the {@code NullPointerException} from iterating the
+     * null listing lands in the method's own outer {@code catch (Exception e)},
+     * which returns the same empty map — the map cannot have been filled yet, the
+     * listing is the first thing the method reads. The guard buys a debug log line
+     * that names the cause instead of an NPE stack, and nothing else. Treat it as a
+     * log-level defence, like {@code recordCreatedSnippet}'s null-URI guard, not as
+     * a line this test covers.
+     */
+    @Test
+    @DisplayName("a snippet listing that returns null falls the row back to the name")
+    void nullSnippetListingFallsBackToTheName() throws Exception {
+        when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(),
+                anyBoolean(), any())).thenReturn(null);
+
+        assertSnippetRowFellBackToItsName();
+    }
+
+    /** Same fallback when the listing throws outright. */
+    @Test
+    @DisplayName("a snippet listing that throws falls the row back to the name")
+    void throwingSnippetListingFallsBackToTheName() throws Exception {
+        doAnswer(invocation -> {
+            throw new IResourceStore.ResourceStoreException("snippet descriptors unavailable");
+        }).when(documentDescriptorStore).readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(),
+                anyBoolean(), any());
+
+        assertSnippetRowFellBackToItsName();
+    }
+
+    /**
+     * And when the listing works but the snippet behind one descriptor cannot be
+     * read, that descriptor drops out of the lookup <em>and the sweep carries
+     * on</em> — the snippet the agent actually references is found behind a later
+     * descriptor and the row resolves normally.
+     * <p>
+     * Two descriptors is the whole point of the test. With one, "drops out" and
+     * "aborts the entire lookup" are indistinguishable: both end in the name
+     * fallback. The assertion here is on the id resolved <em>after</em> the
+     * unreadable document, which only the per-descriptor catch can produce.
+     */
+    @Test
+    @DisplayName("a snippet the store cannot read drops out, the lookup carries on to the next")
+    void unreadableSnippetDropsOutOfTheLookup() throws Exception {
+        when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(),
+                anyBoolean(), any()))
+                .thenReturn(List.of(snippetDescriptor(SNIPPET_ID, 1), snippetDescriptor(SECOND_SNIPPET_ID, 2)));
+        doAnswer(invocation -> {
+            throw new IResourceStore.ResourceStoreException("snippet document is corrupt");
+        }).when(snippetStore).read(SNIPPET_ID, 1);
+        var snippet = new PromptSnippet();
+        snippet.setName("cautious_mode");
+        when(snippetStore.read(SECOND_SNIPPET_ID, 2)).thenReturn(snippet);
+
+        ExportPreview preview = exportService.previewExport(AGENT_ID, 1);
+
+        ExportableResource snippetRow = rowOfType(preview, "snippet");
+        assertEquals(SECOND_SNIPPET_ID, snippetRow.resourceId(),
+                "the corrupt document costs its own descriptor, not the ones after it");
+        assertEquals(2, snippetRow.resourceVersion());
+        assertEquals("cautious_mode", snippetRow.name());
+        assertEquals(LLM_ID, rowOfType(preview, "langchain").resourceId(),
+                "the rest of the preview is unaffected");
+    }
+
+    // ==================== Helpers ====================
+
+    private void assertSnippetRowFellBackToItsName() {
+        ExportPreview preview = exportService.previewExport(AGENT_ID, 1);
+
+        ExportableResource snippetRow = rowOfType(preview, "snippet");
+        assertEquals("cautious_mode", snippetRow.resourceId(),
+                "an unresolved snippet is named, not given an id that was never confirmed");
+        assertEquals("cautious_mode", snippetRow.name());
+        assertNull(snippetRow.resourceVersion());
+        assertEquals(LLM_ID, rowOfType(preview, "langchain").resourceId(),
+                "the rest of the preview is unaffected");
+    }
+
+    private void stubSnippetLookup() throws Exception {
+        when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(),
+                anyBoolean(), any())).thenReturn(List.of(snippetDescriptor()));
+        var snippet = new PromptSnippet();
+        snippet.setName("cautious_mode");
+        when(snippetStore.read(SNIPPET_ID, 1)).thenReturn(snippet);
+    }
+
+    private static DocumentDescriptor snippetDescriptor() {
+        return snippetDescriptor(SNIPPET_ID, 1);
+    }
+
+    private static DocumentDescriptor snippetDescriptor(String snippetId, int version) {
+        var descriptor = new DocumentDescriptor();
+        descriptor.setResource(URI.create(
+                "eddi://ai.labs.snippet/snippetstore/snippets/" + snippetId + "?version=" + version));
+        return descriptor;
+    }
+
+    private static DocumentDescriptor descriptorNamed(String name) {
+        var descriptor = new DocumentDescriptor();
+        descriptor.setName(name);
+        return descriptor;
+    }
+
+    private static ExportableResource rowOfType(ExportPreview preview, String type) {
+        return preview.resources().stream()
+                .filter(resource -> type.equals(resource.resourceType()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no '" + type + "' row in " + preview.resources()));
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceSelectionContractTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceSelectionContractTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IZipArchive;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.apicalls.IApiCallsStore;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.dictionary.IDictionaryStore;
+import ai.labs.eddi.configs.llm.ILlmStore;
+import ai.labs.eddi.configs.mcpcalls.IMcpCallsStore;
+import ai.labs.eddi.configs.output.IOutputStore;
+import ai.labs.eddi.configs.propertysetter.IPropertySetterStore;
+import ai.labs.eddi.configs.rag.IRagStore;
+import ai.labs.eddi.configs.rules.IRuleSetStore;
+import ai.labs.eddi.configs.snippets.IPromptSnippetStore;
+import ai.labs.eddi.configs.snippets.model.PromptSnippet;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.secrets.sanitize.SecretScrubber;
+import ai.labs.eddi.utils.FileUtilities;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * B1 — what a selective export is allowed to leave out.
+ * <p>
+ * Snippets and schedules are selected through their own request parameters, not
+ * through {@code selectedResources}. Filtering them by
+ * {@code selectedResources} turned every selective export from a client built
+ * against the previous contract into a silent partial backup: schedules had
+ * never appeared in the export preview at all, and the snippet row's selection
+ * key had just changed from the snippet's name to its resource id — so such a
+ * client sends a set holding neither, and got back an archive with no snippets
+ * and no schedules. With the import side now genuinely restoring schedules,
+ * that loss stayed invisible until a restore came up with its cron jobs gone.
+ * <p>
+ * The archive contents are sampled while the ZIP is being built, because the
+ * export deletes its scratch tree as soon as it returns.
+ */
+class RestExportServiceSelectionContractTest {
+
+    private static final String AGENT_ID = "b1selectiveexportagent";
+    private static final String WORKFLOW_ID = "aaaa11112222333344445555";
+    private static final String LLM_ID = "bbbb11112222333344445555";
+    private static final String SNIPPET_ID = "cccc11112222333344445555";
+    private static final String OTHER_SNIPPET_ID = "dddd11112222333344445555";
+    private static final String SCHEDULE_ID = "eeee11112222333344445555";
+    private static final String OTHER_SCHEDULE_ID = "ffff11112222333344445555";
+
+    private static final String SNIPPET_FILE = "snippets/" + SNIPPET_ID + ".snippet.json";
+    private static final String SCHEDULE_FILE = "schedules/" + SCHEDULE_ID + ".schedule.json";
+
+    private RestExportService exportService;
+
+    private Path tmpDir;
+    private Path exportRoot;
+
+    /** Archive contents, as '/'-separated paths relative to the ZIP root. */
+    private final List<String> archivedFiles = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        var agentStore = mock(IAgentStore.class);
+        var workflowStore = mock(IWorkflowStore.class);
+        var documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        var jsonSerialization = mock(IJsonSerialization.class);
+        var llmStore = mock(ILlmStore.class);
+        var snippetStore = mock(IPromptSnippetStore.class);
+        var scheduleStore = mock(IScheduleStore.class);
+        var secretScrubber = mock(SecretScrubber.class);
+        var zipArchive = mock(IZipArchive.class);
+
+        exportService = new RestExportService(
+                documentDescriptorStore, agentStore, workflowStore,
+                mock(IDictionaryStore.class), mock(IRuleSetStore.class), mock(IApiCallsStore.class),
+                llmStore, mock(IPropertySetterStore.class), mock(IOutputStore.class),
+                mock(IMcpCallsStore.class), mock(IRagStore.class), snippetStore,
+                jsonSerialization, zipArchive, secretScrubber, scheduleStore,
+                mock(ResourceAccessGuard.class), mock(BackupMetrics.class));
+
+        tmpDir = Paths.get(FileUtilities.buildPath(System.getProperty("user.dir"), "tmp"));
+        exportRoot = tmpDir.resolve("export");
+
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of(URI.create(
+                "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1")));
+        when(agentStore.read(AGENT_ID, 1)).thenReturn(agentConfig);
+        when(workflowStore.read(WORKFLOW_ID, 1)).thenReturn(new WorkflowConfiguration());
+        when(llmStore.read(LLM_ID, 1)).thenReturn(new LlmConfiguration(List.of()));
+
+        // The workflow points at one LLM config; that config references one snippet.
+        String workflowJson = "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.llm\",\"config\":"
+                + "{\"uri\":\"eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=1\"}}]}";
+        String llmJson = "{\"tasks\":[{\"systemMessage\":\"{snippets.greeting}\"}]}";
+        when(jsonSerialization.serialize(any())).thenAnswer(inv -> {
+            Object value = inv.getArgument(0);
+            if (value instanceof WorkflowConfiguration) {
+                return workflowJson;
+            }
+            if (value instanceof LlmConfiguration) {
+                return llmJson;
+            }
+            return "{}";
+        });
+        when(secretScrubber.scrubJson(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+        var agentDescriptor = new DocumentDescriptor();
+        agentDescriptor.setName("Selective Export Agent");
+        when(documentDescriptorStore.readDescriptorWithHistory(anyString(), any())).thenReturn(agentDescriptor);
+
+        var snippetDescriptor = new DocumentDescriptor();
+        snippetDescriptor.setResource(URI.create(
+                "eddi://ai.labs.snippet/snippetstore/snippets/" + SNIPPET_ID + "?version=1"));
+        when(documentDescriptorStore.readDescriptors(eq("ai.labs.snippet"), anyString(), anyInt(), anyInt(),
+                eq(false), any())).thenReturn(List.of(snippetDescriptor));
+        var snippet = new PromptSnippet();
+        snippet.setName("greeting");
+        when(snippetStore.read(SNIPPET_ID, 1)).thenReturn(snippet);
+
+        var schedule = new ScheduleConfiguration();
+        schedule.setId(SCHEDULE_ID);
+        schedule.setName("nightly consolidation");
+        when(scheduleStore.readSchedulesByAgentId(AGENT_ID)).thenReturn(List.of(schedule));
+
+        doAnswer(inv -> {
+            recordArchiveContents(Paths.get(inv.getArgument(0, String.class)));
+            return null;
+        }).when(zipArchive).createZip(anyString(), anyString(), any());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        deleteRecursively(exportRoot);
+        deleteRecursively(tmpDir.resolve("archives"));
+    }
+
+    @Test
+    @DisplayName("a selectedResources set that names only extensions still exports snippets and schedules")
+    void extensionOnlySelectionKeepsSnippetsAndSchedules() {
+        // Exactly what a client built against the previous contract sends: the
+        // extension ids it read out of the preview, and nothing else.
+        exportService.exportAgent(AGENT_ID, 1, LLM_ID, null, null);
+
+        assertTrue(archivedFiles.contains(SNIPPET_FILE),
+                "a selection that never enumerated snippets must not silently drop them, got " + archivedFiles);
+        assertTrue(archivedFiles.contains(SCHEDULE_FILE),
+                "a selection that never enumerated schedules must not silently drop them, got " + archivedFiles);
+    }
+
+    @Test
+    @DisplayName("selectedSnippets filters snippets, and only snippets")
+    void snippetSelectionIsHonoured() {
+        exportService.exportAgent(AGENT_ID, 1, LLM_ID, OTHER_SNIPPET_ID, null);
+
+        assertFalse(archivedFiles.contains(SNIPPET_FILE),
+                "a snippet the caller did not select must stay out of the archive, got " + archivedFiles);
+        assertTrue(archivedFiles.contains(SCHEDULE_FILE),
+                "selecting snippets must not take the schedules with it, got " + archivedFiles);
+    }
+
+    @Test
+    @DisplayName("selectedSchedules filters schedules, and only schedules")
+    void scheduleSelectionIsHonoured() {
+        exportService.exportAgent(AGENT_ID, 1, LLM_ID, null, OTHER_SCHEDULE_ID);
+
+        assertFalse(archivedFiles.contains(SCHEDULE_FILE),
+                "a schedule the caller did not select must stay out of the archive, got " + archivedFiles);
+        assertTrue(archivedFiles.contains(SNIPPET_FILE),
+                "selecting schedules must not take the snippets with it, got " + archivedFiles);
+    }
+
+    @Test
+    @DisplayName("an empty selectedSnippets/selectedSchedules means none, not all")
+    void presentButEmptySelectionMeansNone() {
+        // The parameter being present at all is the client saying it speaks the
+        // newer contract; empty is how it says "I unticked every one of them".
+        exportService.exportAgent(AGENT_ID, 1, null, "", "");
+
+        assertFalse(archivedFiles.contains(SNIPPET_FILE),
+                "an explicitly empty snippet selection must export no snippets, got " + archivedFiles);
+        assertFalse(archivedFiles.contains(SCHEDULE_FILE),
+                "an explicitly empty schedule selection must export no schedules, got " + archivedFiles);
+    }
+
+    @Test
+    @DisplayName("a full export still carries every referenced snippet and every schedule")
+    void fullExportIsUnfiltered() {
+        exportService.exportAgent(AGENT_ID, 1, null, null, null);
+
+        assertTrue(archivedFiles.contains(SNIPPET_FILE), archivedFiles.toString());
+        assertTrue(archivedFiles.contains(SCHEDULE_FILE), archivedFiles.toString());
+    }
+
+    /**
+     * Samples the scratch tree the ZIP is built from. It has to happen here: the
+     * export removes the tree before it returns.
+     */
+    private void recordArchiveContents(Path zipRoot) throws IOException {
+        try (var paths = Files.walk(zipRoot)) {
+            paths.filter(Files::isRegularFile)
+                    .map(path -> zipRoot.relativize(path).toString().replace('\\', '/'))
+                    .forEach(archivedFiles::add);
+        }
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (root == null || !Files.exists(root)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                    // best effort
+                }
+            });
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceSelectionContractTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceSelectionContractTest.java
@@ -28,6 +28,7 @@ import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import ai.labs.eddi.secrets.sanitize.SecretScrubber;
 import ai.labs.eddi.utils.FileUtilities;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +41,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -89,6 +92,9 @@ class RestExportServiceSelectionContractTest {
     /** Archive contents, as '/'-separated paths relative to the ZIP root. */
     private final List<String> archivedFiles = new ArrayList<>();
 
+    /** The same files' text, keyed the same way. */
+    private final Map<String, String> archivedContent = new LinkedHashMap<>();
+
     @BeforeEach
     void setUp() throws Exception {
         var agentStore = mock(IAgentStore.class);
@@ -116,23 +122,35 @@ class RestExportServiceSelectionContractTest {
         agentConfig.setWorkflows(List.of(URI.create(
                 "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1")));
         when(agentStore.read(AGENT_ID, 1)).thenReturn(agentConfig);
-        when(workflowStore.read(WORKFLOW_ID, 1)).thenReturn(new WorkflowConfiguration());
+        var storedWorkflow = new WorkflowConfiguration();
+        when(workflowStore.read(WORKFLOW_ID, 1)).thenReturn(storedWorkflow);
         when(llmStore.read(LLM_ID, 1)).thenReturn(new LlmConfiguration(List.of()));
 
         // The workflow points at one LLM config; that config references one snippet.
         String workflowJson = "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.llm\",\"config\":"
                 + "{\"uri\":\"eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=1\"}}]}";
         String llmJson = "{\"tasks\":[{\"systemMessage\":\"{snippets.greeting}\"}]}";
+        var mapper = new ObjectMapper();
         when(jsonSerialization.serialize(any())).thenAnswer(inv -> {
             Object value = inv.getArgument(0);
-            if (value instanceof WorkflowConfiguration) {
+            if (value == storedWorkflow) {
+                // The object the store hands out is an empty stand-in for the JSON
+                // above; it is never serialized for real.
                 return workflowJson;
+            }
+            if (value instanceof WorkflowConfiguration workflow) {
+                // No other workflow object should reach the exporter: the archive
+                // carries the stored JSON as it is. Serialized for real so a test can
+                // see whatever did land in the archive.
+                return mapper.writeValueAsString(workflow);
             }
             if (value instanceof LlmConfiguration) {
                 return llmJson;
             }
             return "{}";
         });
+        when(jsonSerialization.deserialize(anyString(), eq(WorkflowConfiguration.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), WorkflowConfiguration.class));
         when(secretScrubber.scrubJson(anyString())).thenAnswer(inv -> inv.getArgument(0));
 
         var agentDescriptor = new DocumentDescriptor();
@@ -214,6 +232,43 @@ class RestExportServiceSelectionContractTest {
     }
 
     @Test
+    @DisplayName("a selective export omits the config file but keeps the workflow step that names it")
+    void deselectedExtensionKeepsItsWorkflowStepReference() {
+        String workflowFile = WORKFLOW_ID + "/1/" + WORKFLOW_ID + ".workflow.json";
+
+        // The user unticks the LLM config in the export dialog. The file is omitted,
+        // and the workflow keeps its config.uri — because strategy=merge PUTs this
+        // very workflow over the target's, and answers the reference from the
+        // target's own copy. Dropping the step here deleted it from the live target
+        // instead: promote just the behaviour rules to prod, and prod's LLM step was
+        // gone. The import side drops what it cannot resolve, and only where there
+        // is no local copy to resolve it from
+        // (RestImportServiceArchiveContractTest#missingExtensionFileOnCreateDropsTheStep).
+        exportService.exportAgent(AGENT_ID, 1, "9999111122223333444455aa", null, null);
+
+        assertFalse(archivedFiles.contains(WORKFLOW_ID + "/1/" + LLM_ID + ".langchain.json"),
+                "the deselected config must not be in the archive, got " + archivedFiles);
+        assertTrue(archivedFiles.contains(workflowFile), archivedFiles.toString());
+        assertTrue(archivedContent.get(workflowFile).contains(LLM_ID),
+                "the archived workflow must keep the reference a merge answers from the target's own copy, was "
+                        + archivedContent.get(workflowFile));
+    }
+
+    @Test
+    @DisplayName("a selected extension is written, and the workflow still names it")
+    void selectedExtensionKeepsItsWorkflowStep() {
+        String workflowFile = WORKFLOW_ID + "/1/" + WORKFLOW_ID + ".workflow.json";
+
+        exportService.exportAgent(AGENT_ID, 1, LLM_ID, null, null);
+
+        assertTrue(archivedFiles.contains(WORKFLOW_ID + "/1/" + LLM_ID + ".langchain.json"),
+                archivedFiles.toString());
+        assertTrue(archivedContent.get(workflowFile).contains(LLM_ID),
+                "a selected config must be both written and referenced, was "
+                        + archivedContent.get(workflowFile));
+    }
+
+    @Test
     @DisplayName("a full export still carries every referenced snippet and every schedule")
     void fullExportIsUnfiltered() {
         exportService.exportAgent(AGENT_ID, 1, null, null, null);
@@ -228,9 +283,11 @@ class RestExportServiceSelectionContractTest {
      */
     private void recordArchiveContents(Path zipRoot) throws IOException {
         try (var paths = Files.walk(zipRoot)) {
-            paths.filter(Files::isRegularFile)
-                    .map(path -> zipRoot.relativize(path).toString().replace('\\', '/'))
-                    .forEach(archivedFiles::add);
+            for (Path path : paths.filter(Files::isRegularFile).toList()) {
+                String relative = zipRoot.relativize(path).toString().replace('\\', '/');
+                archivedFiles.add(relative);
+                archivedContent.put(relative, Files.readString(path));
+            }
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestExportServiceTest.java
@@ -85,7 +85,7 @@ class RestExportServiceTest {
                 dictionaryStore, behaviorStore, httpCallsStore, llmStore,
                 propertySetterStore, outputStore, mcpCallsStore, ragStore,
                 snippetStore, jsonSerialization, zipArchive, secretScrubber,
-                scheduleStore, mock(ResourceAccessGuard.class));
+                scheduleStore, mock(ResourceAccessGuard.class), mock(BackupMetrics.class));
     }
 
     // ─── getAgentZipArchive security ─────────────────────────────
@@ -154,35 +154,35 @@ class RestExportServiceTest {
         @DisplayName("should reject agentId with path traversal")
         void pathTraversalInAgentId() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent("../../../etc/passwd", 1, null));
+                    () -> exportService.exportAgent("../../../etc/passwd", 1, null, null, null));
         }
 
         @Test
         @DisplayName("should reject agentId with forward slash")
         void slashInAgentId() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent("agents/evil", 1, null));
+                    () -> exportService.exportAgent("agents/evil", 1, null, null, null));
         }
 
         @Test
         @DisplayName("should reject agentId with backslash")
         void backslashInAgentId() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent("agents\\evil", 1, null));
+                    () -> exportService.exportAgent("agents\\evil", 1, null, null, null));
         }
 
         @Test
         @DisplayName("should reject empty agentId")
         void emptyAgentId() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent("", 1, null));
+                    () -> exportService.exportAgent("", 1, null, null, null));
         }
 
         @Test
         @DisplayName("should reject null agentId")
         void nullAgentId() {
             assertThrows(BadRequestException.class,
-                    () -> exportService.exportAgent(null, 1, null));
+                    () -> exportService.exportAgent(null, 1, null, null, null));
         }
     }
 
@@ -211,7 +211,7 @@ class RestExportServiceTest {
             when(secretScrubber.scrubJson(anyString())).thenAnswer(inv -> inv.getArgument(0));
             when(scheduleStore.readSchedulesByAgentId(agentId)).thenReturn(List.of());
 
-            Response response = exportService.exportAgent(agentId, agentVersion, null);
+            Response response = exportService.exportAgent(agentId, agentVersion, null, null, null);
 
             assertNotNull(response);
             assertEquals(200, response.getStatus());
@@ -227,7 +227,7 @@ class RestExportServiceTest {
                     .thenThrow(new IResourceStore.ResourceNotFoundException("Not found"));
 
             assertThrows(IResourceStore.ResourceNotFoundException.class,
-                    () -> exportService.exportAgent("nonexistent", 1, null));
+                    () -> exportService.exportAgent("nonexistent", 1, null, null, null));
         }
     }
 
@@ -497,14 +497,17 @@ class RestExportServiceTest {
         }
 
         @Test
-        @DisplayName("named agent includes URL-encoded name prefix")
+        @DisplayName("named agent includes a slugified name prefix the download endpoint accepts")
         void namedAgent() throws Exception {
             var desc = new DocumentDescriptor();
             desc.setName("My Agent");
             String filename = invokePrepareZipFilename(desc, "abc123", 2);
             assertTrue(filename.contains("abc123"));
             assertTrue(filename.contains("-2.zip"));
-            assertTrue(filename.contains("My+Agent-") || filename.contains("My%20Agent-"));
+            assertTrue(filename.startsWith("My-Agent-"), filename);
+            // The filename doubles as the download URL's path segment, so it has to
+            // survive sanitizeFileName's character class.
+            assertTrue(filename.matches("^[a-zA-Z0-9_.+\\-]+$"), filename);
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceArchiveContractTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceArchiveContractTest.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IZipArchive;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.migration.IMigrationManager;
+import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
+import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * What an import archive is allowed to contain, and what happens to the parts
+ * of it the importer used to ignore.
+ * <ul>
+ * <li>An EDDI 5.x archive names its agent file {@code <id>.bot.json}; the
+ * importer accepted the v5 {@code .package.json} workflow file and normalized
+ * v5 URIs but looked only for {@code .agent.json}, so a 5.x import created
+ * nothing and answered 200 OK.</li>
+ * <li>Export writes a {@code schedules/} directory; nothing read it back, so a
+ * restore-from-backup came up with every cron and heartbeat silently gone.</li>
+ * <li>A config the archive references but does not contain produced a bare
+ * NullPointerException surfaced as a 500 whose message was literally
+ * "null".</li>
+ * </ul>
+ */
+@DisplayName("RestImportService — archive contract")
+class RestImportServiceArchiveContractTest {
+
+    private static final String AGENT_ORIGIN_ID = "aabb11112222333344445555";
+    private static final String NEW_AGENT_ID = "ccdd11112222333344445555";
+    private static final String NEW_WORKFLOW_ID = "7777111122223333444455bb";
+
+    private IZipArchive zipArchive;
+    private IJsonSerialization jsonSerialization;
+    private IDocumentDescriptorStore documentDescriptorStore;
+    private IScheduleStore scheduleStore;
+    private RestImportService importService;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        zipArchive = mock(IZipArchive.class);
+        jsonSerialization = mock(IJsonSerialization.class);
+        documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        scheduleStore = mock(IScheduleStore.class);
+        var templateSyntaxMigrator = mock(TemplateSyntaxMigrator.class);
+        when(templateSyntaxMigrator.migrate(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+        importService = new RestImportService(
+                zipArchive, jsonSerialization,
+                mock(IMigrationManager.class), documentDescriptorStore,
+                templateSyntaxMigrator, mock(StructuralMatcher.class),
+                mock(UpgradeExecutor.class), scheduleStore, mock(BackupMetrics.class), mock(ResourceAccessGuard.class));
+
+        when(jsonSerialization.deserialize(anyString(), eq(AgentConfiguration.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), AgentConfiguration.class));
+        when(jsonSerialization.deserialize(anyString(), eq(DocumentDescriptor.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), DocumentDescriptor.class));
+        when(jsonSerialization.deserialize(anyString(), eq(ScheduleConfiguration.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), ScheduleConfiguration.class));
+    }
+
+    @Nested
+    @DisplayName("EDDI 5.x archives")
+    class LegacyArchives {
+
+        @Test
+        @DisplayName("an agent file named <id>.bot.json is imported, not silently ignored")
+        void v5AgentFileIsImported() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".bot.json").toPath(), "{\"workflows\":[]}");
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".descriptor.json").toPath(),
+                        "{\"name\":\"Legacy Agent\"}");
+            });
+
+            var agentStore = stubAgentCreation();
+            try (var cdi = stubCdi(IAgentStore.class, agentStore)) {
+                Response response = importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+
+                // The 200-with-empty-resourceUri answer is what let an operator
+                // upgrading from 5.x believe their agent had been imported.
+                assertEquals(201, response.getStatus());
+                assertTrue(response.getHeaderString("Location").contains(NEW_AGENT_ID));
+                verify(agentStore).create(any());
+            }
+        }
+
+        @Test
+        @DisplayName("a preview of a v5 archive names the agent it found")
+        void v5PreviewFindsAgent() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".bot.json").toPath(), "{\"workflows\":[]}");
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".descriptor.json").toPath(),
+                        "{\"name\":\"Legacy Agent\"}");
+            });
+
+            var preview = importService.previewImport(new ByteArrayInputStream(new byte[0]), null);
+
+            assertEquals(AGENT_ORIGIN_ID, preview.sourceAgentId());
+            assertFalse(preview.resources().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("schedules")
+    class Schedules {
+
+        @Test
+        @DisplayName("schedules in the archive are recreated and repointed at the imported agent")
+        void schedulesAreImported() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        """
+                                {"id":"sched1","name":"nightly","agentId":"someOtherAgent",
+                                 "cronExpression":"0 3 * * *","fireStatus":"CLAIMED",
+                                 "claimedBy":"other-instance","failCount":3}""");
+            });
+
+            when(scheduleStore.createSchedule(any())).thenReturn("newSched1");
+
+            var agentStore = stubAgentCreation();
+            try (var cdi = stubCdi(IAgentStore.class, agentStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            }
+
+            var captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
+            verify(scheduleStore).createSchedule(captor.capture());
+            ScheduleConfiguration imported = captor.getValue();
+
+            assertEquals(NEW_AGENT_ID, imported.getAgentId(), "the schedule must fire the agent just created");
+            assertEquals("nightly", imported.getName());
+            assertEquals("0 3 * * *", imported.getCronExpression());
+            // Fire bookkeeping is reset: an imported schedule must not inherit another
+            // deployment's in-flight lease or retry counter.
+            assertNull(imported.getId());
+            assertNull(imported.getClaimedBy());
+            assertEquals(ScheduleConfiguration.FireStatus.PENDING, imported.getFireStatus());
+            assertEquals(0, imported.getFailCount());
+        }
+
+        @Test
+        @DisplayName("a schedule that cannot be created fails the import and rolls the others back")
+        void scheduleFailureRollsBack() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "aaa1.schedule.json").toPath(),
+                        "{\"id\":\"aaa1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\"}");
+                Files.writeString(new File(schedules, "bbb2.schedule.json").toPath(),
+                        "{\"id\":\"bbb2\",\"name\":\"hourly\",\"agentId\":\"someOtherAgent\"}");
+            });
+
+            when(scheduleStore.createSchedule(any()))
+                    .thenReturn("newSched1")
+                    .thenThrow(new IllegalStateException("schedule store down"));
+
+            var agentStore = stubAgentCreation();
+            try (var cdi = stubCdi(IAgentStore.class, agentStore)) {
+                // Restoring an agent with only half its triggers is the failure mode
+                // importing schedules exists to remove, so it is not tolerated.
+                assertThrows(RuntimeException.class, () -> importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "create", null, null, null));
+            }
+
+            verify(scheduleStore).deleteSchedule("newSched1");
+        }
+
+        @Test
+        @DisplayName("the preview lists the schedules a restore would bring back")
+        void schedulesAppearInPreview() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\"}");
+            });
+
+            var preview = importService.previewImport(new ByteArrayInputStream(new byte[0]), null);
+
+            assertTrue(preview.resources().stream().anyMatch(d -> "schedule".equals(d.resourceType())),
+                    "schedules must be visible in the preview: " + preview.resources());
+        }
+    }
+
+    @Nested
+    @DisplayName("an archive that references a config it does not contain")
+    class MissingExtensionFile {
+
+        @Test
+        @DisplayName("is a 400 naming the missing file, not a 500 whose message is 'null'")
+        void missingExtensionFileIsBadRequest() throws Exception {
+            String workflowId = "bbbb11112222333344445555";
+            String llmId = "dddd11112222333344445555";
+
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
+                        "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                                + workflowId + "?version=1\"]}");
+                File versionDir = new File(dir, workflowId + "/1");
+                assertTrue(versionDir.mkdirs());
+                // The workflow still carries the URI of a config a selective export
+                // left out of the archive.
+                Files.writeString(new File(versionDir, workflowId + ".workflow.json").toPath(),
+                        "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.llm\",\"config\":{\"uri\":"
+                                + "\"eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1\"}}]}");
+            });
+
+            var ex = assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "create", null, null, null));
+
+            assertTrue(ex.getMessage().contains(llmId + ".langchain.json"), ex.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("how many agents an archive may hold")
+    class AgentFileCount {
+
+        @Test
+        @DisplayName("two agent files are a 400, not a silent import of both")
+        void twoAgentFilesAreRejected() throws Exception {
+            String secondAgentId = "eeff11112222333344445555";
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                Files.writeString(new File(dir, secondAgentId + ".agent.json").toPath(), "{\"workflows\":[]}");
+            });
+
+            var agentStore = stubAgentCreation();
+            try (var cdi = stubCdi(IAgentStore.class, agentStore)) {
+                // The preview described only the first file it enumerated while the
+                // import created every one of them, so an operator approved one agent
+                // and got several, with a Location header naming whichever came last.
+                var ex = assertThrows(BadRequestException.class, () -> importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "create", null, null, null));
+
+                assertTrue(ex.getMessage().contains("2"), ex.getMessage());
+                verify(agentStore, never()).create(any());
+            }
+        }
+
+        @Test
+        @DisplayName("a preview of a two-agent archive is rejected the same way")
+        void twoAgentFilesAreRejectedInPreview() throws Exception {
+            String secondAgentId = "eeff11112222333344445555";
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                Files.writeString(new File(dir, secondAgentId + ".agent.json").toPath(), "{\"workflows\":[]}");
+            });
+
+            assertThrows(BadRequestException.class, () -> importService.previewImport(
+                    new ByteArrayInputStream(new byte[0]), null));
+        }
+    }
+
+    @Nested
+    @DisplayName("selective merge")
+    class SelectiveMerge {
+
+        @Test
+        @DisplayName("a deselected resource with no local counterpart fails the import instead of writing a dangling URI")
+        void deselectedResourceWithNoLocalCopyIsRejected() throws Exception {
+            String workflowId = "bbbb11112222333344445555";
+            String llmId = "dddd11112222333344445555";
+
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
+                        "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                                + workflowId + "?version=1\"]}");
+                File versionDir = new File(dir, workflowId + "/1");
+                assertTrue(versionDir.mkdirs());
+                Files.writeString(new File(versionDir, workflowId + ".workflow.json").toPath(),
+                        "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.llm\",\"config\":{\"uri\":"
+                                + "\"eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1\"}}]}");
+                Files.writeString(new File(versionDir, llmId + ".langchain.json").toPath(), "{\"tasks\":[]}");
+            });
+
+            when(jsonSerialization.deserialize(anyString(), eq(LlmConfiguration.class)))
+                    .thenReturn(new LlmConfiguration(List.of()));
+            // This deployment has never seen the deselected resource.
+            when(documentDescriptorStore.findByOriginId(anyString())).thenReturn(List.of());
+            when(documentDescriptorStore.getCurrentResourceId(anyString())).thenReturn(null);
+
+            // The operator unticks the LLM config — exactly the case the checkbox
+            // exists for. Keeping the SOURCE deployment's URI stored a workflow step
+            // pointing at a resource id that does not exist here, and the failure only
+            // surfaced later, at deployment or the first conversation turn.
+            var ex = assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "merge", AGENT_ORIGIN_ID, null, null));
+
+            assertTrue(ex.getMessage().contains(llmId), ex.getMessage());
+        }
+
+        /**
+         * The compensating half of the missing-file 400 above. EDDI's own selective
+         * export omits a deselected config from the archive but leaves its URI in the
+         * workflow JSON, and merge answered such an archive from the local deployment
+         * without ever opening the file. Failing before the selection is applied made
+         * the importer reject archives the exporter had just written.
+         */
+        @Test
+        @DisplayName("a deselected resource the archive omits is answered from the local copy, not rejected")
+        void deselectedResourceOmittedFromArchiveUsesTheLocalCopy() throws Exception {
+            String workflowId = "bbbb11112222333344445555";
+            String llmId = "dddd11112222333344445555";
+            String localLlmId = "9999111122223333444455aa";
+
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
+                        "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                                + workflowId + "?version=1\"]}");
+                File versionDir = new File(dir, workflowId + "/1");
+                assertTrue(versionDir.mkdirs());
+                // The workflow keeps the URI; the selective export left the file out.
+                Files.writeString(new File(versionDir, workflowId + ".workflow.json").toPath(),
+                        "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.llm\",\"config\":{\"uri\":"
+                                + "\"eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1\"}}]}");
+            });
+
+            when(jsonSerialization.deserialize(anyString(), eq(WorkflowConfiguration.class)))
+                    .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), WorkflowConfiguration.class));
+
+            // This deployment already has the excluded LLM config.
+            var localDescriptor = new DocumentDescriptor();
+            localDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.llm/llmstore/llms/" + localLlmId + "?version=3"));
+            when(documentDescriptorStore.findByOriginId(llmId)).thenReturn(List.of(localDescriptor));
+            when(documentDescriptorStore.findByOriginId(workflowId)).thenReturn(List.of());
+
+            var agentStore = stubAgentCreation();
+            var workflowStore = mock(IWorkflowStore.class);
+            when(workflowStore.create(any())).thenReturn(resourceId(NEW_WORKFLOW_ID, 1));
+
+            var storedWorkflow = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IWorkflowStore.class, workflowStore)) {
+                Response response = importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "merge", workflowId, null, null);
+
+                assertEquals(201, response.getStatus());
+            }
+
+            verify(workflowStore).create(storedWorkflow.capture());
+            Object uri = storedWorkflow.getValue().getWorkflowSteps().getFirst().getConfig().get("uri");
+            assertTrue(String.valueOf(uri).contains(localLlmId),
+                    "the stored workflow must point at this deployment's own copy, was " + uri);
+        }
+    }
+
+    // ==================== Helpers ====================
+
+    private interface ArchiveContent {
+        void write(File dir) throws IOException;
+    }
+
+    private void stubUnzip(ArchiveContent content) throws Exception {
+        doAnswer(inv -> {
+            File dir = inv.getArgument(1);
+            assertTrue(dir.mkdirs() || dir.isDirectory());
+            content.write(dir);
+            return null;
+        }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
+    }
+
+    private IAgentStore stubAgentCreation() throws Exception {
+        var agentStore = mock(IAgentStore.class);
+        when(agentStore.create(any())).thenReturn(resourceId(NEW_AGENT_ID, 1));
+        when(documentDescriptorStore.getCurrentResourceId(NEW_AGENT_ID)).thenReturn(resourceId(NEW_AGENT_ID, 1));
+
+        var descriptor = new DocumentDescriptor();
+        descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=1"));
+        when(documentDescriptorStore.readDescriptor(NEW_AGENT_ID, 1)).thenReturn(descriptor);
+        return agentStore;
+    }
+
+    private <T> AutoCloseable stubCdi(Class<T> storeClass, T store) {
+        var cdiMock = mockStatic(CDI.class);
+        var cdi = mock(CDI.class);
+        cdiMock.when(CDI::current).thenReturn(cdi);
+        select(cdi, storeClass, store);
+        return cdiMock;
+    }
+
+    private <A, B> AutoCloseable stubCdi(Class<A> firstClass, A first, Class<B> secondClass, B second) {
+        var cdiMock = mockStatic(CDI.class);
+        var cdi = mock(CDI.class);
+        cdiMock.when(CDI::current).thenReturn(cdi);
+        select(cdi, firstClass, first);
+        select(cdi, secondClass, second);
+        return cdiMock;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> void select(CDI cdi, Class<T> storeClass, T store) {
+        var instance = (Instance<T>) mock(Instance.class);
+        when(cdi.select(storeClass)).thenReturn(instance);
+        when(instance.get()).thenReturn(store);
+    }
+
+    private static IResourceId resourceId(String id, int version) {
+        return new IResourceId() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return version;
+            }
+        };
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceArchiveContractTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceArchiveContractTest.java
@@ -5,24 +5,35 @@
 package ai.labs.eddi.backup.impl;
 
 import ai.labs.eddi.backup.IZipArchive;
+import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
+import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.migration.IMigrationManager;
+import ai.labs.eddi.configs.rules.IRuleSetStore;
+import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.schedule.IRestScheduleStore;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.engine.hitl.HitlSchedules;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +48,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -68,9 +81,12 @@ class RestImportServiceArchiveContractTest {
     private IJsonSerialization jsonSerialization;
     private IDocumentDescriptorStore documentDescriptorStore;
     private IScheduleStore scheduleStore;
+    private IRestScheduleStore restScheduleStore;
+    private SpaceContext spaceContext;
     private RestImportService importService;
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    private int createdSchedules;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -78,6 +94,19 @@ class RestImportServiceArchiveContractTest {
         jsonSerialization = mock(IJsonSerialization.class);
         documentDescriptorStore = mock(IDocumentDescriptorStore.class);
         scheduleStore = mock(IScheduleStore.class);
+        restScheduleStore = mock(IRestScheduleStore.class);
+        // Every schedule write goes through the REST bean, which is where the
+        // platform's schedule guards live (run-as-another-user, HITL timeout,
+        // agent USE gate, cron validation, nextFire computation).
+        doAnswer(inv -> {
+            ScheduleConfiguration created = inv.getArgument(0);
+            if (created != null) {
+                created.setId("newSched" + (++createdSchedules));
+            }
+            return Response.status(201).entity(created).build();
+        }).when(restScheduleStore).createSchedule(any());
+        doReturn(Response.ok().build()).when(restScheduleStore).updateSchedule(anyString(), any());
+        spaceContext = mock(SpaceContext.class);
         var templateSyntaxMigrator = mock(TemplateSyntaxMigrator.class);
         when(templateSyntaxMigrator.migrate(anyString())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -85,7 +114,8 @@ class RestImportServiceArchiveContractTest {
                 zipArchive, jsonSerialization,
                 mock(IMigrationManager.class), documentDescriptorStore,
                 templateSyntaxMigrator, mock(StructuralMatcher.class),
-                mock(UpgradeExecutor.class), scheduleStore, mock(BackupMetrics.class), mock(ResourceAccessGuard.class));
+                mock(UpgradeExecutor.class), scheduleStore, mock(BackupMetrics.class), mock(ResourceAccessGuard.class),
+                spaceContext);
 
         when(jsonSerialization.deserialize(anyString(), eq(AgentConfiguration.class)))
                 .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), AgentConfiguration.class));
@@ -122,6 +152,55 @@ class RestImportServiceArchiveContractTest {
         }
 
         @Test
+        @DisplayName("a v5 workflow file keyed by packageExtensions keeps its steps")
+        void v5PackageExtensionsAreMapped() throws Exception {
+            String workflowId = "5af59eca9bcb0f31b4b3b938";
+            String behaviorId = "5af59e929bcb0f31b4b3b935";
+
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".bot.json").toPath(),
+                        "{\"packages\":[\"eddi://ai.labs.package/packagestore/packages/"
+                                + workflowId + "?version=1\"]}");
+                File versionDir = new File(dir, workflowId + "/1");
+                assertTrue(versionDir.mkdirs());
+                // A genuine 5.x export: the workflow file is <id>.package.json and its
+                // step list is keyed "packageExtensions". Unmapped, Jackson silently
+                // produced an EMPTY step list (FAIL_ON_UNKNOWN_PROPERTIES is off) and
+                // the import answered 201 for an agent that answers nothing.
+                Files.writeString(new File(versionDir, workflowId + ".package.json").toPath(),
+                        "{\"packageExtensions\":[{\"type\":\"eddi://ai.labs.behavior\",\"extensions\":{},"
+                                + "\"config\":{\"uri\":\"eddi://ai.labs.behavior/behaviorstore/behaviorsets/"
+                                + behaviorId + "?version=1\"}}]}");
+                Files.writeString(new File(versionDir, behaviorId + ".behavior.json").toPath(),
+                        "{\"behaviorGroups\":[]}");
+            });
+
+            when(jsonSerialization.deserialize(anyString(), eq(WorkflowConfiguration.class)))
+                    .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), WorkflowConfiguration.class));
+            when(jsonSerialization.deserialize(anyString(), eq(RuleSetConfiguration.class)))
+                    .thenReturn(new RuleSetConfiguration());
+
+            var agentStore = stubAgentCreation();
+            var workflowStore = mock(IWorkflowStore.class);
+            when(workflowStore.create(any())).thenReturn(resourceId(NEW_WORKFLOW_ID, 1));
+            var ruleSetStore = mock(IRuleSetStore.class);
+            when(ruleSetStore.create(any())).thenReturn(resourceId("1111111122223333444455cc", 1));
+
+            var storedWorkflow = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IWorkflowStore.class, workflowStore,
+                    IRuleSetStore.class, ruleSetStore)) {
+                Response response = importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+
+                assertEquals(201, response.getStatus());
+            }
+
+            verify(workflowStore).create(storedWorkflow.capture());
+            assertFalse(storedWorkflow.getValue().getWorkflowSteps().isEmpty(),
+                    "a v5 workflow must not be imported as an empty pipeline");
+        }
+
+        @Test
         @DisplayName("a preview of a v5 archive names the agent it found")
         void v5PreviewFindsAgent() throws Exception {
             stubUnzip(dir -> {
@@ -151,19 +230,24 @@ class RestImportServiceArchiveContractTest {
                 Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
                         """
                                 {"id":"sched1","name":"nightly","agentId":"someOtherAgent",
+                                 "agentVersion":7,"tenantId":"other-tenant",
+                                 "persistentConversationId":"conv-on-the-source",
+                                 "nextFire":"2020-01-01T03:00:00Z",
                                  "cronExpression":"0 3 * * *","fireStatus":"CLAIMED",
                                  "claimedBy":"other-instance","failCount":3}""");
             });
 
-            when(scheduleStore.createSchedule(any())).thenReturn("newSched1");
-
             var agentStore = stubAgentCreation();
-            try (var cdi = stubCdi(IAgentStore.class, agentStore)) {
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestScheduleStore.class, restScheduleStore)) {
                 importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
             }
 
             var captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
-            verify(scheduleStore).createSchedule(captor.capture());
+            // The guarded REST surface, never IScheduleStore directly: the raw store
+            // applies none of the checks that stop an archive minting a schedule which
+            // runs as another user or forges a HITL approval timeout.
+            verify(restScheduleStore).createSchedule(captor.capture());
+            verify(scheduleStore, never()).createSchedule(any());
             ScheduleConfiguration imported = captor.getValue();
 
             assertEquals(NEW_AGENT_ID, imported.getAgentId(), "the schedule must fire the agent just created");
@@ -171,10 +255,442 @@ class RestImportServiceArchiveContractTest {
             assertEquals("0 3 * * *", imported.getCronExpression());
             // Fire bookkeeping is reset: an imported schedule must not inherit another
             // deployment's in-flight lease or retry counter.
-            assertNull(imported.getId());
             assertNull(imported.getClaimedBy());
             assertEquals(ScheduleConfiguration.FireStatus.PENDING, imported.getFireStatus());
             assertEquals(0, imported.getFailCount());
+            // ... and neither its due time, its pinned agent version, nor the tenant and
+            // conversation of the deployment it came from. A stale nextFire fires the
+            // moment it is imported; a pinned agentVersion the new agent does not have
+            // dead-letters every fire.
+            assertNull(imported.getNextFire(), "nextFire must be recomputed, not carried over");
+            assertEquals(0, imported.getAgentVersion(), "the imported schedule must follow the latest version");
+            assertNull(imported.getTenantId());
+            assertNull(imported.getPersistentConversationId());
+        }
+
+        @Test
+        @DisplayName("a schedule the operator unticked in the preview is not imported")
+        void deselectedScheduleIsSkipped() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "keep1.schedule.json").toPath(),
+                        "{\"id\":\"keepSched\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\"}");
+                Files.writeString(new File(schedules, "drop1.schedule.json").toPath(),
+                        "{\"id\":\"dropSched\",\"name\":\"hourly\",\"agentId\":\"someOtherAgent\"}");
+            });
+
+            var agentStore = stubAgentCreation();
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestScheduleStore.class, restScheduleStore)) {
+                // The preview renders every schedule as a deselectable row; ignoring the
+                // selection here created schedules the operator had explicitly unticked.
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "create",
+                        AGENT_ORIGIN_ID + ",keepSched", null, null);
+            }
+
+            var captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
+            verify(restScheduleStore).createSchedule(captor.capture());
+            assertEquals("nightly", captor.getValue().getName(),
+                    "only the selected schedule may be created");
+        }
+
+        /**
+         * {@code selectedResources} is one flat list over every row the preview emits,
+         * so the documented selective-merge curls — which name extension origin ids and
+         * nothing else — deselect every schedule in the archive by omission. That is a
+         * legitimate reading of the parameter, but answering a bare 201 for an agent
+         * whose nightly job did not come back is the exact failure importing schedules
+         * at all was meant to end, and a script has no reason to read this instance's
+         * log. So the count travels with the answer.
+         */
+        @Test
+        @DisplayName("schedules the selection left out are counted on the response, not just in the log")
+        void schedulesLeftOutBySelectionAreReportedOnTheResponse() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "drop1.schedule.json").toPath(),
+                        "{\"id\":\"dropSched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\"}");
+                Files.writeString(new File(schedules, "drop2.schedule.json").toPath(),
+                        "{\"id\":\"dropSched2\",\"name\":\"hourly\",\"agentId\":\"someOtherAgent\"}");
+            });
+
+            var agentStore = stubAgentCreation();
+            Response response;
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestScheduleStore.class, restScheduleStore)) {
+                // Scenario 3 of the docs: extension origin ids only, no schedule ids.
+                response = importService.importAgent(new ByteArrayInputStream(new byte[0]), "merge",
+                        "origin-beh-1,origin-http-1", null, null);
+            }
+
+            assertEquals(201, response.getStatus());
+            verify(restScheduleStore, never()).createSchedule(any());
+            assertEquals("2", response.getHeaderString("X-Schedules-Skipped"),
+                    "the caller must be told its selection dropped the archive's schedules, headers were "
+                            + response.getHeaders());
+        }
+
+        @Test
+        @DisplayName("a merge updates the agent's existing schedule instead of adding a second copy")
+        void mergeDoesNotDuplicateSchedules() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\","
+                                + "\"cronExpression\":\"0 4 * * *\"}");
+            });
+
+            // strategy=merge exists for re-importing the same agent repeatedly. The
+            // agent is matched and updated in place, so creating its schedules again
+            // added a second, third, ... copy of every one of them: a nightly
+            // consolidation firing N times per night after N promotions.
+            var existingDescriptor = new DocumentDescriptor();
+            existingDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=4"));
+            when(documentDescriptorStore.findByOriginId(AGENT_ORIGIN_ID)).thenReturn(List.of(existingDescriptor));
+
+            var existingSchedule = new ScheduleConfiguration();
+            existingSchedule.setId("alreadyHere");
+            existingSchedule.setName("nightly");
+            when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(existingSchedule));
+            when(scheduleStore.readSchedule("alreadyHere")).thenReturn(existingSchedule);
+
+            var agentStore = stubAgentCreation();
+            var restAgentStore = mock(IRestAgentStore.class);
+            when(restAgentStore.updateAgent(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+            try (var cdi = stubCdi(IAgentStore.class, agentStore,
+                    IRestScheduleStore.class, restScheduleStore,
+                    IRestAgentStore.class, restAgentStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "merge", null, null, null);
+            }
+
+            verify(restScheduleStore).updateSchedule(eq("alreadyHere"), any());
+            verify(restScheduleStore, never()).createSchedule(any());
+        }
+
+        /**
+         * Nothing makes a schedule name unique per agent — the schedule API validates
+         * the body, never the name — so an archive can legitimately hold two called
+         * "nightly". Matching them by name against a map computed once put both onto
+         * the same target schedule: last write wins, the other archived schedule's
+         * settings gone, and the import still answering 201.
+         */
+        @Test
+        @DisplayName("two archived schedules of the same name do not both overwrite the same target")
+        void sameNamedArchivedSchedulesDoNotCollapse() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\","
+                                + "\"cronExpression\":\"0 4 * * *\"}");
+                Files.writeString(new File(schedules, "sched2.schedule.json").toPath(),
+                        "{\"id\":\"sched2\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\","
+                                + "\"cronExpression\":\"0 5 * * *\"}");
+            });
+
+            var existingDescriptor = new DocumentDescriptor();
+            existingDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=4"));
+            when(documentDescriptorStore.findByOriginId(AGENT_ORIGIN_ID)).thenReturn(List.of(existingDescriptor));
+
+            var existingSchedule = new ScheduleConfiguration();
+            existingSchedule.setId("alreadyHere");
+            existingSchedule.setName("nightly");
+            when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(existingSchedule));
+            when(scheduleStore.readSchedule("alreadyHere")).thenReturn(existingSchedule);
+
+            var agentStore = stubAgentCreation();
+            var restAgentStore = mock(IRestAgentStore.class);
+            when(restAgentStore.updateAgent(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+            try (var cdi = stubCdi(IAgentStore.class, agentStore,
+                    IRestScheduleStore.class, restScheduleStore,
+                    IRestAgentStore.class, restAgentStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "merge", null, null, null);
+            }
+
+            verify(restScheduleStore, times(1)).updateSchedule(eq("alreadyHere"), any());
+            // The second one has no unclaimed target left, so it is created. A
+            // duplicate is visible and deletable; a silently discarded schedule is
+            // neither.
+            verify(restScheduleStore, times(1)).createSchedule(any());
+        }
+
+        /**
+         * The mirror image: the target agent itself has two schedules of that name, so
+         * "the one to overwrite" is a coin toss. Picking either would drop the other's
+         * settings on a 201.
+         */
+        @Test
+        @DisplayName("an ambiguous name on the target is created rather than overwriting an arbitrary one")
+        void ambiguousExistingScheduleNameIsNotMatched() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\","
+                                + "\"cronExpression\":\"0 4 * * *\"}");
+            });
+
+            var existingDescriptor = new DocumentDescriptor();
+            existingDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=4"));
+            when(documentDescriptorStore.findByOriginId(AGENT_ORIGIN_ID)).thenReturn(List.of(existingDescriptor));
+
+            var first = new ScheduleConfiguration();
+            first.setId("alreadyHere");
+            first.setName("nightly");
+            var second = new ScheduleConfiguration();
+            second.setId("alsoHere");
+            second.setName("nightly");
+            when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(first, second));
+            when(scheduleStore.readSchedule("alreadyHere")).thenReturn(first);
+            when(scheduleStore.readSchedule("alsoHere")).thenReturn(second);
+
+            var agentStore = stubAgentCreation();
+            var restAgentStore = mock(IRestAgentStore.class);
+            when(restAgentStore.updateAgent(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+            try (var cdi = stubCdi(IAgentStore.class, agentStore,
+                    IRestScheduleStore.class, restScheduleStore,
+                    IRestAgentStore.class, restAgentStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "merge", null, null, null);
+            }
+
+            verify(restScheduleStore, never()).updateSchedule(anyString(), any());
+            verify(restScheduleStore).createSchedule(any());
+        }
+
+        @Test
+        @DisplayName("a merge that fails after overwriting a schedule puts the original back")
+        void mergeScheduleUpdateIsCompensated() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".descriptor.json").toPath(),
+                        "{\"name\":\"Imported\"}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\","
+                                + "\"cronExpression\":\"0 4 * * *\"}");
+            });
+
+            var existingDescriptor = new DocumentDescriptor();
+            existingDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=4"));
+            when(documentDescriptorStore.findByOriginId(AGENT_ORIGIN_ID)).thenReturn(List.of(existingDescriptor));
+
+            // The operator's live nightly job, which the merge is about to overwrite.
+            var live = new ScheduleConfiguration();
+            live.setId("alreadyHere");
+            live.setName("nightly");
+            live.setCronExpression("0 9 * * *");
+            when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(live));
+            when(scheduleStore.readSchedule("alreadyHere")).thenReturn(live);
+
+            var agentStore = stubAgentCreation();
+            var restAgentStore = mock(IRestAgentStore.class);
+            when(restAgentStore.updateAgent(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+            // The descriptor bookkeeping that runs AFTER the schedules blows up. The
+            // agent and workflow versions are rolled back; a create is compensated by
+            // a delete — but an update overwrote something, and only a snapshot taken
+            // beforehand can undo that. Without one the import failed while leaving
+            // the operator's nightly job running the archive's settings.
+            when(documentDescriptorStore.getCurrentResourceId(NEW_AGENT_ID))
+                    .thenThrow(new IllegalStateException("descriptor store down"));
+
+            try (var cdi = stubCdi(IAgentStore.class, agentStore,
+                    IRestScheduleStore.class, restScheduleStore,
+                    IRestAgentStore.class, restAgentStore)) {
+                assertThrows(RuntimeException.class, () -> importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "merge", null, null, null));
+            }
+
+            verify(restScheduleStore).updateSchedule(eq("alreadyHere"), any());
+            var restored = ArgumentCaptor.forClass(ScheduleConfiguration.class);
+            verify(scheduleStore).updateSchedule(eq("alreadyHere"), restored.capture());
+            assertEquals("0 9 * * *", restored.getValue().getCronExpression(),
+                    "the rollback must put the target's own schedule back, not leave the archive's");
+        }
+
+        @Test
+        @DisplayName("a schedule that ran as somebody else arrives unowned rather than bound to a stranger")
+        void foreignUserIdIsNotCarriedOver() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\","
+                                + "\"userId\":\"victim-42\"}");
+            });
+            when(spaceContext.currentPrincipal()).thenReturn("importer-7");
+
+            var agentStore = stubAgentCreation();
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestScheduleStore.class, restScheduleStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            }
+
+            var captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
+            verify(restScheduleStore).createSchedule(captor.capture());
+            // userId is the identity every fire ACTS AS, and it is minted by the SOURCE
+            // deployment's identity provider. Carried over it either 403s the whole
+            // import for a non-admin (requireOwnUserId) or, for an admin, silently
+            // hands the schedule to whoever holds that id here — for a Dream schedule,
+            // their memories are the ones pruned.
+            assertNull(captor.getValue().getUserId(),
+                    "a foreign identity must not cross deployments with the archive");
+        }
+
+        @Test
+        @DisplayName("a schedule that already ran as the importing user keeps its owner")
+        void ownUserIdIsKept() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\","
+                                + "\"userId\":\"importer-7\"}");
+            });
+            when(spaceContext.currentPrincipal()).thenReturn("importer-7");
+
+            var agentStore = stubAgentCreation();
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestScheduleStore.class, restScheduleStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            }
+
+            var captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
+            verify(restScheduleStore).createSchedule(captor.capture());
+            // Re-importing your own agent — the common case — must not cost you the
+            // owner of your own Dream schedule.
+            assertEquals("importer-7", captor.getValue().getUserId());
+        }
+
+        @Test
+        @DisplayName("a merge leaves the owner of the schedule it overwrites in place")
+        void mergeKeepsTheOwnerOfTheOverwrittenSchedule() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                // The archive ran as somebody the target has never heard of, so the
+                // prepared schedule arrives without an identity of its own.
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\","
+                                + "\"userId\":\"victim-42\",\"cronExpression\":\"0 4 * * *\"}");
+            });
+            when(spaceContext.currentPrincipal()).thenReturn("importer-7");
+
+            var existingDescriptor = new DocumentDescriptor();
+            existingDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=4"));
+            when(documentDescriptorStore.findByOriginId(AGENT_ORIGIN_ID)).thenReturn(List.of(existingDescriptor));
+
+            // The target's working nightly job, owned by the operator who imported it
+            // the first time.
+            var live = new ScheduleConfiguration();
+            live.setId("alreadyHere");
+            live.setName("nightly");
+            live.setUserId("importer-7");
+            when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(live));
+            when(scheduleStore.readSchedule("alreadyHere")).thenReturn(live);
+
+            var agentStore = stubAgentCreation();
+            var restAgentStore = mock(IRestAgentStore.class);
+            when(restAgentStore.updateAgent(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+            try (var cdi = stubCdi(IAgentStore.class, agentStore,
+                    IRestScheduleStore.class, restScheduleStore,
+                    IRestAgentStore.class, restAgentStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "merge", null, null, null);
+            }
+
+            var captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
+            verify(restScheduleStore).updateSchedule(eq("alreadyHere"), captor.capture());
+            // The update is a full replace: a body without a userId is filed under
+            // system:scheduler, which Dream consolidation refuses to run as and the
+            // ownership guard exempts. Every re-promotion silently stopped the nightly
+            // job and made the schedule writable by every editor.
+            assertEquals("importer-7", captor.getValue().getUserId(),
+                    "a merge must not strip the owner the target assigned");
+        }
+
+        @Test
+        @DisplayName("a merge never matches the target's HITL approval timer by name")
+        void hitlTimeoutIsNotOverwrittenByMerge() throws Exception {
+            String timerName = HitlSchedules.regularTimeoutScheduleName("conv-1");
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                // A crafted archive: the HITL name, but no hitlType marker, so the REST
+                // bean's body guard does not recognise it.
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"" + timerName + "\",\"agentId\":\"someOtherAgent\","
+                                + "\"cronExpression\":\"0 4 * * *\"}");
+            });
+
+            var existingDescriptor = new DocumentDescriptor();
+            existingDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=4"));
+            when(documentDescriptorStore.findByOriginId(AGENT_ORIGIN_ID)).thenReturn(List.of(existingDescriptor));
+
+            var liveTimer = new ScheduleConfiguration();
+            liveTimer.setId("liveHitlTimer");
+            liveTimer.setName(timerName);
+            liveTimer.setMetadata(Map.of(HitlSchedules.METADATA_TYPE_KEY, HitlSchedules.METADATA_TYPE_TIMEOUT));
+            when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(liveTimer));
+            when(scheduleStore.readSchedule("liveHitlTimer")).thenReturn(liveTimer);
+
+            var agentStore = stubAgentCreation();
+            var restAgentStore = mock(IRestAgentStore.class);
+            when(restAgentStore.updateAgent(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+            try (var cdi = stubCdi(IAgentStore.class, agentStore,
+                    IRestScheduleStore.class, restScheduleStore,
+                    IRestAgentStore.class, restAgentStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "merge", null, null, null);
+            }
+
+            // requireAdminForHitl lets an admin update a stored HITL timer, so a name
+            // match here would PUT over a live safety timer: the marker and the
+            // deadline gone, the pending approval's ABORT/AUTO_REJECT policy disarmed.
+            // The export side already refuses to archive these; the import must refuse
+            // to match them.
+            verify(restScheduleStore, never()).updateSchedule(eq("liveHitlTimer"), any());
+            verify(restScheduleStore).createSchedule(any());
+        }
+
+        @Test
+        @DisplayName("a schedule the guarded surface refuses fails the import with its own status")
+        void refusedScheduleFailsTheImport() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "hitl1.schedule.json").toPath(),
+                        "{\"id\":\"hitl1\",\"name\":\"forged\",\"agentId\":\"someOtherAgent\","
+                                + "\"userId\":\"victim-42\",\"metadata\":{\"hitlType\":\"hitl_timeout\"}}");
+            });
+
+            // The REST bean answers 400 for a forged HITL timeout and 403 for a
+            // schedule that would run as somebody else. Either way the import must fail
+            // with that status rather than swallowing it or reporting a 500.
+            doReturn(Response.status(400).entity("HITL timeout schedules are minted internally only").build())
+                    .when(restScheduleStore).createSchedule(any());
+
+            var agentStore = stubAgentCreation();
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestScheduleStore.class, restScheduleStore)) {
+                var ex = assertThrows(WebApplicationException.class, () -> importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "create", null, null, null));
+
+                assertEquals(400, ex.getResponse().getStatus());
+                assertTrue(ex.getMessage().contains("hitl1.schedule.json"), ex.getMessage());
+            }
         }
 
         @Test
@@ -190,12 +706,15 @@ class RestImportServiceArchiveContractTest {
                         "{\"id\":\"bbb2\",\"name\":\"hourly\",\"agentId\":\"someOtherAgent\"}");
             });
 
-            when(scheduleStore.createSchedule(any()))
-                    .thenReturn("newSched1")
-                    .thenThrow(new IllegalStateException("schedule store down"));
+            doAnswer(inv -> {
+                ScheduleConfiguration created = inv.getArgument(0);
+                created.setId("newSched1");
+                return Response.status(201).entity(created).build();
+            }).doThrow(new IllegalStateException("schedule store down"))
+                    .when(restScheduleStore).createSchedule(any());
 
             var agentStore = stubAgentCreation();
-            try (var cdi = stubCdi(IAgentStore.class, agentStore)) {
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestScheduleStore.class, restScheduleStore)) {
                 // Restoring an agent with only half its triggers is the failure mode
                 // importing schedules exists to remove, so it is not tolerated.
                 assertThrows(RuntimeException.class, () -> importService.importAgent(
@@ -221,35 +740,133 @@ class RestImportServiceArchiveContractTest {
             assertTrue(preview.resources().stream().anyMatch(d -> "schedule".equals(d.resourceType())),
                     "schedules must be visible in the preview: " + preview.resources());
         }
+
+        /**
+         * A merge matches an archived schedule against the target agent's own by name
+         * and overwrites it in place. Reporting CREATE for that told the operator a
+         * nightly job would be added while the import was about to replace theirs — the
+         * one row where the difference matters, since an overwrite is what they might
+         * have refused.
+         * <p>
+         * The second archived schedule of the same name is a CREATE, because the import
+         * consumes the match rather than PUTting both onto the one target.
+         */
+        @Test
+        @DisplayName("the preview reports UPDATE for a schedule a merge would overwrite by name")
+        void previewMatchesSchedulesByNameAgainstTheTargetAgent() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "sched1.schedule.json").toPath(),
+                        "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\"}");
+                Files.writeString(new File(schedules, "sched2.schedule.json").toPath(),
+                        "{\"id\":\"sched2\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\"}");
+                Files.writeString(new File(schedules, "sched3.schedule.json").toPath(),
+                        "{\"id\":\"sched3\",\"name\":\"heartbeat\",\"agentId\":\"someOtherAgent\"}");
+            });
+
+            // The agent this merge would write into, and the schedule it already runs.
+            var existingDescriptor = new DocumentDescriptor();
+            existingDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=4"));
+            when(documentDescriptorStore.findByOriginId(AGENT_ORIGIN_ID)).thenReturn(List.of(existingDescriptor));
+
+            var existingSchedule = new ScheduleConfiguration();
+            existingSchedule.setId("alreadyHere");
+            existingSchedule.setName("nightly");
+            when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(existingSchedule));
+
+            var preview = importService.previewImport(new ByteArrayInputStream(new byte[0]), null);
+
+            var rows = preview.resources().stream()
+                    .filter(d -> "schedule".equals(d.resourceType()))
+                    .collect(Collectors.toMap(ResourceDiff::sourceId, d -> d));
+            assertEquals(DiffAction.UPDATE, rows.get("sched1").action(),
+                    "a merge overwrites the target's schedule of that name: " + rows);
+            assertEquals("alreadyHere", rows.get("sched1").targetId(),
+                    "the row must name the schedule the import would overwrite");
+            assertEquals(DiffAction.CREATE, rows.get("sched2").action(),
+                    "the match is consumed, so the second archived 'nightly' is added: " + rows);
+            assertEquals(DiffAction.CREATE, rows.get("sched3").action(),
+                    "a name the target does not have is added: " + rows);
+        }
     }
 
     @Nested
     @DisplayName("an archive that references a config it does not contain")
     class MissingExtensionFile {
 
-        @Test
-        @DisplayName("is a 400 naming the missing file, not a 500 whose message is 'null'")
-        void missingExtensionFileIsBadRequest() throws Exception {
-            String workflowId = "bbbb11112222333344445555";
-            String llmId = "dddd11112222333344445555";
+        private static final String WORKFLOW_ID = "bbbb11112222333344445555";
+        private static final String LLM_ID = "dddd11112222333344445555";
 
+        /**
+         * A selective archive: the workflow names the LLM config, the file is not
+         * there.
+         */
+        private void stubSelectiveArchive() throws Exception {
             stubUnzip(dir -> {
                 Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
                         "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
-                                + workflowId + "?version=1\"]}");
-                File versionDir = new File(dir, workflowId + "/1");
+                                + WORKFLOW_ID + "?version=1\"]}");
+                File versionDir = new File(dir, WORKFLOW_ID + "/1");
                 assertTrue(versionDir.mkdirs());
-                // The workflow still carries the URI of a config a selective export
-                // left out of the archive.
-                Files.writeString(new File(versionDir, workflowId + ".workflow.json").toPath(),
-                        "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.llm\",\"config\":{\"uri\":"
-                                + "\"eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1\"}}]}");
+                Files.writeString(new File(versionDir, WORKFLOW_ID + ".workflow.json").toPath(),
+                        "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.parser\"},"
+                                + "{\"type\":\"eddi://ai.labs.llm\",\"config\":{\"uri\":"
+                                + "\"eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=1\"}}]}");
             });
+        }
+
+        @Test
+        @DisplayName("a create drops the step it cannot resolve instead of failing the whole import")
+        void missingExtensionFileOnCreateDropsTheStep() throws Exception {
+            stubSelectiveArchive();
+            when(jsonSerialization.deserialize(anyString(), eq(WorkflowConfiguration.class)))
+                    .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), WorkflowConfiguration.class));
+            when(jsonSerialization.serialize(any())).thenAnswer(inv -> mapper.writeValueAsString(inv.getArgument(0)));
+
+            var agentStore = stubAgentCreation();
+            var workflowStore = mock(IWorkflowStore.class);
+            when(workflowStore.create(any())).thenReturn(resourceId(NEW_WORKFLOW_ID, 1));
+
+            Response response;
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IWorkflowStore.class, workflowStore)) {
+                // A create has no local copy to answer the reference from. Failing the
+                // import with "The archive references ... but does not contain ..." told
+                // the operator to fix an archive the product itself had written.
+                response = importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            }
+
+            assertEquals(201, response.getStatus());
+            var stored = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+            verify(workflowStore).create(stored.capture());
+            assertEquals(1, stored.getValue().getWorkflowSteps().size(),
+                    "the unresolvable step must be dropped, kept: " + stored.getValue().getWorkflowSteps().stream()
+                            .map(step -> String.valueOf(step.getType())).toList());
+            assertEquals("eddi://ai.labs.parser", String.valueOf(
+                    stored.getValue().getWorkflowSteps().getFirst().getType()),
+                    "only the step whose config is missing may be dropped");
+        }
+
+        @Test
+        @DisplayName("a merge is a 400 naming the resource when neither side has the config")
+        void missingExtensionFileOnMergeWithNoLocalCopyIsBadRequest() throws Exception {
+            stubSelectiveArchive();
+
+            // Nothing in the archive, nothing on this deployment: the reference cannot
+            // be answered at all, so the import says which resource and why. Saying so
+            // beats a 500 whose message was literally "null", and beats storing a
+            // workflow step that points at an id this instance does not have.
+            when(documentDescriptorStore.findByOriginId(anyString())).thenReturn(List.of());
+            when(documentDescriptorStore.getCurrentResourceId(anyString())).thenReturn(null);
 
             var ex = assertThrows(BadRequestException.class, () -> importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), "create", null, null, null));
+                    new ByteArrayInputStream(new byte[0]), "merge", LLM_ID, null, null));
 
-            assertTrue(ex.getMessage().contains(llmId + ".langchain.json"), ex.getMessage());
+            assertTrue(ex.getMessage().contains(LLM_ID), ex.getMessage());
+            assertTrue(ex.getMessage().contains("no copy of it"), ex.getMessage());
         }
     }
 
@@ -384,6 +1001,249 @@ class RestImportServiceArchiveContractTest {
             assertTrue(String.valueOf(uri).contains(localLlmId),
                     "the stored workflow must point at this deployment's own copy, was " + uri);
         }
+
+        /**
+         * The promotion flow the merge matching exists for: export only the behaviour
+         * rules from staging, merge them into a prod agent that has its own LLM config.
+         * A merge PUTs the archived workflow over the target's — a full replace — so an
+         * archive that arrives without the LLM step does not leave prod's step alone,
+         * it deletes it, silently, with a 201.
+         */
+        @Test
+        @DisplayName("a merge onto an existing workflow keeps the step whose config the archive omits")
+        void mergeKeepsTheTargetsStepForAnOmittedConfig() throws Exception {
+            String workflowId = "bbbb11112222333344445555";
+            String llmId = "dddd11112222333344445555";
+            String localLlmId = "9999111122223333444455aa";
+            String localWorkflowId = "8888111122223333444455bb";
+
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
+                        "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                                + workflowId + "?version=1\"]}");
+                File versionDir = new File(dir, workflowId + "/1");
+                assertTrue(versionDir.mkdirs());
+                // Exactly what a selective export writes: the file is omitted, the
+                // reference stays.
+                Files.writeString(new File(versionDir, workflowId + ".workflow.json").toPath(),
+                        "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.parser\"},"
+                                + "{\"type\":\"eddi://ai.labs.llm\",\"config\":{\"uri\":"
+                                + "\"eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1\"}}]}");
+            });
+
+            when(jsonSerialization.deserialize(anyString(), eq(WorkflowConfiguration.class)))
+                    .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), WorkflowConfiguration.class));
+
+            // The target already runs this workflow, with its own copy of the config
+            // the archive left out.
+            var localWorkflow = new DocumentDescriptor();
+            localWorkflow.setResource(URI.create(
+                    "eddi://ai.labs.workflow/workflowstore/workflows/" + localWorkflowId + "?version=2"));
+            when(documentDescriptorStore.findByOriginId(workflowId)).thenReturn(List.of(localWorkflow));
+            var localLlm = new DocumentDescriptor();
+            localLlm.setResource(URI.create(
+                    "eddi://ai.labs.llm/llmstore/llms/" + localLlmId + "?version=3"));
+            when(documentDescriptorStore.findByOriginId(llmId)).thenReturn(List.of(localLlm));
+
+            var agentStore = stubAgentCreation();
+            var restWorkflowStore = mock(IRestWorkflowStore.class);
+            when(restWorkflowStore.updateWorkflow(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestWorkflowStore.class, restWorkflowStore)) {
+                Response response = importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "merge", workflowId, null, null);
+
+                assertEquals(201, response.getStatus());
+            }
+
+            var updated = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+            verify(restWorkflowStore).updateWorkflow(eq(localWorkflowId), eq(2), updated.capture());
+            var steps = updated.getValue().getWorkflowSteps();
+            assertEquals(2, steps.size(), "the merge must not delete a step from the live target, kept: "
+                    + steps.stream().map(step -> String.valueOf(step.getType())).toList());
+            Object uri = steps.get(1).getConfig().get("uri");
+            assertTrue(String.valueOf(uri).contains(localLlmId),
+                    "the surviving step must point at the target's own copy, was " + uri);
+        }
+
+        /**
+         * The same archive on the endpoint's <em>default</em> selection —
+         * {@code selectedResources} absent, which is what the documented curl and the
+         * OpenAPI default send.
+         * <p>
+         * "No selection" means "everything", so the omitted config counted as selected
+         * and the absent file was read as a broken archive: the whole promotion flow
+         * answered 400, with a message telling a merge caller to merge.
+         */
+        @Test
+        @DisplayName("a merge with no selectedResources keeps the target's copy instead of answering 400")
+        void mergeWithDefaultSelectionKeepsTheTargetsCopy() throws Exception {
+            String workflowId = "bbbb11112222333344445555";
+            String llmId = "dddd11112222333344445555";
+            String localLlmId = "9999111122223333444455aa";
+            String localWorkflowId = "8888111122223333444455bb";
+
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
+                        "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                                + workflowId + "?version=1\"]}");
+                File versionDir = new File(dir, workflowId + "/1");
+                assertTrue(versionDir.mkdirs());
+                // Exactly what a selective export writes: the file is omitted, the
+                // reference stays.
+                Files.writeString(new File(versionDir, workflowId + ".workflow.json").toPath(),
+                        "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.parser\"},"
+                                + "{\"type\":\"eddi://ai.labs.llm\",\"config\":{\"uri\":"
+                                + "\"eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1\"}}]}");
+            });
+
+            when(jsonSerialization.deserialize(anyString(), eq(WorkflowConfiguration.class)))
+                    .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), WorkflowConfiguration.class));
+
+            var localWorkflow = new DocumentDescriptor();
+            localWorkflow.setResource(URI.create(
+                    "eddi://ai.labs.workflow/workflowstore/workflows/" + localWorkflowId + "?version=2"));
+            when(documentDescriptorStore.findByOriginId(workflowId)).thenReturn(List.of(localWorkflow));
+            var localLlm = new DocumentDescriptor();
+            localLlm.setResource(URI.create(
+                    "eddi://ai.labs.llm/llmstore/llms/" + localLlmId + "?version=3"));
+            when(documentDescriptorStore.findByOriginId(llmId)).thenReturn(List.of(localLlm));
+
+            var agentStore = stubAgentCreation();
+            var restWorkflowStore = mock(IRestWorkflowStore.class);
+            when(restWorkflowStore.updateWorkflow(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestWorkflowStore.class, restWorkflowStore)) {
+                Response response = importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "merge", null, null, null);
+
+                assertEquals(201, response.getStatus(), "the default merge of EDDI's own selective archive"
+                        + " must import, not 400");
+            }
+
+            var updated = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+            verify(restWorkflowStore).updateWorkflow(eq(localWorkflowId), eq(2), updated.capture());
+            var steps = updated.getValue().getWorkflowSteps();
+            assertEquals(2, steps.size(), "the merge must not delete a step from the live target, kept: "
+                    + steps.stream().map(step -> String.valueOf(step.getType())).toList());
+            Object uri = steps.get(1).getConfig().get("uri");
+            assertTrue(String.valueOf(uri).contains(localLlmId),
+                    "the surviving step must point at the target's own copy, was " + uri);
+        }
+
+        /**
+         * The same archive as the Manager's wizard actually posts it. Its merge step
+         * ticks every preview row — {@code setSelected(new Set(data.resources.map(r =>
+         * r.sourceId)))} — and posts the lot as {@code selectedResources}, with no
+         * filter on the row's action, so the SKIP row for the config the archive omits
+         * is named too.
+         * <p>
+         * Treating a named id as proof of a broken archive therefore answered 400 to
+         * the product's own default selection, on the very promotion flow the SKIP row
+         * was introduced to describe. Whether the caller names the id decides nothing
+         * here: a merge answers an omitted config from the target's copy, and the one
+         * case that is genuinely broken — nothing on either side — is caught with a
+         * message naming the resource.
+         */
+        @Test
+        @DisplayName("a merge that names every preview row, SKIP included, keeps the target's copy")
+        void mergeWithEveryPreviewRowTickedKeepsTheTargetsCopy() throws Exception {
+            String workflowId = "bbbb11112222333344445555";
+            String llmId = "dddd11112222333344445555";
+            String localLlmId = "9999111122223333444455aa";
+            String localWorkflowId = "8888111122223333444455bb";
+
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
+                        "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                                + workflowId + "?version=1\"]}");
+                File versionDir = new File(dir, workflowId + "/1");
+                assertTrue(versionDir.mkdirs());
+                Files.writeString(new File(versionDir, workflowId + ".workflow.json").toPath(),
+                        "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.parser\"},"
+                                + "{\"type\":\"eddi://ai.labs.llm\",\"config\":{\"uri\":"
+                                + "\"eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1\"}}]}");
+            });
+
+            when(jsonSerialization.deserialize(anyString(), eq(WorkflowConfiguration.class)))
+                    .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), WorkflowConfiguration.class));
+
+            var localWorkflow = new DocumentDescriptor();
+            localWorkflow.setResource(URI.create(
+                    "eddi://ai.labs.workflow/workflowstore/workflows/" + localWorkflowId + "?version=2"));
+            when(documentDescriptorStore.findByOriginId(workflowId)).thenReturn(List.of(localWorkflow));
+            var localLlm = new DocumentDescriptor();
+            localLlm.setResource(URI.create(
+                    "eddi://ai.labs.llm/llmstore/llms/" + localLlmId + "?version=3"));
+            when(documentDescriptorStore.findByOriginId(llmId)).thenReturn(List.of(localLlm));
+
+            var agentStore = stubAgentCreation();
+            var restWorkflowStore = mock(IRestWorkflowStore.class);
+            when(restWorkflowStore.updateWorkflow(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+
+            // Every sourceId the preview handed the wizard: the agent row, the
+            // workflow row, and the SKIP row for the config the archive omits.
+            String everyTickedRow = AGENT_ORIGIN_ID + "," + workflowId + "," + llmId;
+
+            try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestWorkflowStore.class, restWorkflowStore)) {
+                Response response = importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "merge", everyTickedRow, null, null);
+
+                assertEquals(201, response.getStatus(), "the Manager's own default selection must import,"
+                        + " not 400 on the row it presents as harmless");
+            }
+
+            var updated = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+            verify(restWorkflowStore).updateWorkflow(eq(localWorkflowId), eq(2), updated.capture());
+            var steps = updated.getValue().getWorkflowSteps();
+            assertEquals(2, steps.size(), "the merge must not delete a step from the live target, kept: "
+                    + steps.stream().map(step -> String.valueOf(step.getType())).toList());
+            Object uri = steps.get(1).getConfig().get("uri");
+            assertTrue(String.valueOf(uri).contains(localLlmId),
+                    "the surviving step must point at the target's own copy, was " + uri);
+        }
+
+        /**
+         * The preview the Manager ticks its rows from. A config the archive does not
+         * carry is not going to be updated by the import — it is answered from the
+         * target's copy — so an UPDATE row both described a write that never happens
+         * and, once turned back into {@code selectedResources}, named an id the archive
+         * lacks, which the import then refuses.
+         */
+        @Test
+        @DisplayName("the merge preview marks a referenced-but-absent config SKIP, not UPDATE")
+        void previewMarksAnOmittedConfigAsSkip() throws Exception {
+            String workflowId = "bbbb11112222333344445555";
+            String llmId = "dddd11112222333344445555";
+            String localLlmId = "9999111122223333444455aa";
+
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
+                        "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                                + workflowId + "?version=1\"]}");
+                File versionDir = new File(dir, workflowId + "/1");
+                assertTrue(versionDir.mkdirs());
+                Files.writeString(new File(versionDir, workflowId + ".workflow.json").toPath(),
+                        "{\"workflowSteps\":[{\"type\":\"eddi://ai.labs.llm\",\"config\":{\"uri\":"
+                                + "\"eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1\"}}]}");
+            });
+
+            var localLlm = new DocumentDescriptor();
+            localLlm.setResource(URI.create(
+                    "eddi://ai.labs.llm/llmstore/llms/" + localLlmId + "?version=3"));
+            when(documentDescriptorStore.findByOriginId(llmId)).thenReturn(List.of(localLlm));
+
+            var preview = importService.previewImport(new ByteArrayInputStream(new byte[0]), null);
+
+            var llmRow = preview.resources().stream()
+                    .filter(diff -> llmId.equals(diff.sourceId()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no row for the referenced config: " + preview.resources()));
+            assertEquals(DiffAction.SKIP, llmRow.action(),
+                    "a config the archive does not carry is left alone by the import");
+            assertEquals(localLlmId, llmRow.targetId(),
+                    "the row must still name the local copy the import will keep");
+        }
     }
 
     // ==================== Helpers ====================
@@ -426,6 +1286,17 @@ class RestImportServiceArchiveContractTest {
         cdiMock.when(CDI::current).thenReturn(cdi);
         select(cdi, firstClass, first);
         select(cdi, secondClass, second);
+        return cdiMock;
+    }
+
+    private <A, B, C> AutoCloseable stubCdi(Class<A> firstClass, A first, Class<B> secondClass, B second,
+                                            Class<C> thirdClass, C third) {
+        var cdiMock = mockStatic(CDI.class);
+        var cdi = mock(CDI.class);
+        cdiMock.when(CDI::current).thenReturn(cdi);
+        select(cdi, firstClass, first);
+        select(cdi, secondClass, second);
+        select(cdi, thirdClass, third);
         return cdiMock;
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceArchiveContractTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceArchiveContractTest.java
@@ -791,6 +791,57 @@ class RestImportServiceArchiveContractTest {
             assertEquals(DiffAction.CREATE, rows.get("sched3").action(),
                     "a name the target does not have is added: " + rows);
         }
+
+        /**
+         * Which of two identically named archived schedules overwrites the live one
+         * must not depend on the filesystem.
+         * <p>
+         * The match is <em>consumed</em>: the first file read takes the UPDATE and the
+         * second becomes a CREATE. The archive was walked with
+         * {@code Files.newDirectoryStream}, whose order is unspecified and differs
+         * between platforms, so the same ZIP could overwrite a different schedule on a
+         * different machine — and {@code previewImport} could promise an outcome that
+         * {@code importAgent} then did not perform, which defeats the point of a
+         * preview an operator is meant to refuse.
+         * <p>
+         * The files here are written in the order {@code b-} then {@code a-}, so a
+         * creation-ordered filesystem hands back the wrong one first; only sorting by
+         * file name makes {@code a-} win.
+         */
+        @Test
+        @DisplayName("the archived schedule that wins a name match is chosen by file name, not by the filesystem")
+        void scheduleMatchingDoesNotDependOnDirectoryOrder() throws Exception {
+            stubUnzip(dir -> {
+                Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+                File schedules = new File(dir, "schedules");
+                assertTrue(schedules.mkdirs());
+                Files.writeString(new File(schedules, "b-second.schedule.json").toPath(),
+                        "{\"id\":\"writtenFirst\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\"}");
+                Files.writeString(new File(schedules, "a-first.schedule.json").toPath(),
+                        "{\"id\":\"writtenSecond\",\"name\":\"nightly\",\"agentId\":\"someOtherAgent\"}");
+            });
+
+            var existingDescriptor = new DocumentDescriptor();
+            existingDescriptor.setResource(URI.create(
+                    "eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=4"));
+            when(documentDescriptorStore.findByOriginId(AGENT_ORIGIN_ID)).thenReturn(List.of(existingDescriptor));
+
+            var existingSchedule = new ScheduleConfiguration();
+            existingSchedule.setId("alreadyHere");
+            existingSchedule.setName("nightly");
+            when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(existingSchedule));
+
+            var preview = importService.previewImport(new ByteArrayInputStream(new byte[0]), null);
+
+            var rows = preview.resources().stream()
+                    .filter(d -> "schedule".equals(d.resourceType()))
+                    .collect(Collectors.toMap(ResourceDiff::sourceId, d -> d));
+            assertEquals(DiffAction.UPDATE, rows.get("writtenSecond").action(),
+                    "a-first.schedule.json sorts first, so its schedule takes the match whatever order the "
+                            + "filesystem enumerated the directory in: " + rows);
+            assertEquals(DiffAction.CREATE, rows.get("writtenFirst").action(),
+                    "b-second.schedule.json sorts second, so its schedule is added: " + rows);
+        }
     }
 
     @Nested

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceBranchCoverageTest.java
@@ -4,9 +4,11 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.backup.model.SyncMapping;
 import ai.labs.eddi.backup.model.SyncRequest;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
@@ -15,6 +17,7 @@ import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +65,8 @@ class RestImportServiceBranchCoverageTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
+                mock(ResourceAccessGuard.class));
     }
 
     // =========================================================
@@ -82,10 +86,10 @@ class RestImportServiceBranchCoverageTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            Response response = importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), "merge", null, null, null);
-
-            assertNotNull(response);
+            // An archive with no agent file is rejected. Answering 200 with an empty
+            // resourceUri is how a whole class of broken archives went unnoticed.
+            assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "merge", null, null, null));
         }
 
         @Test
@@ -97,10 +101,8 @@ class RestImportServiceBranchCoverageTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            Response response = importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), null, null, null, null);
-
-            assertNotNull(response);
+            assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), null, null, null, null));
         }
     }
 
@@ -117,7 +119,7 @@ class RestImportServiceBranchCoverageTest {
         void upgradeWithWorkflowOrder() throws Exception {
             URI resultUri = URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=2");
             when(upgradeExecutor.executeUpgrade(any(), eq("target-1"), isNull(), eq(List.of("wf1", "wf2"))))
-                    .thenReturn(resultUri);
+                    .thenReturn(new UpgradeResult(resultUri, true, 1, 0, 0, List.of()));
 
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);
@@ -137,7 +139,7 @@ class RestImportServiceBranchCoverageTest {
         void upgradeWithSelectedOriginIds() throws Exception {
             URI resultUri = URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=3");
             when(upgradeExecutor.executeUpgrade(any(), eq("target-1"), eq(Set.of("res1", "res2")), isNull()))
-                    .thenReturn(resultUri);
+                    .thenReturn(new UpgradeResult(resultUri, true, 1, 0, 0, List.of()));
 
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);
@@ -170,10 +172,8 @@ class RestImportServiceBranchCoverageTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            var result = importService.previewImport(
-                    new ByteArrayInputStream(new byte[0]), null);
-
-            assertNotNull(result);
+            assertThrows(BadRequestException.class, () -> importService.previewImport(
+                    new ByteArrayInputStream(new byte[0]), null));
             verify(structuralMatcher, never()).buildPreview(any(), anyString(), anyBoolean());
         }
 
@@ -187,14 +187,12 @@ class RestImportServiceBranchCoverageTest {
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
             // Empty string targetAgentId — in the code, isNullOrEmpty check
-            var result = importService.previewImport(
-                    new ByteArrayInputStream(new byte[0]), "");
-
-            assertNotNull(result);
+            assertThrows(BadRequestException.class, () -> importService.previewImport(
+                    new ByteArrayInputStream(new byte[0]), ""));
         }
 
         @Test
-        @DisplayName("preview with multiple agent files in ZIP returns first one")
+        @DisplayName("preview with multiple agent files in ZIP is rejected, not silently narrowed")
         void previewMultipleAgentFiles() throws Exception {
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);
@@ -215,10 +213,13 @@ class RestImportServiceBranchCoverageTest {
             // No existing agents
             when(documentDescriptorStore.findByOriginId(anyString())).thenReturn(List.of());
 
-            var result = importService.previewImport(
-                    new ByteArrayInputStream(new byte[0]), null);
-
-            assertNotNull(result);
+            // The preview only ever described the first file it enumerated while the
+            // import created every one of them, so an operator approved an import of
+            // one agent and got several — with a Location header pointing at whichever
+            // happened to be enumerated last.
+            var ex = assertThrows(BadRequestException.class, () -> importService.previewImport(
+                    new ByteArrayInputStream(new byte[0]), null));
+            assertTrue(ex.getMessage().contains("one agent per archive"), ex.getMessage());
         }
     }
 
@@ -373,10 +374,8 @@ class RestImportServiceBranchCoverageTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            Response response = importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), "create", null, null, null);
-
-            assertNotNull(response);
+            assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "create", null, null, null));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceBranchCoverageTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.backup.impl;
 
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.UpgradeResult;
@@ -66,7 +67,7 @@ class RestImportServiceBranchCoverageTest {
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
                 templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
-                mock(ResourceAccessGuard.class));
+                mock(ResourceAccessGuard.class), mock(SpaceContext.class));
     }
 
     // =========================================================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedBranchTest.java
@@ -4,15 +4,18 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.backup.model.SyncMapping;
 import ai.labs.eddi.backup.model.SyncRequest;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,7 +62,8 @@ class RestImportServiceExtendedBranchTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
+                mock(ResourceAccessGuard.class));
     }
 
     // =========================================================
@@ -71,21 +75,15 @@ class RestImportServiceExtendedBranchTest {
     class UpgradeStrategyTarget {
 
         @Test
-        @DisplayName("upgrade strategy with null targetAgentId falls through to normal import")
-        void upgradeWithNullTargetFallsThrough() throws Exception {
-            doAnswer(inv -> {
-                File dir = inv.getArgument(1);
-                dir.mkdirs();
-                return null;
-            }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
+        @DisplayName("upgrade strategy with null targetAgentId is rejected")
+        void upgradeWithNullTargetIsRejected() {
+            // Falling through to the create path here produced a brand-new duplicate
+            // agent and reported 201, so a dropped query parameter silently doubled
+            // the deployment's agent list.
+            var ex = assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "upgrade", null, null, null));
+            assertTrue(ex.getMessage().contains("targetAgentId"), ex.getMessage());
 
-            // "upgrade" strategy + null targetAgentId => does NOT take upgrade path,
-            // falls to importAgentZipFile
-            Response response = importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), "upgrade", null, null, null);
-
-            assertNotNull(response);
-            // Should not have called upgradeExecutor
             verify(upgradeExecutor, never()).executeUpgrade(any(), anyString(), any(), any());
         }
 
@@ -94,7 +92,7 @@ class RestImportServiceExtendedBranchTest {
         void upgradeCaseInsensitive() throws Exception {
             URI resultUri = URI.create("eddi://ai.labs.agent/agentstore/agents/t1?version=1");
             when(upgradeExecutor.executeUpgrade(any(), eq("t1"), isNull(), isNull()))
-                    .thenReturn(resultUri);
+                    .thenReturn(new UpgradeResult(resultUri, true, 1, 0, 0, List.of()));
 
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);
@@ -191,11 +189,10 @@ class RestImportServiceExtendedBranchTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            // " " (whitespace) should be treated as blank → legacy path
-            var result = importService.previewImport(
-                    new ByteArrayInputStream(new byte[0]), "  ");
-
-            assertNotNull(result);
+            // " " (whitespace) should be treated as blank → legacy path, which then
+            // rejects the archive because it holds no agent file at all.
+            assertThrows(BadRequestException.class, () -> importService.previewImport(
+                    new ByteArrayInputStream(new byte[0]), "  "));
             verify(structuralMatcher, never()).buildPreview(any(), anyString(), anyBoolean());
         }
     }
@@ -444,7 +441,7 @@ class RestImportServiceExtendedBranchTest {
         void emptyWorkflowOrder() throws Exception {
             URI resultUri = URI.create("eddi://ai.labs.agent/agentstore/agents/t1?version=1");
             when(upgradeExecutor.executeUpgrade(any(), eq("t1"), isNull(), isNull()))
-                    .thenReturn(resultUri);
+                    .thenReturn(new UpgradeResult(resultUri, true, 1, 0, 0, List.of()));
 
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);
@@ -467,7 +464,7 @@ class RestImportServiceExtendedBranchTest {
         void workflowOrderWithSpaces() throws Exception {
             URI resultUri = URI.create("eddi://ai.labs.agent/agentstore/agents/t1?version=1");
             when(upgradeExecutor.executeUpgrade(any(), eq("t1"), isNull(), eq(List.of("wf1", "wf2"))))
-                    .thenReturn(resultUri);
+                    .thenReturn(new UpgradeResult(resultUri, true, 1, 0, 0, List.of()));
 
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);
@@ -496,7 +493,7 @@ class RestImportServiceExtendedBranchTest {
         void trailingCommas() throws Exception {
             URI resultUri = URI.create("eddi://ai.labs.agent/agentstore/agents/t1?version=1");
             when(upgradeExecutor.executeUpgrade(any(), eq("t1"), eq(Set.of("r1", "r2")), isNull()))
-                    .thenReturn(resultUri);
+                    .thenReturn(new UpgradeResult(resultUri, true, 1, 0, 0, List.of()));
 
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedBranchTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.backup.impl;
 
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.UpgradeResult;
@@ -15,6 +16,7 @@ import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import io.quarkus.runtime.LaunchMode;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Response;
@@ -63,7 +65,7 @@ class RestImportServiceExtendedBranchTest {
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
                 templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
-                mock(ResourceAccessGuard.class));
+                mock(ResourceAccessGuard.class), mock(SpaceContext.class));
     }
 
     // =========================================================
@@ -374,21 +376,19 @@ class RestImportServiceExtendedBranchTest {
         @Test
         @DisplayName("executeSync with HTTP in prod mode throws")
         void httpInProdMode() {
-            // Default quarkus.profile is "prod" (or unset)
-            // http:// should be rejected unless dev mode
-            String originalProfile = System.getProperty("quarkus.profile");
+            // The launch mode, not the quarkus.profile system property: isDevMode
+            // reads LaunchMode.current(), so setting the property here controlled
+            // nothing and this passed only because surefire's default mode happens to
+            // be NORMAL. Set what the code under test actually reads.
+            LaunchMode originalMode = LaunchMode.current();
             try {
-                System.setProperty("quarkus.profile", "prod");
+                LaunchMode.set(LaunchMode.NORMAL);
                 assertThrows(IllegalArgumentException.class,
                         () -> importService.executeSync(
                                 "http://example.com", "src", 1, "tgt",
                                 null, null, null));
             } finally {
-                if (originalProfile != null) {
-                    System.setProperty("quarkus.profile", originalProfile);
-                } else {
-                    System.clearProperty("quarkus.profile");
-                }
+                LaunchMode.set(originalMode);
             }
         }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
@@ -4,9 +4,11 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
 import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import ai.labs.eddi.backup.model.SyncMapping;
@@ -23,6 +25,7 @@ import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +73,8 @@ class RestImportServiceExtendedTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
+                mock(ResourceAccessGuard.class));
     }
 
     // ==================== normalizeVaultReferences ====================
@@ -219,7 +223,10 @@ class RestImportServiceExtendedTest {
                     "https://example.com", mappings, null);
 
             assertEquals(1, results.size());
-            assertTrue(results.getFirst().sourceAgentName().startsWith("Error:"));
+            assertNull(results.getFirst().sourceAgentName());
+            // The failure is a real field now: prefixing the agent NAME with "Error: "
+            // made a client string-match to tell a failed row from a successful one.
+            assertNotNull(results.getFirst().error());
         }
     }
 
@@ -377,7 +384,7 @@ class RestImportServiceExtendedTest {
     class ImportMerge {
 
         @Test
-        @DisplayName("merge strategy with empty zip returns ok response")
+        @DisplayName("merge strategy with empty zip is rejected, not reported as success")
         void mergeEmptyZip() throws Exception {
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);
@@ -385,12 +392,10 @@ class RestImportServiceExtendedTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            Response response = importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), "merge", null, null, null);
-
-            assertNotNull(response);
-            // No agent files → returns 200
-            assertEquals(200, response.getStatus());
+            // An archive with no agent file is rejected. Answering 200 with an empty
+            // resourceUri is how a whole class of broken archives went unnoticed.
+            assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "merge", null, null, null));
         }
 
         @Test
@@ -402,11 +407,8 @@ class RestImportServiceExtendedTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            Response response = importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), "create", "res1,res2", null, null);
-
-            assertNotNull(response);
-            assertEquals(200, response.getStatus());
+            assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "create", "res1,res2", null, null));
         }
     }
 
@@ -423,7 +425,7 @@ class RestImportServiceExtendedTest {
             URI resultUri = URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=2");
             when(upgradeExecutor.executeUpgrade(any(), eq("target-1"),
                     eq(Set.of("res1", "res2")), eq(List.of("wf1", "wf2"))))
-                    .thenReturn(resultUri);
+                    .thenReturn(new UpgradeResult(resultUri, true, 1, 0, 0, List.of()));
 
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);
@@ -765,7 +767,7 @@ class RestImportServiceExtendedTest {
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
             when(upgradeExecutor.executeUpgrade(any(), eq(targetAgentId), isNull(), isNull()))
-                    .thenReturn(resultUri);
+                    .thenReturn(new UpgradeResult(resultUri, true, 1, 0, 0, List.of()));
 
             Response response = importService.importAgent(
                     new ByteArrayInputStream(new byte[0]), "upgrade", null, targetAgentId, null);
@@ -889,12 +891,11 @@ class RestImportServiceExtendedTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            ImportPreview result = importService.previewImport(
-                    new ByteArrayInputStream(new byte[0]), null);
-
-            assertNotNull(result);
-            assertNull(result.sourceAgentId());
-            assertTrue(result.resources().isEmpty());
+            var ex = assertThrows(BadRequestException.class, () -> importService.previewImport(
+                    new ByteArrayInputStream(new byte[0]), null));
+            // The message has to name what was looked for: an empty preview told the
+            // operator there was nothing to import, which is not the same thing.
+            assertTrue(ex.getMessage().contains(".agent.json"), ex.getMessage());
         }
     }
 
@@ -991,8 +992,8 @@ class RestImportServiceExtendedTest {
                     "https://example.com", mappings, null);
 
             assertEquals(2, results.size());
-            assertTrue(results.get(0).sourceAgentName().startsWith("Error:"));
-            assertTrue(results.get(1).sourceAgentName().startsWith("Error:"));
+            assertNotNull(results.get(0).error());
+            assertNotNull(results.get(1).error());
             assertEquals("agent-1", results.get(0).sourceAgentId());
             assertEquals("agent-2", results.get(1).sourceAgentId());
         }
@@ -1110,11 +1111,8 @@ class RestImportServiceExtendedTest {
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
             // With spaces around commas — still works
-            Response response = importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), "create", " res1 , res2 , res3 ", null, null);
-
-            assertNotNull(response);
-            assertEquals(200, response.getStatus());
+            assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "create", " res1 , res2 , res3 ", null, null));
         }
 
         @Test
@@ -1126,11 +1124,8 @@ class RestImportServiceExtendedTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            Response response = importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), "create", "", null, null);
-
-            assertNotNull(response);
-            assertEquals(200, response.getStatus());
+            assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "create", "", null, null));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceExtendedTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.backup.impl;
 
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.UpgradeResult;
@@ -74,7 +75,7 @@ class RestImportServiceExtendedTest {
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
                 templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
-                mock(ResourceAccessGuard.class));
+                mock(ResourceAccessGuard.class), mock(SpaceContext.class));
     }
 
     // ==================== normalizeVaultReferences ====================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceFailureMetricsTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceFailureMetricsTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IZipArchive;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.migration.IMigrationManager;
+import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code eddi.backup.import.failure.count} is the meter an operator alerts on,
+ * so every way {@code importAgent} can end badly has to move it — including the
+ * one nobody anticipated.
+ * <p>
+ * The classification matters as much as the count: a request the caller got
+ * wrong is a 4xx they can act on, and only a genuine fault of this deployment
+ * may become a 500. Both are failures, and a run where the failure meter stayed
+ * at zero while imports were breaking is exactly the blind spot the meter was
+ * added for.
+ */
+@DisplayName("RestImportService — what counts as a failed import")
+class RestImportServiceFailureMetricsTest {
+
+    private static final String AGENT_ORIGIN_ID = "aabb11112222333344445555";
+
+    private IZipArchive zipArchive;
+    private IJsonSerialization jsonSerialization;
+    private BackupMetrics metrics;
+    private RestImportService importService;
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @BeforeEach
+    void setUp() throws Exception {
+        zipArchive = mock(IZipArchive.class);
+        jsonSerialization = mock(IJsonSerialization.class);
+        metrics = mock(BackupMetrics.class);
+
+        var templateSyntaxMigrator = mock(TemplateSyntaxMigrator.class);
+        when(templateSyntaxMigrator.migrate(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+        importService = new RestImportService(
+                zipArchive, jsonSerialization,
+                mock(IMigrationManager.class), mock(IDocumentDescriptorStore.class),
+                templateSyntaxMigrator, mock(StructuralMatcher.class),
+                mock(UpgradeExecutor.class), mock(IScheduleStore.class), metrics,
+                mock(ResourceAccessGuard.class), mock(SpaceContext.class));
+
+        when(jsonSerialization.deserialize(anyString(), eq(AgentConfiguration.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), AgentConfiguration.class));
+        when(jsonSerialization.deserialize(anyString(), eq(DocumentDescriptor.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), DocumentDescriptor.class));
+
+        stubUnzip(dir -> {
+            Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+            Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".descriptor.json").toPath(), "{\"name\":\"Agent\"}");
+        });
+    }
+
+    /**
+     * The catch-all. Anything the import did not anticipate — an agent store that
+     * throws where the contract says it returns — is this deployment's fault, so it
+     * is a 500 that names what went wrong and counts on the failure meter.
+     * Reporting it as anything else would leave a broken instance looking healthy.
+     */
+    @Test
+    @DisplayName("an unexpected store fault is a 500 that names the cause and counts as a failure")
+    void unexpectedStoreFaultIsA500AndCounts() throws Exception {
+        var agentStore = mock(IAgentStore.class);
+        when(agentStore.create(any())).thenThrow(new IllegalStateException("agent store is down"));
+
+        var thrown = assertThrows(InternalServerErrorException.class, () -> {
+            try (var cdi = stubCdi(IAgentStore.class, agentStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            }
+        });
+
+        assertTrue(String.valueOf(thrown.getMessage()).contains("agent store is down"),
+                "the operator has to be told what actually failed, was: " + thrown.getMessage());
+        assertEquals(500, thrown.getResponse().getStatus());
+        verify(metrics).importAttempted();
+        verify(metrics).importFailed();
+    }
+
+    /**
+     * The stores throw {@code ResourceStoreException}, which is checked and which
+     * {@code createResourceDirect} rethrows unwrapped rather than dressing it up as
+     * something else. It must land on the same catch-all: still a 500, still
+     * counted.
+     */
+    @Test
+    @DisplayName("a checked ResourceStoreException from the store lands on the same catch-all")
+    void checkedStoreExceptionIsA500AndCounts() throws Exception {
+        var agentStore = mock(IAgentStore.class);
+        doAnswer(inv -> {
+            throw new IResourceStore.ResourceStoreException("write concern not met");
+        }).when(agentStore).create(any());
+
+        var thrown = assertThrows(InternalServerErrorException.class, () -> {
+            try (var cdi = stubCdi(IAgentStore.class, agentStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            }
+        });
+
+        assertTrue(String.valueOf(thrown.getMessage()).contains("write concern not met"),
+                "the store's own reason must survive, was: " + thrown.getMessage());
+        verify(metrics).importFailed();
+    }
+
+    /**
+     * A store that rejects the configuration itself — an invalid
+     * {@code hitlConfig}, say — raises {@code IllegalArgumentException}, which the
+     * {@code IllegalArgumentExceptionMapper} turns into a 400. Letting the
+     * catch-all have it instead would report the operator's own malformed archive
+     * as a fault of this deployment, so it is classified separately — and counted.
+     */
+    @Test
+    @DisplayName("a rejected configuration keeps its own exception and still counts")
+    void rejectedConfigurationKeepsIts400AndCounts() throws Exception {
+        var agentStore = mock(IAgentStore.class);
+        when(agentStore.create(any()))
+                .thenThrow(new IllegalArgumentException("hitlConfig.timeoutSeconds must be positive"));
+
+        var thrown = assertThrows(IllegalArgumentException.class, () -> {
+            try (var cdi = stubCdi(IAgentStore.class, agentStore)) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            }
+        });
+
+        assertEquals("hitlConfig.timeoutSeconds must be positive", thrown.getMessage(),
+                "the validation message is the whole value of a 400; wrapping it in a 500 would lose it");
+        verify(metrics).importFailed();
+    }
+
+    /**
+     * A strategy the service does not implement is the caller's mistake, so it
+     * stays a 400 — the catch-all must not repackage it as a server fault — and it
+     * is still a failed import as far as the meter is concerned.
+     */
+    @Test
+    @DisplayName("an unknown strategy stays a 400 and still counts as a failure")
+    void unknownStrategyIsA400AndCounts() throws Exception {
+        var thrown = assertThrows(BadRequestException.class,
+                () -> importService.importAgent(new ByteArrayInputStream(new byte[0]), "sideways", null, null, null));
+
+        assertTrue(thrown.getMessage().contains("sideways"),
+                "the message must name the strategy that was rejected, was: " + thrown.getMessage());
+        verify(metrics).importFailed();
+        verify(zipArchive, never()).unzip(any(InputStream.class), any(File.class));
+    }
+
+    // ==================== Helpers ====================
+
+    private interface ArchiveContent {
+        void write(File dir) throws IOException;
+    }
+
+    private void stubUnzip(ArchiveContent content) throws Exception {
+        doAnswer(inv -> {
+            File dir = inv.getArgument(1);
+            assertTrue(dir.mkdirs() || dir.isDirectory());
+            content.write(dir);
+            return null;
+        }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private AutoCloseable stubCdi(Class<?> storeClass, Object store) {
+        var cdiMock = mockStatic(CDI.class);
+        var cdi = mock(CDI.class);
+        cdiMock.when(CDI::current).thenReturn(cdi);
+        var instance = (Instance<Object>) mock(Instance.class);
+        when(cdi.select((Class<Object>) storeClass)).thenReturn(instance);
+        when(instance.get()).thenReturn(store);
+        return cdiMock;
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceHelpersTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceHelpersTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import io.quarkus.runtime.LaunchMode;
 import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Method;
@@ -293,33 +294,29 @@ class RestImportServiceHelpersTest {
     class IsDevMode {
 
         @Test
-        @DisplayName("returns false for prod profile")
-        void prodProfile() throws Exception {
-            String original = System.getProperty("quarkus.profile");
+        @DisplayName("follows the launch mode, not the quarkus.profile system property")
+        void followsLaunchMode() throws Exception {
+            // The system property is only set when someone passed
+            // -Dquarkus.profile=... on the command line, so a container started the
+            // normal way with QUARKUS_PROFILE=dev looked like production and rejected
+            // every http:// sync source with a message pointing at prod configuration.
+            String originalProfile = System.getProperty("quarkus.profile");
+            LaunchMode originalMode = LaunchMode.current();
             try {
+                LaunchMode.set(LaunchMode.DEVELOPMENT);
+
                 System.setProperty("quarkus.profile", "prod");
-                boolean result = invokeIsDevMode();
-                assertFalse(result);
-            } finally {
-                if (original != null) {
-                    System.setProperty("quarkus.profile", original);
-                } else {
-                    System.clearProperty("quarkus.profile");
-                }
-            }
-        }
+                assertTrue(invokeIsDevMode(),
+                        "isDevMode must ignore the quarkus.profile system property and follow the launch mode");
 
-        @Test
-        @DisplayName("returns true for dev profile")
-        void devProfile() throws Exception {
-            String original = System.getProperty("quarkus.profile");
-            try {
+                LaunchMode.set(LaunchMode.NORMAL);
                 System.setProperty("quarkus.profile", "dev");
-                boolean result = invokeIsDevMode();
-                assertTrue(result);
+                assertFalse(invokeIsDevMode(),
+                        "isDevMode must ignore the quarkus.profile system property and follow the launch mode");
             } finally {
-                if (original != null) {
-                    System.setProperty("quarkus.profile", original);
+                LaunchMode.set(originalMode);
+                if (originalProfile != null) {
+                    System.setProperty("quarkus.profile", originalProfile);
                 } else {
                     System.clearProperty("quarkus.profile");
                 }
@@ -327,19 +324,24 @@ class RestImportServiceHelpersTest {
         }
 
         @Test
-        @DisplayName("returns true for test profile")
-        void testProfile() throws Exception {
-            String original = System.getProperty("quarkus.profile");
+        @DisplayName("maps each launch mode to a fixed answer: NORMAL false, DEVELOPMENT and TEST true")
+        void mapsEveryLaunchMode() throws Exception {
+            // This used to compare invokeIsDevMode() against a test-local copy of the
+            // very expression under test, so it passed whatever isDevMode returned —
+            // including, under a plain surefire run (LaunchMode.NORMAL), the opposite
+            // of what its own name claimed.
+            LaunchMode originalMode = LaunchMode.current();
             try {
-                System.setProperty("quarkus.profile", "test");
-                boolean result = invokeIsDevMode();
-                assertTrue(result);
+                LaunchMode.set(LaunchMode.NORMAL);
+                assertFalse(invokeIsDevMode(), "a production launch is not dev mode");
+
+                LaunchMode.set(LaunchMode.DEVELOPMENT);
+                assertTrue(invokeIsDevMode(), "quarkus:dev is dev mode");
+
+                LaunchMode.set(LaunchMode.TEST);
+                assertTrue(invokeIsDevMode(), "a test run is dev mode");
             } finally {
-                if (original != null) {
-                    System.setProperty("quarkus.profile", original);
-                } else {
-                    System.clearProperty("quarkus.profile");
-                }
+                LaunchMode.set(originalMode);
             }
         }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
@@ -4,9 +4,11 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
@@ -23,6 +25,7 @@ import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,7 +97,8 @@ class RestImportServiceRollbackAndCleanupTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 mock(IMigrationManager.class), documentDescriptorStore,
-                mock(TemplateSyntaxMigrator.class), structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
+                mock(TemplateSyntaxMigrator.class), structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
+                mock(ResourceAccessGuard.class));
     }
 
     // ==================== D11 — rollback of a partial import ====================
@@ -255,7 +259,9 @@ class RestImportServiceRollbackAndCleanupTest {
         void createImportCleansUp() throws Exception {
             AtomicReference<File> unzipped = stubEmptyZip();
 
-            importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            // An archive with no agent file is now a 400, and the tree must go anyway.
+            assertThrows(BadRequestException.class, () -> importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "create", null, null, null));
 
             assertUnzippedDirectoryRemoved(unzipped);
         }
@@ -287,9 +293,9 @@ class RestImportServiceRollbackAndCleanupTest {
         void legacyPreviewCleansUp() throws Exception {
             AtomicReference<File> unzipped = stubEmptyZip();
 
-            ImportPreview preview = importService.previewImport(new ByteArrayInputStream(new byte[0]), null);
+            assertThrows(BadRequestException.class,
+                    () -> importService.previewImport(new ByteArrayInputStream(new byte[0]), null));
 
-            assertNotNull(preview);
             assertUnzippedDirectoryRemoved(unzipped);
         }
 
@@ -310,7 +316,8 @@ class RestImportServiceRollbackAndCleanupTest {
         void upgradeImportCleansUp() throws Exception {
             AtomicReference<File> unzipped = stubEmptyZip();
             when(upgradeExecutor.executeUpgrade(any(), eq("target-1"), any(), any()))
-                    .thenReturn(URI.create("eddi://ai.labs.agent/agentstore/agents/" + AGENT_ORIGIN_ID + "?version=2"));
+                    .thenReturn(new UpgradeResult(URI.create("eddi://ai.labs.agent/agentstore/agents/" + AGENT_ORIGIN_ID + "?version=2"), true, 1, 0,
+                            0, List.of()));
 
             importService.importAgent(
                     new ByteArrayInputStream(new byte[0]), "upgrade", null, "target-1", null);

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
@@ -4,7 +4,9 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.schedule.IRestScheduleStore;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.engine.security.spaces.SpaceContext;
 import ai.labs.eddi.backup.IZipArchive;
@@ -76,7 +78,7 @@ import static org.mockito.Mockito.when;
 class RestImportServiceRollbackAndCleanupTest {
 
     private static final String AGENT_ORIGIN_ID = "aaaa11112222333344445555";
-    private static final String SECOND_AGENT_ORIGIN_ID = "ffff11112222333344445555";
+    private static final String SCHEDULE_ORIGIN_ID = "ffff11112222333344445555";
     private static final String NEW_AGENT_ID = "dddd11112222333344445555";
     private static final String WORKFLOW_ORIGIN_ID = "bbbb11112222333344445555";
     private static final String NEW_WORKFLOW_ID = "cccc11112222333344445555";
@@ -244,17 +246,19 @@ class RestImportServiceRollbackAndCleanupTest {
             var workflowStore = mock(IWorkflowStore.class);
             var agentStore = mock(IAgentStore.class);
             var capabilityRegistry = mock(CapabilityRegistryService.class);
-            stubTwoCapableAgentsZip();
+            var restScheduleStore = mock(IRestScheduleStore.class);
+            stubOneCapableAgentWithOneScheduleZip();
 
             when(workflowStore.create(any())).thenReturn(resourceId(NEW_WORKFLOW_ID, 1));
-            // The first Agent lands and is registered; the second blows up, so
-            // everything this ZIP created so far is rolled back.
-            when(agentStore.create(any()))
-                    .thenReturn(resourceId(NEW_AGENT_ID, 1))
-                    .thenThrow(new IResourceStore.ResourceStoreException("agent store unavailable"));
+            // The Agent lands and is registered; the archive's schedule — the first
+            // write after it — blows up, so everything this ZIP created is rolled back.
+            when(agentStore.create(any())).thenReturn(resourceId(NEW_AGENT_ID, 1));
+            when(restScheduleStore.createSchedule(any()))
+                    .thenThrow(new IllegalStateException("schedule store unavailable"));
 
             try (MockedStatic<CDI> cdiMock = mockStatic(CDI.class)) {
-                stubCdi(cdiMock, workflowStore, agentStore, capabilityRegistry);
+                stubBean(stubCdi(cdiMock, workflowStore, agentStore, capabilityRegistry),
+                        IRestScheduleStore.class, restScheduleStore);
 
                 assertThrows(InternalServerErrorException.class,
                         () -> importService.importAgent(
@@ -315,17 +319,19 @@ class RestImportServiceRollbackAndCleanupTest {
             var workflowStore = mock(IWorkflowStore.class);
             var agentStore = mock(IAgentStore.class);
             var capabilityRegistry = mock(CapabilityRegistryService.class);
-            stubTwoCapableAgentsZip();
+            var restScheduleStore = mock(IRestScheduleStore.class);
+            stubOneCapableAgentWithOneScheduleZip();
 
             when(workflowStore.create(any())).thenReturn(resourceId(NEW_WORKFLOW_ID, 1));
-            when(agentStore.create(any()))
-                    .thenReturn(resourceId(NEW_AGENT_ID, 1))
-                    .thenThrow(new IResourceStore.ResourceStoreException("agent store unavailable"));
+            when(agentStore.create(any())).thenReturn(resourceId(NEW_AGENT_ID, 1));
+            when(restScheduleStore.createSchedule(any()))
+                    .thenThrow(new IllegalStateException("schedule store unavailable"));
             doThrow(new IllegalStateException("registry unavailable"))
                     .when(capabilityRegistry).unregister(anyString());
 
             try (MockedStatic<CDI> cdiMock = mockStatic(CDI.class)) {
-                stubCdi(cdiMock, workflowStore, agentStore, capabilityRegistry);
+                stubBean(stubCdi(cdiMock, workflowStore, agentStore, capabilityRegistry),
+                        IRestScheduleStore.class, restScheduleStore);
 
                 assertThrows(InternalServerErrorException.class,
                         () -> importService.importAgent(
@@ -504,33 +510,35 @@ class RestImportServiceRollbackAndCleanupTest {
     }
 
     /**
-     * A ZIP holding TWO capability-declaring agents over one workflow — the shape
-     * that makes a half-imported ZIP reachable: the first agent is created (and
-     * registered) before the second one fails. Both files deserialize to the same
-     * configuration, so the assertions do not depend on the order
-     * {@code Files.newDirectoryStream} happens to return them in.
+     * As {@link #stubOneCapableAgentZip()}, plus a {@code schedules/} directory
+     * holding one schedule — the shape that makes a half-imported ZIP reachable
+     * from a single-agent archive, which is the only kind the import accepts.
+     * <p>
+     * Schedules carry the id of the agent they fire, so they are deliberately
+     * written <em>after</em> the Agent exists (and its skills are registered) and
+     * before the descriptor bookkeeping. A schedule that cannot be written fails
+     * the whole import, so it is the first thing that can blow up with a registered
+     * Agent already recorded on the transaction.
      */
-    private void stubTwoCapableAgentsZip() throws Exception {
-        URI workflowUri = URI.create(
-                "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ORIGIN_ID + "?version=1");
+    private void stubOneCapableAgentWithOneScheduleZip() throws Exception {
+        stubOneCapableAgentZip();
 
         doAnswer(inv -> {
             File dir = inv.getArgument(1);
             dir.mkdirs();
             Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "AGENTJSON");
-            Files.writeString(new File(dir, SECOND_AGENT_ORIGIN_ID + ".agent.json").toPath(), "AGENTJSON");
             File workflowDir = new File(new File(dir, WORKFLOW_ORIGIN_ID), "1");
             workflowDir.mkdirs();
             Files.writeString(new File(workflowDir, WORKFLOW_ORIGIN_ID + ".workflow.json").toPath(), "WORKFLOWJSON");
+            File schedulesDir = new File(dir, "schedules");
+            schedulesDir.mkdirs();
+            Files.writeString(new File(schedulesDir, SCHEDULE_ORIGIN_ID + ".schedule.json").toPath(), "SCHEDULEJSON");
             return null;
         }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-        var agentConfig = new AgentConfiguration();
-        agentConfig.setWorkflows(List.of(workflowUri));
-        agentConfig.setCapabilities(List.of(new AgentConfiguration.Capability("translation", Map.of(), "high")));
-        when(jsonSerialization.deserialize(eq("AGENTJSON"), eq(AgentConfiguration.class))).thenReturn(agentConfig);
-        when(jsonSerialization.deserialize(eq("WORKFLOWJSON"), eq(WorkflowConfiguration.class)))
-                .thenReturn(new WorkflowConfiguration());
+        var schedule = new ScheduleConfiguration();
+        schedule.setName("nightly");
+        when(jsonSerialization.deserialize(eq("SCHEDULEJSON"), eq(ScheduleConfiguration.class))).thenReturn(schedule);
     }
 
     /**
@@ -594,8 +602,8 @@ class RestImportServiceRollbackAndCleanupTest {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private static void stubCdi(MockedStatic<CDI> cdiMock, IWorkflowStore workflowStore, IAgentStore agentStore,
-                                CapabilityRegistryService capabilityRegistry) {
+    private static CDI stubCdi(MockedStatic<CDI> cdiMock, IWorkflowStore workflowStore, IAgentStore agentStore,
+                               CapabilityRegistryService capabilityRegistry) {
         CDI cdi = mock(CDI.class);
         cdiMock.when(CDI::current).thenReturn(cdi);
 
@@ -610,6 +618,16 @@ class RestImportServiceRollbackAndCleanupTest {
         Instance<CapabilityRegistryService> registryInstance = mock(Instance.class);
         when(cdi.select(CapabilityRegistryService.class)).thenReturn(registryInstance);
         when(registryInstance.get()).thenReturn(capabilityRegistry);
+
+        return cdi;
+    }
+
+    /** Adds one more bean to a {@link CDI} already stubbed by {@link #stubCdi}. */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> void stubBean(CDI cdi, Class<T> beanClass, T bean) {
+        Instance<T> instance = mock(Instance.class);
+        when(cdi.select(beanClass)).thenReturn(instance);
+        when(instance.get()).thenReturn(bean);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.backup.impl;
 
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.UpgradeResult;
@@ -98,7 +99,7 @@ class RestImportServiceRollbackAndCleanupTest {
                 zipArchive, jsonSerialization,
                 mock(IMigrationManager.class), documentDescriptorStore,
                 mock(TemplateSyntaxMigrator.class), structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
-                mock(ResourceAccessGuard.class));
+                mock(ResourceAccessGuard.class), mock(SpaceContext.class));
     }
 
     // ==================== D11 — rollback of a partial import ====================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceScheduleFailureTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceScheduleFailureTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -404,8 +405,36 @@ class RestImportServiceScheduleFailureTest {
         }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
     }
 
+    /**
+     * The pairwise helpers below read {@code classThenStore[i + 1]}, so an odd
+     * argument count used to walk off the end of the varargs array and fail with a
+     * bare {@code ArrayIndexOutOfBoundsException} naming neither the helper nor the
+     * missing store. The guard also has to run BEFORE
+     * {@code mockStatic(CDI.class)}, or a rejected call leaks a static mock into
+     * the next test in the class.
+     */
+    @Test
+    @DisplayName("stubCdi rejects an odd argument count instead of reading past the array")
+    void stubCdiRejectsAnUnpairedArgument() {
+        var thrown = assertThrows(IllegalArgumentException.class, () -> stubCdi(IAgentStore.class));
+        assertTrue(thrown.getMessage().contains("PAIRS"),
+                "the message must say what is wrong, not just that something is: " + thrown.getMessage());
+        assertDoesNotThrow(() -> {
+            try (var ignored = stubCdi()) {
+                // An empty (even) argument list is legitimate and must still work; if the
+                // guard had leaked a static CDI mock on the rejected call above, opening
+                // this second one would fail.
+            }
+        }, "the rejected call must not have left a static CDI mock registered");
+    }
+
     @SuppressWarnings("unchecked")
     private AutoCloseable stubCdi(Object... classThenStore) {
+        if (classThenStore.length % 2 != 0) {
+            throw new IllegalArgumentException("stubCdi takes (interface, store) PAIRS; got "
+                    + classThenStore.length + " argument(s). An odd count means a store was left off, and the "
+                    + "loop below would read past the end of the array instead of saying so.");
+        }
         var cdiMock = mockStatic(CDI.class);
         var cdi = mock(CDI.class);
         cdiMock.when(CDI::current).thenReturn(cdi);

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceScheduleFailureTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceScheduleFailureTest.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IZipArchive;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.migration.IMigrationManager;
+import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
+import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.schedule.IRestScheduleStore;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.quarkus.security.ForbiddenException;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * What an import does when the schedule surface refuses, misbehaves, or cannot
+ * be read.
+ * <p>
+ * Restoring an agent whose nightly job is silently missing is the failure that
+ * importing schedules at all exists to remove, so none of these paths may end
+ * in a quiet 201. Equally, a merge that overwrites a live cron must be able to
+ * put it back: the rollback that restores the agent is worthless if the
+ * operator's schedule stays replaced by the archive's.
+ */
+@DisplayName("RestImportService — schedules that cannot be written")
+class RestImportServiceScheduleFailureTest {
+
+    private static final String AGENT_ORIGIN_ID = "aabb11112222333344445555";
+    private static final String NEW_AGENT_ID = "ccdd11112222333344445555";
+
+    private IZipArchive zipArchive;
+    private IJsonSerialization jsonSerialization;
+    private IDocumentDescriptorStore documentDescriptorStore;
+    private IScheduleStore scheduleStore;
+    private IRestScheduleStore restScheduleStore;
+    private SpaceContext spaceContext;
+    private BackupMetrics metrics;
+    private RestImportService importService;
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    private int createdSchedules;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        zipArchive = mock(IZipArchive.class);
+        jsonSerialization = mock(IJsonSerialization.class);
+        documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        scheduleStore = mock(IScheduleStore.class);
+        restScheduleStore = mock(IRestScheduleStore.class);
+        spaceContext = mock(SpaceContext.class);
+        metrics = mock(BackupMetrics.class);
+
+        doAnswer(inv -> {
+            ScheduleConfiguration created = inv.getArgument(0);
+            if (created != null) {
+                created.setId("newSched" + (++createdSchedules));
+            }
+            return Response.status(201).entity(created).build();
+        }).when(restScheduleStore).createSchedule(any());
+        doReturn(Response.ok().build()).when(restScheduleStore).updateSchedule(anyString(), any());
+
+        var templateSyntaxMigrator = mock(TemplateSyntaxMigrator.class);
+        when(templateSyntaxMigrator.migrate(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+        importService = new RestImportService(
+                zipArchive, jsonSerialization,
+                mock(IMigrationManager.class), documentDescriptorStore,
+                templateSyntaxMigrator, mock(StructuralMatcher.class),
+                mock(UpgradeExecutor.class), scheduleStore, metrics,
+                mock(ResourceAccessGuard.class), spaceContext);
+
+        when(jsonSerialization.deserialize(anyString(), eq(AgentConfiguration.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), AgentConfiguration.class));
+        when(jsonSerialization.deserialize(anyString(), eq(DocumentDescriptor.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), DocumentDescriptor.class));
+        when(jsonSerialization.deserialize(anyString(), eq(ScheduleConfiguration.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), ScheduleConfiguration.class));
+    }
+
+    /**
+     * A {@code schedules/} directory holding nothing the importer recognises is not
+     * a failure and not a skipped-schedule count either — there was nothing to
+     * import.
+     */
+    @Test
+    @DisplayName("a schedules directory with no schedule files is imported as nothing")
+    void emptySchedulesDirectoryIsNotAnError() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            File schedules = new File(dir, "schedules");
+            assertTrue(schedules.mkdirs());
+            Files.writeString(new File(schedules, "README.txt").toPath(), "not a schedule");
+        });
+
+        Response response = runImport("create", null);
+
+        assertEquals(201, response.getStatus());
+        assertNull(response.getHeaderString("X-Schedules-Skipped"),
+                "nothing was left out, so nothing may be reported as left out");
+        verify(restScheduleStore, never()).createSchedule(any());
+    }
+
+    /**
+     * The schedule API's own refusal — an agent the caller may not use, a HITL
+     * timer nobody may mint, an invalid cron — must reach the caller with its own
+     * status. Reporting it as a 500 tells the operator the server is broken about a
+     * request the platform deliberately declined.
+     */
+    @Test
+    @DisplayName("a refusal from the schedule API keeps its status instead of becoming a 500")
+    void scheduleApiRefusalKeepsItsStatus() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSchedule(dir, "sched1", "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"other\"}");
+        });
+        doReturn(Response.status(403).entity("agent not usable by this caller").build())
+                .when(restScheduleStore).createSchedule(any());
+
+        var thrown = assertThrows(WebApplicationException.class, () -> runImport("create", null));
+
+        assertEquals(403, thrown.getResponse().getStatus());
+        assertTrue(thrown.getMessage().contains("agent not usable by this caller"),
+                "the refusal's own reason must survive: " + thrown.getMessage());
+        verify(metrics).importFailed();
+    }
+
+    /**
+     * A schedule surface that answers nothing at all is a server fault, and must be
+     * reported as one rather than counted as an import that succeeded.
+     */
+    @Test
+    @DisplayName("a schedule surface answering nothing fails the import as a 500")
+    void scheduleApiAnsweringNothingIsAServerError() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSchedule(dir, "sched1", "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"other\"}");
+        });
+        doReturn(null).when(restScheduleStore).createSchedule(any());
+
+        var thrown = assertThrows(WebApplicationException.class, () -> runImport("create", null));
+
+        assertEquals(500, thrown.getResponse().getStatus());
+    }
+
+    /**
+     * The platform's own authorization refusal is a 403 the caller can act on. The
+     * import's catch-all would otherwise turn it into "the server is broken".
+     */
+    @Test
+    @DisplayName("a ForbiddenException from the schedule API reaches the caller as a 403")
+    void forbiddenFromScheduleApiIsNotRepackaged() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSchedule(dir, "sched1", "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"other\"}");
+        });
+        var forbidden = new ForbiddenException("not allowed to run as that user");
+        doThrow(forbidden).when(restScheduleStore).createSchedule(any());
+
+        var thrown = assertThrows(ForbiddenException.class, () -> runImport("create", null));
+
+        assertEquals(forbidden.getMessage(), thrown.getMessage());
+        verify(metrics).importFailed();
+    }
+
+    /**
+     * Failing closed here would refuse a restore because the store hiccuped.
+     * Failing open re-creates a schedule the agent already has — visible and
+     * deletable, which is the lesser harm — so the merge continues.
+     */
+    @Test
+    @DisplayName("a store that cannot list the agent's schedules still lets the merge finish")
+    void unlistableExistingSchedulesFallBackToCreating() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSchedule(dir, "sched1", "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"other\"}");
+        });
+        stubExistingAgentForMerge();
+        doAnswer(inv -> {
+            throw new IllegalStateException("schedule listing unavailable");
+        }).when(scheduleStore).readSchedulesByAgentId(NEW_AGENT_ID);
+
+        Response response = runImport("merge", null);
+
+        assertEquals(201, response.getStatus());
+        verify(restScheduleStore).createSchedule(any());
+        verify(restScheduleStore, never()).updateSchedule(anyString(), any());
+    }
+
+    /**
+     * A schedule this import could not snapshot is one it must not overwrite: an
+     * overwrite it cannot undo would survive the rollback that puts everything else
+     * back. It is imported as a new schedule instead.
+     */
+    @Test
+    @DisplayName("a target schedule that cannot be snapshotted is added, never overwritten")
+    void unsnapshottableTargetIsCreatedInstead() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSchedule(dir, "sched1", "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"other\"}");
+        });
+        stubExistingAgentForMerge();
+
+        var existing = new ScheduleConfiguration();
+        existing.setId("alreadyHere");
+        existing.setName("nightly");
+        when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(existing));
+        doAnswer(inv -> {
+            throw new IllegalStateException("cannot read that schedule");
+        }).when(scheduleStore).readSchedule("alreadyHere");
+
+        Response response = runImport("merge", null);
+
+        assertEquals(201, response.getStatus());
+        verify(restScheduleStore, never()).updateSchedule(anyString(), any());
+        verify(restScheduleStore).createSchedule(any());
+    }
+
+    /**
+     * The rollback is what makes a merge safe to retry. When it, too, cannot write,
+     * it says so and lets the original failure stand — a rollback error must never
+     * mask the error that caused it.
+     */
+    @Test
+    @DisplayName("a rollback that cannot restore the overwritten schedule does not mask the original failure")
+    void failingRollbackDoesNotMaskTheOriginalFailure() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSchedule(dir, "sched1", "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"other\"}");
+            writeSchedule(dir, "sched2", "{\"id\":\"sched2\",\"name\":\"hourly\",\"agentId\":\"other\"}");
+        });
+        stubExistingAgentForMerge();
+
+        var existing = new ScheduleConfiguration();
+        existing.setId("alreadyHere");
+        existing.setName("nightly");
+        when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(existing));
+        when(scheduleStore.readSchedule("alreadyHere")).thenReturn(existing);
+        // The second archived schedule has no match, so it is created — and refused.
+        doReturn(Response.status(400).entity("invalid cron").build())
+                .when(restScheduleStore).createSchedule(any());
+        doAnswer(inv -> {
+            throw new IllegalStateException("restore unavailable");
+        }).when(scheduleStore).updateSchedule(eq("alreadyHere"), any());
+
+        var thrown = assertThrows(WebApplicationException.class, () -> runImport("merge", null));
+
+        assertEquals(400, thrown.getResponse().getStatus(),
+                "the caller must see why the import failed, not why the rollback did");
+        // The rollback was attempted through the raw store, which re-applies no
+        // defaults and recomputes no nextFire.
+        verify(scheduleStore).updateSchedule(eq("alreadyHere"), any());
+    }
+
+    /**
+     * A schedule's {@code userId} is the identity every fire acts as. The archive's
+     * value is kept only when it already names the importing caller; a merge that
+     * finds no identity to carry keeps the one the target had, so a re-promotion
+     * cannot strip an owner an operator assigned here.
+     */
+    @Test
+    @DisplayName("a merge keeps the importer's own identity and does not adopt the target's")
+    void mergeKeepsTheImportersOwnIdentity() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSchedule(dir, "sched1",
+                    "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"other\",\"userId\":\"alice\"}");
+        });
+        stubExistingAgentForMerge();
+        when(spaceContext.currentPrincipal()).thenReturn("alice");
+
+        var existing = new ScheduleConfiguration();
+        existing.setId("alreadyHere");
+        existing.setName("nightly");
+        existing.setUserId("bob");
+        when(scheduleStore.readSchedulesByAgentId(NEW_AGENT_ID)).thenReturn(List.of(existing));
+        when(scheduleStore.readSchedule("alreadyHere")).thenReturn(existing);
+
+        runImport("merge", null);
+
+        var captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
+        verify(restScheduleStore, times(1)).updateSchedule(eq("alreadyHere"), captor.capture());
+        assertEquals("alice", captor.getValue().getUserId(),
+                "an identity that already names the importer is the one case the archive's value is known to be right");
+    }
+
+    /**
+     * With no identity in the archive at all there is nothing to carry over and
+     * nothing to reject — the schedule surface files it under the system scheduler,
+     * and the import must not invent an owner on the way.
+     */
+    @Test
+    @DisplayName("a schedule with a blank userId is imported without one")
+    void blankUserIdIsLeftAlone() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSchedule(dir, "sched1",
+                    "{\"id\":\"sched1\",\"name\":\"nightly\",\"agentId\":\"other\",\"userId\":\"\"}");
+        });
+        when(spaceContext.currentPrincipal()).thenReturn("alice");
+
+        runImport("create", null);
+
+        var captor = ArgumentCaptor.forClass(ScheduleConfiguration.class);
+        verify(restScheduleStore).createSchedule(captor.capture());
+        assertEquals("", captor.getValue().getUserId(),
+                "there is no foreign identity to reject, so nothing is rewritten");
+    }
+
+    // ==================== Helpers ====================
+
+    private Response runImport(String strategy, String selectedResources) throws Exception {
+        var agentStore = mock(IAgentStore.class);
+        when(agentStore.create(any())).thenReturn(resourceId(NEW_AGENT_ID, 1));
+        when(documentDescriptorStore.getCurrentResourceId(NEW_AGENT_ID)).thenReturn(resourceId(NEW_AGENT_ID, 1));
+        var descriptor = new DocumentDescriptor();
+        descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=1"));
+        when(documentDescriptorStore.readDescriptor(NEW_AGENT_ID, 1)).thenReturn(descriptor);
+
+        var restAgentStore = mock(IRestAgentStore.class);
+        when(restAgentStore.updateAgent(anyString(), anyInt(), any())).thenReturn(Response.ok().build());
+
+        try (var cdi = stubCdi(IAgentStore.class, agentStore,
+                IRestScheduleStore.class, restScheduleStore,
+                IRestAgentStore.class, restAgentStore)) {
+            return importService.importAgent(new ByteArrayInputStream(new byte[0]), strategy,
+                    selectedResources, null, null);
+        }
+    }
+
+    /** Makes the archived agent match an agent this deployment already has. */
+    private void stubExistingAgentForMerge() throws Exception {
+        var existingDescriptor = new DocumentDescriptor();
+        existingDescriptor.setResource(URI.create(
+                "eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=4"));
+        when(documentDescriptorStore.findByOriginId(AGENT_ORIGIN_ID))
+                .thenReturn(List.of(existingDescriptor));
+    }
+
+    private static void writeAgent(File dir) throws IOException {
+        Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+    }
+
+    private static void writeSchedule(File dir, String fileName, String json) throws IOException {
+        File schedules = new File(dir, "schedules");
+        assertTrue(schedules.mkdirs() || schedules.isDirectory());
+        Files.writeString(new File(schedules, fileName + ".schedule.json").toPath(), json);
+    }
+
+    private interface ArchiveContent {
+        void write(File dir) throws IOException;
+    }
+
+    private void stubUnzip(ArchiveContent content) throws Exception {
+        doAnswer(inv -> {
+            File dir = inv.getArgument(1);
+            assertTrue(dir.mkdirs() || dir.isDirectory());
+            content.write(dir);
+            return null;
+        }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private AutoCloseable stubCdi(Object... classThenStore) {
+        var cdiMock = mockStatic(CDI.class);
+        var cdi = mock(CDI.class);
+        cdiMock.when(CDI::current).thenReturn(cdi);
+        for (int i = 0; i < classThenStore.length; i += 2) {
+            select(cdi, (Class<Object>) classThenStore[i], classThenStore[i + 1]);
+        }
+        return cdiMock;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> void select(CDI cdi, Class<T> storeClass, T store) {
+        var instance = (Instance<T>) mock(Instance.class);
+        when(cdi.select(storeClass)).thenReturn(instance);
+        when(instance.get()).thenReturn(store);
+    }
+
+    private static IResourceId resourceId(String id, int version) {
+        return new IResourceId() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return version;
+            }
+        };
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSnippetResilienceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSnippetResilienceTest.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IZipArchive;
+import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
+import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.migration.IMigrationManager;
+import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
+import ai.labs.eddi.configs.snippets.IPromptSnippetStore;
+import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
+import ai.labs.eddi.configs.snippets.model.PromptSnippet;
+import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.description;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Snippets are global resources an archive carries alongside the agent, and
+ * they are deliberately best-effort: a snippet store that is unreachable,
+ * inconsistent, or holding a half-written document must cost the snippet, never
+ * the agent the operator was actually restoring.
+ * <p>
+ * The preview obeys the same rule — a row it cannot build is a row it leaves
+ * out, so the wizard still has something to show.
+ */
+@DisplayName("RestImportService — snippet resilience")
+class RestImportServiceSnippetResilienceTest {
+
+    private static final String AGENT_ORIGIN_ID = "aabb11112222333344445555";
+    private static final String NEW_AGENT_ID = "ccdd11112222333344445555";
+    private static final String EXISTING_SNIPPET_ID = "eeee11112222333344445555";
+    private static final String CREATED_SNIPPET_ID = "ffff11112222333344445555";
+
+    private IZipArchive zipArchive;
+    private IJsonSerialization jsonSerialization;
+    private IDocumentDescriptorStore documentDescriptorStore;
+    private IRestPromptSnippetStore restSnippetStore;
+    private RestImportService importService;
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @BeforeEach
+    void setUp() throws Exception {
+        zipArchive = mock(IZipArchive.class);
+        jsonSerialization = mock(IJsonSerialization.class);
+        documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        restSnippetStore = mock(IRestPromptSnippetStore.class);
+
+        var templateSyntaxMigrator = mock(TemplateSyntaxMigrator.class);
+        when(templateSyntaxMigrator.migrate(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+        importService = new RestImportService(
+                zipArchive, jsonSerialization,
+                mock(IMigrationManager.class), documentDescriptorStore,
+                templateSyntaxMigrator, mock(StructuralMatcher.class),
+                mock(UpgradeExecutor.class), mock(IScheduleStore.class), mock(BackupMetrics.class),
+                mock(ResourceAccessGuard.class), mock(SpaceContext.class));
+
+        when(jsonSerialization.deserialize(anyString(), eq(AgentConfiguration.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), AgentConfiguration.class));
+        when(jsonSerialization.deserialize(anyString(), eq(DocumentDescriptor.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), DocumentDescriptor.class));
+        when(jsonSerialization.deserialize(anyString(), eq(PromptSnippet.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), PromptSnippet.class));
+    }
+
+    /**
+     * A snippet whose name is missing has no natural key — nothing can be matched
+     * or deduplicated against it — so it is left out of the preview rather than
+     * shown as a row that cannot be acted on.
+     */
+    @Test
+    @DisplayName("the preview lists no row for a nameless or unparseable snippet")
+    void namelessAndUnparseableSnippetsAreNotPreviewed() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSnippet(dir, "nameless", "{\"content\":\"no name here\"}");
+            writeSnippet(dir, "broken", "this is not json at all");
+            writeSnippet(dir, "good", "{\"name\":\"cautious_mode\",\"content\":\"be careful\"}");
+        });
+        when(restSnippetStore.readSnippetDescriptors("", 0, 0)).thenReturn(List.of());
+
+        ImportPreview preview = previewImport();
+
+        List<String> snippetNames = preview.resources().stream()
+                .filter(diff -> "snippet".equals(diff.resourceType()))
+                .map(ResourceDiff::name)
+                .toList();
+        assertEquals(List.of("cautious_mode"), snippetNames,
+                "only a snippet with a usable natural key may become a row");
+    }
+
+    /**
+     * The preview's CREATE/UPDATE split comes from a name lookup over every
+     * existing snippet. A descriptor that names no resource, and a snippet the
+     * store cannot hand back, must each drop out of that lookup instead of aborting
+     * it — otherwise one bad document turns every snippet in the archive into a
+     * CREATE that then duplicates the ones already here.
+     */
+    @Test
+    @DisplayName("a descriptor with no resource, and one the store cannot read, do not break the name lookup")
+    void brokenDescriptorsDoNotBreakTheNameLookup() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSnippet(dir, "good", "{\"name\":\"cautious_mode\",\"content\":\"be careful\"}");
+        });
+
+        var noResource = new DocumentDescriptor();
+        var unreadable = new DocumentDescriptor();
+        unreadable.setResource(URI.create(
+                "eddi://ai.labs.snippet/snippetstore/snippets/1111222233334444aaaabbbb?version=1"));
+        var usable = new DocumentDescriptor();
+        usable.setResource(URI.create(
+                "eddi://ai.labs.snippet/snippetstore/snippets/" + EXISTING_SNIPPET_ID + "?version=2"));
+
+        when(restSnippetStore.readSnippetDescriptors("", 0, 0))
+                .thenReturn(List.of(noResource, unreadable, usable));
+        doAnswer(inv -> {
+            throw new IllegalStateException("snippet unreadable");
+        }).when(restSnippetStore).readSnippet("1111222233334444aaaabbbb", 1);
+        var existing = new PromptSnippet();
+        existing.setName("cautious_mode");
+        when(restSnippetStore.readSnippet(EXISTING_SNIPPET_ID, 2)).thenReturn(existing);
+
+        ImportPreview preview = previewImport();
+
+        ResourceDiff snippetRow = preview.resources().stream()
+                .filter(diff -> "snippet".equals(diff.resourceType()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no snippet row: " + preview.resources()));
+        assertEquals(DiffAction.UPDATE, snippetRow.action(),
+                "the readable descriptor must still be found, so the import updates rather than duplicates");
+        assertEquals(EXISTING_SNIPPET_ID, snippetRow.targetId());
+    }
+
+    /**
+     * A snippet store that will not list at all costs the CREATE/UPDATE split, and
+     * nothing more: every archived snippet is previewed as new, which is the
+     * conservative reading, and the agent rows are untouched.
+     */
+    @Test
+    @DisplayName("a snippet store that cannot list still leaves the agent previewable")
+    void unlistableSnippetStoreStillPreviewsTheAgent() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSnippet(dir, "good", "{\"name\":\"cautious_mode\",\"content\":\"be careful\"}");
+        });
+        doAnswer(inv -> {
+            throw new IllegalStateException("snippet store unavailable");
+        }).when(restSnippetStore).readSnippetDescriptors("", 0, 0);
+
+        ImportPreview preview = previewImport();
+
+        assertEquals(AGENT_ORIGIN_ID, preview.sourceAgentId());
+        assertTrue(preview.resources().stream().anyMatch(diff -> "agent".equals(diff.resourceType())),
+                "the agent row must survive a snippet store that will not answer");
+        assertEquals(DiffAction.CREATE, preview.resources().stream()
+                .filter(diff -> "snippet".equals(diff.resourceType()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no snippet row: " + preview.resources()))
+                .action());
+    }
+
+    /**
+     * The import itself follows the same rule: a snippet surface that is not there
+     * must not fail the restore of the agent that came with it.
+     */
+    @Test
+    @DisplayName("an unreachable snippet surface does not fail the agent import")
+    void unreachableSnippetSurfaceDoesNotFailTheImport() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSnippet(dir, "good", "{\"name\":\"cautious_mode\",\"content\":\"be careful\"}");
+        });
+        doAnswer(inv -> {
+            throw new IllegalStateException("snippet store unavailable");
+        }).when(restSnippetStore).readSnippetDescriptors("", 0, 0);
+        doAnswer(inv -> {
+            throw new IllegalStateException("snippet store unavailable");
+        }).when(restSnippetStore).createSnippet(any());
+
+        Response response = runImport();
+
+        assertEquals(201, response.getStatus(),
+                "the agent is what the operator asked to restore; a snippet must not take it down");
+    }
+
+    /**
+     * A snippet this import created is as much an orphan as a workflow when a later
+     * resource blows up, so it is recorded on the import transaction and deleted
+     * again on rollback. The id comes from the {@code X-Resource-URI} header rather
+     * than {@code Response.getLocation()}, which JAX-RS reports as {@code null} for
+     * the {@code eddi://} scheme on an in-process call — read the wrong header and
+     * every imported snippet silently survives a failed import.
+     * <p>
+     * <strong>Premise.</strong> The failure is injected at the agent write, so the
+     * test depends on {@code unpackAndImportAgent} importing snippets
+     * <em>before</em> it creates the agent. That is deliberate — snippets are
+     * global and could plausibly be moved later — so the ordering is asserted
+     * first, with its own message: if a reorder ever makes the snippet write
+     * unreachable, this fails saying so rather than looking like a broken rollback.
+     */
+    @Test
+    @DisplayName("a snippet created by a failed import is deleted again on rollback")
+    void createdSnippetIsRolledBackWhenTheImportFails() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSnippet(dir, "good", "{\"name\":\"cautious_mode\",\"content\":\"be careful\"}");
+        });
+        when(restSnippetStore.readSnippetDescriptors("", 0, 0)).thenReturn(List.of());
+        doReturn(created(CREATED_SNIPPET_ID)).when(restSnippetStore).createSnippet(any());
+
+        var snippetStore = mock(IPromptSnippetStore.class);
+        assertThrows(InternalServerErrorException.class, () -> runFailingImport(snippetStore));
+
+        verify(restSnippetStore, description("premise: snippets must be imported before the failing agent write, "
+                + "otherwise there is no created snippet for the rollback to undo")).createSnippet(any());
+        verify(snippetStore).deleteAllPermanently(CREATED_SNIPPET_ID);
+        verify(documentDescriptorStore).deleteAllDescriptor(CREATED_SNIPPET_ID);
+    }
+
+    /**
+     * The mirror image: a merge matches an archived snippet to the local one of the
+     * same name and updates it in place, rather than creating a second snippet with
+     * the same natural key. And because that snippet already existed, it is not
+     * this import's to delete — rolling it back would destroy a snippet other
+     * agents share.
+     */
+    @Test
+    @DisplayName("a merge updates the snippet of the same name instead of duplicating it")
+    void updatedSnippetIsNotRolledBack() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSnippet(dir, "good", "{\"name\":\"cautious_mode\",\"content\":\"be careful\"}");
+        });
+        var descriptor = new DocumentDescriptor();
+        descriptor.setResource(URI.create(
+                "eddi://ai.labs.snippet/snippetstore/snippets/" + EXISTING_SNIPPET_ID + "?version=2"));
+        when(restSnippetStore.readSnippetDescriptors("", 0, 0)).thenReturn(List.of(descriptor));
+        var existing = new PromptSnippet();
+        existing.setName("cautious_mode");
+        when(restSnippetStore.readSnippet(EXISTING_SNIPPET_ID, 2)).thenReturn(existing);
+        doReturn(Response.status(200).build()).when(restSnippetStore).updateSnippet(eq(EXISTING_SNIPPET_ID), eq(2), any());
+
+        var snippetStore = mock(IPromptSnippetStore.class);
+        assertThrows(InternalServerErrorException.class, () -> runFailingImport(snippetStore, true));
+
+        verify(restSnippetStore).updateSnippet(eq(EXISTING_SNIPPET_ID), eq(2), any());
+        verify(restSnippetStore, never()).createSnippet(any());
+        verify(snippetStore, never()).deleteAllPermanently(anyString());
+    }
+
+    /**
+     * The snippet surface is looked up from CDI <em>outside</em> the per-file guard
+     * — a deployment where the prompt-snippet extension is not installed fails
+     * there and never reaches it. That used to take the whole preview with it. It
+     * costs the snippets and nothing else: the agent row is still there, and no
+     * snippet row is invented for a store nobody could ask.
+     */
+    @Test
+    @DisplayName("a snippet store CDI cannot resolve costs the snippet rows, not the preview")
+    void unresolvableSnippetBeanCostsOnlyTheSnippetRows() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSnippet(dir, "good", "{\"name\":\"cautious_mode\",\"content\":\"be careful\"}");
+        });
+
+        ImportPreview preview;
+        try (var cdi = stubCdiWithUnresolvableSnippetStore()) {
+            preview = importService.previewImport(new ByteArrayInputStream(new byte[0]), null);
+        }
+
+        assertEquals(AGENT_ORIGIN_ID, preview.sourceAgentId());
+        assertTrue(preview.resources().stream().anyMatch(diff -> "agent".equals(diff.resourceType())),
+                "the agent row must survive a snippet bean that cannot be resolved");
+        assertTrue(preview.resources().stream().noneMatch(diff -> "snippet".equals(diff.resourceType())),
+                "no snippet row can be built without the store, and a guessed one would be worse: "
+                        + preview.resources());
+    }
+
+    /**
+     * And the same on the import: the restore the operator asked for still lands.
+     */
+    @Test
+    @DisplayName("a snippet store CDI cannot resolve does not fail the import")
+    void unresolvableSnippetBeanDoesNotFailTheImport() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            writeSnippet(dir, "good", "{\"name\":\"cautious_mode\",\"content\":\"be careful\"}");
+        });
+
+        var agentStore = mock(IAgentStore.class);
+        when(agentStore.create(any())).thenReturn(resourceId(NEW_AGENT_ID, 1));
+        when(documentDescriptorStore.getCurrentResourceId(NEW_AGENT_ID)).thenReturn(resourceId(NEW_AGENT_ID, 1));
+        var descriptor = new DocumentDescriptor();
+        descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=1"));
+        when(documentDescriptorStore.readDescriptor(NEW_AGENT_ID, 1)).thenReturn(descriptor);
+
+        Response response;
+        try (var cdi = stubCdiWithUnresolvableSnippetStore(IAgentStore.class, agentStore)) {
+            response = importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+        }
+
+        assertEquals(201, response.getStatus(),
+                "the agent is what the operator asked to restore; an unresolvable snippet bean must not take it down");
+        verify(agentStore).create(any());
+    }
+
+    // ==================== Helpers ====================
+
+    /** A 201 carrying the header {@code recordCreatedSnippet} reads the id from. */
+    private static Response created(String snippetId) {
+        return Response.status(201)
+                .header("X-Resource-URI",
+                        "eddi://ai.labs.snippet/snippetstore/snippets/" + snippetId + "?version=1")
+                .build();
+    }
+
+    private void runFailingImport(IPromptSnippetStore snippetStore) throws Exception {
+        runFailingImport(snippetStore, false);
+    }
+
+    /**
+     * Imports the archive with an agent store that refuses to write, which is what
+     * drives the rollback.
+     */
+    private void runFailingImport(IPromptSnippetStore snippetStore, boolean merge) throws Exception {
+        var agentStore = mock(IAgentStore.class);
+        when(agentStore.create(any())).thenThrow(new IllegalStateException("agent store is down"));
+
+        try (var cdi = stubCdi(IAgentStore.class, agentStore,
+                IRestPromptSnippetStore.class, restSnippetStore,
+                IPromptSnippetStore.class, snippetStore)) {
+            importService.importAgent(new ByteArrayInputStream(new byte[0]),
+                    merge ? "merge" : "create", null, null, null);
+        }
+    }
+
+    private ImportPreview previewImport() throws Exception {
+        try (var cdi = stubCdi(IRestPromptSnippetStore.class, restSnippetStore)) {
+            return importService.previewImport(new ByteArrayInputStream(new byte[0]), null);
+        }
+    }
+
+    private Response runImport() throws Exception {
+        var agentStore = mock(IAgentStore.class);
+        when(agentStore.create(any())).thenReturn(resourceId(NEW_AGENT_ID, 1));
+        when(documentDescriptorStore.getCurrentResourceId(NEW_AGENT_ID)).thenReturn(resourceId(NEW_AGENT_ID, 1));
+        var descriptor = new DocumentDescriptor();
+        descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=1"));
+        when(documentDescriptorStore.readDescriptor(NEW_AGENT_ID, 1)).thenReturn(descriptor);
+
+        try (var cdi = stubCdi(IAgentStore.class, agentStore, IRestPromptSnippetStore.class, restSnippetStore)) {
+            return importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+        }
+    }
+
+    private static void writeAgent(File dir) throws IOException {
+        Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "{\"workflows\":[]}");
+        Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".descriptor.json").toPath(), "{\"name\":\"Agent\"}");
+    }
+
+    private static void writeSnippet(File dir, String fileName, String json) throws IOException {
+        File snippets = new File(dir, "snippets");
+        assertTrue(snippets.mkdirs() || snippets.isDirectory());
+        Files.writeString(new File(snippets, fileName + ".snippet.json").toPath(), json);
+    }
+
+    private interface ArchiveContent {
+        void write(File dir) throws IOException;
+    }
+
+    private void stubUnzip(ArchiveContent content) throws Exception {
+        doAnswer(inv -> {
+            File dir = inv.getArgument(1);
+            assertTrue(dir.mkdirs() || dir.isDirectory());
+            content.write(dir);
+            return null;
+        }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
+    }
+
+    /**
+     * A CDI container that resolves everything asked of it except the snippet
+     * surface — the failure mode of a deployment where the prompt-snippet extension
+     * is not installed at all.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private AutoCloseable stubCdiWithUnresolvableSnippetStore(Object... classThenStore) {
+        var cdiMock = mockStatic(CDI.class);
+        var cdi = mock(CDI.class);
+        cdiMock.when(CDI::current).thenReturn(cdi);
+        for (int i = 0; i < classThenStore.length; i += 2) {
+            select(cdi, (Class<Object>) classThenStore[i], classThenStore[i + 1]);
+        }
+        when(cdi.select(IRestPromptSnippetStore.class))
+                .thenThrow(new UnsatisfiedResolutionException("no bean for IRestPromptSnippetStore"));
+        return cdiMock;
+    }
+
+    @SuppressWarnings("unchecked")
+    private AutoCloseable stubCdi(Object... classThenStore) {
+        var cdiMock = mockStatic(CDI.class);
+        var cdi = mock(CDI.class);
+        cdiMock.when(CDI::current).thenReturn(cdi);
+        for (int i = 0; i < classThenStore.length; i += 2) {
+            select(cdi, (Class<Object>) classThenStore[i], classThenStore[i + 1]);
+        }
+        return cdiMock;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> void select(CDI cdi, Class<T> storeClass, T store) {
+        var instance = (Instance<T>) mock(Instance.class);
+        when(cdi.select(storeClass)).thenReturn(instance);
+        when(instance.get()).thenReturn(store);
+    }
+
+    private static IResourceId resourceId(String id, int version) {
+        return new IResourceId() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return version;
+            }
+        };
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSnippetResilienceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSnippetResilienceTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -426,8 +427,36 @@ class RestImportServiceSnippetResilienceTest {
      * surface — the failure mode of a deployment where the prompt-snippet extension
      * is not installed at all.
      */
+    /**
+     * The pairwise helpers below read {@code classThenStore[i + 1]}, so an odd
+     * argument count used to walk off the end of the varargs array and fail with a
+     * bare {@code ArrayIndexOutOfBoundsException} naming neither the helper nor the
+     * missing store. The guard also has to run BEFORE
+     * {@code mockStatic(CDI.class)}, or a rejected call leaks a static mock into
+     * the next test in the class.
+     */
+    @Test
+    @DisplayName("stubCdi rejects an odd argument count instead of reading past the array")
+    void stubCdiRejectsAnUnpairedArgument() {
+        var thrown = assertThrows(IllegalArgumentException.class, () -> stubCdi(IAgentStore.class));
+        assertTrue(thrown.getMessage().contains("PAIRS"),
+                "the message must say what is wrong, not just that something is: " + thrown.getMessage());
+        assertDoesNotThrow(() -> {
+            try (var ignored = stubCdi()) {
+                // An empty (even) argument list is legitimate and must still work; if the
+                // guard had leaked a static CDI mock on the rejected call above, opening
+                // this second one would fail.
+            }
+        }, "the rejected call must not have left a static CDI mock registered");
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     private AutoCloseable stubCdiWithUnresolvableSnippetStore(Object... classThenStore) {
+        if (classThenStore.length % 2 != 0) {
+            throw new IllegalArgumentException("stubCdi takes (interface, store) PAIRS; got "
+                    + classThenStore.length + " argument(s). An odd count means a store was left off, and the "
+                    + "loop below would read past the end of the array instead of saying so.");
+        }
         var cdiMock = mockStatic(CDI.class);
         var cdi = mock(CDI.class);
         cdiMock.when(CDI::current).thenReturn(cdi);
@@ -441,6 +470,11 @@ class RestImportServiceSnippetResilienceTest {
 
     @SuppressWarnings("unchecked")
     private AutoCloseable stubCdi(Object... classThenStore) {
+        if (classThenStore.length % 2 != 0) {
+            throw new IllegalArgumentException("stubCdi takes (interface, store) PAIRS; got "
+                    + classThenStore.length + " argument(s). An odd count means a store was left off, and the "
+                    + "loop below would read past the end of the array instead of saying so.");
+        }
         var cdiMock = mockStatic(CDI.class);
         var cdi = mock(CDI.class);
         cdiMock.when(CDI::current).thenReturn(cdi);

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSyncCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSyncCoverageTest.java
@@ -4,25 +4,34 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.SyncMapping;
 import ai.labs.eddi.backup.model.SyncRequest;
+import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.net.URI;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -58,7 +67,8 @@ class RestImportServiceSyncCoverageTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
+                mock(ResourceAccessGuard.class));
     }
 
     // =========================================================
@@ -204,6 +214,94 @@ class RestImportServiceSyncCoverageTest {
             assertThrows(IllegalArgumentException.class,
                     () -> importService.executeSyncBatch("http://127.0.0.1:1", requests, null));
         }
+
+        @Test
+        @DisplayName("a batch where some agents failed answers 207 with one entry per request")
+        void partialFailureIsMultiStatus() {
+            when(upgradeExecutor.executeUpgrade(any(), eq(TARGET_A), any(), any()))
+                    .thenReturn(cleanResult(TARGET_A));
+            when(upgradeExecutor.executeUpgrade(any(), eq(TARGET_B), any(), any()))
+                    .thenThrow(new RuntimeException("remote refused the read"));
+
+            Response response = executeBatch();
+
+            // The endpoint used to answer 200 with the URIs that happened to work, so a
+            // batch in which agents failed was indistinguishable from one with nothing
+            // to do.
+            assertEquals(207, response.getStatus());
+            List<?> results = (List<?>) response.getEntity();
+            assertEquals(2, results.size(), "one entry per request, in request order");
+
+            var first = (RestImportService.BatchSyncResult) results.get(0);
+            assertEquals(TARGET_A, first.targetAgentId());
+            assertNull(first.error());
+            assertNotNull(first.result());
+
+            var second = (RestImportService.BatchSyncResult) results.get(1);
+            assertEquals(TARGET_B, second.targetAgentId());
+            assertNull(second.result());
+            assertTrue(second.error().contains("remote refused the read"), second.error());
+        }
+
+        @Test
+        @DisplayName("a batch where every agent failed is a 500, not a 200 with an empty list")
+        void totalFailureIsServerError() {
+            when(upgradeExecutor.executeUpgrade(any(), anyString(), any(), any()))
+                    .thenThrow(new RuntimeException("expired token"));
+
+            Response response = executeBatch();
+
+            assertEquals(500, response.getStatus());
+            assertEquals(2, ((List<?>) response.getEntity()).size());
+        }
+
+        @Test
+        @DisplayName("an agent whose own resources failed counts as failed, even though the sync ran")
+        void resourceFailuresCountTowardsTheBatchStatus() {
+            when(upgradeExecutor.executeUpgrade(any(), eq(TARGET_A), any(), any()))
+                    .thenReturn(cleanResult(TARGET_A));
+            when(upgradeExecutor.executeUpgrade(any(), eq(TARGET_B), any(), any()))
+                    .thenReturn(new UpgradeResult(URI.create("eddi://ai.labs.agent/agentstore/agents/" + TARGET_B),
+                            true, 1, 0, 0,
+                            List.of(new UpgradeResult.ResourceFailure("src-llm", "langchain", "GPT", "store rejected it"))));
+
+            Response response = executeBatch();
+
+            assertEquals(207, response.getStatus(),
+                    "a half-applied agent is a failure of the batch, not a success with a warning line");
+        }
+
+        @Test
+        @DisplayName("an interrupted batch aborts instead of hammering the remote instance")
+        void interruptAbortsTheBatch() {
+            Thread.currentThread().interrupt();
+            try {
+                assertThrows(InternalServerErrorException.class,
+                        () -> importService.executeSyncBatch(PUBLIC_SOURCE_URL, twoRequests(), null));
+                verify(upgradeExecutor, never()).executeUpgrade(any(), anyString(), any(), any());
+            } finally {
+                // Never leak the flag into the next test on this thread.
+                Thread.interrupted();
+            }
+        }
+
+        /**
+         * Runs the batch with {@link RemoteApiResourceSource} construction stubbed out.
+         * The real constructor builds an {@link java.net.http.HttpClient}, which opens
+         * a selector and so needs a loopback socket a sandboxed build does not have —
+         * and none of these tests is about the remote read.
+         */
+        private Response executeBatch() {
+            try (var ignored = mockConstruction(RemoteApiResourceSource.class)) {
+                return importService.executeSyncBatch(PUBLIC_SOURCE_URL, twoRequests(), null);
+            }
+        }
+
+        private List<SyncRequest> twoRequests() {
+            return List.of(
+                    new SyncRequest("aabbccddeeff112233445566", 1, TARGET_A, Set.of(), List.of()),
+                    new SyncRequest("aabbccddeeff112233445577", 1, TARGET_B, Set.of(), List.of()));
+        }
     }
 
     // =========================================================
@@ -232,5 +330,85 @@ class RestImportServiceSyncCoverageTest {
             assertThrows(IllegalArgumentException.class,
                     () -> importService.previewSyncBatch("ftp://bad.server.com", List.of(), null));
         }
+    }
+
+    // =========================================================
+    // The status code an upgrade answers with
+    // =========================================================
+
+    /**
+     * Every upgrade used to answer 201 CREATED regardless of what happened, so a
+     * half-applied sync was indistinguishable from a clean one and a no-op sync
+     * still looked like it had written a new agent version. The status code is the
+     * only thing a scripted promotion job can key off.
+     */
+    @Nested
+    @DisplayName("upgrade response")
+    class UpgradeResponseTests {
+
+        private static final String TARGET = "aabbccddeeff112233445599";
+        private static final URI AGENT_URI = URI.create("eddi://ai.labs.agent/agentstore/agents/" + TARGET + "?version=4");
+
+        private Response upgradeWith(UpgradeResult result) {
+            when(upgradeExecutor.executeUpgrade(any(), eq(TARGET), any(), any())).thenReturn(result);
+            return importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "upgrade", null, TARGET, null);
+        }
+
+        @Test
+        @DisplayName("201 when something was written")
+        void writtenIsCreated() {
+            Response response = upgradeWith(new UpgradeResult(AGENT_URI, true, 2, 1, 0, List.of()));
+
+            assertEquals(201, response.getStatus());
+            assertEquals(AGENT_URI.toString(), response.getHeaderString("Location"));
+            assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+            assertInstanceOf(UpgradeResult.class, response.getEntity());
+        }
+
+        @Test
+        @DisplayName("200 when source and target were already identical")
+        void nothingWrittenIsOk() {
+            Response response = upgradeWith(new UpgradeResult(AGENT_URI, false, 0, 0, 3, List.of()));
+
+            // No agent version was burned, so answering 201 CREATED was a lie that a CI
+            // promotion job could not tell from a real change.
+            assertEquals(200, response.getStatus());
+            assertEquals(AGENT_URI.toString(), response.getHeaderString("Location"));
+        }
+
+        @Test
+        @DisplayName("207 Multi-Status when some resources failed, with the failures in the body")
+        void failuresAreMultiStatus() {
+            var failure = new UpgradeResult.ResourceFailure("src-llm", "langchain", "GPT Config",
+                    "IllegalStateException: store rejected it");
+            Response response = upgradeWith(new UpgradeResult(AGENT_URI, true, 1, 0, 0, List.of(failure)));
+
+            assertEquals(207, response.getStatus());
+            assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+            var body = assertInstanceOf(UpgradeResult.class, response.getEntity());
+            assertEquals(List.of(failure), body.failures(),
+                    "the caller has to be able to see which resources did not land");
+            // Clients that only read the header keep working.
+            assertEquals(AGENT_URI.toString(), response.getHeaderString("Location"));
+        }
+    }
+
+    // ==================== Helpers ====================
+
+    /**
+     * A routable, non-private literal address (RFC 5737 TEST-NET-3). A hostname
+     * would make {@link SourceUrlValidator}'s fail-closed DNS lookup decide whether
+     * these tests run.
+     */
+    private static final String PUBLIC_SOURCE_URL = "https://203.0.113.10";
+
+    private static final String TARGET_A = "aabbccddeeff112233445567";
+    private static final String TARGET_B = "aabbccddeeff112233445568";
+
+    private static UpgradeResult cleanResult(String targetAgentId) {
+        return new UpgradeResult(
+                URI.create("eddi://ai.labs.agent/agentstore/agents/" + targetAgentId + "?version=2"),
+                true, 1, 0, 0, List.of());
     }
 }

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSyncCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceSyncCoverageTest.java
@@ -6,16 +6,19 @@ package ai.labs.eddi.backup.impl;
 
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.SyncMapping;
 import ai.labs.eddi.backup.model.SyncRequest;
 import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.migration.IMigrationManager;
 import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 /**
@@ -68,7 +72,7 @@ class RestImportServiceSyncCoverageTest {
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
                 templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
-                mock(ResourceAccessGuard.class));
+                mock(ResourceAccessGuard.class), mock(SpaceContext.class));
     }
 
     // =========================================================
@@ -113,6 +117,46 @@ class RestImportServiceSyncCoverageTest {
             assertThrows(IllegalArgumentException.class,
                     () -> importService.listRemoteAgents("http://127.0.0.1:1", null));
         }
+
+        /**
+         * A remote instance that cannot be listed becomes a 500 that says so and keeps
+         * the original as its cause. The connect failure, the expired token and the
+         * wrong port all arrive here, and the operator only gets to tell them apart if
+         * the reason survives the wrapping.
+         */
+        @Test
+        @DisplayName("a remote instance that will not answer becomes a 500 that keeps the reason")
+        void unreachableRemoteBecomesAServerError() {
+            var cause = new RuntimeException("Failed to list agents: connection refused");
+
+            InternalServerErrorException thrown;
+            try (var statics = mockStatic(RemoteApiResourceSource.class)) {
+                statics.when(() -> RemoteApiResourceSource.listRemoteAgentDescriptors(
+                        eq(PUBLIC_SOURCE_URL), eq("Bearer stale"), any())).thenThrow(cause);
+
+                thrown = assertThrows(InternalServerErrorException.class,
+                        () -> importService.listRemoteAgents(PUBLIC_SOURCE_URL, "Bearer stale"));
+            }
+
+            assertEquals(500, thrown.getResponse().getStatus());
+            assertTrue(thrown.getMessage().contains("connection refused"),
+                    "the reason must survive, was: " + thrown.getMessage());
+            assertSame(cause, thrown.getCause());
+        }
+
+        /** The list a reachable instance hands over reaches the caller unchanged. */
+        @Test
+        @DisplayName("the descriptors a reachable instance returns are passed through")
+        void reachableRemoteReturnsItsDescriptors() {
+            var descriptors = List.of(new DocumentDescriptor());
+
+            try (var statics = mockStatic(RemoteApiResourceSource.class)) {
+                statics.when(() -> RemoteApiResourceSource.listRemoteAgentDescriptors(
+                        eq(PUBLIC_SOURCE_URL), isNull(), any())).thenReturn(descriptors);
+
+                assertSame(descriptors, importService.listRemoteAgents(PUBLIC_SOURCE_URL, null));
+            }
+        }
     }
 
     // =========================================================
@@ -149,6 +193,56 @@ class RestImportServiceSyncCoverageTest {
                             "aabbccddeeff112233445566", 1,
                             "aabbccddeeff112233445567", null));
         }
+
+        /**
+         * A remote instance that cannot be read is this deployment's problem to report:
+         * the failure becomes a 500 that still names what went wrong and keeps the
+         * original as its cause, so the server log has the stack and the operator has
+         * the reason.
+         */
+        @Test
+        @DisplayName("a matcher failure becomes a 500 that keeps the reason and the cause")
+        void matcherFailureBecomesAServerError() {
+            var cause = new RuntimeException("remote instance closed the connection");
+            when(structuralMatcher.buildPreview(any(), eq(TARGET_A), eq(true))).thenThrow(cause);
+
+            var thrown = assertThrows(InternalServerErrorException.class, this::preview);
+
+            assertEquals(500, thrown.getResponse().getStatus());
+            assertTrue(thrown.getMessage().contains("remote instance closed the connection"),
+                    "the reason must survive the wrapping, was: " + thrown.getMessage());
+            assertSame(cause, thrown.getCause(), "the original must stay reachable for the server log");
+        }
+
+        /**
+         * The one failure that must <em>not</em> be wrapped. A target agent that is not
+         * there is a 404 the operator can act on — "you named an agent this instance
+         * does not have" — and repackaging it as a 500 turns a fixable mistake into an
+         * outage report.
+         */
+        @Test
+        @DisplayName("a 404 from the matcher is passed through, not repackaged as a 500")
+        void notFoundFromTheMatcherIsPassedThrough() {
+            var notFound = new NotFoundException("No agent found with id " + TARGET_A);
+            when(structuralMatcher.buildPreview(any(), eq(TARGET_A), eq(true))).thenThrow(notFound);
+
+            var thrown = assertThrows(NotFoundException.class, this::preview);
+
+            assertSame(notFound, thrown, "the matcher's own 404 has to reach the caller unchanged");
+        }
+
+        /**
+         * Runs the preview with {@link RemoteApiResourceSource} construction stubbed
+         * out — the real constructor builds an {@link java.net.http.HttpClient}, which
+         * opens a selector and so needs a loopback socket a sandboxed build does not
+         * have, and neither test is about the remote read itself.
+         */
+        private ImportPreview preview() {
+            try (var ignored = mockConstruction(RemoteApiResourceSource.class)) {
+                return importService.previewSync(PUBLIC_SOURCE_URL,
+                        "aabbccddeeff112233445566", 1, TARGET_A, null);
+            }
+        }
     }
 
     // =========================================================
@@ -184,6 +278,74 @@ class RestImportServiceSyncCoverageTest {
                     () -> importService.executeSync("https://[::1]:8443",
                             "aabbccddeeff112233445566", 1,
                             "aabbccddeeff112233445567", null, null, null));
+        }
+
+        /**
+         * Same split as the preview, and it matters more here because a sync writes: an
+         * upgrade that blew up mid-flight is a 500 naming the reason, with the original
+         * kept as the cause.
+         */
+        @Test
+        @DisplayName("an upgrade failure becomes a 500 that keeps the reason and the cause")
+        void upgradeFailureBecomesAServerError() {
+            var cause = new IllegalStateException("the target agent changed under the sync");
+            when(upgradeExecutor.executeUpgrade(any(), eq(TARGET_A), any(), any())).thenThrow(cause);
+
+            var thrown = assertThrows(InternalServerErrorException.class, this::sync);
+
+            assertEquals(500, thrown.getResponse().getStatus());
+            assertTrue(thrown.getMessage().contains("the target agent changed under the sync"),
+                    "the reason must survive the wrapping, was: " + thrown.getMessage());
+            assertSame(cause, thrown.getCause());
+        }
+
+        /**
+         * And a 404 for a target that does not exist survives the catch-all here too —
+         * a promotion job keying off the status code has to be able to tell "no such
+         * agent" from "this instance is broken".
+         */
+        @Test
+        @DisplayName("a 404 from the upgrade executor is passed through, not repackaged as a 500")
+        void notFoundFromTheExecutorIsPassedThrough() {
+            var notFound = new NotFoundException("No agent found with id " + TARGET_A);
+            when(upgradeExecutor.executeUpgrade(any(), eq(TARGET_A), any(), any())).thenThrow(notFound);
+
+            var thrown = assertThrows(NotFoundException.class, this::sync);
+
+            assertSame(notFound, thrown);
+        }
+
+        /**
+         * The happy path, which is what makes the two failure paths above meaningful: a
+         * sync that ran hands back the upgrade's own result and status, with the agent
+         * URI in the Location header, and passes the caller's selection and workflow
+         * order through to the executor rather than quietly syncing everything.
+         */
+        @Test
+        @DisplayName("a sync that ran answers with the upgrade's result, status and Location")
+        void successfulSyncAnswersWithTheUpgradeResult() {
+            var result = cleanResult(TARGET_A);
+            when(upgradeExecutor.executeUpgrade(any(), eq(TARGET_A), eq(Set.of("res-1", "res-2")),
+                    eq(List.of("wf-b", "wf-a")))).thenReturn(result);
+
+            Response response;
+            try (var ignored = mockConstruction(RemoteApiResourceSource.class)) {
+                response = importService.executeSync(PUBLIC_SOURCE_URL,
+                        "aabbccddeeff112233445566", 1, TARGET_A, "res-1,res-2", "wf-b, wf-a", null);
+            }
+
+            assertEquals(201, response.getStatus(), "something was written, so it is a 201");
+            assertSame(result, response.getEntity());
+            assertEquals(result.agentUri().toString(), response.getHeaderString("Location"));
+            assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+        }
+
+        /** See {@code PreviewSyncTests#preview()} for why construction is stubbed. */
+        private Response sync() {
+            try (var ignored = mockConstruction(RemoteApiResourceSource.class)) {
+                return importService.executeSync(PUBLIC_SOURCE_URL,
+                        "aabbccddeeff112233445566", 1, TARGET_A, null, null, null);
+            }
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceTest.java
@@ -4,9 +4,11 @@
  */
 package ai.labs.eddi.backup.impl;
 
+import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
 import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import ai.labs.eddi.backup.model.SyncMapping;
@@ -18,6 +20,7 @@ import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,7 +66,8 @@ class RestImportServiceTest {
         importService = new RestImportService(
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
-                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(ResourceAccessGuard.class));
+                templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
+                mock(ResourceAccessGuard.class));
     }
 
     // ==================== Strategy Dispatch ====================
@@ -77,7 +81,7 @@ class RestImportServiceTest {
         void upgradeStrategy() throws Exception {
             URI resultUri = URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=2");
             when(upgradeExecutor.executeUpgrade(any(), eq("target-1"), isNull(), isNull()))
-                    .thenReturn(resultUri);
+                    .thenReturn(new UpgradeResult(resultUri, true, 1, 0, 0, List.of()));
 
             // Mock zipArchive.unzip to create minimal directory
             doAnswer(inv -> {
@@ -95,27 +99,34 @@ class RestImportServiceTest {
         }
 
         @Test
-        @DisplayName("upgrade strategy without targetAgentId falls through to create path")
-        void upgradeWithoutTarget() throws Exception {
-            // Without targetAgentId, upgrade strategy is ignored → falls to create/merge
-            // This will fail during import (empty zip), wrapped in
-            // InternalServerErrorException
-            doAnswer(inv -> {
-                File dir = inv.getArgument(1);
-                dir.mkdirs();
-                return null;
-            }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
+        @DisplayName("upgrade strategy without targetAgentId is rejected, not silently created")
+        void upgradeWithoutTarget() {
+            // This used to fall through to the create path and answer 201 with a
+            // brand-new duplicate agent, so a dropped query parameter silently
+            // doubled the deployment's agent list.
+            assertThrows(BadRequestException.class,
+                    () -> importService.importAgent(
+                            new ByteArrayInputStream(new byte[0]), "upgrade", null, null, null));
 
-            // Empty zip → no agent files → returns 200 with null location
-            Response response = importService.importAgent(
-                    new ByteArrayInputStream(new byte[0]), "upgrade", null, null, null);
-
-            // With empty ZIP and CDI calls for importSnippets, this will throw
-            // because getRestResourceStore needs CDI — but importSnippets checks
-            // for snippets dir first. Empty dir → no snippets dir → skips.
-            // Then no .agent.json files → returns null → 200 response
-            assertNotNull(response);
             verify(upgradeExecutor, never()).executeUpgrade(any(), anyString(), any(), any());
+        }
+
+        @Test
+        @DisplayName("upgrade strategy with blank targetAgentId is rejected")
+        void upgradeWithBlankTarget() {
+            assertThrows(BadRequestException.class,
+                    () -> importService.importAgent(
+                            new ByteArrayInputStream(new byte[0]), "upgrade", null, "   ", null));
+
+            verify(upgradeExecutor, never()).executeUpgrade(any(), anyString(), any(), any());
+        }
+
+        @Test
+        @DisplayName("an unknown strategy is rejected instead of silently creating")
+        void unknownStrategyRejected() {
+            assertThrows(BadRequestException.class,
+                    () -> importService.importAgent(
+                            new ByteArrayInputStream(new byte[0]), "UPGRAGE", null, "target-1", null));
         }
 
         @Test
@@ -199,7 +210,7 @@ class RestImportServiceTest {
     class PreviewMerge {
 
         @Test
-        @DisplayName("empty ZIP returns preview with empty diffs")
+        @DisplayName("empty ZIP is rejected with a message naming the file it looked for")
         void emptyZip() throws Exception {
             doAnswer(inv -> {
                 File dir = inv.getArgument(1);
@@ -207,12 +218,13 @@ class RestImportServiceTest {
                 return null;
             }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
 
-            ImportPreview result = importService.previewImport(
-                    new ByteArrayInputStream(new byte[0]), null);
+            var ex = assertThrows(BadRequestException.class, () -> importService.previewImport(
+                    new ByteArrayInputStream(new byte[0]), null));
 
-            assertNotNull(result);
-            assertNull(result.sourceAgentId());
-            assertTrue(result.resources().isEmpty());
+            // A preview with zero resources told the operator there was nothing to
+            // import — indistinguishable from an archive the importer cannot read.
+            assertTrue(ex.getMessage().contains(".agent.json"), ex.getMessage());
+            assertTrue(ex.getMessage().contains(".bot.json"), ex.getMessage());
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.backup.impl;
 
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
 import ai.labs.eddi.backup.model.UpgradeResult;
@@ -67,7 +68,7 @@ class RestImportServiceTest {
                 zipArchive, jsonSerialization,
                 migrationManager, documentDescriptorStore,
                 templateSyntaxMigrator, structuralMatcher, upgradeExecutor, mock(IScheduleStore.class), mock(BackupMetrics.class),
-                mock(ResourceAccessGuard.class));
+                mock(ResourceAccessGuard.class), mock(SpaceContext.class));
     }
 
     // ==================== Strategy Dispatch ====================

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUncoveredBranchTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUncoveredBranchTest.java
@@ -149,51 +149,16 @@ class RestImportServiceUncoveredBranchTest {
         }
 
         @Test
-        @DisplayName("extracts legacy dictionary URIs")
-        void extractLegacyDictionaryUris() throws Exception {
-            String input = "\"eddi://ai.labs.regulardictionary/regulardictionarystore/regulardictionaries/d1?version=1\"";
-            List<URI> result = invokeExtractResourcesUris(input, AbstractBackupService.LEGACY_DICTIONARY_URI_PATTERN);
-            assertEquals(1, result.size());
-        }
-
-        @Test
-        @DisplayName("extracts legacy behavior URIs")
-        void extractLegacyBehaviorUris() throws Exception {
-            String input = "\"eddi://ai.labs.behavior/behaviorstore/behaviorsets/b1?version=1\"";
-            List<URI> result = invokeExtractResourcesUris(input, AbstractBackupService.LEGACY_BEHAVIOR_URI_PATTERN);
-            assertEquals(1, result.size());
-        }
-
-        @Test
-        @DisplayName("extracts legacy httpcalls URIs")
-        void extractLegacyHttpcallsUris() throws Exception {
-            String input = "\"eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/h1?version=1\"";
-            List<URI> result = invokeExtractResourcesUris(input, AbstractBackupService.LEGACY_HTTPCALLS_URI_PATTERN);
-            assertEquals(1, result.size());
-        }
-
-        @Test
-        @DisplayName("extracts legacy langchain URIs")
-        void extractLegacyLangchainUris() throws Exception {
-            String input = "\"eddi://ai.labs.langchain/langchainstore/langchains/l1?version=1\"";
-            List<URI> result = invokeExtractResourcesUris(input, AbstractBackupService.LEGACY_LANGCHAIN_URI_PATTERN);
-            assertEquals(1, result.size());
-        }
-
-        @Test
-        @DisplayName("extracts legacy workflow URIs")
-        void extractLegacyWorkflowUris() throws Exception {
-            String input = "\"eddi://ai.labs.package/packagestore/packages/p1?version=1\"";
-            List<URI> result = invokeExtractResourcesUris(input, AbstractBackupService.LEGACY_WORKFLOW_URI_PATTERN);
-            assertEquals(1, result.size());
-        }
-
-        @Test
-        @DisplayName("extracts legacy agent URIs")
-        void extractLegacyAgentUris() throws Exception {
-            String input = "\"eddi://ai.labs.bot/botstore/bots/bot1?version=1\"";
-            List<URI> result = invokeExtractResourcesUris(input, AbstractBackupService.LEGACY_AGENT_URI_PATTERN);
-            assertEquals(1, result.size());
+        @DisplayName("every legacy authority in the rewrite table maps to a v6 URI")
+        void legacyUrisAreNormalizedNotMatched() {
+            // The six LEGACY_*_URI_PATTERN constants these cases used to exercise had
+            // no production call site; normalizeLegacyUris and its rewrite table are
+            // the live v5 mechanism, so that is what is asserted here.
+            for (String[] rewrite : AbstractBackupService.LEGACY_URI_REWRITES) {
+                String legacy = "\"" + rewrite[0] + "res1?version=1\"";
+                assertEquals("\"" + rewrite[1] + "res1?version=1\"",
+                        AbstractBackupService.normalizeLegacyUris(legacy));
+            }
         }
 
         @SuppressWarnings("unchecked")
@@ -862,19 +827,15 @@ class RestImportServiceUncoveredBranchTest {
     class CrossMatchPatterns {
 
         @Test
-        @DisplayName("legacy patterns don't match v6 URIs")
-        void legacyDontMatchV6() throws Exception {
-            String v6Dict = "\"eddi://ai.labs.dictionary/dictionarystore/dictionaries/x?version=1\"";
-            assertTrue(extractUris(v6Dict, AbstractBackupService.LEGACY_DICTIONARY_URI_PATTERN).isEmpty());
-
-            String v6Behavior = "\"eddi://ai.labs.rules/rulestore/rulesets/x?version=1\"";
-            assertTrue(extractUris(v6Behavior, AbstractBackupService.LEGACY_BEHAVIOR_URI_PATTERN).isEmpty());
-
-            String v6HttpCalls = "\"eddi://ai.labs.apicalls/apicallstore/apicalls/x?version=1\"";
-            assertTrue(extractUris(v6HttpCalls, AbstractBackupService.LEGACY_HTTPCALLS_URI_PATTERN).isEmpty());
-
-            String v6Llm = "\"eddi://ai.labs.llm/llmstore/llms/x?version=1\"";
-            assertTrue(extractUris(v6Llm, AbstractBackupService.LEGACY_LANGCHAIN_URI_PATTERN).isEmpty());
+        @DisplayName("normalizing an already-v6 URI leaves it untouched")
+        void normalizingV6IsIdempotent() {
+            for (String v6 : List.of(
+                    "\"eddi://ai.labs.dictionary/dictionarystore/dictionaries/x?version=1\"",
+                    "\"eddi://ai.labs.rules/rulestore/rulesets/x?version=1\"",
+                    "\"eddi://ai.labs.apicalls/apicallstore/apicalls/x?version=1\"",
+                    "\"eddi://ai.labs.llm/llmstore/llms/x?version=1\"")) {
+                assertEquals(v6, AbstractBackupService.normalizeLegacyUris(v6));
+            }
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUnresolvableReferenceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUnresolvableReferenceTest.java
@@ -1,0 +1,559 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IZipArchive;
+import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.configs.agents.IAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.dictionary.IDictionaryStore;
+import ai.labs.eddi.configs.dictionary.model.DictionaryConfiguration;
+import ai.labs.eddi.configs.llm.ILlmStore;
+import ai.labs.eddi.configs.migration.IMigrationManager;
+import ai.labs.eddi.configs.migration.TemplateSyntaxMigrator;
+import ai.labs.eddi.configs.rules.IRuleSetStore;
+import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
+import ai.labs.eddi.configs.workflows.IWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore.IResourceId;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.security.spaces.SpaceContext;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * What {@code strategy=create} does with an archive that references a
+ * configuration it does not carry.
+ * <p>
+ * EDDI's own selective export writes the workflow whole — references to the
+ * omitted configs included — because that is what {@code strategy=merge} needs:
+ * it answers such a reference from the target's own copy, and a workflow
+ * arriving without the step would <em>delete</em> that step from the live
+ * agent. A create has no copy to fall back on, so it used to fail the whole
+ * import with "The archive references … but does not contain …" — an
+ * instruction the operator could not act on, because the product had written
+ * the archive. It now drops what it cannot honour, and says so.
+ * <p>
+ * The pruning is deliberately narrow, and each limit is asserted here: a step
+ * whose own {@code config.uri} is missing goes entirely, a nested list entry
+ * loses only that entry, and anything the walk cannot classify — an unparseable
+ * URI, a resource type the backup package does not move, a reference nested
+ * deeper than the recursion guard — is left exactly where it is.
+ */
+@DisplayName("RestImportService — unresolvable references on a create")
+class RestImportServiceUnresolvableReferenceTest {
+
+    private static final String AGENT_ORIGIN_ID = "aabb11112222333344445555";
+    private static final String NEW_AGENT_ID = "ccdd11112222333344445555";
+    private static final String WORKFLOW_ID = "bbbb11112222333344445555";
+    private static final String BEHAVIOR_ID = "eeee11112222333344445555";
+    private static final String MISSING_LLM_ID = "dddd11112222333344445555";
+    private static final String PRESENT_DICT_ID = "1111222233334444aaaabbbb";
+    private static final String MISSING_DICT_ID = "5555666677778888ccccdddd";
+
+    private static final String BEHAVIOR_URI = "eddi://ai.labs.rules/rulestore/rulesets/" + BEHAVIOR_ID + "?version=1";
+    private static final String MISSING_LLM_URI = "eddi://ai.labs.llm/llmstore/llms/" + MISSING_LLM_ID + "?version=1";
+    private static final String PRESENT_DICT_URI = "eddi://ai.labs.dictionary/dictionarystore/dictionaries/" + PRESENT_DICT_ID + "?version=1";
+    private static final String MISSING_DICT_URI = "eddi://ai.labs.dictionary/dictionarystore/dictionaries/" + MISSING_DICT_ID + "?version=1";
+
+    private IZipArchive zipArchive;
+    private IJsonSerialization jsonSerialization;
+    private IDocumentDescriptorStore documentDescriptorStore;
+    private RestImportService importService;
+    private BackupMetrics metrics;
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @BeforeEach
+    void setUp() throws Exception {
+        zipArchive = mock(IZipArchive.class);
+        jsonSerialization = mock(IJsonSerialization.class);
+        documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        metrics = mock(BackupMetrics.class);
+        var templateSyntaxMigrator = mock(TemplateSyntaxMigrator.class);
+        when(templateSyntaxMigrator.migrate(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+        importService = new RestImportService(
+                zipArchive, jsonSerialization,
+                mock(IMigrationManager.class), documentDescriptorStore,
+                templateSyntaxMigrator, mock(StructuralMatcher.class),
+                mock(UpgradeExecutor.class), mock(IScheduleStore.class), metrics,
+                mock(ResourceAccessGuard.class), mock(SpaceContext.class));
+
+        when(jsonSerialization.deserialize(anyString(), eq(AgentConfiguration.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), AgentConfiguration.class));
+        when(jsonSerialization.deserialize(anyString(), eq(WorkflowConfiguration.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), WorkflowConfiguration.class));
+        when(jsonSerialization.deserialize(anyString(), eq(DocumentDescriptor.class)))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), DocumentDescriptor.class));
+        when(jsonSerialization.deserialize(anyString(), eq(RuleSetConfiguration.class)))
+                .thenReturn(new RuleSetConfiguration());
+        when(jsonSerialization.deserialize(anyString(), eq(DictionaryConfiguration.class)))
+                .thenReturn(new DictionaryConfiguration());
+        when(jsonSerialization.serialize(any())).thenAnswer(inv -> mapper.writeValueAsString(inv.getArgument(0)));
+    }
+
+    /**
+     * The headline case: a selective export that kept the behaviour rules and left
+     * the LLM config out. The LLM step cannot be honoured on a create, so it goes —
+     * and nothing is written for it.
+     */
+    @Test
+    @DisplayName("a step whose config names a file the archive lacks is dropped, the rest is imported")
+    void dropsStepWhoseConfigNamesAMissingFile() throws Exception {
+        archiveWithWorkflowSteps("""
+                {"type":"eddi://ai.labs.behavior","config":{"uri":"%s"}},
+                {"type":"eddi://ai.labs.llm","config":{"uri":"%s"}}
+                """.formatted(BEHAVIOR_URI, MISSING_LLM_URI), true);
+
+        var workflowStore = mock(IWorkflowStore.class);
+        when(workflowStore.create(any())).thenReturn(resourceId("7777111122223333444455bb", 1));
+        var ruleSetStore = mock(IRuleSetStore.class);
+        when(ruleSetStore.create(any())).thenReturn(resourceId("1111111122223333444455cc", 1));
+        var llmStore = mock(ILlmStore.class);
+
+        var stored = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+        try (var cdi = stubCdi(IAgentStore.class, stubAgentCreation(),
+                IWorkflowStore.class, workflowStore,
+                IRuleSetStore.class, ruleSetStore,
+                ILlmStore.class, llmStore)) {
+            Response response = importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+
+            assertEquals(201, response.getStatus(),
+                    "an archive EDDI's own selective export wrote must import, not 400");
+        }
+
+        verify(workflowStore).create(stored.capture());
+        List<WorkflowConfiguration.WorkflowStep> steps = stored.getValue().getWorkflowSteps();
+        assertEquals(1, steps.size(), "only the unresolvable step may go, kept: " + stepTypes(steps));
+        assertEquals("eddi://ai.labs.behavior", steps.getFirst().getType().toString());
+        // Creating the LLM anyway would have written a resource nothing references.
+        verify(llmStore, never()).create(any(LlmConfiguration.class));
+    }
+
+    /**
+     * A missing reference reached through a list inside the step's config drops the
+     * step too.
+     */
+    @Test
+    @DisplayName("a missing reference nested in a list under config still drops the step")
+    void dropsStepWhenMissingReferenceIsNestedInAList() throws Exception {
+        // The kept step also carries a list, of references the archive does carry:
+        // a list is only a reason to drop when something in it is actually absent.
+        archiveWithWorkflowSteps("""
+                {"type":"eddi://ai.labs.behavior","config":{"uri":"%s","fallbacks":[{"uri":"%s"}]}},
+                {"type":"eddi://ai.labs.llm","config":{"models":[{"uri":"%s"}]}}
+                """.formatted(BEHAVIOR_URI, BEHAVIOR_URI, MISSING_LLM_URI), true);
+
+        var workflowStore = mock(IWorkflowStore.class);
+        when(workflowStore.create(any())).thenReturn(resourceId("7777111122223333444455bb", 1));
+        var ruleSetStore = mock(IRuleSetStore.class);
+        when(ruleSetStore.create(any())).thenReturn(resourceId("1111111122223333444455cc", 1));
+
+        var stored = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+        try (var cdi = stubCdi(IAgentStore.class, stubAgentCreation(),
+                IWorkflowStore.class, workflowStore,
+                IRuleSetStore.class, ruleSetStore)) {
+            importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+        }
+
+        verify(workflowStore).create(stored.capture());
+        List<WorkflowConfiguration.WorkflowStep> steps = stored.getValue().getWorkflowSteps();
+        assertEquals(1, steps.size(), "kept: " + stepTypes(steps));
+        assertEquals("eddi://ai.labs.behavior", steps.getFirst().getType().toString());
+    }
+
+    /**
+     * A parser's regular dictionaries are a list of nested references. Losing one
+     * of them must cost the list entry, never the parser step — dropping the parser
+     * would leave the agent unable to understand any input at all.
+     */
+    @Test
+    @DisplayName("a missing entry in a nested extensions list is pruned, its step survives")
+    void prunesOnlyTheMissingEntryFromANestedList() throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            File versionDir = versionDir(dir);
+            Files.writeString(new File(versionDir, WORKFLOW_ID + ".workflow.json").toPath(), """
+                    {"workflowSteps":[{"type":"eddi://ai.labs.parser","extensions":{"dictionaries":[
+                      {"config":{"uri":"%s"}},
+                      {"config":{"uri":"%s"}}]}}]}
+                    """.formatted(MISSING_DICT_URI, PRESENT_DICT_URI));
+            Files.writeString(new File(versionDir, PRESENT_DICT_ID + ".regulardictionary.json").toPath(),
+                    "{\"words\":[]}");
+        });
+
+        var workflowStore = mock(IWorkflowStore.class);
+        when(workflowStore.create(any())).thenReturn(resourceId("7777111122223333444455bb", 1));
+        var dictionaryStore = mock(IDictionaryStore.class);
+        when(dictionaryStore.create(any())).thenReturn(resourceId("2222333344445555aaaabbbb", 1));
+
+        var stored = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+        try (var cdi = stubCdi(IAgentStore.class, stubAgentCreation(),
+                IWorkflowStore.class, workflowStore,
+                IDictionaryStore.class, dictionaryStore)) {
+            importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+        }
+
+        verify(workflowStore).create(stored.capture());
+        List<WorkflowConfiguration.WorkflowStep> steps = stored.getValue().getWorkflowSteps();
+        assertEquals(1, steps.size(), "the parser step must survive losing one dictionary");
+        Object dictionaries = steps.getFirst().getExtensions().get("dictionaries");
+        assertTrue(dictionaries instanceof List<?> list && list.size() == 1,
+                "only the missing dictionary may be pruned, was " + dictionaries);
+        // The dictionary the archive does carry is still imported.
+        verify(dictionaryStore).create(any());
+    }
+
+    /**
+     * Jackson turns a {@code null} element in the archived step list into a null
+     * entry. It has to go with the rewrite rather than be serialized back into the
+     * stored workflow, where the engine would meet it on the next turn.
+     */
+    @Test
+    @DisplayName("a null step entry does not survive the rewrite")
+    void nullStepEntryDoesNotSurviveTheRewrite() throws Exception {
+        archiveWithWorkflowSteps("""
+                null,
+                {"type":"eddi://ai.labs.behavior","config":{"uri":"%s"}},
+                {"type":"eddi://ai.labs.llm","config":{"uri":"%s"}}
+                """.formatted(BEHAVIOR_URI, MISSING_LLM_URI), true);
+
+        var workflowStore = mock(IWorkflowStore.class);
+        when(workflowStore.create(any())).thenReturn(resourceId("7777111122223333444455bb", 1));
+        var ruleSetStore = mock(IRuleSetStore.class);
+        when(ruleSetStore.create(any())).thenReturn(resourceId("1111111122223333444455cc", 1));
+
+        var stored = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+        try (var cdi = stubCdi(IAgentStore.class, stubAgentCreation(),
+                IWorkflowStore.class, workflowStore,
+                IRuleSetStore.class, ruleSetStore)) {
+            importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+        }
+
+        verify(workflowStore).create(stored.capture());
+        List<WorkflowConfiguration.WorkflowStep> steps = stored.getValue().getWorkflowSteps();
+        assertEquals(1, steps.size(), "kept: " + stepTypes(steps));
+        assertEquals("eddi://ai.labs.behavior", steps.getFirst().getType().toString());
+    }
+
+    /**
+     * A workflow with nothing to prune must reach the store as the <em>archive
+     * wrote it</em>, not as this deployment's model would re-emit it.
+     * Re-serializing every archived workflow on every import is how a field the
+     * model does not know gets silently dropped, so the pass-through branch is
+     * asserted on the text: the exact string the archive carried is the one that
+     * goes on to be stored, and nothing was ever handed back to
+     * {@code jsonSerialization.serialize} for a rewrite.
+     * <p>
+     * The archived JSON below is deliberately spaced the way no serializer would
+     * emit it — an assertion on the parsed result cannot tell a pass-through from a
+     * round-trip, because {@code {"workflowSteps":null}} parses to null steps
+     * either way.
+     */
+    @Test
+    @DisplayName("a workflow with no step list is passed through verbatim, not re-serialized")
+    void workflowWithoutStepsIsPassedThroughUnchanged() throws Exception {
+        String archived = "{ \"workflowSteps\" : null }";
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            Files.writeString(new File(versionDir(dir), WORKFLOW_ID + ".workflow.json").toPath(), archived);
+        });
+
+        var workflowStore = mock(IWorkflowStore.class);
+        when(workflowStore.create(any())).thenReturn(resourceId("7777111122223333444455bb", 1));
+
+        var stored = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+        try (var cdi = stubCdi(IAgentStore.class, stubAgentCreation(), IWorkflowStore.class, workflowStore)) {
+            Response response = importService.importAgent(
+                    new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            assertEquals(201, response.getStatus());
+        }
+
+        verify(workflowStore).create(stored.capture());
+        assertNull(stored.getValue().getWorkflowSteps(),
+                "an explicit null step list must reach the store as it was archived");
+
+        // Every workflow string this import parsed is still the archive's, character
+        // for character — an always-rewrite would hand on the serializer's rendering
+        // instead. How many times the import parses it is its own business, so the
+        // assertion is over all of them rather than on a count.
+        var workflowText = ArgumentCaptor.forClass(String.class);
+        verify(jsonSerialization, atLeastOnce())
+                .deserialize(workflowText.capture(), eq(WorkflowConfiguration.class));
+        assertTrue(workflowText.getAllValues().stream().allMatch(archived::equals),
+                "the pruner must hand back the archived text untouched, not this model's re-rendering, was: "
+                        + workflowText.getAllValues());
+        verify(jsonSerialization, never()).serialize(any(WorkflowConfiguration.class));
+    }
+
+    /**
+     * The same promise for the branch that carries it in the common case: a
+     * workflow whose every reference the archive <em>does</em> satisfy has nothing
+     * dropped, so the pruner hands back the string it was given rather than
+     * re-emitting the parsed model.
+     * <p>
+     * Here the text cannot be compared whole — the import rewrites the behaviour
+     * URI to the id it just created — so the assertion is that the archive's own
+     * spacing survived into the text the import went on to store, and that the
+     * workflow was never handed back to the serializer at all.
+     */
+    @Test
+    @DisplayName("a workflow with nothing to prune is passed through, not re-serialized")
+    void workflowWithNothingToPruneIsPassedThroughUnchanged() throws Exception {
+        String archived = "{ \"workflowSteps\" : [ {\"type\":\"eddi://ai.labs.behavior\","
+                + "\"config\":{\"uri\":\"" + BEHAVIOR_URI + "\"}} ] }";
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            File versionDir = versionDir(dir);
+            Files.writeString(new File(versionDir, WORKFLOW_ID + ".workflow.json").toPath(), archived);
+            Files.writeString(new File(versionDir, BEHAVIOR_ID + ".behavior.json").toPath(),
+                    "{\"behaviorGroups\":[]}");
+        });
+
+        var workflowStore = mock(IWorkflowStore.class);
+        when(workflowStore.create(any())).thenReturn(resourceId("7777111122223333444455bb", 1));
+        var ruleSetStore = mock(IRuleSetStore.class);
+        when(ruleSetStore.create(any())).thenReturn(resourceId("1111111122223333444455cc", 1));
+
+        var stored = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+        try (var cdi = stubCdi(IAgentStore.class, stubAgentCreation(),
+                IWorkflowStore.class, workflowStore,
+                IRuleSetStore.class, ruleSetStore)) {
+            importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+        }
+
+        verify(workflowStore).create(stored.capture());
+        assertEquals(1, stored.getValue().getWorkflowSteps().size(), "nothing was unresolvable, so nothing may go");
+
+        var workflowText = ArgumentCaptor.forClass(String.class);
+        verify(jsonSerialization, atLeastOnce())
+                .deserialize(workflowText.capture(), eq(WorkflowConfiguration.class));
+        String storedText = workflowText.getAllValues().getLast();
+        assertTrue(storedText.startsWith("{ \"workflowSteps\" : [ "),
+                "the archive's own text must survive the pruner, was: " + storedText);
+        verify(jsonSerialization, never()).serialize(any(WorkflowConfiguration.class));
+    }
+
+    /**
+     * Two URI shapes the pruner must refuse to judge: one it cannot parse at all,
+     * and one whose authority names a resource kind the backup package does not
+     * move. Guessing "missing" for either would silently delete a working step.
+     */
+    @Test
+    @DisplayName("an unparseable URI and an unknown resource type are never treated as missing")
+    void unparseableAndUnknownUrisAreNeverTreatedAsMissing() throws Exception {
+        archiveWithWorkflowSteps("""
+                {"type":"eddi://ai.labs.parser","config":{"uri":"http://exa mple.com/parser"}},
+                {"type":"eddi://ai.labs.normalizer","config":{"uri":"eddi://ai.labs.unknown/store/things/%s?version=1"}},
+                {"type":"eddi://ai.labs.llm","config":{"uri":"%s"}}
+                """.formatted(BEHAVIOR_ID, MISSING_LLM_URI), false);
+
+        var workflowStore = mock(IWorkflowStore.class);
+        when(workflowStore.create(any())).thenReturn(resourceId("7777111122223333444455bb", 1));
+
+        var stored = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+        try (var cdi = stubCdi(IAgentStore.class, stubAgentCreation(), IWorkflowStore.class, workflowStore)) {
+            importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+        }
+
+        verify(workflowStore).create(stored.capture());
+        List<WorkflowConfiguration.WorkflowStep> steps = stored.getValue().getWorkflowSteps();
+        assertEquals(2, steps.size(), "only the genuinely unresolvable step may go, kept: " + stepTypes(steps));
+        assertEquals("eddi://ai.labs.parser", steps.get(0).getType().toString());
+        assertEquals("eddi://ai.labs.normalizer", steps.get(1).getType().toString());
+    }
+
+    /**
+     * The recursion guard is a real limit. A reference buried deeper than it goes
+     * is not pruned — and because the URI scan that follows works on raw text, that
+     * import fails, naming the resource and the strategy that can answer it. Better
+     * a message the operator can act on than an unbounded walk.
+     */
+    @Test
+    @DisplayName("a reference deeper than the recursion guard fails the import, pointing at strategy=merge")
+    void referenceDeeperThanTheGuardFailsWithAnActionableMessage() throws Exception {
+        StringBuilder deepConfig = new StringBuilder();
+        StringBuilder deepExtensions = new StringBuilder();
+        for (int i = 0; i < 12; i++) {
+            deepConfig.append("{\"level").append(i).append("\":");
+            deepExtensions.append("{\"level").append(i).append("\":");
+        }
+        deepConfig.append("{\"uri\":\"").append(MISSING_LLM_URI).append("\"}");
+        deepExtensions.append("{\"uri\":\"").append(MISSING_LLM_URI).append("\"}");
+        deepConfig.append("}".repeat(12));
+        deepExtensions.append("}".repeat(12));
+
+        archiveWithWorkflowSteps("""
+                {"type":"eddi://ai.labs.llm","config":%s},
+                {"type":"eddi://ai.labs.llm","extensions":%s}
+                """.formatted(deepConfig, deepExtensions), false);
+
+        var thrown = assertThrows(BadRequestException.class, () -> {
+            try (var cdi = stubCdi(IAgentStore.class, stubAgentCreation(),
+                    IWorkflowStore.class, mock(IWorkflowStore.class))) {
+                importService.importAgent(new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+            }
+        });
+
+        assertTrue(thrown.getMessage().contains("strategy=merge"),
+                "the operator must be told which strategy can answer the reference, was: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains(MISSING_LLM_ID),
+                "the message must name the resource, was: " + thrown.getMessage());
+    }
+
+    /**
+     * The preview walks the agent's workflow list before anything is written, and a
+     * {@code null} entry there — which Jackson produces from
+     * {@code "workflows":[null]} — has no resource id to look anything up by. It is
+     * skipped, so the operator still sees the rows the archive can actually deliver
+     * rather than a 500 with nothing to act on.
+     */
+    @Test
+    @DisplayName("a null workflow reference is skipped by the preview, not fatal to it")
+    void nullWorkflowReferenceIsSkippedByThePreview() throws Exception {
+        stubUnzip(dir -> {
+            Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
+                    "{\"workflows\":[null,\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                            + WORKFLOW_ID + "?version=1\"]}");
+            Files.writeString(new File(versionDir(dir), WORKFLOW_ID + ".workflow.json").toPath(),
+                    "{\"workflowSteps\":[]}");
+        });
+
+        ImportPreview preview = importService.previewImport(new ByteArrayInputStream(new byte[0]), null);
+
+        assertEquals(AGENT_ORIGIN_ID, preview.sourceAgentId());
+        List<String> workflowRows = preview.resources().stream()
+                .filter(diff -> "workflow".equals(diff.resourceType()))
+                .map(ImportPreview.ResourceDiff::sourceId)
+                .toList();
+        assertEquals(List.of(WORKFLOW_ID), workflowRows,
+                "the null entry cannot become a row, and must not cost the one that can");
+    }
+
+    // ==================== Helpers ====================
+
+    private static String stepTypes(List<WorkflowConfiguration.WorkflowStep> steps) {
+        return steps.stream().map(step -> step == null ? "null" : String.valueOf(step.getType())).toList().toString();
+    }
+
+    private void archiveWithWorkflowSteps(String stepsJson, boolean withBehaviorFile) throws Exception {
+        stubUnzip(dir -> {
+            writeAgent(dir);
+            File versionDir = versionDir(dir);
+            Files.writeString(new File(versionDir, WORKFLOW_ID + ".workflow.json").toPath(),
+                    "{\"workflowSteps\":[" + stepsJson + "]}");
+            if (withBehaviorFile) {
+                Files.writeString(new File(versionDir, BEHAVIOR_ID + ".behavior.json").toPath(),
+                        "{\"behaviorGroups\":[]}");
+            }
+        });
+    }
+
+    private static void writeAgent(File dir) throws IOException {
+        Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(),
+                "{\"workflows\":[\"eddi://ai.labs.workflow/workflowstore/workflows/"
+                        + WORKFLOW_ID + "?version=1\"]}");
+    }
+
+    private static File versionDir(File dir) {
+        File versionDir = new File(dir, WORKFLOW_ID + "/1");
+        assertTrue(versionDir.mkdirs() || versionDir.isDirectory());
+        return versionDir;
+    }
+
+    private interface ArchiveContent {
+        void write(File dir) throws IOException;
+    }
+
+    private void stubUnzip(ArchiveContent content) throws Exception {
+        doAnswer(inv -> {
+            File dir = inv.getArgument(1);
+            assertTrue(dir.mkdirs() || dir.isDirectory());
+            content.write(dir);
+            return null;
+        }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
+    }
+
+    private IAgentStore stubAgentCreation() throws Exception {
+        var agentStore = mock(IAgentStore.class);
+        when(agentStore.create(any())).thenReturn(resourceId(NEW_AGENT_ID, 1));
+        when(documentDescriptorStore.getCurrentResourceId(NEW_AGENT_ID)).thenReturn(resourceId(NEW_AGENT_ID, 1));
+
+        var descriptor = new DocumentDescriptor();
+        descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + NEW_AGENT_ID + "?version=1"));
+        when(documentDescriptorStore.readDescriptor(NEW_AGENT_ID, 1)).thenReturn(descriptor);
+        return agentStore;
+    }
+
+    @SuppressWarnings("unchecked")
+    private AutoCloseable stubCdi(Object... classThenStore) {
+        var cdiMock = mockStatic(CDI.class);
+        var cdi = mock(CDI.class);
+        cdiMock.when(CDI::current).thenReturn(cdi);
+        for (int i = 0; i < classThenStore.length; i += 2) {
+            select(cdi, (Class<Object>) classThenStore[i], classThenStore[i + 1]);
+        }
+        return cdiMock;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> void select(CDI cdi, Class<T> storeClass, T store) {
+        var instance = (Instance<T>) mock(Instance.class);
+        when(cdi.select(storeClass)).thenReturn(instance);
+        when(instance.get()).thenReturn(store);
+    }
+
+    private static IResourceId resourceId(String id, int version) {
+        return new IResourceId() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return version;
+            }
+        };
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUnresolvableReferenceTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceUnresolvableReferenceTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -525,8 +526,36 @@ class RestImportServiceUnresolvableReferenceTest {
         return agentStore;
     }
 
+    /**
+     * The pairwise helpers below read {@code classThenStore[i + 1]}, so an odd
+     * argument count used to walk off the end of the varargs array and fail with a
+     * bare {@code ArrayIndexOutOfBoundsException} naming neither the helper nor the
+     * missing store. The guard also has to run BEFORE
+     * {@code mockStatic(CDI.class)}, or a rejected call leaks a static mock into
+     * the next test in the class.
+     */
+    @Test
+    @DisplayName("stubCdi rejects an odd argument count instead of reading past the array")
+    void stubCdiRejectsAnUnpairedArgument() {
+        var thrown = assertThrows(IllegalArgumentException.class, () -> stubCdi(IAgentStore.class));
+        assertTrue(thrown.getMessage().contains("PAIRS"),
+                "the message must say what is wrong, not just that something is: " + thrown.getMessage());
+        assertDoesNotThrow(() -> {
+            try (var ignored = stubCdi()) {
+                // An empty (even) argument list is legitimate and must still work; if the
+                // guard had leaked a static CDI mock on the rejected call above, opening
+                // this second one would fail.
+            }
+        }, "the rejected call must not have left a static CDI mock registered");
+    }
+
     @SuppressWarnings("unchecked")
     private AutoCloseable stubCdi(Object... classThenStore) {
+        if (classThenStore.length % 2 != 0) {
+            throw new IllegalArgumentException("stubCdi takes (interface, store) PAIRS; got "
+                    + classThenStore.length + " argument(s). An odd count means a store was left off, and the "
+                    + "loop below would read past the end of the array instead of saying so.");
+        }
         var cdiMock = mockStatic(CDI.class);
         var cdi = mock(CDI.class);
         cdiMock.when(CDI::current).thenReturn(cdi);

--- a/src/test/java/ai/labs/eddi/backup/impl/ScrubbedSecretsTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/ScrubbedSecretsTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * How a target's own credentials are put back into content the export's secret
+ * scrubber redacted — and, above all, which credential goes where.
+ */
+class ScrubbedSecretsTest {
+
+    private IJsonSerialization jsonSerialization;
+
+    @BeforeEach
+    void useRealJsonRoundTripping() throws Exception {
+        // The merge under test is about JSON, not about mocks.
+        var mapper = new ObjectMapper();
+        jsonSerialization = Mockito.mock(IJsonSerialization.class);
+        when(jsonSerialization.deserialize(anyString()))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), Object.class));
+        when(jsonSerialization.serialize(any()))
+                .thenAnswer(inv -> mapper.writeValueAsString(inv.getArgument(0)));
+    }
+
+    /**
+     * The disclosure this pins shut. Pairing array elements by index alone took the
+     * value at position i of the target and wrote it into the source object at
+     * position i — which, after a reorder, is a <em>different</em> API call, with a
+     * different {@code targetServerUrl} of its own. The credential is not lost, it
+     * is handed to the other endpoint.
+     */
+    @Test
+    @DisplayName("a reordered credential entry keeps its own secret, never the neighbour's")
+    void reorderedEntriesDoNotSwapCredentials() throws Exception {
+        String source = """
+                {"httpCalls":[
+                  {"name":"billing","request":{"uri":"https://billing.example.com",
+                     "headers":{"Authorization":"${vault:REDACTED}"}}},
+                  {"name":"analytics","request":{"uri":"https://analytics.example.com",
+                     "headers":{"Authorization":"${vault:REDACTED}"}}}
+                ]}""";
+        // Same two calls, the other way round, as the target actually holds them.
+        String target = """
+                {"httpCalls":[
+                  {"name":"analytics","request":{"uri":"https://analytics.example.com",
+                     "headers":{"Authorization":"Bearer analytics-token"}}},
+                  {"name":"billing","request":{"uri":"https://billing.example.com",
+                     "headers":{"Authorization":"Bearer billing-token"}}}
+                ]}""";
+
+        String merged = ScrubbedSecrets.restore(source, target, jsonSerialization);
+
+        int billing = merged.indexOf("billing.example.com");
+        int analytics = merged.indexOf("analytics.example.com");
+        assertTrue(billing >= 0 && analytics >= 0, merged);
+        // Each endpoint must be followed by its own token, not the other one's.
+        assertTrue(merged.indexOf("billing-token") > billing && merged.indexOf("billing-token") < analytics,
+                "the billing call must carry the billing token: " + merged);
+        assertTrue(merged.indexOf("analytics-token") > analytics,
+                "the analytics call must carry the analytics token: " + merged);
+    }
+
+    /**
+     * An inserted entry shifts every position after it. Without a stable binding
+     * the target's first credential lands in the newly added call — a secret handed
+     * to an endpoint the operator has just typed in.
+     */
+    @Test
+    @DisplayName("an inserted entry does not inherit the credential of the one it displaced")
+    void insertedEntryDoesNotInheritACredential() throws Exception {
+        String source = """
+                {"httpCalls":[
+                  {"name":"new-call","request":{"uri":"https://attacker.example.com",
+                     "headers":{"Authorization":"${vault:REDACTED}"}}},
+                  {"name":"billing","request":{"uri":"https://billing.example.com",
+                     "headers":{"Authorization":"${vault:REDACTED}"}}}
+                ]}""";
+        String target = """
+                {"httpCalls":[
+                  {"name":"billing","request":{"uri":"https://billing.example.com",
+                     "headers":{"Authorization":"Bearer billing-token"}}}
+                ]}""";
+
+        String merged = ScrubbedSecrets.restore(source, target, jsonSerialization);
+
+        int newCall = merged.indexOf("attacker.example.com");
+        int billing = merged.indexOf("billing.example.com");
+        assertTrue(newCall >= 0 && newCall < billing, merged);
+        assertTrue(merged.indexOf("billing-token") > billing,
+                "the only credential in the target belongs to the billing call: " + merged);
+        // The new call has nothing to inherit, so its gap stays visible.
+        assertTrue(merged.substring(newCall, billing).contains(ScrubbedSecrets.PLACEHOLDER),
+                "an entry the target has no counterpart for must keep its placeholder: " + merged);
+    }
+
+    /**
+     * The everyday path has to keep working: an entry the target still has under
+     * the same name gets its own value back even when the operator edited
+     * everything else about it.
+     */
+    @Test
+    @DisplayName("an entry edited but not renamed still gets its own secret back")
+    void identityBindingSurvivesAnEdit() throws Exception {
+        String source = """
+                {"httpCalls":[{"name":"billing","request":{"uri":"https://billing.example.com/v2",
+                   "headers":{"Authorization":"${vault:REDACTED}"}}}]}""";
+        String target = """
+                {"httpCalls":[{"name":"billing","request":{"uri":"https://billing.example.com/v1",
+                   "headers":{"Authorization":"Bearer billing-token"}}}]}""";
+
+        String merged = ScrubbedSecrets.restore(source, target, jsonSerialization);
+
+        assertTrue(merged.contains("Bearer billing-token"), merged);
+        assertTrue(merged.contains("/v2"), "everything that is not a secret still comes from the source: " + merged);
+        assertFalse(merged.contains(ScrubbedSecrets.PLACEHOLDER), merged);
+    }
+
+    /**
+     * An element with no natural key can still be bound by position, but only when
+     * the surrounding content proves the two are the same entry.
+     */
+    @Test
+    @DisplayName("an anonymous entry is bound by position only when everything else matches")
+    void anonymousEntriesNeedTheirContentToMatch() throws Exception {
+        String source = "{\"keys\":[\"${vault:REDACTED}\"]}";
+        String target = "{\"keys\":[\"sk-live-abc\"]}";
+        assertEquals("{\"keys\":[\"sk-live-abc\"]}",
+                ScrubbedSecrets.restore(source, target, jsonSerialization));
+
+        String changed = """
+                {"entries":[{"host":"a.example.com","token":"${vault:REDACTED}"},
+                            {"host":"b.example.com","token":"${vault:REDACTED}"}]}""";
+        String stored = """
+                {"entries":[{"host":"b.example.com","token":"token-b"},
+                            {"host":"a.example.com","token":"token-a"}]}""";
+
+        String merged = ScrubbedSecrets.restore(changed, stored, jsonSerialization);
+
+        assertFalse(merged.contains("token-b"),
+                "b's token must not be written into the entry that calls a: " + merged);
+        assertFalse(merged.contains("token-a"),
+                "a's token must not be written into the entry that calls b: " + merged);
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherFailurePathTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherFailurePathTest.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IResourceSource;
+import ai.labs.eddi.backup.IResourceSource.AgentSourceData;
+import ai.labs.eddi.backup.IResourceSource.ExtensionSourceData;
+import ai.labs.eddi.backup.IResourceSource.WorkflowSourceData;
+import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
+import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
+import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
+import ai.labs.eddi.configs.dictionary.model.DictionaryConfiguration;
+import ai.labs.eddi.configs.llm.IRestLlmStore;
+import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * How {@link StructuralMatcher} answers when the target side of a sync cannot
+ * be read, and how it compares content that carries a scrubbed secret.
+ * <p>
+ * Two behaviours are load-bearing here. First, the difference between "that
+ * agent does not exist" (404, the operator mistyped an id) and "I could not
+ * read it" (500, the datastore is unwell): reporting an outage as not-found
+ * sends the operator to look for a resource that is there, and a client that
+ * retries a 404 by creating the agent duplicates it. Second, an export scrubs
+ * every credential, so comparing the raw source against a live target made
+ * every configuration holding an API key differ by the placeholder alone — such
+ * a resource could never SKIP, and a sync that changed nothing still burned a
+ * version on exactly the agents that matter most.
+ */
+@DisplayName("StructuralMatcher — unreadable targets and scrubbed content")
+class StructuralMatcherFailurePathTest {
+
+    private static final String TARGET_AGENT_ID = "112233445566aabbccddeeff";
+    private static final String WORKFLOW_ID = "aabbccddeeff112233445566";
+    private static final String LLM_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String DICT_ID = "cccccccccccccccccccccccc";
+    private static final String LLM_KEY = "eddi://ai.labs.llm#0/config";
+
+    private IRestAgentStore agentStore;
+    private IDocumentDescriptorStore documentDescriptorStore;
+    private IRestPromptSnippetStore snippetStore;
+    private IRestWorkflowStore workflowStore;
+    private IRestInterfaceFactory restInterfaceFactory;
+    private IJsonSerialization jsonSerialization;
+    private StructuralMatcher matcher;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        agentStore = mock(IRestAgentStore.class);
+        documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        snippetStore = mock(IRestPromptSnippetStore.class);
+        workflowStore = mock(IRestWorkflowStore.class);
+        restInterfaceFactory = mock(IRestInterfaceFactory.class);
+        jsonSerialization = mock(IJsonSerialization.class);
+
+        matcher = new StructuralMatcher(agentStore, documentDescriptorStore, snippetStore,
+                workflowStore, restInterfaceFactory, jsonSerialization);
+
+        when(snippetStore.readSnippetDescriptors(anyString(), anyInt(), anyInt()))
+                .thenReturn(Collections.emptyList());
+        when(jsonSerialization.serialize(any()))
+                .thenAnswer(inv -> mapper.writeValueAsString(inv.getArgument(0)));
+        when(jsonSerialization.deserialize(anyString()))
+                .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), Object.class));
+
+        var agentDescriptor = new DocumentDescriptor();
+        agentDescriptor.setName("Target Agent");
+        agentDescriptor.setResource(URI.create(
+                "eddi://ai.labs.agent/agentstore/agents/" + TARGET_AGENT_ID + "?version=1"));
+        when(documentDescriptorStore.readDescriptor(TARGET_AGENT_ID, null)).thenReturn(agentDescriptor);
+    }
+
+    /**
+     * The store's own not-found is passed through as a 404 naming the agent. It
+     * used to be turned into a generic "could not read", which is the same answer a
+     * datastore outage gives.
+     */
+    @Test
+    @DisplayName("a target agent that does not exist is a 404, not a 500")
+    void missingTargetAgentIsNotFound() {
+        // Sneaky-thrown, exactly as the REST proxy delivers it in production: the
+        // store's checked exceptions are not declared on this signature.
+        doAnswer(throwing(new IResourceStore.ResourceNotFoundException("no such agent")))
+                .when(agentStore).readAgent(TARGET_AGENT_ID, 1);
+
+        var thrown = assertThrows(NotFoundException.class,
+                () -> matcher.buildPreview(sourceWithNoWorkflows(), TARGET_AGENT_ID, true));
+
+        assertTrue(thrown.getMessage().contains(TARGET_AGENT_ID), thrown.getMessage());
+    }
+
+    /**
+     * Anything that is not the store's not-found is a server fault. Reporting a
+     * datastore failure as "target agent not found" is what sent operators looking
+     * for a resource that was there all along.
+     */
+    @Test
+    @DisplayName("a target agent that cannot be read for any other reason is a 500")
+    void unreadableTargetAgentIsAServerError() {
+        doAnswer(throwing(new IResourceStore.ResourceStoreException("connection reset")))
+                .when(agentStore).readAgent(TARGET_AGENT_ID, 1);
+
+        var thrown = assertThrows(InternalServerErrorException.class,
+                () -> matcher.buildPreview(sourceWithNoWorkflows(), TARGET_AGENT_ID, true));
+
+        assertTrue(thrown.getMessage().contains("connection reset"), thrown.getMessage());
+    }
+
+    /**
+     * A store answering null for an existing id is still "does not exist" to the
+     * caller.
+     */
+    @Test
+    @DisplayName("a target agent the store answers null for is a 404")
+    void nullTargetAgentIsNotFound() {
+        when(agentStore.readAgent(TARGET_AGENT_ID, 1)).thenReturn(null);
+
+        assertThrows(NotFoundException.class,
+                () -> matcher.buildPreview(sourceWithNoWorkflows(), TARGET_AGENT_ID, true));
+    }
+
+    /**
+     * A NotFoundException the REST layer already raised must reach the caller
+     * unchanged rather than be re-wrapped into a second one whose message hides the
+     * first.
+     */
+    @Test
+    @DisplayName("a NotFoundException the store already raised is passed straight through")
+    void alreadyMappedNotFoundIsPassedThrough() {
+        var notFound = new NotFoundException("agent gone");
+        when(agentStore.readAgent(TARGET_AGENT_ID, 1)).thenThrow(notFound);
+
+        var thrown = assertThrows(NotFoundException.class,
+                () -> matcher.buildPreview(sourceWithNoWorkflows(), TARGET_AGENT_ID, true));
+
+        assertSame(notFound, thrown);
+    }
+
+    /**
+     * An unreadable target <em>workflow</em> is not an unreadable target agent: the
+     * preview is still worth showing. The workflow is reported as an UPDATE, which
+     * is the safe reading — the operator can see the sync intends to write it.
+     */
+    @Test
+    @DisplayName("an unreadable target workflow leaves the preview standing, reporting UPDATE")
+    void unreadableTargetWorkflowStillPreviews() throws Exception {
+        stubTargetAgentWithOneWorkflow();
+        when(workflowStore.readWorkflow(WORKFLOW_ID, 1))
+                .thenThrow(new IllegalStateException("workflow unreadable"));
+
+        var sourceExt = new ExtensionSourceData("src-ext-1", "GPT Config", "langchain",
+                "eddi://ai.labs.llm", "{\"model\":\"gpt-4\"}");
+        var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
+                new WorkflowConfiguration(), Map.of(LLM_KEY, sourceExt));
+
+        ImportPreview preview = matcher.buildPreview(sourceWith(sourceWf), TARGET_AGENT_ID, true);
+
+        ResourceDiff wfDiff = diffOf(preview, "src-wf-1");
+        assertEquals(DiffAction.UPDATE, wfDiff.action());
+        // The extensions could not be read either, so the source's own extension has
+        // nothing to match against and is reported as new rather than dropped.
+        assertEquals(DiffAction.CREATE, diffOf(preview, "src-ext-1").action());
+    }
+
+    /**
+     * The dictionary branch of the typed-store dispatch, which is the one a parser
+     * step's regular dictionaries go through. Matching on the workflow step type
+     * instead of the resource authority resolved every extension to "unknown", so
+     * each of these branches is worth pinning.
+     */
+    @Test
+    @DisplayName("a target dictionary is read through the dictionary store and compared")
+    void dictionaryExtensionIsReadFromItsOwnStore() throws Exception {
+        stubTargetAgentWithOneWorkflow();
+
+        var targetWorkflow = new WorkflowConfiguration();
+        targetWorkflow.setWorkflowSteps(new ArrayList<>(List.of(
+                step("eddi://ai.labs.parser", Map.of("dictionaries", List.of(Map.of("config",
+                        Map.of("uri", "eddi://ai.labs.dictionary/dictionarystore/dictionaries/"
+                                + DICT_ID + "?version=1"))))))));
+        when(workflowStore.readWorkflow(WORKFLOW_ID, 1)).thenReturn(targetWorkflow);
+
+        var dictionaryStore = mock(IRestDictionaryStore.class);
+        var targetDictionary = new DictionaryConfiguration();
+        when(restInterfaceFactory.get(IRestDictionaryStore.class)).thenReturn(dictionaryStore);
+        when(dictionaryStore.readRegularDictionary(DICT_ID, 1, "", "", 0, 0)).thenReturn(targetDictionary);
+
+        String dictKey = "eddi://ai.labs.parser#0/extensions/dictionaries/0/config";
+        var sourceExt = new ExtensionSourceData("src-dict-1", "Dictionary", "regulardictionary",
+                "eddi://ai.labs.parser", mapper.writeValueAsString(targetDictionary));
+        var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
+                targetWorkflow, Map.of(dictKey, sourceExt));
+
+        ImportPreview preview = matcher.buildPreview(sourceWith(sourceWf), TARGET_AGENT_ID, true);
+
+        // Identical content on both sides: the sync must leave it alone.
+        assertEquals(DiffAction.SKIP, diffOf(preview, "src-dict-1").action());
+    }
+
+    /**
+     * The headline of the secret-neutral comparison: the export replaced the API
+     * key with a placeholder, everything else is identical, and the sync must
+     * therefore write nothing. Comparing the raw source instead reported UPDATE for
+     * every agent holding a credential.
+     */
+    @Test
+    @DisplayName("a config differing only by a scrubbed secret compares equal and is skipped")
+    void scrubbedSecretDoesNotMakeAConfigDiffer() throws Exception {
+        String written = extensionActionFor(
+                "{\"apiKey\":\"${vault:REDACTED}\",\"model\":\"gpt-4\"}",
+                "{\"apiKey\":\"sk-live-abc\",\"model\":\"gpt-4\"}").action().name();
+
+        assertEquals(DiffAction.SKIP.name(), written);
+    }
+
+    /**
+     * The neutralisation must not hide a real change. Restoring the target's key
+     * still leaves the model different, so this one is an UPDATE.
+     */
+    @Test
+    @DisplayName("a real change beside a scrubbed secret is still an UPDATE")
+    void realChangeBesideAScrubbedSecretIsStillAnUpdate() throws Exception {
+        assertEquals(DiffAction.UPDATE,
+                extensionActionFor("{\"apiKey\":\"${vault:REDACTED}\",\"model\":\"gpt-4\"}",
+                        "{\"apiKey\":\"sk-live-abc\",\"model\":\"gpt-3\"}").action());
+    }
+
+    /**
+     * When the merge cannot be performed at all, the comparison falls back to the
+     * raw source. The result is an UPDATE — the safe direction: the operator is
+     * shown a write that may be unnecessary rather than not shown one that matters.
+     */
+    @Test
+    @DisplayName("content that cannot be parsed falls back to comparing the raw source")
+    void unparseableContentFallsBackToTheRawComparison() throws Exception {
+        // doThrow, not when(...).thenThrow: the when-form would first invoke the
+        // answer already installed in setUp with an empty argument.
+        doThrow(new java.io.IOException("not JSON")).when(jsonSerialization).deserialize(anyString());
+
+        assertEquals(DiffAction.UPDATE,
+                extensionActionFor("{\"apiKey\":\"${vault:REDACTED}\",\"model\":\"gpt-4\"}",
+                        "{\"apiKey\":\"sk-live-abc\",\"model\":\"gpt-4\"}").action());
+    }
+
+    /**
+     * The version shown beside the agent row is best-effort. A descriptor store
+     * that throws must cost the version number, not the whole preview.
+     */
+    @Test
+    @DisplayName("a descriptor store that throws costs the version, not the preview")
+    void descriptorFailureLeavesTheVersionUnknown() throws Exception {
+        var targetConfig = new AgentConfiguration();
+        targetConfig.setWorkflows(List.of());
+        when(agentStore.readAgent(eq(TARGET_AGENT_ID), anyInt())).thenReturn(targetConfig);
+        doAnswer(throwing(new IResourceStore.ResourceStoreException("descriptor unreadable")))
+                .when(documentDescriptorStore).readDescriptor(eq(TARGET_AGENT_ID), isNull());
+
+        ImportPreview preview = matcher.buildPreview(sourceWithNoWorkflows(), TARGET_AGENT_ID, true);
+
+        ResourceDiff agentDiff = diffOf(preview, "src-1");
+        assertNotNull(agentDiff);
+        assertEquals(TARGET_AGENT_ID, agentDiff.targetId());
+        assertNull(agentDiff.targetVersion(),
+                "an unknown version must be reported as unknown, not guessed");
+    }
+
+    /** Sneaky-throws a checked store exception the way the REST proxy does. */
+    private static Answer<Object> throwing(Exception exception) {
+        return invocation -> {
+            throw exception;
+        };
+    }
+
+    // ==================== Helpers ====================
+
+    /**
+     * Runs one LLM extension through the matcher and returns its diff row.
+     */
+    private ResourceDiff extensionActionFor(String sourceContent, String targetContent) throws Exception {
+        stubTargetAgentWithOneWorkflow();
+
+        var targetWorkflow = new WorkflowConfiguration();
+        targetWorkflow.setWorkflowSteps(new ArrayList<>(List.of(
+                step("eddi://ai.labs.llm", null,
+                        Map.of("uri", "eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=2")))));
+        when(workflowStore.readWorkflow(WORKFLOW_ID, 1)).thenReturn(targetWorkflow);
+
+        var llmStore = mock(IRestLlmStore.class);
+        var targetLlm = new LlmConfiguration(List.of());
+        when(restInterfaceFactory.get(IRestLlmStore.class)).thenReturn(llmStore);
+        when(llmStore.readLlm(LLM_ID, 2)).thenReturn(targetLlm);
+        // The target's config as JSON — serializeSafe is what the matcher calls, so
+        // this is where the target content enters the comparison.
+        when(jsonSerialization.serialize(targetLlm)).thenReturn(targetContent);
+
+        var sourceExt = new ExtensionSourceData("src-ext-1", "GPT Config", "langchain",
+                "eddi://ai.labs.llm", sourceContent);
+        var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
+                targetWorkflow, Map.of(LLM_KEY, sourceExt));
+
+        return diffOf(matcher.buildPreview(sourceWith(sourceWf), TARGET_AGENT_ID, true), "src-ext-1");
+    }
+
+    private void stubTargetAgentWithOneWorkflow() throws Exception {
+        var targetConfig = new AgentConfiguration();
+        targetConfig.setWorkflows(List.of(URI.create(
+                "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1")));
+        when(agentStore.readAgent(eq(TARGET_AGENT_ID), anyInt())).thenReturn(targetConfig);
+
+        var wfDescriptor = new DocumentDescriptor();
+        wfDescriptor.setName("Target Workflow");
+        when(documentDescriptorStore.readDescriptor(WORKFLOW_ID, null)).thenReturn(wfDescriptor);
+    }
+
+    private static WorkflowConfiguration.WorkflowStep step(String type,
+                                                           Map<String, Object> extensions,
+                                                           Map<String, Object> config) {
+        var step = new WorkflowConfiguration.WorkflowStep();
+        step.setType(URI.create(type));
+        step.setExtensions(extensions == null ? new HashMap<>() : new HashMap<>(extensions));
+        step.setConfig(config == null ? new HashMap<>() : new HashMap<>(config));
+        return step;
+    }
+
+    private static WorkflowConfiguration.WorkflowStep step(String type, Map<String, Object> extensions) {
+        return step(type, extensions, null);
+    }
+
+    private static ResourceDiff diffOf(ImportPreview preview, String sourceId) {
+        return preview.resources().stream()
+                .filter(diff -> sourceId.equals(diff.sourceId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no row for " + sourceId + " in " + preview.resources()));
+    }
+
+    private IResourceSource sourceWithNoWorkflows() {
+        return sourceWith();
+    }
+
+    private IResourceSource sourceWith(WorkflowSourceData... workflows) {
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of());
+        return new IResourceSource() {
+            @Override
+            public AgentSourceData readAgent() {
+                return new AgentSourceData("src-1", "Source Agent", agentConfig);
+            }
+
+            @Override
+            public List<WorkflowSourceData> readWorkflows() {
+                return List.of(workflows);
+            }
+
+            @Override
+            public List<IResourceSource.SnippetSourceData> readSnippets() {
+                return List.of();
+            }
+        };
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherFailurePathTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherFailurePathTest.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -280,7 +281,7 @@ class StructuralMatcherFailurePathTest {
     void unparseableContentFallsBackToTheRawComparison() throws Exception {
         // doThrow, not when(...).thenThrow: the when-form would first invoke the
         // answer already installed in setUp with an empty argument.
-        doThrow(new java.io.IOException("not JSON")).when(jsonSerialization).deserialize(anyString());
+        doThrow(new IOException("not JSON")).when(jsonSerialization).deserialize(anyString());
 
         assertEquals(DiffAction.UPDATE,
                 extensionActionFor("{\"apiKey\":\"${vault:REDACTED}\",\"model\":\"gpt-4\"}",

--- a/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherRealWorkflowTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherRealWorkflowTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IResourceSource;
+import ai.labs.eddi.backup.IResourceSource.AgentSourceData;
+import ai.labs.eddi.backup.IResourceSource.ExtensionSourceData;
+import ai.labs.eddi.backup.IResourceSource.WorkflowSourceData;
+import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
+import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
+import ai.labs.eddi.configs.agents.IRestAgentStore;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.llm.IRestLlmStore;
+import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Runs the real {@link StructuralMatcher} against a workflow shaped the way
+ * {@code AgentSetupService} writes one and the way the shipped reference config
+ * looks — step {@code type} is the {@code eddi://} step-type URI and the
+ * extension reference lives in {@code config.uri}.
+ * <p>
+ * Three independent breaks in the flagship sync capability met here:
+ * <ul>
+ * <li>the URI was read from {@code step.getExtensions()}, which no real
+ * workflow populates, so the matcher saw zero target extensions;</li>
+ * <li>source and target keyed their extension maps in two different namespaces,
+ * so nothing could join even once the URI was found;</li>
+ * <li>the {@link DiffAction} was decided from content the matcher had been told
+ * not to load, so every matched resource compared equal and every sync silently
+ * updated nothing.</li>
+ * </ul>
+ */
+@DisplayName("StructuralMatcher — against a real-shaped workflow")
+class StructuralMatcherRealWorkflowTest {
+
+    private static final String TARGET_AGENT_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String TARGET_WF_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String TARGET_LLM_ID = "cccccccccccccccccccccccc";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private IRestAgentStore agentStore;
+    private IDocumentDescriptorStore documentDescriptorStore;
+    private IRestWorkflowStore workflowStore;
+    private IRestInterfaceFactory restInterfaceFactory;
+    private IRestLlmStore llmStore;
+    private StructuralMatcher matcher;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        agentStore = mock(IRestAgentStore.class);
+        documentDescriptorStore = mock(IDocumentDescriptorStore.class);
+        IRestPromptSnippetStore snippetStore = mock(IRestPromptSnippetStore.class);
+        workflowStore = mock(IRestWorkflowStore.class);
+        restInterfaceFactory = mock(IRestInterfaceFactory.class);
+        llmStore = mock(IRestLlmStore.class);
+
+        matcher = new StructuralMatcher(agentStore, documentDescriptorStore, snippetStore,
+                workflowStore, restInterfaceFactory, new JacksonJsonSerialization());
+
+        doReturn(Collections.emptyList()).when(snippetStore).readSnippetDescriptors(anyString(), anyInt(), anyInt());
+        doReturn(llmStore).when(restInterfaceFactory).get(IRestLlmStore.class);
+
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of(
+                URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + TARGET_WF_ID + "?version=1")));
+        doReturn(agentConfig).when(agentStore).readAgent(TARGET_AGENT_ID, 1);
+
+        stubDescriptor(TARGET_AGENT_ID, "eddi://ai.labs.agent/agentstore/agents/" + TARGET_AGENT_ID + "?version=1");
+        stubDescriptor(TARGET_WF_ID, "eddi://ai.labs.workflow/workflowstore/workflows/" + TARGET_WF_ID + "?version=1");
+
+        doReturn(realShapedWorkflow()).when(workflowStore).readWorkflow(TARGET_WF_ID, 1);
+    }
+
+    @Test
+    @DisplayName("target extensions are found and matched — not reported as CREATE")
+    void matchesExtensionAgainstRealWorkflow() throws Exception {
+        doReturn(llm("answer questions")).when(llmStore).readLlm(TARGET_LLM_ID, 1);
+
+        ImportPreview preview = matcher.buildPreview(sourceWith(llmJson("answer questions")), TARGET_AGENT_ID, true);
+
+        ResourceDiff llmDiff = diffOfType(preview, "langchain");
+        // CREATE here meant executeUpgrade called createExtension for every
+        // extension, duplicating the whole configuration tree on every sync.
+        assertEquals(DiffAction.SKIP, llmDiff.action());
+        assertEquals(TARGET_LLM_ID, llmDiff.targetId());
+        assertEquals("type", llmDiff.matchStrategy());
+    }
+
+    @Test
+    @DisplayName("differing content is UPDATE even when the diff view is not requested")
+    void decidesActionWithoutIncludeContent() throws Exception {
+        doReturn(llm("answer questions")).when(llmStore).readLlm(TARGET_LLM_ID, 1);
+
+        // includeContent=false is what UpgradeExecutor passed. Deciding the action
+        // from content that was not loaded compared null against null, so every
+        // matched resource was SKIP and a sync updated nothing while still bumping
+        // the agent version and answering 201 CREATED.
+        ImportPreview preview = matcher.buildPreview(sourceWith(llmJson("summarise tickets")), TARGET_AGENT_ID, false);
+
+        ResourceDiff llmDiff = diffOfType(preview, "langchain");
+        assertEquals(DiffAction.UPDATE, llmDiff.action());
+        assertEquals(TARGET_LLM_ID, llmDiff.targetId());
+        // includeContent still governs whether the JSON is returned for the UI.
+        assertNull(llmDiff.sourceContent());
+        assertNull(llmDiff.targetContent());
+    }
+
+    @Test
+    @DisplayName("identical content differing only in whitespace and key order still SKIPs")
+    void normalizesBeforeComparing() throws Exception {
+        doReturn(llm("answer questions")).when(llmStore).readLlm(TARGET_LLM_ID, 1);
+
+        // Source content is verbatim ZIP text or a verbatim HTTP body; target
+        // content is a fresh serialization. Comparing them as strings made every
+        // resource look modified, so SKIP effectively never fired.
+        String reordered = prettyWithReversedKeys(llmJson("answer questions"));
+        assertNotEquals(reordered, llmJson("answer questions"), "the fixture must actually differ as text");
+
+        ImportPreview preview = matcher.buildPreview(sourceWith(reordered), TARGET_AGENT_ID, true);
+
+        assertEquals(DiffAction.SKIP, diffOfType(preview, "langchain").action());
+    }
+
+    @Test
+    @DisplayName("an unreadable target agent is a 404, not a silent switch to create-everything")
+    void unreadableTargetIsNotFound() throws Exception {
+        doThrow(new RuntimeException("datastore down")).when(agentStore).readAgent(eq(TARGET_AGENT_ID), anyInt());
+
+        var ex = assertThrows(NotFoundException.class,
+                () -> matcher.buildPreview(sourceWith(llmJson("answer questions")), TARGET_AGENT_ID, true));
+        assertTrue(ex.getMessage().contains(TARGET_AGENT_ID), ex.getMessage());
+    }
+
+    // ==================== Fixtures ====================
+
+    /**
+     * A workflow step in the shape AgentSetupService writes and the shipped
+     * reference config uses: an {@code eddi://} step type and {@code config.uri}.
+     */
+    private static WorkflowConfiguration realShapedWorkflow() {
+        var step = new WorkflowConfiguration.WorkflowStep();
+        step.setType(URI.create("eddi://ai.labs.llm"));
+        step.setConfig(new HashMap<>(Map.of("uri",
+                "eddi://ai.labs.llm/llmstore/llms/" + TARGET_LLM_ID + "?version=1")));
+        step.setExtensions(new HashMap<>());
+
+        var config = new WorkflowConfiguration();
+        config.setWorkflowSteps(new ArrayList<>(List.of(step)));
+        return config;
+    }
+
+    /**
+     * The source content an export or a remote read would carry: the same config
+     * class serialized, not a hand-written subset.
+     */
+    private static String llmJson(String description) throws Exception {
+        return MAPPER.writeValueAsString(llm(description));
+    }
+
+    /**
+     * The same document rendered by a different producer — indented, and with every
+     * object's keys in the opposite order.
+     */
+    private static String prettyWithReversedKeys(String json) throws Exception {
+        Object tree = MAPPER.readValue(json, Object.class);
+        return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(reverseKeys(tree));
+    }
+
+    private static Object reverseKeys(Object node) {
+        if (node instanceof Map<?, ?> map) {
+            List<?> keys = new ArrayList<>(map.keySet());
+            Collections.reverse(keys);
+            Map<String, Object> reversed = new LinkedHashMap<>();
+            for (Object key : keys) {
+                reversed.put(String.valueOf(key), reverseKeys(map.get(key)));
+            }
+            return reversed;
+        }
+        if (node instanceof List<?> list) {
+            return list.stream().map(StructuralMatcherRealWorkflowTest::reverseKeys).toList();
+        }
+        return node;
+    }
+
+    private static LlmConfiguration llm(String description) {
+        var task = new LlmConfiguration.Task();
+        task.setId("main");
+        task.setType("llm");
+        task.setDescription(description);
+        return new LlmConfiguration(new ArrayList<>(List.of(task)));
+    }
+
+    private IResourceSource sourceWith(String llmContentJson) {
+        var sourceWfConfig = realShapedWorkflow();
+        String extensionKey = WorkflowExtensions.scan(sourceWfConfig).getFirst().key();
+
+        var extension = new ExtensionSourceData("src-llm", "GPT Config", "langchain",
+                "eddi://ai.labs.llm", llmContentJson);
+        var workflow = new WorkflowSourceData("src-wf", "Workflow", 0, sourceWfConfig,
+                Map.of(extensionKey, extension));
+
+        return new IResourceSource() {
+            @Override
+            public AgentSourceData readAgent() {
+                return new AgentSourceData("src-agent", "Source Agent", new AgentConfiguration());
+            }
+
+            @Override
+            public List<WorkflowSourceData> readWorkflows() {
+                return List.of(workflow);
+            }
+
+            @Override
+            public List<SnippetSourceData> readSnippets() {
+                return List.of();
+            }
+        };
+    }
+
+    private void stubDescriptor(String id, String resourceUri) throws Exception {
+        var descriptor = new DocumentDescriptor();
+        descriptor.setName("Target " + id);
+        descriptor.setResource(URI.create(resourceUri));
+        doReturn(descriptor).when(documentDescriptorStore).readDescriptor(eq(id), isNull());
+    }
+
+    private static ResourceDiff diffOfType(ImportPreview preview, String resourceType) {
+        return preview.resources().stream()
+                .filter(d -> resourceType.equals(d.resourceType()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "no '" + resourceType + "' diff in preview: " + preview.resources()));
+    }
+
+    /** A real serializer — the comparison under test is about JSON, not mocks. */
+    private static final class JacksonJsonSerialization implements IJsonSerialization {
+        private final ObjectMapper mapper = MAPPER;
+
+        @Override
+        public String serialize(Object model) throws IOException {
+            return mapper.writeValueAsString(model);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T deserialize(String json) throws IOException {
+            return (T) mapper.readValue(json, Object.class);
+        }
+
+        @Override
+        public <T> T deserialize(String json, Class<T> type) throws IOException {
+            return mapper.readValue(json, type);
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherRealWorkflowTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/StructuralMatcherRealWorkflowTest.java
@@ -19,10 +19,13 @@ import ai.labs.eddi.configs.llm.IRestLlmStore;
 import ai.labs.eddi.configs.snippets.IRestPromptSnippetStore;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.secrets.sanitize.SecretScrubber;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -151,13 +154,52 @@ class StructuralMatcherRealWorkflowTest {
     }
 
     @Test
-    @DisplayName("an unreadable target agent is a 404, not a silent switch to create-everything")
-    void unreadableTargetIsNotFound() throws Exception {
-        doThrow(new RuntimeException("datastore down")).when(agentStore).readAgent(eq(TARGET_AGENT_ID), anyInt());
+    @DisplayName("a target agent that does not exist is a 404, not a silent switch to create-everything")
+    void missingTargetIsNotFound() throws Exception {
+        // doThrow refuses a checked exception the method does not declare; the store
+        // reaches this frame through SneakyThrow, so an answer is how it is simulated.
+        doAnswer(inv -> {
+            throw new IResourceStore.ResourceNotFoundException("no such agent");
+        }).when(agentStore).readAgent(eq(TARGET_AGENT_ID), anyInt());
 
         var ex = assertThrows(NotFoundException.class,
                 () -> matcher.buildPreview(sourceWith(llmJson("answer questions")), TARGET_AGENT_ID, true));
         assertTrue(ex.getMessage().contains(TARGET_AGENT_ID), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("a target agent that cannot be read is a 5xx — a store outage is not 'not found'")
+    void unreadableTargetIsServerError() throws Exception {
+        doThrow(new RuntimeException("datastore down")).when(agentStore).readAgent(eq(TARGET_AGENT_ID), anyInt());
+
+        // Reporting an outage as 404 sends the operator looking for an agent that is
+        // there, and a client that reacts to 404 by creating the agent duplicates it.
+        var ex = assertThrows(InternalServerErrorException.class,
+                () -> matcher.buildPreview(sourceWith(llmJson("answer questions")), TARGET_AGENT_ID, true));
+        assertTrue(ex.getMessage().contains(TARGET_AGENT_ID), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("content differing only by an exported secret placeholder still SKIPs")
+    void scrubbedSecretsDoNotCountAsAChange() throws Exception {
+        // Everything in an export ZIP (and everything a remote instance hands out) has
+        // been through the secret scrubber, so a config holding a credential arrives as
+        // ${vault:REDACTED} while the target still carries the live value. Comparing
+        // those raw made every agent WITH a credential compare unequal, so it could
+        // never SKIP: a nightly sync that changed nothing still wrote the resource,
+        // bumped its version, repointed the workflow and bumped the agent version.
+        LlmConfiguration target = llm("answer questions");
+        target.tasks().getFirst().setParameters(new LinkedHashMap<>(Map.of("apiKey", "sk-live-abc")));
+        doReturn(target).when(llmStore).readLlm(TARGET_LLM_ID, 1);
+
+        LlmConfiguration exported = llm("answer questions");
+        exported.tasks().getFirst().setParameters(new LinkedHashMap<>(Map.of("apiKey", SecretScrubber.REDACTED)));
+        String scrubbedSource = MAPPER.writeValueAsString(exported);
+        assertTrue(scrubbedSource.contains(SecretScrubber.REDACTED), scrubbedSource);
+
+        ImportPreview preview = matcher.buildPreview(sourceWith(scrubbedSource), TARGET_AGENT_ID, true);
+
+        assertEquals(DiffAction.SKIP, diffOfType(preview, "langchain").action());
     }
 
     // ==================== Fixtures ====================

--- a/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IResourceSource;
 import ai.labs.eddi.backup.IResourceSource.*;
 import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.backup.model.UpgradeResult;
 import ai.labs.eddi.backup.model.ImportPreview.DiffAction;
 import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
@@ -38,6 +39,9 @@ import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,6 +52,7 @@ import org.mockito.Mockito;
 
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -78,7 +83,7 @@ class UpgradeExecutorTest {
         descriptorStore = Mockito.mock(IDocumentDescriptorStore.class);
 
         executor = new UpgradeExecutor(agentStore, workflowStore,
-                snippetStore, jsonSerialization, structuralMatcher, descriptorStore, mock(ResourceAccessGuard.class));
+                snippetStore, jsonSerialization, structuralMatcher, descriptorStore, mock(BackupMetrics.class), mock(ResourceAccessGuard.class));
     }
 
     // ==================== Snippet Processing ====================
@@ -183,7 +188,7 @@ class UpgradeExecutorTest {
     class AgentConfigUpdate {
 
         @Test
-        @DisplayName("should update agent with new version and return URI")
+        @DisplayName("should update agent with new version and return URI when a workflow order is given")
         void updatesAgentAndReturnsUri() throws Exception {
             var source = createSource(List.of(), List.of());
 
@@ -198,11 +203,34 @@ class UpgradeExecutorTest {
             when(agentStore.updateAgent(eq("target-1"), eq(3), any()))
                     .thenReturn(Response.ok().build());
 
-            URI result = executor.executeUpgrade(source, "target-1", null, null);
+            var result = executor.executeUpgrade(source, "target-1", null, List.of("wf-1"));
 
-            assertNotNull(result);
-            assertTrue(result.toString().contains("target-1"));
-            assertTrue(result.toString().contains("version=4"));
+            assertTrue(result.agentUpdated());
+            assertNotNull(result.agentUri());
+            assertTrue(result.agentUri().toString().contains("target-1"));
+            assertTrue(result.agentUri().toString().contains("version=4"));
+        }
+
+        @Test
+        @DisplayName("should NOT burn an agent version when nothing changed")
+        void leavesAgentVersionAloneWhenNothingChanged() throws Exception {
+            var source = createSource(List.of(), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+
+            setupPreviewAndAgent("target-1", 3, diffs);
+
+            var result = executor.executeUpgrade(source, "target-1", null, null);
+
+            // An unconditional updateAgent wrote a byte-identical configuration and
+            // bumped the version, so a CI job that synced on every build inflated the
+            // version history and "v14" said nothing about whether anything changed.
+            verify(agentStore, never()).updateAgent(anyString(), anyInt(), any());
+            assertFalse(result.agentUpdated());
+            assertFalse(result.wroteAnything());
+            assertEquals("eddi://ai.labs.agent/agentstore/agents/target-1?version=3",
+                    result.agentUri().toString());
         }
     }
 
@@ -228,7 +256,7 @@ class UpgradeExecutorTest {
 
             // Setup preview and descriptor without setting up default agentConfig
             var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
-            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(false))).thenReturn(preview);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
 
             var descriptor = new DocumentDescriptor();
             descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=1"));
@@ -265,15 +293,23 @@ class UpgradeExecutorTest {
     class ExtensionProcessing {
 
         @Test
-        @DisplayName("should update matched extension and rewrite workflow URI")
+        @DisplayName("should update matched extension and rewrite the step's config.uri")
         @SuppressWarnings("unchecked")
         void updatesExtensionAndRewritesWorkflowUri() throws Exception {
             String wfId = "aaaaaaaaaaaaaaaaaaaaaaaa";
             String extId = "bbbbbbbbbbbbbbbbbbbbbbbb";
+            String oldExtUri = "eddi://ai.labs.llm/llmstore/llms/" + extId + "?version=2";
 
-            var llmExt = new ExtensionSourceData("src-ext-1", "GPT Config", "langchain", "ai.labs.llm", "{\"model\":\"gpt-4\"}");
+            // A workflow shaped the way AgentSetupService writes one and the way the
+            // shipped reference config looks: type is the eddi:// step-type URI and
+            // the extension reference lives in config.uri, not in extensions.
+            var sourceWfConfig = workflowWithLlmStep(oldExtUri);
+            String extensionKey = WorkflowExtensions.scan(sourceWfConfig).getFirst().key();
+
+            var llmExt = new ExtensionSourceData("src-ext-1", "GPT Config", "langchain",
+                    "eddi://ai.labs.llm", "{\"model\":\"gpt-4\"}");
             var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
-                    new WorkflowConfiguration(), Map.of("ai.labs.llm", llmExt));
+                    sourceWfConfig, Map.of(extensionKey, llmExt));
             var source = createSource(List.of(sourceWf), List.of());
 
             // Diffs: agent SKIP, workflow UPDATE with extension UPDATE
@@ -285,7 +321,7 @@ class UpgradeExecutorTest {
                     DiffAction.UPDATE, extId, 2, "type", null, null, -1));
 
             var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
-            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(false))).thenReturn(preview);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
 
             // Setup agent descriptor
             var descriptor = new DocumentDescriptor();
@@ -298,12 +334,7 @@ class UpgradeExecutorTest {
                     .thenReturn(new LlmConfiguration(List.of()));
             when(llmStore.updateLlm(eq(extId), eq(2), any())).thenReturn(Response.ok().build());
 
-            // Workflow config with workflowStep referencing old extension URI
-            var targetWfConfig = new WorkflowConfiguration();
-            var step = new WorkflowConfiguration.WorkflowStep();
-            step.setType(URI.create("ai.labs.llm"));
-            step.setExtensions(new HashMap<>(Map.of("uri", "eddi://ai.labs.llm/llmstore/llms/" + extId + "?version=2")));
-            targetWfConfig.setWorkflowSteps(List.of(step));
+            var targetWfConfig = workflowWithLlmStep(oldExtUri);
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(targetWfConfig);
             when(workflowStore.updateWorkflow(eq(wfId), eq(1), any())).thenReturn(Response.ok().build());
 
@@ -315,21 +346,116 @@ class UpgradeExecutorTest {
             when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(llmStore);
 
-                URI result = executor.executeUpgrade(source, "target-1", null, null);
+                var result = executor.executeUpgrade(source, "target-1", null, null);
 
-                assertNotNull(result);
+                assertNotNull(result.agentUri());
+                assertFalse(result.hasFailures());
                 verify(llmStore).updateLlm(eq(extId), eq(2), any());
-                verify(workflowStore).updateWorkflow(eq(wfId), eq(1), any());
+
+                var captor = org.mockito.ArgumentCaptor.forClass(WorkflowConfiguration.class);
+                verify(workflowStore).updateWorkflow(eq(wfId), eq(1), captor.capture());
+
+                // The engine reads config.uri. Writing the new version into
+                // extensions.uri left the deployed pipeline on the OLD extension
+                // version while the agent version was bumped, and left a stray key
+                // that reference scans do not count as a reference.
+                var updatedStep = captor.getValue().getWorkflowSteps().getFirst();
+                assertEquals("eddi://ai.labs.llm/llmstore/llms/" + extId + "?version=3",
+                        updatedStep.getConfig().get("uri"));
+                assertFalse(updatedStep.getExtensions().containsKey("uri"));
+
+                // ... and the agent is versioned because the workflow genuinely changed
+                verify(agentStore).updateAgent(eq("target-1"), eq(1), any());
             }
+        }
+
+        @Test
+        @DisplayName("a scrubbed secret is replaced by the target's own value, not written as a placeholder")
+        @SuppressWarnings("unchecked")
+        void restoresScrubbedSecretsFromTarget() throws Exception {
+            String wfId = "aaaaaaaaaaaaaaaaaaaaaaaa";
+            String extId = "bbbbbbbbbbbbbbbbbbbbbbbb";
+
+            // Everything in an export ZIP has been through the secret scrubber, which
+            // replaces live credentials with ${vault:REDACTED}. Writing that straight
+            // into the target replaced a production agent's working API keys with
+            // placeholders — an upgrade from an export broke the agent it updated.
+            String scrubbedSource = "{\"apiKey\":\"${vault:REDACTED}\",\"model\":\"gpt-4\"}";
+            String targetContent = "{\"apiKey\":\"sk-live-abc\",\"model\":\"gpt-3\"}";
+
+            var llmExt = new ExtensionSourceData("src-ext-1", "GPT Config", "langchain",
+                    "eddi://ai.labs.llm", scrubbedSource);
+            var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
+                    new WorkflowConfiguration(), Map.of("k", llmExt));
+            var source = createSource(List.of(sourceWf), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+            diffs.add(new ResourceDiff("src-wf-1", "workflow", "Workflow 1",
+                    DiffAction.UPDATE, wfId, 1, "position", null, null, 0));
+            diffs.add(new ResourceDiff("src-ext-1", "langchain", "GPT Config",
+                    DiffAction.UPDATE, extId, 2, "type", scrubbedSource, targetContent, -1));
+
+            setupPreviewAndAgent("target-1", 1, diffs);
+            when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
+
+            // Real JSON round-tripping — the merge under test is about JSON, not mocks.
+            var mapper = new ObjectMapper();
+            when(jsonSerialization.deserialize(anyString()))
+                    .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), Object.class));
+            when(jsonSerialization.serialize(any()))
+                    .thenAnswer(inv -> mapper.writeValueAsString(inv.getArgument(0)));
+
+            var mergedJson = new AtomicReference<String>();
+            when(jsonSerialization.deserialize(anyString(), eq(LlmConfiguration.class)))
+                    .thenAnswer(inv -> {
+                        mergedJson.set(inv.getArgument(0));
+                        return new LlmConfiguration(List.of());
+                    });
+
+            var llmStore = Mockito.mock(IRestLlmStore.class);
+            when(llmStore.updateLlm(eq(extId), eq(2), any())).thenReturn(Response.ok().build());
+
+            @SuppressWarnings("rawtypes")
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
+            try (cdiMock) {
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito
+                        .mock(Instance.class);
+                when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
+                when(instanceLlm.get()).thenReturn(llmStore);
+
+                executor.executeUpgrade(source, "target-1", null, null);
+            }
+
+            assertNotNull(mergedJson.get(), "the store update never ran");
+            assertFalse(mergedJson.get().contains("${vault:REDACTED}"), mergedJson.get());
+            assertTrue(mergedJson.get().contains("sk-live-abc"), mergedJson.get());
+            // Everything that is not a scrubbed secret still comes from the source.
+            assertTrue(mergedJson.get().contains("gpt-4"), mergedJson.get());
+        }
+
+        /**
+         * A workflow step in the shape the engine and the exporter actually produce.
+         */
+        private WorkflowConfiguration workflowWithLlmStep(String extensionUri) {
+            var config = new WorkflowConfiguration();
+            var step = new WorkflowConfiguration.WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.llm"));
+            step.setConfig(new HashMap<>(Map.of("uri", extensionUri)));
+            step.setExtensions(new HashMap<>());
+            config.setWorkflowSteps(new ArrayList<>(List.of(step)));
+            return config;
         }
 
         @Test
@@ -351,7 +477,7 @@ class UpgradeExecutorTest {
                     DiffAction.CREATE, null, null, null, null, null, -1));
 
             var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
-            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(false))).thenReturn(preview);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
 
             var descriptor = new DocumentDescriptor();
             descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=1"));
@@ -384,20 +510,20 @@ class UpgradeExecutorTest {
             when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
 
                 // CDI lookup for IRestRagStore (getStore in resolveExtensionOps)
-                var instanceRestRag = (jakarta.enterprise.inject.Instance<IRestRagStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var instanceRestRag = (Instance<IRestRagStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestRagStore.class)).thenReturn(instanceRestRag);
                 when(instanceRestRag.get()).thenReturn(ragRestStore);
 
                 // CDI lookup for IRagStore (dispatchCreateDirect)
-                var instanceRag = (jakarta.enterprise.inject.Instance<IRagStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var instanceRag = (Instance<IRagStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRagStore.class)).thenReturn(instanceRag);
                 when(instanceRag.get()).thenReturn(ragDirectStore);
 
@@ -445,16 +571,16 @@ class UpgradeExecutorTest {
             when(wfDirectStore.create(any())).thenReturn(wfResourceId);
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceWf = (jakarta.enterprise.inject.Instance<IWorkflowStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceWf = (Instance<IWorkflowStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IWorkflowStore.class)).thenReturn(instanceWf);
                 when(instanceWf.get()).thenReturn(wfDirectStore);
 
-                URI result = executor.executeUpgrade(source, "target-1", null, null);
+                URI result = executor.executeUpgrade(source, "target-1", null, null).agentUri();
 
                 assertNotNull(result);
                 verify(wfDirectStore).create(any());
@@ -493,7 +619,7 @@ class UpgradeExecutorTest {
             diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
 
             var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
-            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(false))).thenReturn(preview);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
 
             var descriptor = new DocumentDescriptor();
             descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=1"));
@@ -505,8 +631,10 @@ class UpgradeExecutorTest {
             when(agentStore.updateAgent(eq("target-1"), eq(1), any()))
                     .thenThrow(new RuntimeException("DB error"));
 
+            // A workflow order is what makes the agent config genuinely need writing;
+            // without one the executor deliberately does not touch the agent at all.
             assertThrows(RuntimeException.class,
-                    () -> executor.executeUpgrade(source, "target-1", null, null));
+                    () -> executor.executeUpgrade(source, "target-1", null, List.of("wf-1")));
         }
     }
 
@@ -518,7 +646,7 @@ class UpgradeExecutorTest {
 
     private void setupPreviewAndAgent(String targetAgentId, int version, List<ResourceDiff> diffs) throws Exception {
         var preview = new ImportPreview("src-1", "Source Agent", targetAgentId, "Target Agent", diffs);
-        when(structuralMatcher.buildPreview(any(), eq(targetAgentId), eq(false))).thenReturn(preview);
+        when(structuralMatcher.buildPreview(any(), eq(targetAgentId), eq(true))).thenReturn(preview);
 
         var descriptor = new DocumentDescriptor();
         descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + targetAgentId + "?version=" + version));
@@ -562,15 +690,80 @@ class UpgradeExecutorTest {
     @DisplayName("Unknown extension type handling")
     class UnknownExtensionType {
 
+        /**
+         * m5, on the CREATE side. {@code createExtension} resolves the store through
+         * the same registry {@code updateExtension} does, and used to swallow the
+         * {@code IllegalArgumentException} that names an unregistered type — so a
+         * brand-new extension of a type nobody had wired up was reported as "the store
+         * did not accept the create", pointing the operator at a store that was never
+         * consulted.
+         * <p>
+         * This test replaces one that asserted only {@code assertNotNull} on the agent
+         * URI, which that path can never answer null.
+         */
         @Test
-        @DisplayName("should return null URI when extension type is unknown")
+        @DisplayName("an unregistered type on the create path is a wiring error too, and writes nothing")
         @SuppressWarnings("unchecked")
-        void unknownTypeReturnsNull() throws Exception {
+        void unregisteredTypeOnCreateIsReportedAsWiringError() throws Exception {
             String wfId = "aabbccddeeff112233445566";
 
-            var unknownExt = new ExtensionSourceData("src-ext-u", "Unknown Config", "unknowntype", "ai.labs.unknown", "{}");
+            var unknownExt = new ExtensionSourceData("src-ext-u", "Unknown Config", "unknowntype",
+                    "eddi://ai.labs.unknown", "{}");
             var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
-                    new WorkflowConfiguration(), Map.of("ai.labs.unknown", unknownExt));
+                    new WorkflowConfiguration(), Map.of("eddi://ai.labs.unknown#0/config", unknownExt));
+            var source = createSource(List.of(sourceWf), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+            diffs.add(new ResourceDiff("src-wf-1", "workflow", "Workflow 1",
+                    DiffAction.UPDATE, wfId, 1, "position", null, null, 0));
+            // CREATE, not UPDATE: this extension has no counterpart in the target.
+            diffs.add(new ResourceDiff("src-ext-u", "unknowntype", "Unknown Config",
+                    DiffAction.CREATE, null, null, null, null, null, -1));
+
+            setupPreviewAndAgent("target-1", 1, diffs);
+            when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
+
+            @SuppressWarnings("rawtypes")
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
+            try (cdiMock) {
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+
+                UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
+
+                assertEquals(1, result.failures().size(), result.failures().toString());
+                String reason = result.failures().getFirst().reason();
+                assertTrue(reason.contains("No store operations are registered"),
+                        "the operator must be told the type is unregistered, got: " + reason);
+                assertTrue(reason.contains("unknowntype"), "the reason must name the type, got: " + reason);
+                assertFalse(reason.contains("did not accept"),
+                        "a wiring mistake must not be reported as a store rejection, got: " + reason);
+
+                // Nothing landed, so nothing may be reported as written either.
+                assertEquals(0, result.created());
+                assertEquals(0, result.updated());
+                assertFalse(result.agentUpdated(), "a failed create must not bump the agent version");
+            }
+        }
+
+        /**
+         * m5 — an extension type with no registered store is a wiring mistake, and the
+         * operator has to be told that. {@code updateExtension} used to catch the
+         * {@code IllegalArgumentException} that says so and answer null, which the
+         * caller reported as "the store did not accept the update" — the opposite
+         * diagnosis, pointing at a store that was never consulted.
+         */
+        @Test
+        @DisplayName("an unregistered extension type is reported as a wiring error, not a store rejection")
+        @SuppressWarnings("unchecked")
+        void unregisteredTypeIsReportedAsWiringError() throws Exception {
+            String wfId = "aabbccddeeff112233445566";
+
+            var unknownExt = new ExtensionSourceData("src-ext-u", "Unknown Config", "unknowntype",
+                    "eddi://ai.labs.unknown", "{}");
+            var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
+                    new WorkflowConfiguration(), Map.of("eddi://ai.labs.unknown#0/config", unknownExt));
             var source = createSource(List.of(sourceWf), List.of());
 
             List<ResourceDiff> diffs = new ArrayList<>();
@@ -581,21 +774,81 @@ class UpgradeExecutorTest {
                     DiffAction.UPDATE, "cccccccccccccccccccccccc", 2, "type", null, null, -1));
 
             setupPreviewAndAgent("target-1", 1, diffs);
-
-            // Workflow config (empty)
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
 
-                URI result = executor.executeUpgrade(source, "target-1", null, null);
+                UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
 
-                // Should succeed (unknown type logged but skipped), no extension update
-                assertNotNull(result);
+                assertEquals(1, result.failures().size(), result.failures().toString());
+                String reason = result.failures().get(0).reason();
+                assertTrue(reason.contains("No store operations are registered"),
+                        "the operator must be told the type is unregistered, got: " + reason);
+                assertTrue(reason.contains("unknowntype"), "the reason must name the type, got: " + reason);
+                assertFalse(reason.contains("did not accept"),
+                        "a wiring mistake must not be reported as a store rejection, got: " + reason);
             }
+        }
+    }
+
+    // ==================== 'nothing to do' agent URI ====================
+
+    @Nested
+    @DisplayName("Agent URI of an upgrade that wrote nothing")
+    class NoOpAgentUri {
+
+        /**
+         * m8 — when an upgrade writes nothing, the agent URI it reports must not name a
+         * version that was guessed. The version lookup swallows every descriptor
+         * failure and answers 1, so this path handed the caller {@code ?version=1} for
+         * an agent that may well have been at v14.
+         */
+        @Test
+        @DisplayName("reports no version rather than guessing 1 when the descriptor cannot be read")
+        void unreadableDescriptorReportsNoVersion() throws Exception {
+            var source = createSource(List.of(), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+
+            var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
+            when(descriptorStore.readDescriptor(eq("target-1"), isNull()))
+                    .thenThrow(new RuntimeException("descriptor store unavailable"));
+
+            // Nothing to write: no workflow was updated or created, no order given.
+            UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
+
+            assertFalse(result.agentUpdated(), "nothing changed, so the agent must not be rewritten");
+            assertEquals(IRestAgentStore.resourceURI + "target-1", result.agentUri().toString(),
+                    "an unresolvable version must be omitted, never guessed as 1");
+            verify(agentStore, never()).updateAgent(anyString(), anyInt(), any());
+        }
+
+        @Test
+        @DisplayName("reports the version the descriptor actually names")
+        void readableDescriptorReportsItsVersion() throws Exception {
+            var source = createSource(List.of(), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+
+            var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
+
+            var descriptor = new DocumentDescriptor();
+            descriptor.setResource(URI.create(
+                    "eddi://ai.labs.agent/agentstore/agents/target-1?version=14"));
+            when(descriptorStore.readDescriptor(eq("target-1"), isNull())).thenReturn(descriptor);
+
+            UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
+
+            assertEquals(IRestAgentStore.resourceURI + "target-1?version=14",
+                    result.agentUri().toString());
         }
     }
 
@@ -636,16 +889,16 @@ class UpgradeExecutorTest {
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(llmStore);
 
-                URI result = executor.executeUpgrade(source, "target-1", null, null);
+                URI result = executor.executeUpgrade(source, "target-1", null, null).agentUri();
 
                 // Should still succeed (extension update returned null URI, no workflow update
                 // needed)
@@ -679,21 +932,24 @@ class UpgradeExecutorTest {
             setupPreviewAndAgent("target-1", 1, diffs);
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceWf = (jakarta.enterprise.inject.Instance<IWorkflowStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceWf = (Instance<IWorkflowStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IWorkflowStore.class)).thenReturn(instanceWf);
                 when(instanceWf.get()).thenThrow(new RuntimeException("CDI lookup failed"));
 
-                // Should NOT throw — createNewWorkflow catches and returns null
-                URI result = executor.executeUpgrade(source, "target-1", null, null);
+                // Should NOT throw — createNewWorkflow catches and records the failure
+                var result = executor.executeUpgrade(source, "target-1", null, null);
 
-                assertNotNull(result);
-                // Agent should still be updated (without the failed new workflow)
-                verify(agentStore).updateAgent(eq("target-1"), eq(1), any());
+                assertNotNull(result.agentUri());
+                // Nothing landed, so no agent version is burned — and the failure is
+                // reported rather than logged and forgotten behind a 201.
+                verify(agentStore, never()).updateAgent(anyString(), anyInt(), any());
+                assertTrue(result.hasFailures());
+                assertEquals("workflow", result.failures().getFirst().resourceType());
             }
         }
     }
@@ -739,16 +995,16 @@ class UpgradeExecutorTest {
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(targetWfConfig);
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(llmStore);
 
-                URI result = executor.executeUpgrade(source, "target-1", null, null);
+                URI result = executor.executeUpgrade(source, "target-1", null, null).agentUri();
 
                 assertNotNull(result);
                 // Workflow should NOT be updated since null type step was skipped (no match)
@@ -772,7 +1028,7 @@ class UpgradeExecutorTest {
             diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
 
             var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
-            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(false))).thenReturn(preview);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
 
             // Return null descriptor
             when(descriptorStore.readDescriptor(eq("target-1"), isNull())).thenReturn(null);
@@ -783,7 +1039,7 @@ class UpgradeExecutorTest {
             when(agentStore.readAgent("target-1", 1)).thenReturn(agentConfig);
             when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
 
-            URI result = executor.executeUpgrade(source, "target-1", null, null);
+            URI result = executor.executeUpgrade(source, "target-1", null, List.of("wf-1")).agentUri();
 
             assertNotNull(result);
             assertTrue(result.toString().contains("version=2")); // 1 + 1
@@ -798,7 +1054,7 @@ class UpgradeExecutorTest {
             diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
 
             var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
-            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(false))).thenReturn(preview);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
 
             // Return descriptor with null resource
             var descriptor = new DocumentDescriptor();
@@ -810,7 +1066,7 @@ class UpgradeExecutorTest {
             when(agentStore.readAgent("target-1", 1)).thenReturn(agentConfig);
             when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
 
-            URI result = executor.executeUpgrade(source, "target-1", null, null);
+            URI result = executor.executeUpgrade(source, "target-1", null, List.of("wf-1")).agentUri();
 
             assertNotNull(result);
             assertTrue(result.toString().contains("version=2")); // 1 + 1
@@ -825,7 +1081,7 @@ class UpgradeExecutorTest {
             diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
 
             var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
-            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(false))).thenReturn(preview);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
 
             when(descriptorStore.readDescriptor(eq("target-1"), isNull()))
                     .thenThrow(new RuntimeException("descriptor not found"));
@@ -835,7 +1091,7 @@ class UpgradeExecutorTest {
             when(agentStore.readAgent("target-1", 1)).thenReturn(agentConfig);
             when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
 
-            URI result = executor.executeUpgrade(source, "target-1", null, null);
+            URI result = executor.executeUpgrade(source, "target-1", null, List.of("wf-1")).agentUri();
 
             assertNotNull(result);
             assertTrue(result.toString().contains("version=2"));
@@ -867,7 +1123,7 @@ class UpgradeExecutorTest {
                     .when(snippetStore).updateSnippet(anyString(), anyInt(), any());
 
             // Should NOT throw — processSnippet catches and logs
-            URI result = executor.executeUpgrade(source, "target-1", null, null);
+            URI result = executor.executeUpgrade(source, "target-1", null, null).agentUri();
             assertNotNull(result);
         }
     }
@@ -905,17 +1161,17 @@ class UpgradeExecutorTest {
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
 
             @SuppressWarnings("rawtypes")
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
-                var instanceLlm = (jakarta.enterprise.inject.Instance<IRestLlmStore>) Mockito
-                        .mock(jakarta.enterprise.inject.Instance.class);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito
+                        .mock(Instance.class);
                 when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(Mockito.mock(IRestLlmStore.class));
 
                 // Should NOT throw — extension processing catches and logs
-                URI result = executor.executeUpgrade(source, "target-1", null, null);
+                URI result = executor.executeUpgrade(source, "target-1", null, null).agentUri();
                 assertNotNull(result);
             }
         }
@@ -1012,12 +1268,12 @@ class UpgradeExecutorTest {
             // Workflow config (empty)
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
 
-            MockedStatic<jakarta.enterprise.inject.spi.CDI> cdiMock = Mockito.mockStatic(jakarta.enterprise.inject.spi.CDI.class);
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
-                var cdiInstance = Mockito.mock(jakarta.enterprise.inject.spi.CDI.class);
-                cdiMock.when(jakarta.enterprise.inject.spi.CDI::current).thenReturn(cdiInstance);
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
 
-                var instance = (jakarta.enterprise.inject.Instance) Mockito.mock(jakarta.enterprise.inject.Instance.class);
+                var instance = (Instance) Mockito.mock(Instance.class);
                 when(cdiInstance.select(restStoreClass)).thenReturn(instance);
                 when(instance.get()).thenReturn(mockStore);
 
@@ -1026,7 +1282,7 @@ class UpgradeExecutorTest {
                 // for mock).
                 // This exercises the resolveExtensionOps + dispatchUpdate path, which will
                 // result in null response → null URI → no workflow update.
-                URI result = executor.executeUpgrade(source, "target-1", null, null);
+                URI result = executor.executeUpgrade(source, "target-1", null, null).agentUri();
 
                 assertNotNull(result);
             }

--- a/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
@@ -57,6 +57,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.inject.Instance;
+import jakarta.ws.rs.NotFoundException;
+import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -1500,10 +1502,10 @@ class UpgradeExecutorTest {
         @Test
         @DisplayName("a WebApplicationException from the preview reaches the caller unwrapped")
         void webApplicationExceptionIsRethrownAsItIs() throws Exception {
-            var notFound = new jakarta.ws.rs.NotFoundException("Target agent target-1 does not exist.");
+            var notFound = new NotFoundException("Target agent target-1 does not exist.");
             when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenThrow(notFound);
 
-            var thrown = assertThrows(jakarta.ws.rs.NotFoundException.class,
+            var thrown = assertThrows(NotFoundException.class,
                     () -> executorWithMetrics.executeUpgrade(createSource(List.of(), List.of()),
                             "target-1", null, null));
 
@@ -1590,7 +1592,7 @@ class UpgradeExecutorTest {
             // doThrow, not when(...).thenThrow: the when-form would first invoke the
             // round-tripping answer the helper installs, with an empty argument.
             String written = writeExtension(SCRUBBED, "{\"apiKey\":\"sk-live-abc\"}",
-                    () -> doThrow(new java.io.IOException("not JSON"))
+                    () -> doThrow(new IOException("not JSON"))
                             .when(jsonSerialization).deserialize(anyString()));
 
             assertEquals(SCRUBBED, written);

--- a/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -275,7 +276,7 @@ class UpgradeExecutorTest {
             // Reverse order
             executor.executeUpgrade(source, "target-1", null, List.of(wfIdC, wfIdB, wfIdA));
 
-            var captor = org.mockito.ArgumentCaptor.forClass(AgentConfiguration.class);
+            var captor = ArgumentCaptor.forClass(AgentConfiguration.class);
             verify(agentStore).updateAgent(eq("target-1"), eq(1), captor.capture());
 
             List<URI> workflows = captor.getValue().getWorkflows();
@@ -361,7 +362,7 @@ class UpgradeExecutorTest {
                 assertFalse(result.hasFailures());
                 verify(llmStore).updateLlm(eq(extId), eq(2), any());
 
-                var captor = org.mockito.ArgumentCaptor.forClass(WorkflowConfiguration.class);
+                var captor = ArgumentCaptor.forClass(WorkflowConfiguration.class);
                 verify(workflowStore).updateWorkflow(eq(wfId), eq(1), captor.capture());
 
                 // The engine reads config.uri. Writing the new version into
@@ -458,10 +459,18 @@ class UpgradeExecutorTest {
             return config;
         }
 
+        /**
+         * An extension the target workflow has no step for cannot be wired up:
+         * {@code updateWorkflowExtensionUris} can only repoint a reference the target
+         * already has, and CREATE means by definition that it has none. Creating the
+         * resource anyway left it in the store unreferenced, counted it as created,
+         * answered 201, changed the agent's behaviour not at all, and previewed the
+         * same CREATE again next time — so every sync added another dead copy.
+         */
         @Test
-        @DisplayName("should create new extension when action is CREATE")
+        @DisplayName("an extension the target workflow has no step for is refused, not created as an orphan")
         @SuppressWarnings("unchecked")
-        void createsNewExtension() throws Exception {
+        void refusesToCreateAnOrphanExtension() throws Exception {
             String wfId = "aaaaaaaaaaaaaaaaaaaaaaaa";
 
             var ragExt = new ExtensionSourceData("src-ext-2", "RAG Config", "rag", "ai.labs.rag", "{\"vectorStore\":\"pgvector\"}");
@@ -483,24 +492,12 @@ class UpgradeExecutorTest {
             descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=1"));
             when(descriptorStore.readDescriptor(eq("target-1"), isNull())).thenReturn(descriptor);
 
-            // Mock RAG direct store via CDI for create (dispatchCreateDirect uses CDI)
             var ragDirectStore = Mockito.mock(IRagStore.class);
             var ragRestStore = Mockito.mock(IRestRagStore.class);
-            var ragResourceId = new IResourceStore.IResourceId() {
-                @Override
-                public String getId() {
-                    return "newragid1234567890123456";
-                }
-                @Override
-                public Integer getVersion() {
-                    return 1;
-                }
-            };
             when(jsonSerialization.deserialize(eq("{\"vectorStore\":\"pgvector\"}"), any()))
                     .thenReturn(new RagConfiguration());
-            when(ragDirectStore.create(any())).thenReturn(ragResourceId);
 
-            // Workflow config (empty steps — no URI rewriting needed for CREATE)
+            // The target workflow has no rag step — that is what CREATE means.
             when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
 
             var agentConfig = new AgentConfiguration();
@@ -515,21 +512,183 @@ class UpgradeExecutorTest {
                 var cdiInstance = Mockito.mock(CDI.class);
                 cdiMock.when(CDI::current).thenReturn(cdiInstance);
 
-                // CDI lookup for IRestRagStore (getStore in resolveExtensionOps)
                 var instanceRestRag = (Instance<IRestRagStore>) Mockito
                         .mock(Instance.class);
                 when(cdiInstance.select(IRestRagStore.class)).thenReturn(instanceRestRag);
                 when(instanceRestRag.get()).thenReturn(ragRestStore);
 
-                // CDI lookup for IRagStore (dispatchCreateDirect)
                 var instanceRag = (Instance<IRagStore>) Mockito
                         .mock(Instance.class);
                 when(cdiInstance.select(IRagStore.class)).thenReturn(instanceRag);
                 when(instanceRag.get()).thenReturn(ragDirectStore);
 
-                executor.executeUpgrade(source, "target-1", null, null);
+                UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
 
-                verify(ragDirectStore).create(any());
+                verify(ragDirectStore, never()).create(any());
+                assertEquals(0, result.created(), "an unreferenceable resource must not be reported as created");
+                assertEquals(1, result.failures().size(), result.failures().toString());
+                String reason = result.failures().getFirst().reason();
+                assertTrue(reason.contains("no step"), "the operator must be told why, got: " + reason);
+                assertFalse(result.agentUpdated(), "nothing was written, so no agent version may be burned");
+            }
+        }
+
+        /**
+         * The flagship path: export an agent, edit one extension inside the ZIP,
+         * upgrade the same agent. The workflow JSON is byte-identical on both sides, so
+         * the matcher answers SKIP for the workflow while the extension is UPDATE.
+         * Reading the extension diffs only inside the workflow's UPDATE branch threw
+         * away every change the preview had just shown the operator, and the response
+         * still said 200 OK with updated=0.
+         */
+        @Test
+        @DisplayName("a workflow whose skeleton is unchanged still has its extension changes applied")
+        @SuppressWarnings("unchecked")
+        void skippedWorkflowStillAppliesExtensionUpdates() throws Exception {
+            String wfId = "aaaaaaaaaaaaaaaaaaaaaaaa";
+            String extId = "bbbbbbbbbbbbbbbbbbbbbbbb";
+            String oldExtUri = "eddi://ai.labs.llm/llmstore/llms/" + extId + "?version=2";
+
+            var sourceWfConfig = workflowWithLlmStep(oldExtUri);
+            String extensionKey = WorkflowExtensions.scan(sourceWfConfig).getFirst().key();
+
+            var llmExt = new ExtensionSourceData("src-ext-1", "GPT Config", "langchain",
+                    "eddi://ai.labs.llm", "{\"model\":\"gpt-4\"}");
+            var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
+                    sourceWfConfig, Map.of(extensionKey, llmExt));
+            var source = createSource(List.of(sourceWf), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+            // SKIP: the workflow skeleton is identical on both sides — the ZIP was
+            // produced from this very agent and only the LLM content was edited.
+            diffs.add(new ResourceDiff("src-wf-1", "workflow", "Workflow 1",
+                    DiffAction.SKIP, wfId, 1, "position", null, null, 0));
+            diffs.add(new ResourceDiff("src-ext-1", "langchain", "GPT Config",
+                    DiffAction.UPDATE, extId, 2, "type", null, null, -1));
+
+            var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
+
+            var descriptor = new DocumentDescriptor();
+            descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=1"));
+            when(descriptorStore.readDescriptor(eq("target-1"), isNull())).thenReturn(descriptor);
+
+            var llmStore = Mockito.mock(IRestLlmStore.class);
+            when(jsonSerialization.deserialize(eq("{\"model\":\"gpt-4\"}"), any()))
+                    .thenReturn(new LlmConfiguration(List.of()));
+            when(llmStore.updateLlm(eq(extId), eq(2), any())).thenReturn(Response.ok().build());
+
+            when(workflowStore.readWorkflow(wfId, 1)).thenReturn(workflowWithLlmStep(oldExtUri));
+            when(workflowStore.updateWorkflow(eq(wfId), eq(1), any())).thenReturn(Response.ok().build());
+
+            var agentConfig = new AgentConfiguration();
+            agentConfig.setWorkflows(new ArrayList<>(List.of(
+                    URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + wfId + "?version=1"))));
+            when(agentStore.readAgent("target-1", 1)).thenReturn(agentConfig);
+            when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
+
+            @SuppressWarnings("rawtypes")
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
+            try (cdiMock) {
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito.mock(Instance.class);
+                when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
+                when(instanceLlm.get()).thenReturn(llmStore);
+
+                UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
+
+                // The edit the operator previewed actually reaches the store...
+                verify(llmStore).updateLlm(eq(extId), eq(2), any());
+                // ...the workflow is repointed at the new extension version...
+                var captor = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+                verify(workflowStore).updateWorkflow(eq(wfId), eq(1), captor.capture());
+                assertEquals("eddi://ai.labs.llm/llmstore/llms/" + extId + "?version=3",
+                        captor.getValue().getWorkflowSteps().getFirst().getConfig().get("uri"));
+                // ...and the run reports what it did instead of "skipped 1, wrote nothing".
+                assertEquals(2, result.updated(), "the extension and its workflow were both written");
+                assertTrue(result.agentUpdated(), "the agent must point at the new workflow version");
+                assertTrue(result.wroteAnything());
+            }
+        }
+
+        /**
+         * The other half of the orphan problem. Here the extension IS written — the
+         * matcher joined it to a target resource, so the update goes through and the
+         * store now holds a new version — but the target workflow carries no reference
+         * at that key, so {@code updateWorkflowExtensionUris} has nothing to repoint.
+         * Left unreported, the run answered success while the deployed pipeline still
+         * loaded the old version and the new one sat there consumed by nothing. Every
+         * key the scan cannot place has to surface as a failure.
+         */
+        @Test
+        @DisplayName("an updated extension the target workflow does not reference is reported, not silently orphaned")
+        @SuppressWarnings("unchecked")
+        void unplaceableExtensionUriIsReportedAsFailure() throws Exception {
+            String wfId = "aaaaaaaaaaaaaaaaaaaaaaaa";
+            String extId = "bbbbbbbbbbbbbbbbbbbbbbbb";
+            String oldExtUri = "eddi://ai.labs.llm/llmstore/llms/" + extId + "?version=2";
+
+            var sourceWfConfig = workflowWithLlmStep(oldExtUri);
+            String extensionKey = WorkflowExtensions.scan(sourceWfConfig).getFirst().key();
+
+            var llmExt = new ExtensionSourceData("src-ext-1", "GPT Config", "langchain",
+                    "eddi://ai.labs.llm", "{\"model\":\"gpt-4\"}");
+            var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
+                    sourceWfConfig, Map.of(extensionKey, llmExt));
+            var source = createSource(List.of(sourceWf), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+            diffs.add(new ResourceDiff("src-wf-1", "workflow", "Workflow 1",
+                    DiffAction.UPDATE, wfId, 1, "position", null, null, 0));
+            diffs.add(new ResourceDiff("src-ext-1", "langchain", "GPT Config",
+                    DiffAction.UPDATE, extId, 2, "type", null, null, -1));
+
+            var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
+
+            var descriptor = new DocumentDescriptor();
+            descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=1"));
+            when(descriptorStore.readDescriptor(eq("target-1"), isNull())).thenReturn(descriptor);
+
+            var llmStore = Mockito.mock(IRestLlmStore.class);
+            when(jsonSerialization.deserialize(eq("{\"model\":\"gpt-4\"}"), any()))
+                    .thenReturn(new LlmConfiguration(List.of()));
+            when(llmStore.updateLlm(eq(extId), eq(2), any())).thenReturn(Response.ok().build());
+
+            // The target workflow has no step at all, so nothing in it names the
+            // extension the update just versioned.
+            when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
+
+            var agentConfig = new AgentConfiguration();
+            agentConfig.setWorkflows(new ArrayList<>(List.of(
+                    URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + wfId + "?version=1"))));
+            when(agentStore.readAgent("target-1", 1)).thenReturn(agentConfig);
+            when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
+
+            @SuppressWarnings("rawtypes")
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
+            try (cdiMock) {
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito.mock(Instance.class);
+                when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
+                when(instanceLlm.get()).thenReturn(llmStore);
+
+                UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
+
+                assertTrue(result.hasFailures(),
+                        "a URI nothing consumes must be reported, not counted as a clean run");
+                String reason = result.failures().getFirst().reason();
+                assertTrue(reason.contains(extensionKey),
+                        "the failure must name the key that could not be placed, got: " + reason);
+                assertTrue(reason.contains("not deployed"),
+                        "the operator must be told the written resource is not live, got: " + reason);
+                verify(workflowStore, never()).updateWorkflow(eq(wfId), eq(1), any());
+                assertFalse(result.agentUpdated(),
+                        "no workflow reference changed, so no agent version may be burned");
             }
         }
     }
@@ -585,7 +744,7 @@ class UpgradeExecutorTest {
                 assertNotNull(result);
                 verify(wfDirectStore).create(any());
                 // Verify agent was updated with new workflow appended
-                var captor = org.mockito.ArgumentCaptor.forClass(AgentConfiguration.class);
+                var captor = ArgumentCaptor.forClass(AgentConfiguration.class);
                 verify(agentStore).updateAgent(eq("target-1"), eq(1), captor.capture());
                 assertTrue(captor.getValue().getWorkflows().stream()
                         .anyMatch(uri -> uri.toString().contains(newWfId)));
@@ -691,20 +850,17 @@ class UpgradeExecutorTest {
     class UnknownExtensionType {
 
         /**
-         * m5, on the CREATE side. {@code createExtension} resolves the store through
-         * the same registry {@code updateExtension} does, and used to swallow the
-         * {@code IllegalArgumentException} that names an unregistered type — so a
-         * brand-new extension of a type nobody had wired up was reported as "the store
-         * did not accept the create", pointing the operator at a store that was never
-         * consulted.
-         * <p>
-         * This test replaces one that asserted only {@code assertNotNull} on the agent
-         * URI, which that path can never answer null.
+         * The CREATE side, which no longer consults the store registry at all: an
+         * extension the target workflow has no step for is refused before any store is
+         * chosen, because nothing could reference the resource once written. What still
+         * has to hold is that such a resource is reported as a failure naming it, and
+         * that nothing at all is written — not reported as created, and no agent
+         * version burned.
          */
         @Test
-        @DisplayName("an unregistered type on the create path is a wiring error too, and writes nothing")
+        @DisplayName("a CREATE that cannot be applied is a reported failure that writes nothing")
         @SuppressWarnings("unchecked")
-        void unregisteredTypeOnCreateIsReportedAsWiringError() throws Exception {
+        void createOfAnUnreferenceableExtensionIsReportedAndWritesNothing() throws Exception {
             String wfId = "aabbccddeeff112233445566";
 
             var unknownExt = new ExtensionSourceData("src-ext-u", "Unknown Config", "unknowntype",
@@ -734,11 +890,12 @@ class UpgradeExecutorTest {
 
                 assertEquals(1, result.failures().size(), result.failures().toString());
                 String reason = result.failures().getFirst().reason();
-                assertTrue(reason.contains("No store operations are registered"),
-                        "the operator must be told the type is unregistered, got: " + reason);
                 assertTrue(reason.contains("unknowntype"), "the reason must name the type, got: " + reason);
+                assertTrue(reason.contains("no step"),
+                        "the operator must be told the target workflow cannot reference it, got: " + reason);
                 assertFalse(reason.contains("did not accept"),
-                        "a wiring mistake must not be reported as a store rejection, got: " + reason);
+                        "nothing was offered to a store, so no store may be blamed, got: " + reason);
+                assertEquals("Unknown Config", result.failures().getFirst().name());
 
                 // Nothing landed, so nothing may be reported as written either.
                 assertEquals(0, result.created());
@@ -1237,6 +1394,21 @@ class UpgradeExecutorTest {
                     IRestMcpCallsStore.class);
         }
 
+        /**
+         * RAG was the one registered extension type with no dispatch test, so a typo in
+         * its row of the store table would have shipped: every RAG config in a synced
+         * agent would be reported as "the store did not accept the update" while the
+         * other seven types synced fine.
+         */
+        @Test
+        @DisplayName("should dispatch update for RagConfiguration")
+        @SuppressWarnings("unchecked")
+        void dispatchRag() throws Exception {
+            verifyDispatchUpdate("rag", "ai.labs.rag",
+                    RagConfiguration.class,
+                    IRestRagStore.class);
+        }
+
         @SuppressWarnings({"unchecked", "rawtypes"})
         private void verifyDispatchUpdate(String extensionType, String stepType,
                                           Class<?> configClass, Class<?> restStoreClass)
@@ -1286,6 +1458,223 @@ class UpgradeExecutorTest {
 
                 assertNotNull(result);
             }
+        }
+    }
+
+    // ==================== Failure reporting and secret fallbacks
+    // ====================
+
+    /**
+     * What an upgrade does when the pieces it depends on misbehave. Every case here
+     * used to end the same way — a 500 with a message the operator could not act
+     * on, or a production credential overwritten with the export's placeholder.
+     */
+    @Nested
+    @DisplayName("Failure reporting and secret fallbacks")
+    class FailurePathsAndSecretFallbacks {
+
+        private static final String WF_ID = "aabbccddeeff112233445566";
+        private static final String EXT_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+        private static final String SCRUBBED = "{\"apiKey\":\"${vault:REDACTED}\",\"model\":\"gpt-4\"}";
+
+        private BackupMetrics metrics;
+        private UpgradeExecutor executorWithMetrics;
+
+        @BeforeEach
+        void useAnObservableMetricsBean() {
+            metrics = Mockito.mock(BackupMetrics.class);
+            executorWithMetrics = new UpgradeExecutor(agentStore, workflowStore, snippetStore,
+                    jsonSerialization, structuralMatcher, descriptorStore, metrics,
+                    mock(ResourceAccessGuard.class));
+        }
+
+        /**
+         * A target agent that cannot be read is the one actionable failure of a sync.
+         * Wrapping it in a RuntimeException turned the operator's 404 into a 500, which
+         * says "the server is broken" about a mistyped agent id.
+         */
+        @Test
+        @DisplayName("a WebApplicationException from the preview reaches the caller unwrapped")
+        void webApplicationExceptionIsRethrownAsItIs() throws Exception {
+            var notFound = new jakarta.ws.rs.NotFoundException("Target agent target-1 does not exist.");
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenThrow(notFound);
+
+            var thrown = assertThrows(jakarta.ws.rs.NotFoundException.class,
+                    () -> executorWithMetrics.executeUpgrade(createSource(List.of(), List.of()),
+                            "target-1", null, null));
+
+            assertSame(notFound, thrown, "the status the operator needs must not be repackaged");
+            verify(metrics).upgradeFailed();
+            verify(metrics, never()).upgradeCompleted(anyInt(), anyInt(), anyInt(), anyInt());
+        }
+
+        /**
+         * A snippet and an extension the preview marked SKIP must be counted as
+         * skipped, not silently ignored: "skipped 2" is how an operator tells "the sync
+         * found nothing to do" from "the sync did nothing".
+         */
+        @Test
+        @DisplayName("SKIP rows are counted as skipped, and nothing is written for them")
+        void skippedRowsAreCounted() throws Exception {
+            var snippet = new SnippetSourceData("src-snp-1", "greeting", createSnippet("greeting", "Hi"));
+            var ext = new ExtensionSourceData("src-ext-1", "GPT Config", "langchain",
+                    "eddi://ai.labs.llm", "{}");
+            var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
+                    new WorkflowConfiguration(), Map.of("eddi://ai.labs.llm#0/config", ext));
+            var source = createSource(List.of(sourceWf), List.of(snippet));
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+            diffs.add(new ResourceDiff("src-snp-1", "snippet", "greeting",
+                    DiffAction.SKIP, "tgt-snp-1", 1, "name", null, null, -1));
+            diffs.add(new ResourceDiff("src-wf-1", "workflow", "Workflow 1",
+                    DiffAction.UPDATE, WF_ID, 1, "position", null, null, 0));
+            diffs.add(new ResourceDiff("src-ext-1", "langchain", "GPT Config",
+                    DiffAction.SKIP, EXT_ID, 2, "type", null, null, -1));
+
+            setupPreviewAndAgent("target-1", 1, diffs);
+
+            UpgradeResult result = executorWithMetrics.executeUpgrade(source, "target-1", null, null);
+
+            // snippet + extension + the workflow that had nothing to write
+            assertEquals(3, result.skipped());
+            assertEquals(0, result.updated());
+            assertEquals(0, result.created());
+            assertFalse(result.hasFailures());
+            verify(snippetStore, never()).updateSnippet(anyString(), anyInt(), any());
+            verify(agentStore, never()).updateAgent(anyString(), anyInt(), any());
+            verify(metrics).upgradeCompleted(0, 0, 3, 0);
+        }
+
+        /**
+         * With no readable target config there is no value to put back, so the
+         * placeholder is written and reported rather than guessed at. Silently
+         * substituting anything else would be inventing a credential.
+         */
+        @Test
+        @DisplayName("an unreadable target leaves the placeholder in place instead of guessing")
+        void unreadableTargetKeepsThePlaceholder() throws Exception {
+            String written = writeExtension(SCRUBBED, null);
+
+            assertEquals(SCRUBBED, written,
+                    "with nothing to restore from, the source content must go through untouched");
+        }
+
+        /**
+         * A placeholder the target has no counterpart for stays a placeholder. The
+         * operator has to supply that value by hand — writing the target's unrelated
+         * neighbouring field into it would be worse than leaving the gap visible.
+         */
+        @Test
+        @DisplayName("a placeholder the target cannot answer survives the merge")
+        void placeholderWithoutACounterpartSurvives() throws Exception {
+            String written = writeExtension(SCRUBBED, "{\"model\":\"gpt-3\"}");
+
+            assertNotNull(written);
+            assertTrue(written.contains("${vault:REDACTED}"),
+                    "the gap must stay visible rather than be filled with something else: " + written);
+            assertTrue(written.contains("gpt-4"), "everything else still comes from the source: " + written);
+        }
+
+        /**
+         * If the merge itself cannot be completed, the source content is written as it
+         * stands. Returning null instead would have blanked the target's config.
+         */
+        @Test
+        @DisplayName("content that cannot be parsed is written as-is, never as nothing")
+        void unparseableContentIsWrittenAsIs() throws Exception {
+            // doThrow, not when(...).thenThrow: the when-form would first invoke the
+            // round-tripping answer the helper installs, with an empty argument.
+            String written = writeExtension(SCRUBBED, "{\"apiKey\":\"sk-live-abc\"}",
+                    () -> doThrow(new java.io.IOException("not JSON"))
+                            .when(jsonSerialization).deserialize(anyString()));
+
+            assertEquals(SCRUBBED, written);
+        }
+
+        /**
+         * Same guarantee on the other side of the merge: a serializer answering null
+         * must not turn into a null config write.
+         */
+        @Test
+        @DisplayName("a serializer answering null falls back to the source content")
+        void serializerAnsweringNullFallsBackToTheSource() throws Exception {
+            String written = writeExtension(SCRUBBED, "{\"apiKey\":\"sk-live-abc\"}",
+                    () -> doReturn(null).when(jsonSerialization).serialize(any()));
+
+            assertEquals(SCRUBBED, written);
+        }
+
+        /** Stubbing applied after the helper's own JSON defaults, so it wins. */
+        private interface JsonStubs {
+            void apply() throws Exception;
+        }
+
+        /**
+         * Runs one LLM extension UPDATE through the executor and returns the JSON the
+         * store was actually asked to write.
+         *
+         * @param targetContent
+         *            the target's current config as the preview reports it, or null
+         *            when it could not be read
+         */
+        private String writeExtension(String sourceContent, String targetContent) throws Exception {
+            return writeExtension(sourceContent, targetContent, null);
+        }
+
+        @SuppressWarnings("unchecked")
+        private String writeExtension(String sourceContent, String targetContent, JsonStubs overrides)
+                throws Exception {
+            var ext = new ExtensionSourceData("src-ext-1", "GPT Config", "langchain",
+                    "eddi://ai.labs.llm", sourceContent);
+            var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
+                    new WorkflowConfiguration(), Map.of("eddi://ai.labs.llm#0/config", ext));
+            var source = createSource(List.of(sourceWf), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+            diffs.add(new ResourceDiff("src-wf-1", "workflow", "Workflow 1",
+                    DiffAction.UPDATE, WF_ID, 1, "position", null, null, 0));
+            diffs.add(new ResourceDiff("src-ext-1", "langchain", "GPT Config",
+                    DiffAction.UPDATE, EXT_ID, 2, "type", sourceContent, targetContent, -1));
+
+            setupPreviewAndAgent("target-1", 1, diffs);
+            when(workflowStore.readWorkflow(WF_ID, 1)).thenReturn(new WorkflowConfiguration());
+
+            // Real JSON round-tripping — the merge under test is about JSON, not mocks.
+            var mapper = new ObjectMapper();
+            when(jsonSerialization.deserialize(anyString()))
+                    .thenAnswer(inv -> mapper.readValue((String) inv.getArgument(0), Object.class));
+            when(jsonSerialization.serialize(any()))
+                    .thenAnswer(inv -> mapper.writeValueAsString(inv.getArgument(0)));
+            if (overrides != null) {
+                overrides.apply();
+            }
+
+            var writtenJson = new AtomicReference<String>();
+            when(jsonSerialization.deserialize(anyString(), eq(LlmConfiguration.class)))
+                    .thenAnswer(inv -> {
+                        writtenJson.set(inv.getArgument(0));
+                        return new LlmConfiguration(List.of());
+                    });
+
+            var llmStore = Mockito.mock(IRestLlmStore.class);
+            when(llmStore.updateLlm(eq(EXT_ID), eq(2), any())).thenReturn(Response.ok().build());
+
+            @SuppressWarnings("rawtypes")
+            MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
+            try (cdiMock) {
+                var cdiInstance = Mockito.mock(CDI.class);
+                cdiMock.when(CDI::current).thenReturn(cdiInstance);
+                var instanceLlm = (Instance<IRestLlmStore>) Mockito.mock(Instance.class);
+                when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
+                when(instanceLlm.get()).thenReturn(llmStore);
+
+                executorWithMetrics.executeUpgrade(source, "target-1", null, null);
+            }
+
+            assertNotNull(writtenJson.get(), "the store update never ran");
+            return writtenJson.get();
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/UpgradeExecutorTest.java
@@ -59,6 +59,10 @@ import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.inject.Instance;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -115,6 +119,69 @@ class UpgradeExecutorTest {
             executor.executeUpgrade(source, "target-1", null, null);
 
             verify(snippetStore).updateSnippet(eq("tgt-snp-1"), eq(2), any(PromptSnippet.class));
+        }
+
+        /**
+         * A snippet name comes from the archive, which a caller supplies, and it is
+         * free-form text - unlike the URI-derived ids around it, which cannot carry a
+         * control character and still parse. A CR/LF in it reached the "Created
+         * snippet" INFO unsanitized, so a sync could write forged lines into the
+         * operator's log (CWE-117).
+         */
+        @Test
+        @DisplayName("a CR/LF snippet name cannot forge a log record on the create path")
+        void snippetNameCannotForgeALogRecord() throws Exception {
+            String poisoned = "new_snippet\r\n2026-01-01 00:00:00,000 INFO  [io.quarkus] Forged admin login succeeded";
+            var sourceSnippet = new SnippetSourceData("src-snp-2", poisoned, createSnippet(poisoned, "Brand new"));
+            var source = createSource(List.of(), List.of(sourceSnippet));
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+            diffs.add(new ResourceDiff("src-snp-2", "snippet", poisoned,
+                    DiffAction.CREATE, null, null, null, null, null, -1));
+
+            setupPreviewAndAgent("target-1", 1, diffs);
+
+            List<String> captured = new ArrayList<>();
+            Handler handler = new Handler() {
+                @Override
+                public void publish(LogRecord record) {
+                    captured.add(String.valueOf(record.getMessage()));
+                    if (record.getParameters() != null) {
+                        for (Object parameter : record.getParameters()) {
+                            captured.add(String.valueOf(parameter));
+                        }
+                    }
+                }
+
+                @Override
+                public void flush() {
+                }
+
+                @Override
+                public void close() {
+                }
+            };
+            // logging.properties turns ai.labs.eddi OFF for plain unit tests, so the
+            // logger has to be opened or nothing is captured and this passes vacuously.
+            Logger julLogger = Logger.getLogger(UpgradeExecutor.class.getName());
+            Level previous = julLogger.getLevel();
+            julLogger.setLevel(Level.ALL);
+            julLogger.addHandler(handler);
+            try {
+                executor.executeUpgrade(source, "target-1", null, null);
+            } finally {
+                julLogger.removeHandler(handler);
+                julLogger.setLevel(previous);
+            }
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing - the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("Created snippet")),
+                    "the line under test did not fire; captured: " + captured);
+            for (String value : captured) {
+                assertFalse(value.contains("\n") || value.contains("\r"),
+                        "a CR/LF reached the log, so a caller can forge records (CWE-117); offending value: " + value);
+            }
         }
 
         @Test
@@ -758,6 +825,160 @@ class UpgradeExecutorTest {
         }
     }
 
+    // ==================== Workflow document changes ====================
+
+    /**
+     * What happens when the thing that changed is the workflow document itself —
+     * the steps, their order, their own config — and not the extension configs
+     * hanging off it.
+     */
+    @Nested
+    @DisplayName("Workflow document changes")
+    class WorkflowDocumentChanges {
+
+        private static final String WF_ID = "aabbccddeeff112233445566";
+        private static final String BEHAVIOR_URI = "eddi://ai.labs.rules/rulestore/rulesets/aaaaaaaaaaaaaaaaaaaaaaaa?version=1";
+        private static final String LLM_URI = "eddi://ai.labs.llm/llmstore/llms/bbbbbbbbbbbbbbbbbbbbbbbb?version=1";
+
+        /**
+         * The preview says UPDATE for the workflow because its steps really did change.
+         * Counting that as {@code skipped} and writing nothing dropped the operator's
+         * edit and answered 200 OK with "nothing to do" — the executor disagreeing with
+         * the preview it had just shown them.
+         */
+        @Test
+        @DisplayName("a reordered pipeline is written, not counted as skipped")
+        void reorderedStepsAreApplied() throws Exception {
+            var sourceWfConfig = twoStepWorkflow(true);
+            var extensionKeys = WorkflowExtensions.scan(sourceWfConfig).stream()
+                    .map(WorkflowExtensions.ExtensionRef::key).toList();
+
+            var behaviorExt = new ExtensionSourceData("src-ext-b", "Rules", "behavior",
+                    "eddi://ai.labs.behavior", "{}");
+            var llmExt = new ExtensionSourceData("src-ext-l", "GPT Config", "langchain",
+                    "eddi://ai.labs.llm", "{}");
+            var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0, sourceWfConfig,
+                    Map.of(extensionKeys.get(0), behaviorExt, extensionKeys.get(1), llmExt));
+            var source = createSource(List.of(sourceWf), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+            diffs.add(new ResourceDiff("src-wf-1", "workflow", "Workflow 1",
+                    DiffAction.UPDATE, WF_ID, 1, "position", null, null, 0));
+            // Neither extension's content changed — only the pipeline around them.
+            diffs.add(new ResourceDiff("src-ext-b", "behavior", "Rules",
+                    DiffAction.SKIP, "aaaaaaaaaaaaaaaaaaaaaaaa", 1, "type", null, null, -1));
+            diffs.add(new ResourceDiff("src-ext-l", "langchain", "GPT Config",
+                    DiffAction.SKIP, "bbbbbbbbbbbbbbbbbbbbbbbb", 1, "type", null, null, -1));
+
+            var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
+
+            var descriptor = new DocumentDescriptor();
+            descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=1"));
+            when(descriptorStore.readDescriptor(eq("target-1"), isNull())).thenReturn(descriptor);
+
+            // The target still runs the two steps the other way round.
+            when(workflowStore.readWorkflow(WF_ID, 1)).thenReturn(twoStepWorkflow(false));
+            when(workflowStore.updateWorkflow(eq(WF_ID), eq(1), any())).thenReturn(Response.ok().build());
+
+            var agentConfig = new AgentConfiguration();
+            agentConfig.setWorkflows(new ArrayList<>(List.of(
+                    URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + WF_ID + "?version=1"))));
+            when(agentStore.readAgent("target-1", 1)).thenReturn(agentConfig);
+            when(agentStore.updateAgent(eq("target-1"), eq(1), any())).thenReturn(Response.ok().build());
+
+            UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
+
+            var captor = ArgumentCaptor.forClass(WorkflowConfiguration.class);
+            verify(workflowStore).updateWorkflow(eq(WF_ID), eq(1), captor.capture());
+            List<WorkflowConfiguration.WorkflowStep> written = captor.getValue().getWorkflowSteps();
+            assertEquals("eddi://ai.labs.behavior", written.get(0).getType().toString(),
+                    "the source's step order is what the operator previewed");
+            assertEquals("eddi://ai.labs.llm", written.get(1).getType().toString());
+            // ...still pointing at the target's own resources, never the source's ids.
+            assertEquals(BEHAVIOR_URI, written.get(0).getConfig().get("uri"));
+            assertEquals(LLM_URI, written.get(1).getConfig().get("uri"));
+
+            assertFalse(result.hasFailures(), result.failures().toString());
+            assertEquals(1, result.updated(), "the workflow itself was written");
+            assertTrue(result.agentUpdated(), "the agent must point at the new workflow version");
+
+            var agentCaptor = ArgumentCaptor.forClass(AgentConfiguration.class);
+            verify(agentStore).updateAgent(eq("target-1"), eq(1), agentCaptor.capture());
+            assertEquals("eddi://ai.labs.workflow/workflowstore/workflows/" + WF_ID + "?version=2",
+                    agentCaptor.getValue().getWorkflows().getFirst().toString());
+        }
+
+        /**
+         * The other side of the same decision. A source step referencing something the
+         * target workflow does not have would be written pointing at a resource id from
+         * the other instance, so the pipeline is left alone and the operator is told
+         * why instead of being handed a silent success.
+         */
+        @Test
+        @DisplayName("a source step the target cannot resolve leaves the pipeline alone and is reported")
+        void unresolvableSourceStepIsRefused() throws Exception {
+            var sourceWfConfig = twoStepWorkflow(true);
+            var extensionKeys = WorkflowExtensions.scan(sourceWfConfig).stream()
+                    .map(WorkflowExtensions.ExtensionRef::key).toList();
+
+            var behaviorExt = new ExtensionSourceData("src-ext-b", "Rules", "behavior",
+                    "eddi://ai.labs.behavior", "{}");
+            var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0, sourceWfConfig,
+                    Map.of(extensionKeys.get(0), behaviorExt));
+            var source = createSource(List.of(sourceWf), List.of());
+
+            List<ResourceDiff> diffs = new ArrayList<>();
+            diffs.add(agentDiff("src-1", "target-1", DiffAction.SKIP));
+            diffs.add(new ResourceDiff("src-wf-1", "workflow", "Workflow 1",
+                    DiffAction.UPDATE, WF_ID, 1, "position", null, null, 0));
+            diffs.add(new ResourceDiff("src-ext-b", "behavior", "Rules",
+                    DiffAction.SKIP, "aaaaaaaaaaaaaaaaaaaaaaaa", 1, "type", null, null, -1));
+
+            var preview = new ImportPreview("src-1", "Source Agent", "target-1", "Target Agent", diffs);
+            when(structuralMatcher.buildPreview(any(), eq("target-1"), eq(true))).thenReturn(preview);
+
+            var descriptor = new DocumentDescriptor();
+            descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/target-1?version=1"));
+            when(descriptorStore.readDescriptor(eq("target-1"), isNull())).thenReturn(descriptor);
+
+            // The target has the behavior step but no LLM step at all.
+            var targetWfConfig = new WorkflowConfiguration();
+            targetWfConfig.setWorkflowSteps(new ArrayList<>(
+                    List.of(step("eddi://ai.labs.behavior", BEHAVIOR_URI))));
+            when(workflowStore.readWorkflow(WF_ID, 1)).thenReturn(targetWfConfig);
+
+            UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
+
+            verify(workflowStore, never()).updateWorkflow(anyString(), anyInt(), any());
+            assertTrue(result.hasFailures(), "a dropped pipeline change must not be reported as a clean run");
+            String reason = result.failures().getFirst().reason();
+            assertTrue(reason.contains("eddi://ai.labs.llm#0/config"),
+                    "the operator must be told which step could not be applied, got: " + reason);
+            assertFalse(result.agentUpdated(), "nothing was written, so no agent version may be burned");
+        }
+
+        /** A workflow with a behavior step and an LLM step, in either order. */
+        private WorkflowConfiguration twoStepWorkflow(boolean behaviorFirst) {
+            var behaviorStep = step("eddi://ai.labs.behavior", BEHAVIOR_URI);
+            var llmStep = step("eddi://ai.labs.llm", LLM_URI);
+            var config = new WorkflowConfiguration();
+            config.setWorkflowSteps(new ArrayList<>(behaviorFirst
+                    ? List.of(behaviorStep, llmStep)
+                    : List.of(llmStep, behaviorStep)));
+            return config;
+        }
+
+        private WorkflowConfiguration.WorkflowStep step(String stepType, String extensionUri) {
+            var step = new WorkflowConfiguration.WorkflowStep();
+            step.setType(URI.create(stepType));
+            step.setConfig(new HashMap<>(Map.of("uri", extensionUri)));
+            step.setExtensions(new HashMap<>());
+            return step;
+        }
+    }
+
     // ==================== Error Handling ====================
 
     @Nested
@@ -1285,9 +1506,15 @@ class UpgradeExecutorTest {
             doThrow(new RuntimeException("DB error"))
                     .when(snippetStore).updateSnippet(anyString(), anyInt(), any());
 
-            // Should NOT throw — processSnippet catches and logs
-            URI result = executor.executeUpgrade(source, "target-1", null, null).agentUri();
-            assertNotNull(result);
+            // Should NOT throw — processSnippet catches and reports
+            UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
+
+            // A non-null agent URI comes back whether or not anything was written, so
+            // it says nothing on its own: the snippet that did not land has to be named.
+            assertNotNull(result.agentUri());
+            assertEquals(1, result.failures().size(), result.failures().toString());
+            assertEquals("snippet", result.failures().getFirst().resourceType());
+            assertEquals(0, result.updated());
         }
     }
 
@@ -1333,9 +1560,15 @@ class UpgradeExecutorTest {
                 when(cdiInstance.select(IRestLlmStore.class)).thenReturn(instanceLlm);
                 when(instanceLlm.get()).thenReturn(Mockito.mock(IRestLlmStore.class));
 
-                // Should NOT throw — extension processing catches and logs
-                URI result = executor.executeUpgrade(source, "target-1", null, null).agentUri();
-                assertNotNull(result);
+                // Should NOT throw — extension processing catches and reports
+                UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
+
+                // The agent URI is reported even by a run that wrote nothing, so the
+                // extension that could not be deserialized has to be named as a failure.
+                assertNotNull(result.agentUri());
+                assertEquals(1, result.failures().size(), result.failures().toString());
+                assertEquals("langchain", result.failures().getFirst().resourceType());
+                assertEquals(0, result.updated());
             }
         }
     }
@@ -1350,7 +1583,7 @@ class UpgradeExecutorTest {
         @DisplayName("should dispatch update for DictionaryConfiguration")
         @SuppressWarnings("unchecked")
         void dispatchDictionary() throws Exception {
-            verifyDispatchUpdate("regulardictionary", "ai.labs.parser",
+            verifyDispatchUpdate("regulardictionary", "ai.labs.parser", "ai.labs.dictionary",
                     DictionaryConfiguration.class,
                     IRestDictionaryStore.class);
         }
@@ -1359,7 +1592,7 @@ class UpgradeExecutorTest {
         @DisplayName("should dispatch update for RuleSetConfiguration")
         @SuppressWarnings("unchecked")
         void dispatchRuleSet() throws Exception {
-            verifyDispatchUpdate("behavior", "ai.labs.behavior",
+            verifyDispatchUpdate("behavior", "ai.labs.behavior", "ai.labs.rules",
                     RuleSetConfiguration.class,
                     IRestRuleSetStore.class);
         }
@@ -1368,7 +1601,7 @@ class UpgradeExecutorTest {
         @DisplayName("should dispatch update for ApiCallsConfiguration")
         @SuppressWarnings("unchecked")
         void dispatchApiCalls() throws Exception {
-            verifyDispatchUpdate("httpcalls", "ai.labs.httpcalls",
+            verifyDispatchUpdate("httpcalls", "ai.labs.httpcalls", "ai.labs.apicalls",
                     ApiCallsConfiguration.class,
                     IRestApiCallsStore.class);
         }
@@ -1377,7 +1610,7 @@ class UpgradeExecutorTest {
         @DisplayName("should dispatch update for PropertySetterConfiguration")
         @SuppressWarnings("unchecked")
         void dispatchPropertySetter() throws Exception {
-            verifyDispatchUpdate("property", "ai.labs.property",
+            verifyDispatchUpdate("property", "ai.labs.property", "ai.labs.property",
                     PropertySetterConfiguration.class,
                     IRestPropertySetterStore.class);
         }
@@ -1386,7 +1619,7 @@ class UpgradeExecutorTest {
         @DisplayName("should dispatch update for OutputConfigurationSet")
         @SuppressWarnings("unchecked")
         void dispatchOutput() throws Exception {
-            verifyDispatchUpdate("output", "ai.labs.output",
+            verifyDispatchUpdate("output", "ai.labs.output", "ai.labs.output",
                     OutputConfigurationSet.class,
                     IRestOutputStore.class);
         }
@@ -1395,7 +1628,7 @@ class UpgradeExecutorTest {
         @DisplayName("should dispatch update for McpCallsConfiguration")
         @SuppressWarnings("unchecked")
         void dispatchMcpCalls() throws Exception {
-            verifyDispatchUpdate("mcpcalls", "ai.labs.mcpcalls",
+            verifyDispatchUpdate("mcpcalls", "ai.labs.mcpcalls", "ai.labs.mcpcalls",
                     McpCallsConfiguration.class,
                     IRestMcpCallsStore.class);
         }
@@ -1410,21 +1643,36 @@ class UpgradeExecutorTest {
         @DisplayName("should dispatch update for RagConfiguration")
         @SuppressWarnings("unchecked")
         void dispatchRag() throws Exception {
-            verifyDispatchUpdate("rag", "ai.labs.rag",
+            verifyDispatchUpdate("rag", "ai.labs.rag", "ai.labs.rag",
                     RagConfiguration.class,
                     IRestRagStore.class);
         }
 
+        /**
+         * Runs one extension of the given type all the way through: store dispatch, the
+         * workflow repoint that follows it, and the agent version that follows that.
+         * <p>
+         * The old form asserted only that {@code agentUri()} came back non-null, which
+         * an upgrade returns even when every resource in it failed — the agent URI is
+         * reported whether or not anything was written. A row of the store table
+         * pointing at the wrong CDI type therefore left the dispatch throwing, the
+         * extension recorded as a failure, and this test green. The assertion has to be
+         * that the run is clean.
+         */
         @SuppressWarnings({"unchecked", "rawtypes"})
-        private void verifyDispatchUpdate(String extensionType, String stepType,
+        private void verifyDispatchUpdate(String extensionType, String stepType, String resourceAuthority,
                                           Class<?> configClass, Class<?> restStoreClass)
                 throws Exception {
             String wfId = "aabbccddeeff112233445566";
             String extId = "bbbbbbbbbbbbbbbbbbbbbbbb";
+            String extUri = "eddi://" + resourceAuthority + "/store/resources/" + extId + "?version=2";
+
+            var sourceWfConfig = workflowWithStep(stepType, extUri);
+            String extensionKey = WorkflowExtensions.scan(sourceWfConfig).getFirst().key();
 
             var ext = new ExtensionSourceData("src-ext-1", "Config", extensionType, stepType, "{}");
             var sourceWf = new WorkflowSourceData("src-wf-1", "Workflow 1", 0,
-                    new WorkflowConfiguration(), Map.of(stepType, ext));
+                    sourceWfConfig, Map.of(extensionKey, ext));
             var source = createSource(List.of(sourceWf), List.of());
 
             List<ResourceDiff> diffs = new ArrayList<>();
@@ -1436,15 +1684,16 @@ class UpgradeExecutorTest {
 
             setupPreviewAndAgent("target-1", 1, diffs);
 
-            Object mockStore = Mockito.mock(restStoreClass);
+            // Every store's update method answers 200, whatever it is called, so the
+            // only thing that can go wrong here is the dispatch itself.
+            Object mockStore = Mockito.mock(restStoreClass, invocation -> invocation.getMethod().getReturnType() == Response.class
+                    ? Response.ok().build()
+                    : Mockito.RETURNS_DEFAULTS.answer(invocation));
             Object mockConfig = Mockito.mock(configClass);
             when(jsonSerialization.deserialize(eq("{}"), any())).thenReturn(mockConfig);
 
-            // The mock will return null (default) for the unstubbed update method.
-            // This exercises the resolveExtensionOps dispatch path for each config type.
-
-            // Workflow config (empty)
-            when(workflowStore.readWorkflow(wfId, 1)).thenReturn(new WorkflowConfiguration());
+            when(workflowStore.readWorkflow(wfId, 1)).thenReturn(workflowWithStep(stepType, extUri));
+            when(workflowStore.updateWorkflow(eq(wfId), eq(1), any())).thenReturn(Response.ok().build());
 
             MockedStatic<CDI> cdiMock = Mockito.mockStatic(CDI.class);
             try (cdiMock) {
@@ -1455,15 +1704,25 @@ class UpgradeExecutorTest {
                 when(cdiInstance.select(restStoreClass)).thenReturn(instance);
                 when(instance.get()).thenReturn(mockStore);
 
-                // The actual dispatch will call the specific update method.
-                // Since we haven't stubbed the specific method, it will return null (default
-                // for mock).
-                // This exercises the resolveExtensionOps + dispatchUpdate path, which will
-                // result in null response → null URI → no workflow update.
-                URI result = executor.executeUpgrade(source, "target-1", null, null).agentUri();
+                UpgradeResult result = executor.executeUpgrade(source, "target-1", null, null);
 
-                assertNotNull(result);
+                assertNotNull(result.agentUri());
+                assertFalse(result.hasFailures(), result.failures().toString());
+                assertEquals(2, result.updated(),
+                        "the extension and the workflow that references it are both written");
+                assertFalse(Mockito.mockingDetails(mockStore).getInvocations().isEmpty(),
+                        "the update never reached " + restStoreClass.getSimpleName());
             }
+        }
+
+        private WorkflowConfiguration workflowWithStep(String stepType, String extensionUri) {
+            var step = new WorkflowConfiguration.WorkflowStep();
+            step.setType(URI.create("eddi://" + stepType));
+            step.setConfig(new HashMap<>(Map.of("uri", extensionUri)));
+            step.setExtensions(new HashMap<>());
+            var config = new WorkflowConfiguration();
+            config.setWorkflowSteps(new ArrayList<>(List.of(step)));
+            return config;
         }
     }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/WorkflowExtensionsTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/WorkflowExtensionsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link WorkflowExtensions}, the single source of truth for how a
+ * workflow points at its extension configs.
+ * <p>
+ * Before it existed the ZIP side keyed the extension map by resource-store
+ * authority ({@code ai.labs.rules}) while the target side keyed it by the
+ * workflow step type URI ({@code eddi://ai.labs.behavior}), so no extension
+ * could ever match and every sync reported CREATE — duplicating every LLM
+ * config, ruleset and output set in the target instead of updating in place.
+ */
+@DisplayName("WorkflowExtensions")
+class WorkflowExtensionsTest {
+
+    private static final String LLM_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String HTTP_ID_A = "bbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String HTTP_ID_B = "cccccccccccccccccccccccc";
+    private static final String DICT_ID = "dddddddddddddddddddddddd";
+
+    @Test
+    @DisplayName("reads the extension URI from the step's config, where the engine reads it")
+    void readsUriFromConfig() {
+        var config = workflow(step("eddi://ai.labs.llm",
+                Map.of("uri", "eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=2"),
+                Map.of()));
+
+        List<WorkflowExtensions.ExtensionRef> refs = WorkflowExtensions.scan(config);
+
+        assertEquals(1, refs.size());
+        assertEquals(LLM_ID, refs.getFirst().resourceId().getId());
+        assertEquals(2, refs.getFirst().resourceId().getVersion());
+        assertEquals("langchain", refs.getFirst().fileExtension());
+        assertEquals("/llmstore/llms/", refs.getFirst().type().restPath());
+    }
+
+    @Test
+    @DisplayName("finds a parser's nested dictionaries, which live under extensions")
+    void findsNestedDictionaries() {
+        var config = workflow(step("eddi://ai.labs.parser",
+                Map.of(),
+                Map.of("dictionaries", List.of(Map.of(
+                        "config", Map.of("uri",
+                                "eddi://ai.labs.dictionary/dictionarystore/dictionaries/" + DICT_ID + "?version=1"))))));
+
+        List<WorkflowExtensions.ExtensionRef> refs = WorkflowExtensions.scan(config);
+
+        assertEquals(1, refs.size());
+        assertEquals(DICT_ID, refs.getFirst().resourceId().getId());
+        assertEquals("regulardictionary", refs.getFirst().fileExtension());
+    }
+
+    @Test
+    @DisplayName("two steps of the same type keep two distinct keys")
+    void twoStepsOfSameTypeDoNotCollapse() {
+        var config = workflow(
+                step("eddi://ai.labs.httpcalls",
+                        Map.of("uri", "eddi://ai.labs.apicalls/apicallstore/apicalls/" + HTTP_ID_A + "?version=1"),
+                        Map.of()),
+                step("eddi://ai.labs.httpcalls",
+                        Map.of("uri", "eddi://ai.labs.apicalls/apicallstore/apicalls/" + HTTP_ID_B + "?version=1"),
+                        Map.of()));
+
+        List<WorkflowExtensions.ExtensionRef> refs = WorkflowExtensions.scan(config);
+
+        // Keying by type alone synced only the second step, and then repointed BOTH
+        // steps at it — the first step's config was silently replaced.
+        assertEquals(2, refs.size());
+        assertNotEquals(refs.get(0).key(), refs.get(1).key());
+        assertEquals(HTTP_ID_A, refs.get(0).resourceId().getId());
+        assertEquals(HTTP_ID_B, refs.get(1).resourceId().getId());
+    }
+
+    @Test
+    @DisplayName("the same workflow shape always produces the same keys, so source and target join")
+    void keysAreStableAcrossInstances() {
+        String uri = "eddi://ai.labs.rules/rulestore/rulesets/" + LLM_ID + "?version=1";
+        var source = workflow(step("eddi://ai.labs.behavior", Map.of("uri", uri), Map.of()));
+        var target = workflow(step("eddi://ai.labs.behavior", Map.of("uri", uri), Map.of()));
+
+        assertEquals(WorkflowExtensions.scan(source).getFirst().key(),
+                WorkflowExtensions.scan(target).getFirst().key());
+    }
+
+    @Test
+    @DisplayName("repointTo rewrites config.uri and leaves extensions untouched")
+    void repointToWritesIntoConfig() {
+        var step = step("eddi://ai.labs.llm",
+                new HashMap<>(Map.of("uri", "eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=2")),
+                new HashMap<>());
+        var config = workflow(step);
+
+        WorkflowExtensions.scan(config).getFirst()
+                .repointTo(URI.create("eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=3"));
+
+        // The engine hands step.getConfig() to the lifecycle task; writing the new
+        // version into extensions left the deployed pipeline on the OLD one.
+        assertEquals("eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=3",
+                step.getConfig().get("uri"));
+        assertFalse(step.getExtensions().containsKey("uri"));
+    }
+
+    @Test
+    @DisplayName("null-safe: a null config, step list, step or map contributes nothing")
+    void nullSafe() {
+        assertTrue(WorkflowExtensions.scan(null).isEmpty());
+
+        var noSteps = new WorkflowConfiguration();
+        noSteps.setWorkflowSteps(null);
+        assertTrue(WorkflowExtensions.scan(noSteps).isEmpty());
+
+        var nullStepType = new WorkflowConfiguration.WorkflowStep();
+        nullStepType.setType(null);
+        nullStepType.setConfig(null);
+        nullStepType.setExtensions(null);
+        assertTrue(WorkflowExtensions.scan(workflow(nullStepType)).isEmpty());
+    }
+
+    @Test
+    @DisplayName("a URI of an unregistered type produces no reference")
+    void unknownTypeIgnored() {
+        var config = workflow(step("eddi://ai.labs.something",
+                Map.of("uri", "eddi://ai.labs.unknown/store/things/" + LLM_ID + "?version=1"),
+                Map.of()));
+
+        assertTrue(WorkflowExtensions.scan(config).isEmpty());
+    }
+
+    // ==================== Helpers ====================
+
+    private static WorkflowConfiguration.WorkflowStep step(String type,
+                                                           Map<String, Object> stepConfig,
+                                                           Map<String, Object> extensions) {
+        var step = new WorkflowConfiguration.WorkflowStep();
+        step.setType(URI.create(type));
+        step.setConfig(stepConfig);
+        step.setExtensions(extensions);
+        return step;
+    }
+
+    private static WorkflowConfiguration workflow(WorkflowConfiguration.WorkflowStep... steps) {
+        var config = new WorkflowConfiguration();
+        config.setWorkflowSteps(new ArrayList<>(List.of(steps)));
+        return config;
+    }
+}

--- a/src/test/java/ai/labs/eddi/backup/impl/WorkflowExtensionsTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/WorkflowExtensionsTest.java
@@ -142,6 +142,122 @@ class WorkflowExtensionsTest {
         assertTrue(WorkflowExtensions.scan(config).isEmpty());
     }
 
+    /**
+     * {@code typeOf} is asked about URIs that came out of a foreign archive, so it
+     * has to answer "not a resource I move" rather than throw. A null URI, and one
+     * with no authority at all, are both such answers — a throw here would abort
+     * the scan of an otherwise importable workflow.
+     */
+    @Test
+    @DisplayName("typeOf answers null for a null URI and for one carrying no authority")
+    void typeOfIsNullSafe() {
+        assertNull(WorkflowExtensions.typeOf(null));
+        assertNull(WorkflowExtensions.typeOf(URI.create("/llmstore/llms/" + LLM_ID)));
+        assertNotNull(WorkflowExtensions.typeOf(URI.create("eddi://ai.labs.llm/llmstore/llms/" + LLM_ID)));
+    }
+
+    /**
+     * A workflow list may legitimately hold a null entry — Jackson produces one for
+     * a {@code null} element in the archived JSON. Scanning it must skip the hole
+     * rather than fail the whole import with a NullPointerException.
+     */
+    @Test
+    @DisplayName("a null entry in the step list is skipped, the steps around it are still scanned")
+    void nullStepInListIsSkipped() {
+        var config = new WorkflowConfiguration();
+        var steps = new ArrayList<WorkflowConfiguration.WorkflowStep>();
+        steps.add(null);
+        steps.add(step("eddi://ai.labs.llm",
+                Map.of("uri", "eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=1"),
+                Map.of()));
+        config.setWorkflowSteps(steps);
+
+        List<WorkflowExtensions.ExtensionRef> refs = WorkflowExtensions.scan(config);
+
+        assertEquals(1, refs.size());
+        assertEquals(LLM_ID, refs.getFirst().resourceId().getId());
+    }
+
+    /**
+     * The depth guard exists so a pathological (or cyclic-looking) nested config
+     * cannot make the scan recurse forever. It is a real limit, not decoration: a
+     * reference buried deeper than it is simply not seen.
+     */
+    @Test
+    @DisplayName("a reference nested deeper than the depth guard is not returned")
+    void depthGuardStopsTheWalk() {
+        Object nested = new HashMap<>(Map.of("uri",
+                "eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=1"));
+        for (int i = 0; i < 12; i++) {
+            nested = new HashMap<>(Map.of("level" + i, nested));
+        }
+        @SuppressWarnings("unchecked")
+        var deepConfig = (Map<String, Object>) nested;
+
+        assertTrue(WorkflowExtensions.scan(workflow(step("eddi://ai.labs.llm", deepConfig, Map.of()))).isEmpty());
+    }
+
+    /**
+     * Three shapes a {@code uri} entry can take that must all yield no reference
+     * instead of an exception. Each one is reachable from a real archive: a blank
+     * value from a half-written config, a non-string from a hand-edited ZIP, and a
+     * space-bearing value from a name pasted into the id position.
+     */
+    @Test
+    @DisplayName("a blank, non-string or unparseable uri value yields no reference")
+    void unusableUriValuesYieldNoReference() {
+        assertTrue(WorkflowExtensions.scan(workflow(
+                step("eddi://ai.labs.llm", Map.of("uri", "   "), Map.of()))).isEmpty());
+
+        assertTrue(WorkflowExtensions.scan(workflow(
+                step("eddi://ai.labs.llm", Map.of("uri", 42), Map.of()))).isEmpty());
+
+        // URI.create rejects the space, and the scan has to survive that.
+        assertTrue(WorkflowExtensions.scan(workflow(
+                step("eddi://ai.labs.llm",
+                        Map.of("uri", "eddi://ai.labs.llm/llmstore/llms/my llm?version=1"),
+                        Map.of())))
+                .isEmpty());
+    }
+
+    /**
+     * {@code RestUtilities.extractResourceId} rejects a non-integer
+     * {@code ?version=} with an IllegalArgumentException. A workflow carrying one
+     * must contribute no reference rather than abort the scan — the other steps of
+     * that workflow are still importable.
+     */
+    @Test
+    @DisplayName("a non-integer ?version leaves the rest of the workflow scannable")
+    void nonIntegerVersionYieldsNoReferenceButDoesNotAbortTheScan() {
+        var config = workflow(
+                step("eddi://ai.labs.llm",
+                        Map.of("uri", "eddi://ai.labs.llm/llmstore/llms/" + LLM_ID + "?version=latest"),
+                        Map.of()),
+                step("eddi://ai.labs.httpcalls",
+                        Map.of("uri", "eddi://ai.labs.apicalls/apicallstore/apicalls/" + HTTP_ID_A + "?version=1"),
+                        Map.of()));
+
+        List<WorkflowExtensions.ExtensionRef> refs = WorkflowExtensions.scan(config);
+
+        assertEquals(1, refs.size());
+        assertEquals(HTTP_ID_A, refs.getFirst().resourceId().getId());
+    }
+
+    /**
+     * A URI of a known authority whose last segment is not a valid resource id
+     * yields an id of null. Emitting a reference for it would send the sync to read
+     * {@code /llmstore/llms/null}.
+     */
+    @Test
+    @DisplayName("a known authority with no usable resource id yields no reference")
+    void knownAuthorityWithoutIdYieldsNoReference() {
+        var config = workflow(step("eddi://ai.labs.llm",
+                Map.of("uri", "eddi://ai.labs.llm/llmstore/llms/nope?version=1"),
+                Map.of()));
+
+        assertTrue(WorkflowExtensions.scan(config).isEmpty());
+    }
+
     // ==================== Helpers ====================
 
     private static WorkflowConfiguration.WorkflowStep step(String type,

--- a/src/test/java/ai/labs/eddi/backup/impl/ZipResourceSourceMissingExtensionTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/ZipResourceSourceMissingExtensionTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.backup.impl;
+
+import ai.labs.eddi.backup.IResourceSource.ExtensionSourceData;
+import ai.labs.eddi.backup.IResourceSource.WorkflowSourceData;
+import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * What the upgrade path does with an archive that references an extension
+ * config it does not carry — the shape EDDI's own selective export produces.
+ * <p>
+ * Skipping the reference rather than failing is what lets a sync run from a
+ * partial archive at all: the matcher then reports nothing for that extension
+ * and the target's own copy is left alone. Failing here would make every
+ * selective export un-syncable.
+ */
+@DisplayName("ZipResourceSource — extensions the archive does not carry")
+class ZipResourceSourceMissingExtensionTest {
+
+    private static final String WORKFLOW_ID = "aabbccddeeff112233445566";
+    private static final String PRESENT_LLM_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String MISSING_LLM_ID = "cccccccccccccccccccccccc";
+
+    private IJsonSerialization jsonSerialization;
+    private Path tempDir;
+    private Path versionDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jsonSerialization = mock(IJsonSerialization.class);
+        tempDir = Files.createTempDirectory("zrs-missing-ext");
+        versionDir = Files.createDirectories(
+                tempDir.resolve("agentDir").resolve(WORKFLOW_ID).resolve("1"));
+        Files.writeString(tempDir.resolve("agent1.agent.json"), "{}", StandardCharsets.UTF_8);
+        Files.writeString(versionDir.resolve(WORKFLOW_ID + ".workflow.json"), "{}", StandardCharsets.UTF_8);
+
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of(URI.create(
+                "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1")));
+        doReturn(agentConfig).when(jsonSerialization).deserialize(anyString(), eq(AgentConfiguration.class));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (tempDir != null && Files.exists(tempDir)) {
+            try (var paths = Files.walk(tempDir)) {
+                paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException ignored) {
+                        // best effort
+                    }
+                });
+            }
+        }
+    }
+
+    /**
+     * The reference the archive cannot satisfy contributes nothing, and — the part
+     * that matters — the one beside it is still read. An early failure would have
+     * cost the whole workflow's extensions, not just the absent one.
+     */
+    @Test
+    @DisplayName("a referenced config the archive lacks is skipped, its neighbour is still read")
+    void missingExtensionIsSkippedWithoutLosingTheOthers() throws Exception {
+        Files.writeString(versionDir.resolve(PRESENT_LLM_ID + ".langchain.json"),
+                "{\"model\":\"gpt-4\"}", StandardCharsets.UTF_8);
+        stubWorkflow(llmStep(PRESENT_LLM_ID), llmStep(MISSING_LLM_ID));
+
+        var source = new ZipResourceSource(tempDir, jsonSerialization);
+        List<WorkflowSourceData> workflows = source.readWorkflows();
+
+        assertEquals(1, workflows.size());
+        Map<String, ExtensionSourceData> extensions = workflows.getFirst().extensions();
+        assertEquals(1, extensions.size(), "only the readable extension may appear, got " + extensions.keySet());
+        var present = extensions.get("eddi://ai.labs.llm#0/config");
+        assertNotNull(present, "the present extension must keep its canonical key, got " + extensions.keySet());
+        assertEquals("{\"model\":\"gpt-4\"}", present.contentJson());
+    }
+
+    /**
+     * A path that exists but cannot be read as a file — a directory where a config
+     * belongs, which is what a mis-packed ZIP produces — must be reported as an
+     * unreadable extension, not propagated as an IOException that kills the sync.
+     */
+    @Test
+    @DisplayName("a referenced config that cannot be read is skipped rather than thrown")
+    void unreadableExtensionIsSkipped() throws Exception {
+        // A directory in the place of the config file: Files.exists says yes, reading
+        // it does not.
+        Files.createDirectories(versionDir.resolve(PRESENT_LLM_ID + ".langchain.json"));
+        stubWorkflow(llmStep(PRESENT_LLM_ID));
+
+        var source = new ZipResourceSource(tempDir, jsonSerialization);
+        var workflows = source.readWorkflows();
+
+        assertEquals(1, workflows.size());
+        assertTrue(workflows.getFirst().extensions().isEmpty(),
+                "an unreadable config must contribute nothing: " + workflows.getFirst().extensions().keySet());
+    }
+
+    private void stubWorkflow(WorkflowConfiguration.WorkflowStep... steps) throws Exception {
+        var config = new WorkflowConfiguration();
+        config.setWorkflowSteps(new ArrayList<>(List.of(steps)));
+        doReturn(config).when(jsonSerialization).deserialize(anyString(), eq(WorkflowConfiguration.class));
+    }
+
+    private static WorkflowConfiguration.WorkflowStep llmStep(String llmId) {
+        var step = new WorkflowConfiguration.WorkflowStep();
+        step.setType(URI.create("eddi://ai.labs.llm"));
+        step.setConfig(new HashMap<>(Map.of("uri",
+                "eddi://ai.labs.llm/llmstore/llms/" + llmId + "?version=1")));
+        step.setExtensions(new HashMap<>());
+        return step;
+    }
+}


### PR DESCRIPTION
**Granular sync/upgrade did nothing at all, and its preview said otherwise.** This was the most serious finding of the review, and it was broken three independent ways at once.

## What was broken

1. `UpgradeExecutor` asked `StructuralMatcher.buildPreview` for a *content-less* preview, so `sourceJson` and `targetJson` were both `null` for every matched resource. The action then reduced to `Objects.equals(null, null)` → `SKIP`, and the executor skips every SKIP.
2. Extension URIs were read from `step.getExtensions()`, but the engine stores them under `step.getConfig().get("uri")`, so the target extension map came back empty.
3. The ZIP and remote sources keyed extensions by resource-store authority (`ai.labs.rules`) while the target keyed by workflow step type (`eddi://ai.labs.behavior`), so the two sides could never join even with (1) and (2) fixed.

The REST preview endpoints pass `includeContent=true` and therefore showed real differences. An operator saw a diff, clicked apply, received success, and nothing changed.

## What changed

A new `WorkflowExtensions` is the single source of truth for how a workflow points at its extension configs. Both producers and the matcher derive their keys from it, so source and target are guaranteed to join. The canonical key is `<stepType>#<occurrence>/<path>`, which additionally fixes a workflow with two steps of the same type collapsing onto one key and repointing both at the second resource. The diff action is now decided from content that is always loaded; `includeContent` governs only what is returned to the caller.

Also in this branch, each its own finding:

- Exported ZIPs were never deleted and accumulated in the working directory. They now land in `tmp/archives/` and are swept by age, and the 404 message states the real retention instead of a fictional one.
- A non-ASCII agent name produced an archive that could never be downloaded: `URLEncoder` output was written literally to disk and the download endpoint's character class then rejected the decoded form. Names are slugified, and `Content-Disposition` carries the readable filename.
- Schedules were written into the export ZIP but never read on import, so a restore silently lost them while the archive visibly contained them.
- A genuine EDDI 5.x export imported nothing and reported HTTP 200, because the importer only looked for `.agent.json` and never the v5 `.bot.json`.
- `strategy=upgrade` without `targetAgentId` fell through to create and produced a duplicate agent; now a 400 naming the parameter.
- A selectively-exported ZIP could not be re-imported: a deselected extension is absent from the archive while the workflow still references it, and the resulting `null` was handed to `store.create()`.

## How it is proven

Every behavioural change is pinned by a regression test **verified to fail with its fix reverted**. `ExtensionSourceKeyContractTest` writes a real archive to disk and stubs a real remote, then asserts both producers emit identical canonical keys *and* that every extension joins the target as UPDATE rather than CREATE. Its fixture deliberately carries two `httpcalls` steps so the collapse-by-type defect is caught as well.

Two tests are recorded in the branch as characterization rather than guards, and say so in their own comments: the snippet name-fallback row is what `main` always emitted, and one refactor is behaviourally identical. Neither can fail without its change, and neither is claimed to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selectively export resources, prompt snippets, and scheduled triggers.
  * Import and sync operations now restore schedules and provide detailed per-resource results.
  * Added backup export, import, upgrade, and sync metrics for monitoring.
  * Added support for importing legacy EDDI 5.x archives.

* **Bug Fixes**
  * Improved workflow extension matching, secret preservation, archive validation, and failure reporting.
  * Prevented unsafe redirects and sanitized sensitive log output.

* **Documentation**
  * Expanded backup, sync, configuration, metrics, and response-code documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->