### PR TITLE
fix(configs): make destructive configuration deletes safe, atomic and honest

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,56 @@ bottom of this file and are never archived.
 
 ---
 
+## 🗑️ fix(configs): make destructive configuration deletes safe, atomic and honest (2026-09-04)
+
+**Repo:** EDDI (`fix/review-config-delete`)
+
+From the whole-repository code review. The destructive configuration paths destroyed data
+that was still in use, and reported success while doing it.
+
+**Orphan purge deleted live configuration.** References are version-pinned by design, and
+`DocumentDescriptorFilter` rewrites a descriptor's `resource` to the new version on every
+PUT. So a single edit of a rule set leaves the descriptor saying `?version=2` while every
+workflow that was not re-pointed still says `?version=1`. The scan compared those full
+versioned URI strings, found no match, classified the config an orphan, and
+`DELETE /administration/orphans` removed **all** of its versions — destroying a config a
+live workflow was still resolving. The comparison is now on version-independent identity,
+so any referenced version protects the resource. The remaining deliberate gap (only the
+current version of each agent is scanned) is documented rather than silently present.
+
+**Cascade delete tore down workflows before the guard that could still reject it.** A
+version-mismatched cascade deleted the workflows and schedules of the version it read, then
+answered 409. And the reference check asked whether *one pinned version* was still
+referenced before deleting *every* version, so a workflow another agent still used was
+destroyed.
+
+**Reverse lookups crashed on soft-deleted rows.** `AgentStore` and `WorkflowStore` threw
+`ResourceNotFoundException` as soon as one referencing document had been soft-deleted,
+which disabled the "is this still referenced?" check entirely — the check is caught and
+logged, so cascade delete simply stopped protecting shared resources.
+
+**Version-0 history rows escaped permanent deletion** on MongoDB, so `deletePermanently`
+and GDPR erasure both reported success while leaving an undeletable descriptor tombstone
+behind forever.
+
+### Regression coverage
+
+Every behavioural change is pinned by a test proven to fail with its fix reverted.
+
+Two things the auditor caught and this branch corrects rather than ships: the signing
+keypair was being destroyed from the vault on a **soft** delete, on the path that exists
+precisely to be recoverable; and a unique compound index was created unconditionally at
+startup, which fails with a duplicate-key error on exactly the deployments the finding says
+already hold duplicates. Both are now conditional and safe.
+
+Six pre-existing cascade assertions were flipped from `permanent=true` to `permanent=false`.
+That inversion is deliberate and correct: permanently removing a shared resource stays an
+explicit, non-cascading request. A functional regression in `RetryConfiguration`'s new
+backoff budget was found by the auditor while the class's own suite stayed green, and is
+fixed with a test that fails without it.
+
+---
+
 ## 📋 docs(config): document the four workspace properties that were breaking `main` (2026-08-30)
 
 **Repo:** EDDI (`fix/connection-extra-auth-params-code-verifier`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,34 @@ bottom of this file and are never archived.
 
 ---
 
+## 🧼 fix(configs): sanitize every cascade-delete log argument, not most of them (2026-09-06)
+
+**Repo:** EDDI (`fix/review-config-delete`)
+
+CodeQL raised eight log-injection alerts on this branch: a REST path parameter reached a log call
+unsanitized, so a caller could put CR/LF in an Agent or workflow id and forge log records
+(CWE-117). Every flagged argument now goes through `LogSanitizer.sanitize`.
+
+The more useful part was what the alerts did *not* cover. `RestAgentStore` was left with the same
+tainted `id` sanitized on one line and raw sixteen lines above it, on the schedule-cascade pair
+that CodeQL could not reach because it needs the schedule store to throw. Uneven coverage in one
+file is worse than none, because the next reader assumes the file is done. Every log argument in
+that class is now sanitized: caller ids, store-sourced ids, and exception messages.
+
+`URI`-typed arguments are deliberately left alone — `URI.create` rejects control characters, so a
+URI object cannot carry a record boundary in the first place.
+
+Ten regression tests drive a CR/LF payload through the real code paths and assert no newline
+reaches the log. They guard against vacuity twice: the capture must be non-empty, and it must
+contain a marker from the specific line under test — otherwise a closed logger or an unreached
+branch would pass. `captureLogsOf` moved to a shared `LogCaptureSupport` rather than being copied.
+
+One argument is honestly not pinned: `pinned.getId()` on the plan-cascade failure path. It comes
+from `RestUtilities.extractResourceId`, whose validity gate returns null for anything containing
+CR/LF, so the value cannot be driven. It is defensive, not reachable.
+
+---
+
 ## 🧹 fix(configs): stop cascading deletes removing resources someone else still uses (2026-09-06)
 
 **Repo:** EDDI (`fix/review-config-delete`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,35 @@ bottom of this file and are never archived.
 
 ---
 
+## 🛡️ fix(configs): close the CodeQL alerts and the review round (2026-09-04)
+
+**Repo:** EDDI (`fix/review-config-delete`)
+
+Follow-up on the same branch, from two independent review rounds, a diff-coverage pass, and
+four CodeQL alerts this branch introduced.
+
+**CodeQL, all four fixed in code rather than dismissed.** Two high-severity integer overflows
+in the new `ResourceUtilities` paging helper, where a caller-supplied index and limit were
+combined without bounds so a large value wrapped and produced a nonsensical window; the inputs
+are now clamped before the arithmetic. Two log-injection sites where a user-provided value
+reached a log statement unsanitised, now routed through the sanitiser the codebase already
+uses elsewhere rather than a second one.
+
+**A functional regression the branch's own suite could not see.** `RetryConfiguration` gained a
+total-backoff budget, and every test in that class stayed green while the behaviour changed.
+Found by the reviewer, fixed, and pinned by a test that fails without it.
+
+**Four tests were proven vacuous by mutation.** One claimed to pin a new
+`!config.getCapabilities().isEmpty()` guard; removing that guard left it green. Another
+asserted the consequence of a stub the real collaborator refuses to produce. Each was rewritten
+to fail on the regression it names, or deleted with an honest gap recorded — a test that cannot
+fail is worse than none, because it hides the hole.
+
+**Diff coverage** of changed lines: 89.9% to 99.5% line, 80.1% to 92.7% branch, with 38 tests
+added and each proven against a mutation of the line it protects.
+
+---
+
 ## 🗑️ fix(configs): make destructive configuration deletes safe, atomic and honest (2026-09-04)
 
 **Repo:** EDDI (`fix/review-config-delete`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,40 @@ bottom of this file and are never archived.
 
 ---
 
+## 🧹 fix(configs): stop cascading deletes removing resources someone else still uses (2026-09-06)
+
+**Repo:** EDDI (`fix/review-config-delete`)
+
+Review round on this branch: 20 comments, 6 fixed, 13 confirmed already correct, 1 disputed with
+code evidence. The six fixes share one shape — a delete that asked the right question at the wrong
+moment.
+
+**Cascade deletes checked references before the parent was gone.** `planCascade` has to ask
+"is this referenced by more than one thing" while the Agent still counts itself, but by the time
+each child delete actually runs the Agent is deleted and the count has moved. A workflow that a
+second Agent adopted in between was deleted anyway. Both `RestAgentStore` and `RestWorkflowStore`
+now re-ask immediately before each child delete, and a candidate that is still referenced
+increments the `X-Cascade-Skipped` counter instead of being removed.
+
+**The orphan purge trusted a reverse lookup that ignores old versions.** Both lookups in
+`isReferencedNow` skip referrers that are not a resource's current version, while the mark scan
+deliberately counts every version a deployment record pins. The purge loop now also re-runs the
+deployed-agent scan per candidate and fails closed when the scan is incomplete or throws.
+
+**Vault key rotation could sweep the key it had just written.** `versionsToSweep` treated an empty
+list of valid versions as "nothing to keep" rather than as an unknown bound, so a rotation whose
+identity update had not yet landed swept the new key. Empty is now handled exactly like null: the
+full scan range is preserved and nothing is deleted on an unknown bound.
+
+**Soft-deleting a descriptor marked the wrong version.** Descriptor versions advance independently
+of the resource's, so the soft path now resolves the descriptor's own current version the way the
+permanent path already did.
+
+**Files:** `RestAgentStore`, `RestWorkflowStore`, `RestOrphanAdmin`, `AgentSigningService`,
+`RestVersionInfo`, and their tests.
+
+---
+
 ## 🛡️ fix(configs): close the CodeQL alerts and the review round (2026-09-04)
 
 **Repo:** EDDI (`fix/review-config-delete`)

--- a/docs/deployment-management-of-agents.md
+++ b/docs/deployment-management-of-agents.md
@@ -245,7 +245,7 @@ Agent
 | HTTP Method  | `DELETE`                                                                                               |
 | API endpoint | `/agentstore/agents/{id}?version={version}&cascade=true&permanent=true`                                |
 | cascade      | (`Query parameter`) `Boolean` default `false`. If `true`, deletes packages and all extension resources |
-| permanent    | (`Query parameter`) `Boolean` default `false`. Recommended `true` with cascade                         |
+| permanent    | (`Query parameter`) `Boolean` default `false`. Applies to the **agent only** — see below                |
 
 #### Example
 
@@ -257,9 +257,23 @@ DELETE /agentstore/agents/5aaf98e19f7dd421ac3c7de9?version=1&cascade=true&perman
 This will:
 
 1. Read the agent configuration to discover its packages
-2. For each package, read its extensions and delete all resources (behavior sets, HTTP calls, output sets, langchains, property setters, parser dictionaries)
-3. Delete each package
-4. Delete the agent itself
+2. Resolve each package reference to the package's **current** version — references are version-pinned and are not re-pointed when the package is edited, so the pinned version frequently is not the one that exists
+3. Skip any package another agent still references (at any version), and any package with no live version left
+4. Soft-delete each remaining package, which cascades the same way into its extensions (behavior sets, HTTP calls, output sets, langchains, property setters, parser dictionaries)
+5. Delete the agent itself
+
+> **`permanent=true` never cascades.** It applies to the resource named in the request — every
+> version and every history row of that agent, plus its Ed25519 signing keys in the secrets vault,
+> which no endpoint can regenerate. Cascaded resources are always **soft-deleted**, whatever
+> `permanent` says: the "is anyone else using this?" check can only speak for the versions it can
+> see, while `permanent` erases all of them. To erase a shared resource, delete it explicitly,
+> without cascade.
+
+> **`permanent=true` requires the current version.** It is ID-scoped, so a request naming a stale
+> version is refused with **409** before anything is deleted — as `cascade=true` already was. A
+> resource that is already soft-deleted has no current version to be stale against: purging its
+> remaining history still works (and does remove its vault keys), and the cascade is skipped rather
+> than refused.
 
 > **Note:** Cascade delete is error-tolerant. If individual resource deletions fail (e.g., resource already deleted), the operation continues and the agent itself is still deleted. Failures are logged server-side.
 
@@ -270,9 +284,15 @@ This will:
 Workflows can also be individually cascade-deleted:
 
 ```
-DELETE /workflowstore/workflows/{id}?version={version}&cascade=true&permanent=true
-→ 200 OK (package + all extension resources deleted)
+DELETE /workflowstore/workflows/{id}?version={version}&cascade=true
+→ 200 OK (package deleted, exclusively-owned extension resources soft-deleted)
 ```
+
+The workflow delete reports how many extensions the cascade left alone — still referenced, not
+routable, or a delete that failed — in the `X-Cascade-Skipped` response header. It is absent when
+nothing was skipped, so a cascade that removed everything it walked no longer looks exactly like one
+that removed half the graph. The header is **not** propagated onto the agent-delete response; the
+packages a cascading agent delete skipped are named in the server log.
 
 ### Important: Undeploy Before Deleting
 
@@ -313,6 +333,8 @@ Returns a report listing all unreferenced resources across all stores (workflows
 {
   "totalOrphans": 3,
   "deletedCount": 0,
+  "scanComplete": true,
+  "scanWarning": null,
   "orphans": [
     {
       "resourceUri": "eddi://ai.labs.workflow/workflowstore/workflows/abc123?version=1",
@@ -329,6 +351,21 @@ Returns a report listing all unreferenced resources across all stores (workflows
   ]
 }
 ```
+
+> **Check `scanComplete` before acting on this list.** It is `false` when part of the traversal
+> failed — an unreadable agent or workflow, an unreadable deployment record, a store type past the
+> scan ceiling — and `scanWarning` then says which. Every failure *removes* entries from the
+> referenced set, so a partial scan lists live, in-use resources as orphans. The read-only scan still
+> answers so you can see the cause; the purge refuses outright (409, below).
+
+What counts as a reference: the current version of every agent, the current version of every
+workflow, **and** every agent version named by a `deployed` deployment record together with the exact
+workflow versions that version pins. A resource referenced only by a superseded *and* undeployed
+agent version is still reported as an orphan — history is not a reference — so rolling an agent back
+to an older version after a purge can leave it unresolvable. References are compared by resource
+identity, not by URI string, so a version-pinned reference protects every version of the resource,
+and a reference written with a legacy authority (`ai.labs.behavior`, `ai.labs.httpcalls`,
+`ai.labs.regulardictionary`) protects the same resource as the canonical one.
 
 ### Purge Orphans
 
@@ -357,6 +394,18 @@ reviewed.
 > old default now purges *less*; pass `includeDeleted=true` to restore the wider sweep.
 
 The purge refuses with **409** rather than proceeding when the referenced-resource scan could not be
-completed (an unreadable Agent or workflow, or a store type exceeding the scan ceiling). A partial
-reference set makes live, in-use resources look unreferenced, so purging against one could destroy
-working configuration.
+completed (an unreadable Agent or workflow, an unreadable deployment record, or a store type
+exceeding the scan ceiling). A partial reference set makes live, in-use resources look unreferenced,
+so purging against one could destroy working configuration.
+
+Each candidate is re-checked against a fresh reverse lookup immediately before it is deleted, so a
+resource that became referenced between the scan and the purge is skipped rather than erased. That
+narrows the mark/sweep window rather than closing it: there is no deployment-wide write lock, because
+taking one would block configuration editing for the duration of an administrative sweep.
+
+The purge also removes each purged resource's descriptor, so the sweep converges. Descriptors are
+normally only *flagged* as deleted — the HTTP delete filter reads one back afterwards and a missing
+row would answer 404 to a delete that succeeded — but that filter does not run for
+`/administration/orphans`, and a flagged descriptor whose resource is gone is exactly what
+`includeDeleted=true` selects. Left in place, every purged resource came back as an orphan on the next
+`includeDeleted=true` run and was counted as deleted again, forever.

--- a/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
+++ b/src/main/java/ai/labs/eddi/backup/impl/RestImportService.java
@@ -12,6 +12,7 @@ import ai.labs.eddi.backup.model.ImportPreview.ResourceDiff;
 import ai.labs.eddi.backup.model.SyncMapping;
 import ai.labs.eddi.backup.model.SyncRequest;
 import ai.labs.eddi.configs.IRestVersionInfo;
+import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.apicalls.IApiCallsStore;
 import ai.labs.eddi.configs.dictionary.IDictionaryStore;
@@ -735,10 +736,16 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     // ==================== Resource Creation ====================
     //
     // All create methods use direct I*Store.create() via CDI instead of going
-    // through
-    // the IRest*Store layer. This bypasses Response.getLocation() which returns
-    // null
-    // for eddi:// scheme URIs when called in-process (CDI direct calls).
+    // through the IRest*Store layer, because what an import needs is the new id and
+    // version, not an HTTP envelope to unwrap again — and because the store call
+    // has no JAX-RS filters to run, which is why createResourceDirect writes the
+    // DocumentDescriptor itself.
+    //
+    // NOT because Response.getLocation() is broken for eddi:// URIs. It is not:
+    // RestWorkflowStoreCrudTest.duplicateDeepCopyWithParserDictionaries builds a
+    // Response.created(eddi://...) with the real JAX-RS RuntimeDelegate and reads
+    // the Location back. That claim used to sit here and in four other classes; it
+    // was wrong in all five.
 
     /**
      * Creates a resource directly via CDI store lookup, bypassing the REST layer
@@ -775,7 +782,38 @@ public class RestImportService extends AbstractBackupService implements IRestImp
     }
 
     private URI createNewAgent(AgentConfiguration agentConfiguration, ImportTransaction transaction) {
-        return createResourceDirect(IAgentStore.class, agentConfiguration, IRestAgentStore.resourceURI, transaction);
+        URI createdAgentUri = createResourceDirect(IAgentStore.class, agentConfiguration, IRestAgentStore.resourceURI, transaction);
+        registerCapabilities(createdAgentUri, agentConfiguration);
+        return createdAgentUri;
+    }
+
+    /**
+     * Adds an imported Agent's skills to the capability index.
+     *
+     * <p>
+     * The index has no observer mechanism: it is seeded once at startup and then
+     * maintained by explicit {@code register}/{@code unregister} calls from
+     * {@code RestAgentStore}. Import creates Agents through the store directly, so
+     * without this an imported Agent's skills stayed invisible to
+     * {@code capabilityMatch} behaviour rules and to A2A discovery until the node
+     * was restarted, with no error to explain it.
+     * </p>
+     *
+     * <p>
+     * Best-effort: a discovery index that cannot be updated must not fail an import
+     * whose Agent is already written.
+     * </p>
+     */
+    private void registerCapabilities(URI createdAgentUri, AgentConfiguration agentConfiguration) {
+        if (createdAgentUri == null || agentConfiguration.getCapabilities() == null || agentConfiguration.getCapabilities().isEmpty()) {
+            return;
+        }
+        try {
+            IResourceId resourceId = RestUtilities.extractResourceId(createdAgentUri);
+            CDI.current().select(CapabilityRegistryService.class).get().register(resourceId.getId(), agentConfiguration);
+        } catch (Exception e) {
+            LOGGER.warnf("Imported Agent %s could not be added to the capability registry: %s", createdAgentUri, e.getMessage());
+        }
     }
 
     private URI createNewWorkflow(String workflowFileString, ImportTransaction transaction) throws IOException {
@@ -981,9 +1019,11 @@ public class RestImportService extends AbstractBackupService implements IRestImp
      * and a partial import leaves them behind, contradicting the guarantee
      * {@link #importAgentZipFile} advertises.
      * <p>
-     * The id is read from the {@code X-Resource-URI} header rather than
-     * {@code Response.getLocation()}, which JAX-RS reports as {@code null} for the
-     * {@code eddi://} scheme on an in-process call. A snippet that was only
+     * The id is read from the {@code X-Resource-URI} header, which
+     * {@code RestVersionInfo.create} sets alongside {@code Location}. Either would
+     * do — {@code Response.getLocation()} works for {@code eddi://} URIs, contrary
+     * to the claim that used to stand here — but the header is the one this method
+     * has always read and there is no reason to move it. A snippet that was only
      * <em>updated</em> during a merge is deliberately not recorded: it already
      * existed and is not an orphan.
      */
@@ -1130,6 +1170,31 @@ public class RestImportService extends AbstractBackupService implements IRestImp
                 LOGGER.warnf("Rollback could not delete descriptor of '%s': %s", LogSanitizer.sanitize(resource.id()),
                         LogSanitizer.sanitize(e.getMessage()));
             }
+            unregisterCapabilities(resource);
+        }
+    }
+
+    /**
+     * Takes a rolled-back Agent back out of the capability index.
+     *
+     * <p>
+     * {@link #createNewAgent} registers an imported Agent's skills, and the index
+     * is a process-local map that nothing else prunes. Without this, a ZIP that
+     * created an Agent and then failed on a later resource deleted the Agent row
+     * while leaving its skills in the index, so {@code findBySkill} and A2A
+     * discovery answered with an agent id that no longer exists — until the next
+     * restart.
+     * </p>
+     */
+    private void unregisterCapabilities(ImportTransaction.CreatedResource resource) {
+        if (!IAgentStore.class.equals(resource.storeClass())) {
+            return;
+        }
+        try {
+            CDI.current().select(CapabilityRegistryService.class).get().unregister(resource.id());
+        } catch (Exception e) {
+            LOGGER.warnf("Rollback could not clear the capability registration of Agent '%s': %s",
+                    LogSanitizer.sanitize(resource.id()), LogSanitizer.sanitize(e.getMessage()));
         }
     }
 
@@ -1266,7 +1331,7 @@ public class RestImportService extends AbstractBackupService implements IRestImp
         // Use direct CDI lookup instead of HTTP loopback proxy.
         // The MP REST Client proxy strips response headers (Location, X-Resource-URI)
         // and runs on the Vert.x IO event loop, causing deadlocks during import.
-        return jakarta.enterprise.inject.spi.CDI.current().select(clazz).get();
+        return CDI.current().select(clazz).get();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/ai/labs/eddi/configs/admin/IRestOrphanAdmin.java
+++ b/src/main/java/ai/labs/eddi/configs/admin/IRestOrphanAdmin.java
@@ -37,7 +37,10 @@ public interface IRestOrphanAdmin {
             + "(workflows, behavior sets, HTTP calls, output sets, LLMs, "
             + "property setters, dictionaries, parsers) and returns resources not referenced by any Agent or workflow. "
             + "includeDeleted=true additionally includes soft-deleted resources; false (the default) reports live resources only.")
-    @APIResponse(responseCode = "200", description = "Orphan report with list of unreferenced resources.")
+    @APIResponse(responseCode = "200", description = "Orphan report with list of unreferenced resources. "
+            + "Check scanComplete before acting on the list: when it is false the reference scan failed part-way "
+            + "(scanWarning says why) and resources that are still in use may appear as orphans. "
+            + "A resource counts as referenced when ANY version of it is referenced, not only the pinned one.")
     // @formatter:off
     OrphanReport scanOrphans(
             @Parameter(description = "Also include soft-deleted resources. Default: false (live resources only).")

--- a/src/main/java/ai/labs/eddi/configs/admin/model/OrphanReport.java
+++ b/src/main/java/ai/labs/eddi/configs/admin/model/OrphanReport.java
@@ -13,14 +13,48 @@ public class OrphanReport {
     private int totalOrphans;
     private int deletedCount; // only set after purge
     private List<OrphanInfo> orphans;
+    /**
+     * Whether the reference scan behind this report completed.
+     * <p>
+     * A partial scan is missing references, and every resource whose only referrer
+     * could not be read is then listed below as an "orphan". The purge refuses
+     * outright in that case; the read-only scan still answers, so it has to say so
+     * — the list is the operator's review surface for an irreversible deletion, and
+     * without this flag a partial list is indistinguishable from a clean one.
+     */
+    private boolean scanComplete = true;
+    /** Human-readable cause when {@link #scanComplete} is false. */
+    private String scanWarning;
 
     public OrphanReport() {
     }
 
     public OrphanReport(int totalOrphans, int deletedCount, List<OrphanInfo> orphans) {
+        this(totalOrphans, deletedCount, orphans, true, null);
+    }
+
+    public OrphanReport(int totalOrphans, int deletedCount, List<OrphanInfo> orphans, boolean scanComplete, String scanWarning) {
         this.totalOrphans = totalOrphans;
         this.deletedCount = deletedCount;
         this.orphans = orphans;
+        this.scanComplete = scanComplete;
+        this.scanWarning = scanWarning;
+    }
+
+    public boolean isScanComplete() {
+        return scanComplete;
+    }
+
+    public void setScanComplete(boolean scanComplete) {
+        this.scanComplete = scanComplete;
+    }
+
+    public String getScanWarning() {
+        return scanWarning;
+    }
+
+    public void setScanWarning(String scanWarning) {
+        this.scanWarning = scanWarning;
     }
 
     public int getTotalOrphans() {

--- a/src/main/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdmin.java
+++ b/src/main/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdmin.java
@@ -11,6 +11,7 @@ import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration.WorkflowStep;
@@ -71,24 +72,29 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
      */
     private static final int MAX_PAGES = 100;
 
+    private static final String WORKFLOW_TYPE = "ai.labs.workflow";
+
     private final IAgentStore agentStore;
     private final IWorkflowStore workflowStore;
     private final IDocumentDescriptorStore documentDescriptorStore;
     private final IResourceClientLibrary resourceClientLibrary;
+    private final IRestWorkflowStore restWorkflowStore;
 
     @Inject
     public RestOrphanAdmin(IAgentStore agentStore, IWorkflowStore workflowStore, IDocumentDescriptorStore documentDescriptorStore,
-            IResourceClientLibrary resourceClientLibrary) {
+            IResourceClientLibrary resourceClientLibrary, IRestWorkflowStore restWorkflowStore) {
         this.agentStore = agentStore;
         this.workflowStore = workflowStore;
         this.documentDescriptorStore = documentDescriptorStore;
         this.resourceClientLibrary = resourceClientLibrary;
+        this.restWorkflowStore = restWorkflowStore;
     }
 
     @Override
     public OrphanReport scanOrphans(Boolean includeDeleted) {
-        List<OrphanInfo> orphans = findOrphans(includeDeleted);
-        return new OrphanReport(orphans.size(), 0, orphans);
+        ReferenceScan scan = scanReferencedUris();
+        List<OrphanInfo> orphans = collectOrphans(scan.referencedResources(), includeDeleted);
+        return new OrphanReport(orphans.size(), 0, orphans, scan.complete(), scan.failureReason());
     }
 
     @Override
@@ -111,12 +117,12 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
                     .type(MediaType.APPLICATION_JSON).build());
         }
 
-        List<OrphanInfo> orphans = collectOrphans(scan.referencedUris(), includeDeleted);
+        List<OrphanInfo> orphans = collectOrphans(scan.referencedResources(), includeDeleted);
         int deletedCount = 0;
 
         for (OrphanInfo orphan : orphans) {
             try {
-                resourceClientLibrary.deleteResource(orphan.getResourceUri(), true);
+                deleteOrphan(orphan);
                 deletedCount++;
                 log.infof("Purged orphan: %s [%s]", orphan.getResourceUri(), orphan.getType());
             } catch (Exception e) {
@@ -125,29 +131,90 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
         }
 
         log.infof("Orphan purge complete: %d/%d deleted", deletedCount, orphans.size());
-        return new OrphanReport(orphans.size(), deletedCount, orphans);
+        return new OrphanReport(orphans.size(), deletedCount, orphans, true, null);
     }
 
     /**
-     * Outcome of building the referenced-URI set.
+     * Deletes one orphan, or throws so the caller does not count it.
      *
-     * @param referencedUris
-     *            every URI referenced by at least one Agent or workflow
+     * <p>
+     * Workflows go through {@link IRestWorkflowStore} directly:
+     * {@code ResourceClientLibrary} registers no {@code ai.labs.workflow} proxy, so
+     * routing them there deleted nothing. Cascade is deliberately off — every
+     * resource a workflow references is itself enumerated by this scan, and is only
+     * an orphan if nothing else points at it.
+     * </p>
+     */
+    private void deleteOrphan(OrphanInfo orphan) throws Exception {
+        if (!WORKFLOW_TYPE.equals(orphan.getType())) {
+            resourceClientLibrary.deleteResource(orphan.getResourceUri(), true);
+            return;
+        }
+
+        // deletedCount is the operator's only feedback for an irreversible operation,
+        // so each way this can fail to delete anything has to raise rather than fall
+        // through to the caller's deletedCount++.
+        var resourceId = RestUtilities.extractResourceId(orphan.getResourceUri());
+        if (resourceId == null || isNullOrEmpty(resourceId.getId())) {
+            throw new IllegalStateException("Orphan workflow URI carries no resource id: " + orphan.getResourceUri());
+        }
+
+        Response response = restWorkflowStore.deleteWorkflow(resourceId.getId(), resourceId.getVersion(), true, false);
+        if (response == null) {
+            throw new IllegalStateException("Workflow delete answered -1 for " + orphan.getResourceUri());
+        }
+        if (response.getStatus() < 200 || response.getStatus() >= 300) {
+            throw new IllegalStateException("Workflow delete answered " + response.getStatus() + " for " + orphan.getResourceUri());
+        }
+    }
+
+    /**
+     * Outcome of building the referenced-resource set.
+     *
+     * @param referencedResources
+     *            every resource referenced by at least one Agent or workflow, keyed
+     *            by {@link #resourceKey(URI)} — identity WITHOUT the pinned version
      * @param complete
      *            false when any part of the traversal failed, meaning the set may
      *            be missing references and is therefore unsafe to delete against
      * @param failureReason
      *            human-readable cause when {@code complete} is false
      */
-    private record ReferenceScan(Set<String> referencedUris, boolean complete, String failureReason) {
+    private record ReferenceScan(Set<String> referencedResources, boolean complete, String failureReason) {
     }
 
-    private List<OrphanInfo> findOrphans(boolean includeDeleted) {
-        return collectOrphans(scanReferencedUris().referencedUris(), includeDeleted);
+    /**
+     * A resource's identity, independent of the version a reference pins.
+     *
+     * <p>
+     * References are version-pinned by design, and {@code DocumentDescriptorFilter}
+     * rewrites a descriptor's {@code resource} to the NEW version on every PUT. So
+     * one edit of a rule set leaves the descriptor saying {@code ?version=2} while
+     * every workflow that was not re-pointed still says {@code ?version=1}. Under a
+     * literal string compare that rule set looked unreferenced, and the purge —
+     * which deletes ALL versions — destroyed a config a live workflow was still
+     * resolving. Comparing identity means any referenced version protects the
+     * resource.
+     * </p>
+     *
+     * <p>
+     * Note the remaining, deliberate gap: only the CURRENT version of each agent
+     * and workflow contributes references, so a resource referenced solely by a
+     * superseded agent version is still reported. That is the documented meaning of
+     * "orphan" here — history is not a reference — but it does mean rolling an
+     * agent back to an older version after a purge can leave it unresolvable.
+     * </p>
+     */
+    private static String resourceKey(URI uri) {
+        if (uri == null) {
+            return null;
+        }
+        String withoutVersion = RestUtilities.pathWithoutVersionQuery(uri);
+        return withoutVersion != null ? withoutVersion : uri.toString();
     }
 
-    private List<OrphanInfo> collectOrphans(Set<String> referencedUris, boolean includeDeleted) {
-        log.infof("Orphan scan: found %d referenced resource URIs", referencedUris.size());
+    private List<OrphanInfo> collectOrphans(Set<String> referencedResources, boolean includeDeleted) {
+        log.infof("Orphan scan: found %d referenced resources", referencedResources.size());
 
         List<OrphanInfo> orphans = new ArrayList<>();
 
@@ -158,7 +225,7 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
                 List<DocumentDescriptor> descriptors = readAllDescriptors(type, includeDeleted);
                 for (DocumentDescriptor descriptor : descriptors) {
                     URI resourceUri = descriptor.getResource();
-                    if (resourceUri != null && !referencedUris.contains(resourceUri.toString())) {
+                    if (resourceUri != null && !referencedResources.contains(resourceKey(resourceUri))) {
                         orphans.add(new OrphanInfo(resourceUri, type, descriptor.getName() != null ? descriptor.getName() : "(unnamed)",
                                 descriptor.isDeleted()));
                     }
@@ -187,7 +254,7 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
      * </p>
      */
     private ReferenceScan scanReferencedUris() {
-        Set<String> referencedUris = new HashSet<>();
+        Set<String> referencedResources = new HashSet<>();
         String failureReason = null;
 
         try {
@@ -202,7 +269,7 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
                     AgentConfiguration agentConfig = agentStore.read(resourceId.getId(), resourceId.getVersion());
                     if (agentConfig.getWorkflows() != null) {
                         for (URI workflowUri : agentConfig.getWorkflows()) {
-                            referencedUris.add(workflowUri.toString());
+                            referencedResources.add(resourceKey(workflowUri));
                         }
                     }
                 } catch (IResourceStore.ResourceNotFoundException e) {
@@ -223,7 +290,7 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
                         continue;
 
                     WorkflowConfiguration workflowConfig = workflowStore.read(resourceId.getId(), resourceId.getVersion());
-                    collectExtensionUris(workflowConfig, referencedUris);
+                    collectExtensionUris(workflowConfig, referencedResources);
                 } catch (IResourceStore.ResourceNotFoundException e) {
                     // Workflow descriptor exists but resource doesn't — genuinely
                     // unreferenced, so this does not make the scan incomplete.
@@ -238,21 +305,21 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
             failureReason = "could not enumerate Agent/workflow descriptors: " + e.getMessage();
         }
 
-        return new ReferenceScan(referencedUris, failureReason == null, failureReason);
+        return new ReferenceScan(referencedResources, failureReason == null, failureReason);
     }
 
     /**
      * Extract all extension resource URIs from a workflow configuration. Follows
      * the same traversal as RestWorkflowStore.deleteWorkflowCascade().
      */
-    private void collectExtensionUris(WorkflowConfiguration workflowConfig, Set<String> referencedUris) {
+    private void collectExtensionUris(WorkflowConfiguration workflowConfig, Set<String> referencedResources) {
         for (WorkflowStep ext : workflowConfig.getWorkflowSteps()) {
             // Main extension resource URI (config.uri)
             Map<String, Object> config = ext.getConfig();
             if (config != null) {
                 Object uriObj = config.get("uri");
                 if (uriObj != null && !isNullOrEmpty(uriObj.toString())) {
-                    referencedUris.add(uriObj.toString());
+                    addReference(referencedResources, uriObj);
                 }
             }
 
@@ -267,13 +334,31 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
                             if (dictConfig instanceof Map<?, ?> dictConfigMap) {
                                 Object dictUri = dictConfigMap.get("uri");
                                 if (dictUri != null && !isNullOrEmpty(dictUri.toString())) {
-                                    referencedUris.add(dictUri.toString());
+                                    addReference(referencedResources, dictUri);
                                 }
                             }
                         }
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Records a workflow-step reference, keyed by identity. A value that is not a
+     * parsable URI is still recorded verbatim: it protects nothing that way, but
+     * dropping it silently would be worse than an entry that simply never matches.
+     */
+    private static void addReference(Set<String> referencedResources, Object uriObj) {
+        String raw = uriObj.toString();
+        try {
+            referencedResources.add(resourceKey(URI.create(raw)));
+        } catch (IllegalArgumentException e) {
+            // Letting this out would cost the scan every OTHER reference this workflow
+            // holds — the per-workflow catch upstream discards the whole traversal —
+            // and that is exactly what promotes live resources to "orphan".
+            log.warnf("Workflow references a malformed resource uri '%s'; recording it verbatim: %s", raw, e.getMessage());
+            referencedResources.add(raw);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdmin.java
+++ b/src/main/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdmin.java
@@ -9,6 +9,8 @@ import ai.labs.eddi.configs.admin.model.OrphanInfo;
 import ai.labs.eddi.configs.admin.model.OrphanReport;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.deployment.IDeploymentStore;
+import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
@@ -79,15 +81,17 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
     private final IDocumentDescriptorStore documentDescriptorStore;
     private final IResourceClientLibrary resourceClientLibrary;
     private final IRestWorkflowStore restWorkflowStore;
+    private final IDeploymentStore deploymentStore;
 
     @Inject
     public RestOrphanAdmin(IAgentStore agentStore, IWorkflowStore workflowStore, IDocumentDescriptorStore documentDescriptorStore,
-            IResourceClientLibrary resourceClientLibrary, IRestWorkflowStore restWorkflowStore) {
+            IResourceClientLibrary resourceClientLibrary, IRestWorkflowStore restWorkflowStore, IDeploymentStore deploymentStore) {
         this.agentStore = agentStore;
         this.workflowStore = workflowStore;
         this.documentDescriptorStore = documentDescriptorStore;
         this.resourceClientLibrary = resourceClientLibrary;
         this.restWorkflowStore = restWorkflowStore;
+        this.deploymentStore = deploymentStore;
     }
 
     @Override
@@ -122,7 +126,25 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
 
         for (OrphanInfo orphan : orphans) {
             try {
-                deleteOrphan(orphan);
+                // Re-checked immediately before the irreversible delete, not only in
+                // the scan above. The scan is a mark phase over the whole deployment
+                // and takes as long as it takes; a workflow created (or re-pointed) in
+                // that window makes a resource live again, and this loop would then
+                // erase every version of something in use. A targeted reverse lookup
+                // costs one query per candidate and closes all but the last instants
+                // of that window — narrowing it, not eliminating it: there is no
+                // deployment-wide write lock here, and taking one would serialise
+                // configuration editing against an administrative sweep.
+                //
+                // Resolved once and used for BOTH the re-check and the delete: asking
+                // the two questions at different versions is how a guard that passes
+                // can still be followed by a delete of something in use.
+                Integer version = resolveVersion(orphan);
+                if (isReferencedNow(orphan, version)) {
+                    log.warnf("Skipping orphan %s — it became referenced after the scan and before the purge", orphan.getResourceUri());
+                    continue;
+                }
+                deleteOrphan(orphan, version);
                 deletedCount++;
                 log.infof("Purged orphan: %s [%s]", orphan.getResourceUri(), orphan.getType());
             } catch (Exception e) {
@@ -135,6 +157,73 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
     }
 
     /**
+     * Fresh reverse lookup for one purge candidate, run between the scan and the
+     * delete.
+     *
+     * <p>
+     * Asked at {@code version} — the version {@link #deleteOrphan} is about to
+     * address, i.e. the LIVE one. Both reverse lookups take
+     * {@code includePreviousVersions=true}, which walks from the version given DOWN
+     * to 1, so a referrer pinning a version ABOVE the one asked about is invisible.
+     * Asked at the descriptor's version, a stale descriptor (v1) would hide an
+     * agent that started referencing the resource at v2 in the mark/sweep window,
+     * and the purge would then erase a resource in use. Starting from the current
+     * version means there is no newer version above it for the walk to miss — the
+     * same argument {@code RestWorkflowStore.collectCascadeCandidate} makes.
+     * </p>
+     *
+     * <p>
+     * Fails CLOSED: a lookup that cannot answer reports "referenced", because the
+     * alternative is a permanent delete decided on a question nobody answered.
+     * </p>
+     */
+    private boolean isReferencedNow(OrphanInfo orphan, Integer version) {
+        var resourceId = RestUtilities.extractResourceId(orphan.getResourceUri());
+        if (resourceId == null || version == null || version < 1) {
+            // Nothing to re-query with. Do not upgrade the scan's classification to a
+            // permanent delete on a reference we cannot ask about.
+            log.warnf("Cannot re-check orphan %s (no usable version) — NOT purging it", orphan.getResourceUri());
+            return true;
+        }
+
+        try {
+            if (WORKFLOW_TYPE.equals(orphan.getType())) {
+                if (isNullOrEmpty(resourceId.getId())) {
+                    log.warnf("Cannot re-check orphan workflow %s (no usable id) — NOT purging it", orphan.getResourceUri());
+                    return true;
+                }
+                return !agentStore.getAgentDescriptorsContainingWorkflow(resourceId.getId(), version, true).isEmpty();
+            }
+            // Extensions are looked up by URI, so this branch needs no resource id.
+            return !workflowStore.getWorkflowDescriptorsContainingResource(atVersion(orphan.getResourceUri(), version).toString(), true)
+                    .isEmpty();
+        } catch (Exception e) {
+            log.warnf("Re-check of orphan %s failed — NOT purging it: %s", orphan.getResourceUri(), e.getMessage());
+            return true;
+        }
+    }
+
+    /**
+     * The version this orphan's re-check and delete must both use: the resource's
+     * LIVE version, falling back to the descriptor's when nothing is live.
+     *
+     * <p>
+     * Resolved ONCE per candidate and threaded through both steps, so the question
+     * "is anyone still using this?" and the answer "then erase it" cannot be asked
+     * about different versions. See {@link #liveVersion} for why the descriptor's
+     * own version cannot be trusted.
+     * </p>
+     */
+    private Integer resolveVersion(OrphanInfo orphan) {
+        var resourceId = RestUtilities.extractResourceId(orphan.getResourceUri());
+        if (WORKFLOW_TYPE.equals(orphan.getType())) {
+            String id = resourceId != null ? resourceId.getId() : null;
+            return liveVersion(isNullOrEmpty(id) ? null : currentWorkflowId(id), resourceId);
+        }
+        return liveVersion(resourceClientLibrary.getCurrentResourceId(orphan.getResourceUri()), resourceId);
+    }
+
+    /**
      * Deletes one orphan, or throws so the caller does not count it.
      *
      * <p>
@@ -144,27 +233,163 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
      * resource a workflow references is itself enumerated by this scan, and is only
      * an orphan if nothing else points at it.
      * </p>
+     *
+     * <p>
+     * {@code version} is the resource's LIVE version, resolved by
+     * {@link #resolveVersion} and already used by {@link #isReferencedNow} — not
+     * the one the descriptor carries. See {@link #liveVersion}.
+     * </p>
      */
-    private void deleteOrphan(OrphanInfo orphan) throws Exception {
+    private void deleteOrphan(OrphanInfo orphan, Integer version) throws Exception {
+        var resourceId = RestUtilities.extractResourceId(orphan.getResourceUri());
+
         if (!WORKFLOW_TYPE.equals(orphan.getType())) {
-            resourceClientLibrary.deleteResource(orphan.getResourceUri(), true);
+            resourceClientLibrary.deleteResource(atVersion(orphan.getResourceUri(), version), true);
+            removeDescriptor(resourceId);
             return;
         }
 
         // deletedCount is the operator's only feedback for an irreversible operation,
         // so each way this can fail to delete anything has to raise rather than fall
         // through to the caller's deletedCount++.
-        var resourceId = RestUtilities.extractResourceId(orphan.getResourceUri());
         if (resourceId == null || isNullOrEmpty(resourceId.getId())) {
             throw new IllegalStateException("Orphan workflow URI carries no resource id: " + orphan.getResourceUri());
         }
 
-        Response response = restWorkflowStore.deleteWorkflow(resourceId.getId(), resourceId.getVersion(), true, false);
+        Response response = restWorkflowStore.deleteWorkflow(resourceId.getId(), version, true, false);
         if (response == null) {
             throw new IllegalStateException("Workflow delete answered -1 for " + orphan.getResourceUri());
         }
         if (response.getStatus() < 200 || response.getStatus() >= 300) {
             throw new IllegalStateException("Workflow delete answered " + response.getStatus() + " for " + orphan.getResourceUri());
+        }
+        removeDescriptor(resourceId);
+    }
+
+    /**
+     * The version a permanent delete must be addressed at: the resource's LIVE
+     * version, falling back to the descriptor's when there is no live version left.
+     *
+     * <p>
+     * A permanent delete is ID-scoped — {@code deleteAllPermanently} drops every
+     * version and every history row — but {@code RestVersionInfo.delete} now
+     * refuses one addressed at anything but the current version, so a stale tab
+     * cannot erase a resource that has since moved on. Descriptor versions go stale
+     * routinely: {@code DocumentDescriptorFilter} advances them only on an HTTP
+     * PUT/PATCH, so every in-process update path (MCP's injected facades, ZIP
+     * import, the upgrade executor) leaves the descriptor saying {@code ?version=1}
+     * while the resource is at v2 — the skew {@link #resourceKey(URI)} documents as
+     * normal. Addressing the purge's delete at the descriptor's version therefore
+     * made every such orphan fail with a caught 409, on every run, for ever:
+     * exactly the non-convergence this endpoint exists to remove.
+     * </p>
+     *
+     * <p>
+     * A null {@code current} means no live version — an already soft-deleted
+     * resource whose history is being purged, which {@code requireCurrentVersion}
+     * deliberately admits — so the descriptor's version is the right thing to
+     * address it at.
+     * </p>
+     */
+    private static Integer liveVersion(IResourceStore.IResourceId current, IResourceStore.IResourceId fromDescriptor) {
+        if (current != null && current.getVersion() != null) {
+            return current.getVersion();
+        }
+        return fromDescriptor != null ? fromDescriptor.getVersion() : null;
+    }
+
+    /**
+     * The workflow's live id/version, or null when it has none left.
+     * {@code IWorkflowStore} reports "gone" by exception where
+     * {@code ResourceClientLibrary} reports it by null; {@link #liveVersion} takes
+     * the null form.
+     */
+    private IResourceStore.IResourceId currentWorkflowId(String id) {
+        try {
+            return workflowStore.getCurrentResourceId(id);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * The same resource, addressed at {@code version}.
+     *
+     * <p>
+     * {@code pathWithoutVersionQuery} answers null for BOTH "no query at all" and
+     * "a query that carries no usable version", and returning the URI unchanged in
+     * those cases was not a no-op: it handed
+     * {@code getWorkflowDescriptorsContainingResource} exactly the shape
+     * {@code WorkflowStore} refuses ("Reverse lookup requires a versioned resource
+     * URI"), so {@link #isReferencedNow} caught, logged "NOT purging it" and
+     * answered true — a descriptor whose URI carries no {@code ?version=} was
+     * re-listed by every scan and purged by none, the non-convergence this endpoint
+     * exists to remove. {@code deleteOrphan} would have fared no better:
+     * {@code ResourceClientLibrary.deleteResource} reads the version straight out
+     * of the URI.
+     * </p>
+     *
+     * <p>
+     * Everything before the query is therefore re-addressed at {@code version},
+     * exactly as {@code RestWorkflowStore.withVersion} does for the cascade's
+     * references — the two walk the same stored URIs and must not disagree about
+     * what "at this version" means.
+     * </p>
+     *
+     * <p>
+     * No null guard, deliberately: both call sites are downstream of
+     * {@link #isReferencedNow}'s {@code resourceId == null || version == null ||
+     * version < 1} check, so a null URI or a null version cannot reach here — and a
+     * defensive branch nothing can execute is a line no test can pin.
+     * </p>
+     */
+    private static URI atVersion(URI resourceUri, Integer version) {
+        String withoutVersion = RestUtilities.pathWithoutVersionQuery(resourceUri);
+        if (withoutVersion == null) {
+            String raw = resourceUri.toString();
+            int queryStart = raw.indexOf('?');
+            withoutVersion = queryStart >= 0 ? raw.substring(0, queryStart) : raw;
+        }
+        return URI.create(withoutVersion + "?version=" + version);
+    }
+
+    /**
+     * Removes the descriptor of a resource this endpoint has just purged
+     * permanently — the one place where erasing it is both safe and necessary.
+     *
+     * <p>
+     * {@code RestVersionInfo.markDescriptorDeleted} only FLAGS descriptors, and has
+     * to: on the HTTP path {@code DocumentDescriptorFilter} reads the descriptor
+     * back after the delete and a missing row there answers 404 to a delete that in
+     * fact succeeded. That filter does not run for {@code /administration/orphans}
+     * — {@code extractResourceId} yields no id for this request URI, so it skips —
+     * which is what makes erasing the row safe here.
+     * </p>
+     *
+     * <p>
+     * And necessary, because a flagged descriptor whose resource is gone is exactly
+     * what {@code readDescriptors(includeDeleted=true)} selects. Left behind, every
+     * purged resource came back as an orphan on the next
+     * {@code ?includeDeleted=true} sweep, {@code deleteAllPermanently} on a
+     * non-existent id answered silently, {@code deletedCount} counted it again —
+     * and the tombstone set grew with every run. The purge could never converge,
+     * which is the "reports success while doing nothing" it exists to remove.
+     * </p>
+     *
+     * <p>
+     * Best-effort: the resource IS gone by now, so a descriptor that cannot be
+     * removed must not turn a completed purge into a failure.
+     * </p>
+     */
+    private void removeDescriptor(IResourceStore.IResourceId resourceId) {
+        if (resourceId == null || isNullOrEmpty(resourceId.getId())) {
+            return;
+        }
+        try {
+            documentDescriptorStore.deleteAllDescriptor(resourceId.getId());
+        } catch (Exception e) {
+            log.warnf("Purged resource %s but could not remove its descriptor; it will be re-reported as an orphan: %s", resourceId.getId(),
+                    e.getMessage());
         }
     }
 
@@ -198,11 +423,25 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
      * </p>
      *
      * <p>
+     * The host is canonicalised too. {@code ResourceClientLibrary.init()} registers
+     * three stores under two authorities each ({@code behavior}/{@code rules},
+     * {@code httpcalls}/{@code apicalls},
+     * {@code regulardictionary}/{@code dictionary}), so a workflow step written
+     * through REST or MCP with the legacy authority resolves perfectly at runtime
+     * while the descriptor always carries the canonical one that
+     * {@code RestVersionInfo.create} writes. Only ZIP import normalises; a literal
+     * host compare therefore reported a rule set that a live workflow still
+     * references as unreferenced, and the purge erased it.
+     * </p>
+     *
+     * <p>
      * Note the remaining, deliberate gap: only the CURRENT version of each agent
-     * and workflow contributes references, so a resource referenced solely by a
-     * superseded agent version is still reported. That is the documented meaning of
-     * "orphan" here — history is not a reference — but it does mean rolling an
-     * agent back to an older version after a purge can leave it unresolvable.
+     * and workflow contributes references (plus every version named by a deployment
+     * record — see {@link #scanReferencedUris()}), so a resource referenced solely
+     * by a superseded, undeployed agent version is still reported. That is the
+     * documented meaning of "orphan" here — history is not a reference — but it
+     * does mean rolling an agent back to an older version after a purge can leave
+     * it unresolvable.
      * </p>
      */
     private static String resourceKey(URI uri) {
@@ -210,7 +449,34 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
             return null;
         }
         String withoutVersion = RestUtilities.pathWithoutVersionQuery(uri);
-        return withoutVersion != null ? withoutVersion : uri.toString();
+        String path = withoutVersion != null ? withoutVersion : uri.toString();
+        return canonicalHost(uri.getHost(), path);
+    }
+
+    /**
+     * The legacy authority a store also answers to, mapped to the canonical one
+     * descriptors are written with. Mirrors the aliases
+     * {@code ResourceClientLibrary.init()} registers — the runtime resolves both,
+     * so the orphan scan has to compare both as one.
+     */
+    private static final Map<String, String> CANONICAL_HOSTS = Map.of("ai.labs.behavior", "ai.labs.rules", "ai.labs.httpcalls",
+            "ai.labs.apicalls", "ai.labs.regulardictionary", "ai.labs.dictionary");
+
+    /**
+     * A reference keyed by canonical type and resource id, dropping the store path.
+     * The two authorities of an aliased store carry different paths as well
+     * ({@code behaviorstore/behaviorsets} vs {@code rulestore/rulesets}), so
+     * rewriting the host alone would not make them compare equal.
+     */
+    private static String canonicalHost(String host, String path) {
+        if (host == null) {
+            return path;
+        }
+        var resourceId = RestUtilities.extractResourceId(URI.create(path));
+        if (resourceId == null || resourceId.getId() == null) {
+            return path;
+        }
+        return CANONICAL_HOSTS.getOrDefault(host, host) + "/" + resourceId.getId();
     }
 
     private List<OrphanInfo> collectOrphans(Set<String> referencedResources, boolean includeDeleted) {
@@ -300,12 +566,92 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
                 }
             }
 
+            // Step 1c: every DEPLOYED Agent version, not just the current one.
+            //
+            // Deployments are version-pinned: AgentDeploymentManagement.checkDeployments
+            // reads (agentId, agentVersion) straight out of the deployment store and
+            // redeploys exactly that version on every startup and every 10-second sweep.
+            // Steps 1a/1b only see each Agent's CURRENT version, so an author editing a
+            // deployed Agent to point at a new workflow made the old one look
+            // unreferenced — and purging it left the still-deployed version unable to
+            // resolve its own workflow, with the history rows gone and no recovery path.
+            // Superseded-and-undeployed versions remain out of scope by design (see
+            // resourceKey); "deployed" is not history.
+            failureReason = scanDeployedAgents(referencedResources, failureReason);
+
         } catch (Exception e) {
             log.errorf("Error building referenced URIs set: %s", e.getMessage());
             failureReason = "could not enumerate Agent/workflow descriptors: " + e.getMessage();
         }
 
         return new ReferenceScan(referencedResources, failureReason == null, failureReason);
+    }
+
+    /**
+     * Folds the workflows (and their extensions) of every deployed Agent version
+     * into the referenced set.
+     *
+     * @param currentFailure
+     *            the failure reason accumulated so far
+     * @return {@code currentFailure}, or a new reason when this step could not
+     *         complete — a deployment store that cannot be read leaves the scan
+     *         incomplete, because everything a deployed version protects would
+     *         otherwise be reported as an orphan
+     */
+    private String scanDeployedAgents(Set<String> referencedResources, String currentFailure) {
+        String failureReason = currentFailure;
+        List<DeploymentInfo> deployments;
+        try {
+            deployments = deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed);
+        } catch (Exception e) {
+            log.errorf("Could not read the deployment records: %s", e.getMessage());
+            return "could not read the deployment records: " + e.getMessage();
+        }
+
+        for (DeploymentInfo deployment : deployments) {
+            if (deployment == null || isNullOrEmpty(deployment.getAgentId()) || deployment.getAgentVersion() == null) {
+                continue;
+            }
+            try {
+                AgentConfiguration deployedAgent = agentStore.read(deployment.getAgentId(), deployment.getAgentVersion());
+                if (deployedAgent.getWorkflows() == null) {
+                    continue;
+                }
+                for (URI workflowUri : deployedAgent.getWorkflows()) {
+                    referencedResources.add(resourceKey(workflowUri));
+                    failureReason = collectExtensionUrisOfPinnedWorkflow(workflowUri, referencedResources, failureReason);
+                }
+            } catch (IResourceStore.ResourceNotFoundException e) {
+                // The deployed version is gone from the store already; it protects
+                // nothing, and that is not an incomplete scan.
+            } catch (Exception e) {
+                log.warnf("Error reading deployed Agent %s (v%d): %s", deployment.getAgentId(), deployment.getAgentVersion(), e.getMessage());
+                failureReason = "could not read deployed Agent " + deployment.getAgentId() + " (v" + deployment.getAgentVersion() + "): "
+                        + e.getMessage();
+            }
+        }
+        return failureReason;
+    }
+
+    /**
+     * Reads the exact workflow version a deployed Agent pins — which the
+     * descriptor-driven walk in {@link #scanReferencedUris()} does not see, because
+     * that only visits current versions — and records its extension references.
+     */
+    private String collectExtensionUrisOfPinnedWorkflow(URI workflowUri, Set<String> referencedResources, String currentFailure) {
+        var resourceId = RestUtilities.extractResourceId(workflowUri);
+        if (resourceId == null || isNullOrEmpty(resourceId.getId()) || resourceId.getVersion() == null || resourceId.getVersion() < 1) {
+            return currentFailure;
+        }
+        try {
+            collectExtensionUris(workflowStore.read(resourceId.getId(), resourceId.getVersion()), referencedResources);
+            return currentFailure;
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            return currentFailure;
+        } catch (Exception e) {
+            log.warnf("Error reading deployed workflow %s: %s", workflowUri, e.getMessage());
+            return "could not read deployed workflow " + workflowUri + ": " + e.getMessage();
+        }
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdmin.java
+++ b/src/main/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdmin.java
@@ -140,7 +140,7 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
                 // the two questions at different versions is how a guard that passes
                 // can still be followed by a delete of something in use.
                 Integer version = resolveVersion(orphan);
-                if (isReferencedNow(orphan, version)) {
+                if (isReferencedNow(orphan, version) || isReferencedByADeployedVersionNow(orphan)) {
                     log.warnf("Skipping orphan %s — it became referenced after the scan and before the purge", orphan.getResourceUri());
                     continue;
                 }
@@ -201,6 +201,56 @@ public class RestOrphanAdmin implements IRestOrphanAdmin {
             log.warnf("Re-check of orphan %s failed — NOT purging it: %s", orphan.getResourceUri(), e.getMessage());
             return true;
         }
+    }
+
+    /**
+     * The second half of the fresh re-check: the references held by DEPLOYED Agent
+     * versions, which {@link #isReferencedNow} cannot see.
+     *
+     * <p>
+     * Both reverse lookups {@link #isReferencedNow} uses skip a referrer that is
+     * not a resource's current version
+     * ({@code AbstractResourceStore.isStaleReference}), so they answer only for
+     * current Agents and current workflows. The mark scan deliberately counts more
+     * than that — {@link #scanDeployedAgents} folds in every version a deployment
+     * record pins, because {@code checkDeployments} redeploys exactly those on
+     * every startup and every 10-second sweep. Re-checking with the narrower
+     * question would therefore have DISCARDED a referrer the scan itself treats as
+     * live: a deployment record that starts pinning an older Agent version in the
+     * mark/sweep window, whose workflow (or extension) this loop would then erase
+     * with every version and every history row.
+     * </p>
+     *
+     * <p>
+     * Costs one deployment enumeration per candidate — deliberately not hoisted out
+     * of the loop, since a set computed once before the loop would be exactly the
+     * stale answer this re-check exists to replace. Fails CLOSED: an incomplete
+     * deployment scan reports "referenced".
+     * </p>
+     */
+    private boolean isReferencedByADeployedVersionNow(OrphanInfo orphan) {
+        String key = resourceKey(orphan.getResourceUri());
+        if (key == null) {
+            log.warnf("Cannot re-check orphan %s against deployed versions (no usable key) — NOT purging it", orphan.getResourceUri());
+            return true;
+        }
+        Set<String> deployedReferences = new HashSet<>();
+        String failureReason;
+        try {
+            failureReason = scanDeployedAgents(deployedReferences, null);
+        } catch (Exception e) {
+            log.warnf("Deployed-version re-check of orphan %s failed — NOT purging it: %s", orphan.getResourceUri(), e.getMessage());
+            return true;
+        }
+        if (failureReason != null) {
+            log.warnf("Deployed-version re-check of orphan %s was incomplete (%s) — NOT purging it", orphan.getResourceUri(), failureReason);
+            return true;
+        }
+        if (deployedReferences.contains(key)) {
+            log.warnf("Skipping orphan %s — a deployed Agent version started referencing it after the scan", orphan.getResourceUri());
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
@@ -16,6 +16,8 @@ import org.jboss.logging.Logger;
 
 import java.nio.charset.StandardCharsets;
 import java.security.*;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,8 +53,11 @@ public class AgentSigningService {
     private static final Logger LOGGER = Logger.getLogger(AgentSigningService.class);
     private static final String ALGORITHM = "Ed25519";
     private static final String VAULT_KEY_PREFIX = "agent-signing-key:";
-    /** Maximum key version to scan during deletion cleanup. */
-    private static final int MAX_KEY_VERSION_SCAN = 100;
+    /**
+     * Maximum key version to scan during deletion cleanup. Package-private so the
+     * test can pin the number of vault round trips one agent deletion costs.
+     */
+    static final int MAX_KEY_VERSION_SCAN = 100;
 
     private final ISecretProvider secretProvider;
     private final MeterRegistry meterRegistry;
@@ -127,18 +132,7 @@ public class AgentSigningService {
      */
     public String sign(String tenantId, String agentId, String payload) throws AgentSigningException {
         try {
-            PrivateKey privateKey = privateKeyCache.computeIfAbsent(cacheKey(tenantId, agentId), k -> {
-                try {
-                    SecretReference ref = new SecretReference(tenantId, vaultKeyName(agentId));
-                    String privateKeyB64 = secretProvider.resolve(ref);
-                    byte[] privateKeyBytes = Base64.getDecoder().decode(privateKeyB64);
-                    KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM);
-                    return keyFactory.generatePrivate(
-                            new java.security.spec.PKCS8EncodedKeySpec(privateKeyBytes));
-                } catch (Exception e) {
-                    throw new PrivateKeyLoadException(agentId, e);
-                }
-            });
+            PrivateKey privateKey = loadPrivateKey(tenantId, agentId, 0);
 
             Signature sig = Signature.getInstance(ALGORITHM);
             sig.initSign(privateKey);
@@ -177,8 +171,7 @@ public class AgentSigningService {
         try {
             byte[] publicKeyBytes = Base64.getDecoder().decode(publicKeyB64);
             KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM);
-            PublicKey publicKey = keyFactory.generatePublic(
-                    new java.security.spec.X509EncodedKeySpec(publicKeyBytes));
+            PublicKey publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
 
             Signature sig = Signature.getInstance(ALGORITHM);
             sig.initVerify(publicKey);
@@ -200,30 +193,95 @@ public class AgentSigningService {
 
     /**
      * Delete the signing keypair for an agent (cleanup on agent deletion). Removes
-     * both the legacy unversioned key and any versioned keys found.
+     * both the legacy unversioned key and any versioned keys.
+     *
+     * <p>
+     * The whole version range is scanned rather than stopped at the first gap:
+     * {@code rotateKey} takes an arbitrary version number from its caller, so a
+     * rotation that skipped a number (v1, v3) used to leave every key after the gap
+     * in the vault forever. And the legacy key is deleted in its own guard, because
+     * it not existing is the ordinary state of a rotated agent — letting that
+     * {@code SecretNotFoundException} out skipped the versioned scan entirely and
+     * leaked exactly the keys this method exists to remove.
+     * </p>
+     *
+     * <p>
+     * "Absent" and "vault unreachable" are told apart. A blanket
+     * {@code catch (Exception ignored)} across a hundred iterations meant a vault
+     * outage mid-delete left every remaining key behind in complete silence, which
+     * is the same leak wearing a success message.
+     * </p>
      */
     public void deleteKeyPair(String tenantId, String agentId) {
-        try {
-            // Delete legacy unversioned key
-            SecretReference ref = new SecretReference(tenantId, vaultKeyName(agentId));
-            secretProvider.delete(ref);
-            privateKeyCache.remove(cacheKey(tenantId, agentId));
+        deleteVaultKey(tenantId, agentId, vaultKeyName(agentId), cacheKey(tenantId, agentId));
 
-            // Delete versioned keys (scan reasonable range)
-            for (int v = 1; v <= MAX_KEY_VERSION_SCAN; v++) {
-                try {
-                    SecretReference vRef = new SecretReference(tenantId, vaultKeyNameVersioned(agentId, v));
-                    secretProvider.delete(vRef);
-                    privateKeyCache.remove(cacheKey(tenantId, agentId) + ";v=" + v);
-                } catch (Exception ignored) {
-                    // Version doesn't exist — stop scanning
-                    break;
-                }
-            }
-            LOGGER.infof("Deleted signing keys for agent '%s' in tenant '%s' (cache evicted)", agentId, tenantId);
-        } catch (Exception e) {
-            LOGGER.warnf("Failed to delete signing key for agent '%s': %s", agentId, e.getMessage());
+        for (int v = 1; v <= MAX_KEY_VERSION_SCAN; v++) {
+            deleteVaultKey(tenantId, agentId, vaultKeyNameVersioned(agentId, v), cacheKey(tenantId, agentId) + ";v=" + v);
         }
+        LOGGER.infof("Deleted signing keys for agent '%s' in tenant '%s' (cache evicted)", agentId, tenantId);
+    }
+
+    /**
+     * Removes one vault entry and its cache line, treating "no such key" as the
+     * expected case and anything else as a leak worth reporting.
+     */
+    private void deleteVaultKey(String tenantId, String agentId, String vaultKey, String cacheKeyStr) {
+        try {
+            secretProvider.delete(new SecretReference(tenantId, vaultKey));
+            privateKeyCache.remove(cacheKeyStr);
+        } catch (ISecretProvider.SecretNotFoundException e) {
+            // Expected for every version this agent never had.
+            privateKeyCache.remove(cacheKeyStr);
+        } catch (Exception e) {
+            LOGGER.warnf("Could not delete vault key '%s' for agent '%s' in tenant '%s' — it may still hold private key "
+                    + "material: %s", vaultKey, agentId, tenantId, e.getMessage());
+        }
+    }
+
+    /**
+     * Loads (and caches) an agent's private key.
+     *
+     * <p>
+     * One implementation for both signing paths — {@link #sign} and
+     * {@link #signEnvelope} each carried a verbatim copy, so a fix to key loading
+     * had to be applied twice, and their error handling had already drifted apart.
+     * </p>
+     *
+     * <p>
+     * The vault round-trip happens OUTSIDE {@code computeIfAbsent}: doing it inside
+     * held a ConcurrentHashMap bin lock across network I/O, blocking unrelated
+     * agents that hash to the same bin. A racing loser simply loads the same key
+     * twice, which is harmless.
+     * </p>
+     *
+     * @param keyVersion
+     *            the rotated key version, or {@code <= 0} for the legacy
+     *            unversioned key
+     * @throws PrivateKeyLoadException
+     *             wrapping the original cause, so callers can report precisely
+     */
+    private PrivateKey loadPrivateKey(String tenantId, String agentId, int keyVersion) {
+        String cacheKeyStr = keyVersion > 0 ? cacheKey(tenantId, agentId) + ";v=" + keyVersion : cacheKey(tenantId, agentId);
+
+        PrivateKey cached = privateKeyCache.get(cacheKeyStr);
+        if (cached != null) {
+            return cached;
+        }
+
+        String vaultKey = keyVersion > 0 ? vaultKeyNameVersioned(agentId, keyVersion) : vaultKeyName(agentId);
+        PrivateKey loaded;
+        try {
+            SecretReference ref = new SecretReference(tenantId, vaultKey);
+            String privateKeyB64 = secretProvider.resolve(ref);
+            byte[] privateKeyBytes = Base64.getDecoder().decode(privateKeyB64);
+            KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM);
+            loaded = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
+        } catch (Exception e) {
+            throw new PrivateKeyLoadException(agentId, e);
+        }
+
+        PrivateKey raced = privateKeyCache.putIfAbsent(cacheKeyStr, loaded);
+        return raced != null ? raced : loaded;
     }
 
     private String vaultKeyName(String agentId) {
@@ -308,27 +366,7 @@ public class AgentSigningService {
             throws AgentSigningException {
         try {
             String canonicalForm = envelope.canonicalForm();
-            String vaultKey = keyVersion > 0
-                    ? vaultKeyNameVersioned(agentId, keyVersion)
-                    : vaultKeyName(agentId);
-
-            // Use versioned cache key so different key versions don't collide
-            String cacheKeyStr = keyVersion > 0
-                    ? cacheKey(tenantId, agentId) + ";v=" + keyVersion
-                    : cacheKey(tenantId, agentId);
-
-            PrivateKey privateKey = privateKeyCache.computeIfAbsent(cacheKeyStr, k -> {
-                try {
-                    SecretReference ref = new SecretReference(tenantId, vaultKey);
-                    String privateKeyB64 = secretProvider.resolve(ref);
-                    byte[] privateKeyBytes = Base64.getDecoder().decode(privateKeyB64);
-                    KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM);
-                    return keyFactory.generatePrivate(
-                            new java.security.spec.PKCS8EncodedKeySpec(privateKeyBytes));
-                } catch (Exception e) {
-                    throw new PrivateKeyLoadException(agentId, e);
-                }
-            });
+            PrivateKey privateKey = loadPrivateKey(tenantId, agentId, keyVersion);
 
             Signature sig = Signature.getInstance(ALGORITHM);
             sig.initSign(privateKey);
@@ -338,7 +376,13 @@ public class AgentSigningService {
             signCounter.increment();
             return envelope.withSignature(signatureB64, keyVersion);
         } catch (PrivateKeyLoadException e) {
+            // Unwrapped the same way sign() does — the two used to diverge, so the
+            // envelope path reported "InvalidKeySpecException" where the plain path said
+            // "No signing key found" for the identical failure.
             Throwable cause = e.getCause();
+            if (cause instanceof ISecretProvider.SecretNotFoundException) {
+                throw new AgentSigningException("No signing key found for agent " + agentId, cause);
+            }
             throw new AgentSigningException("Envelope signing failed for agent " + agentId
                     + ": " + cause.getClass().getSimpleName(), cause);
         } catch (Exception e) {

--- a/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
@@ -249,14 +249,16 @@ public class AgentSigningService {
      *            the rotated key versions the configuration declares, used as the
      *            upper bound of the sweep, or {@code null} when they are unknown
      *            and the whole 1..{@value #MAX_KEY_VERSION_SCAN} range has to be
-     *            swept
+     *            swept. A list holding no positive version is treated as
+     *            {@code null}: it bounds nothing — see
+     *            {@link #versionsToSweep(Collection)}
      */
     public void deleteKeyPair(String tenantId, String agentId, Collection<Integer> knownVersions) {
         DeleteTally tally = new DeleteTally();
 
-        deleteVaultKey(tenantId, agentId, vaultKeyName(agentId), cacheKey(tenantId, agentId), tally);
+        deleteVaultKey(tenantId, vaultKeyName(agentId), cacheKey(tenantId, agentId), tally);
         for (int v : versionsToSweep(knownVersions)) {
-            deleteVaultKey(tenantId, agentId, vaultKeyNameVersioned(agentId, v), cacheKey(tenantId, agentId) + ";v=" + v, tally);
+            deleteVaultKey(tenantId, vaultKeyNameVersioned(agentId, v), cacheKey(tenantId, agentId) + ";v=" + v, tally);
         }
 
         // Reports what actually happened. The old unconditional "Deleted signing
@@ -300,6 +302,19 @@ public class AgentSigningService {
      * ABOVE the cap are still attempted individually — they are known to exist,
      * where the range is only a guess.
      * </p>
+     *
+     * <p>
+     * An empty list of valid versions is an UNKNOWN bound, not a known-empty one,
+     * and falls back to the full sweep exactly as {@code null} does. It is the same
+     * argument as the gaps above, at its extreme: {@code rotateKey} writes the
+     * vault entry and the caller then updates {@code identity.keys} separately, so
+     * a first rotation whose config write failed leaves v1 in the vault with
+     * {@code keys[]} still empty — and treating that as "no rotated versions,
+     * nothing to sweep" left an Ed25519 private key behind after a permanent delete
+     * while the tally reported success. An operator who pruned {@code keys[]} by
+     * hand produces the same shape. The 101 round trips are the price of not
+     * leaking a private key on a rare, irreversible operation.
+     * </p>
      */
     private static List<Integer> versionsToSweep(Collection<Integer> knownVersions) {
         if (knownVersions == null) {
@@ -307,9 +322,8 @@ public class AgentSigningService {
         }
         List<Integer> declared = knownVersions.stream().filter(v -> v != null && v > 0).distinct().sorted().toList();
         if (declared.isEmpty()) {
-            // "Key material, but no rotated versions" — the legacy unversioned key,
-            // which deleteKeyPair removes on its own. Nothing to sweep for.
-            return List.of();
+            // Nothing usable to bound the sweep with — see above.
+            return IntStream.rangeClosed(1, MAX_KEY_VERSION_SCAN).boxed().toList();
         }
         int highest = Math.min(declared.get(declared.size() - 1), MAX_KEY_VERSION_SCAN);
         Set<Integer> versions = new TreeSet<>(declared);
@@ -336,7 +350,7 @@ public class AgentSigningService {
      * than the vault entry the WARN is about.
      * </p>
      */
-    private void deleteVaultKey(String tenantId, String agentId, String vaultKey, String cacheKeyStr, DeleteTally tally) {
+    private void deleteVaultKey(String tenantId, String vaultKey, String cacheKeyStr, DeleteTally tally) {
         try {
             secretProvider.delete(new SecretReference(tenantId, vaultKey));
             tally.deleted++;

--- a/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.IntStream;
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
  * Ed25519-based signing and verification service for agent identity.
@@ -267,12 +268,14 @@ public class AgentSigningService {
         // Javadoc warns about — and equally after deleting nothing at all.
         if (tally.failed > 0) {
             LOGGER.warnf("Signing key cleanup for agent '%s' in tenant '%s': %d key(s) deleted, %d could NOT be deleted and may "
-                    + "still hold private key material (first failure: %s)", agentId, tenantId, tally.deleted, tally.failed,
-                    tally.firstFailure);
+                    + "still hold private key material (first failure: %s)", sanitize(agentId), sanitize(tenantId),
+                    tally.deleted, tally.failed, sanitize(tally.firstFailure));
         } else if (tally.deleted > 0) {
-            LOGGER.infof("Deleted %d signing key(s) for agent '%s' in tenant '%s' (cache evicted)", tally.deleted, agentId, tenantId);
+            LOGGER.infof("Deleted %d signing key(s) for agent '%s' in tenant '%s' (cache evicted)", tally.deleted,
+                    sanitize(agentId), sanitize(tenantId));
         } else {
-            LOGGER.debugf("No signing keys found in the vault for agent '%s' in tenant '%s' (cache evicted)", agentId, tenantId);
+            LOGGER.debugf("No signing keys found in the vault for agent '%s' in tenant '%s' (cache evicted)",
+                    sanitize(agentId), sanitize(tenantId));
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/AgentSigningService.java
@@ -19,8 +19,12 @@ import java.security.*;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
 
 /**
  * Ed25519-based signing and verification service for agent identity.
@@ -196,13 +200,16 @@ public class AgentSigningService {
      * both the legacy unversioned key and any versioned keys.
      *
      * <p>
-     * The whole version range is scanned rather than stopped at the first gap:
-     * {@code rotateKey} takes an arbitrary version number from its caller, so a
-     * rotation that skipped a number (v1, v3) used to leave every key after the gap
-     * in the vault forever. And the legacy key is deleted in its own guard, because
-     * it not existing is the ordinary state of a rotated agent — letting that
-     * {@code SecretNotFoundException} out skipped the versioned scan entirely and
-     * leaked exactly the keys this method exists to remove.
+     * With no list of versions to work from this sweeps the whole range rather than
+     * stopping at the first gap: {@code rotateKey} takes an arbitrary version
+     * number from its caller, so a rotation that skipped a number (v1, v3) used to
+     * leave every key after the gap in the vault forever. Callers that have read
+     * the agent's configuration should pass its declared versions instead — see
+     * {@link #deleteKeyPair(String, String, Collection)}. And the legacy key is
+     * deleted in its own guard, because it not existing is the ordinary state of a
+     * rotated agent — letting that {@code SecretNotFoundException} out skipped the
+     * versioned scan entirely and leaked exactly the keys this method exists to
+     * remove.
      * </p>
      *
      * <p>
@@ -213,28 +220,135 @@ public class AgentSigningService {
      * </p>
      */
     public void deleteKeyPair(String tenantId, String agentId) {
-        deleteVaultKey(tenantId, agentId, vaultKeyName(agentId), cacheKey(tenantId, agentId));
+        deleteKeyPair(tenantId, agentId, null);
+    }
 
-        for (int v = 1; v <= MAX_KEY_VERSION_SCAN; v++) {
-            deleteVaultKey(tenantId, agentId, vaultKeyNameVersioned(agentId, v), cacheKey(tenantId, agentId) + ";v=" + v);
+    /**
+     * As {@link #deleteKeyPair(String, String)}, but told which rotated versions
+     * the agent's configuration actually declares.
+     *
+     * <p>
+     * The blind 1..{@value #MAX_KEY_VERSION_SCAN} sweep is the fallback, not the
+     * normal path. An agent holding one or two keys paid 101 vault round trips per
+     * delete — 101 {@code deleteSecret} calls and 101 increments of the vault
+     * delete metric — and on a vault-less dev instance every one of them failed
+     * with the same "may still hold private key material" WARN, for versions that
+     * never existed. The agent config lists its versions
+     * ({@code identity.keys[].version}) and the caller has already read it to
+     * decide whether there is anything to clean up at all.
+     * </p>
+     *
+     * <p>
+     * "Told which versions" bounds the sweep; it does not narrow it to exactly that
+     * list. Everything up to the highest declared version is attempted, because a
+     * key can exist in the vault without being listed — see
+     * {@link #versionsToSweep(Collection)}.
+     * </p>
+     *
+     * @param knownVersions
+     *            the rotated key versions the configuration declares, used as the
+     *            upper bound of the sweep, or {@code null} when they are unknown
+     *            and the whole 1..{@value #MAX_KEY_VERSION_SCAN} range has to be
+     *            swept
+     */
+    public void deleteKeyPair(String tenantId, String agentId, Collection<Integer> knownVersions) {
+        DeleteTally tally = new DeleteTally();
+
+        deleteVaultKey(tenantId, agentId, vaultKeyName(agentId), cacheKey(tenantId, agentId), tally);
+        for (int v : versionsToSweep(knownVersions)) {
+            deleteVaultKey(tenantId, agentId, vaultKeyNameVersioned(agentId, v), cacheKey(tenantId, agentId) + ";v=" + v, tally);
         }
-        LOGGER.infof("Deleted signing keys for agent '%s' in tenant '%s' (cache evicted)", agentId, tenantId);
+
+        // Reports what actually happened. The old unconditional "Deleted signing
+        // keys … (cache evicted)" claimed success after a vault outage had left
+        // every key behind — the leak wearing a success message this method's own
+        // Javadoc warns about — and equally after deleting nothing at all.
+        if (tally.failed > 0) {
+            LOGGER.warnf("Signing key cleanup for agent '%s' in tenant '%s': %d key(s) deleted, %d could NOT be deleted and may "
+                    + "still hold private key material (first failure: %s)", agentId, tenantId, tally.deleted, tally.failed,
+                    tally.firstFailure);
+        } else if (tally.deleted > 0) {
+            LOGGER.infof("Deleted %d signing key(s) for agent '%s' in tenant '%s' (cache evicted)", tally.deleted, agentId, tenantId);
+        } else {
+            LOGGER.debugf("No signing keys found in the vault for agent '%s' in tenant '%s' (cache evicted)", agentId, tenantId);
+        }
+    }
+
+    /**
+     * The versioned keys to attempt: the blind 1..{@value #MAX_KEY_VERSION_SCAN}
+     * range when the configuration is unknown, and otherwise everything up to the
+     * highest version it declares. Positive versions only — {@code rotateKey}
+     * rejects anything else, so a stored zero or negative names no vault entry.
+     *
+     * <p>
+     * Deliberately NOT just the declared list. {@code rotateKey} writes the vault
+     * entry and returns; adding the version to {@code identity.keys} is a SEPARATE
+     * config write by the caller, which can fail after the vault write succeeded —
+     * and {@code keys[]} is operator-editable JSON that nothing prunes. Sweeping
+     * only what is listed therefore left an Ed25519 private key in the vault
+     * forever after a permanent delete, while the tally reported "Deleted N signing
+     * key(s)": the same leak wearing a success message that this class's Javadoc
+     * warns about, on a narrower path. Covering the gaps and the skipped numbers
+     * {@code rotateKey} allows costs a handful of extra round trips for a normal
+     * agent — not the 101 the blind sweep cost, which is what the declared-versions
+     * path exists to avoid.
+     * </p>
+     *
+     * <p>
+     * The range is capped at {@value #MAX_KEY_VERSION_SCAN} so a stored version of,
+     * say, 50 000 cannot turn one delete into 50 000 vault calls. Declared versions
+     * ABOVE the cap are still attempted individually — they are known to exist,
+     * where the range is only a guess.
+     * </p>
+     */
+    private static List<Integer> versionsToSweep(Collection<Integer> knownVersions) {
+        if (knownVersions == null) {
+            return IntStream.rangeClosed(1, MAX_KEY_VERSION_SCAN).boxed().toList();
+        }
+        List<Integer> declared = knownVersions.stream().filter(v -> v != null && v > 0).distinct().sorted().toList();
+        if (declared.isEmpty()) {
+            // "Key material, but no rotated versions" — the legacy unversioned key,
+            // which deleteKeyPair removes on its own. Nothing to sweep for.
+            return List.of();
+        }
+        int highest = Math.min(declared.get(declared.size() - 1), MAX_KEY_VERSION_SCAN);
+        Set<Integer> versions = new TreeSet<>(declared);
+        IntStream.rangeClosed(1, highest).forEach(versions::add);
+        return List.copyOf(versions);
+    }
+
+    /** Running count of one {@link #deleteKeyPair} call's vault deletions. */
+    private static final class DeleteTally {
+        private int deleted;
+        private int failed;
+        private String firstFailure;
     }
 
     /**
      * Removes one vault entry and its cache line, treating "no such key" as the
-     * expected case and anything else as a leak worth reporting.
+     * expected case and anything else as a leak worth counting.
+     *
+     * <p>
+     * The cache line is dropped in a {@code finally}: a vault delete that fails
+     * leaves the private key in the vault, but leaving the loaded key in
+     * {@link #privateKeyCache} as well would let this process keep SIGNING as the
+     * deleted agent from memory, for as long as it lives — a strictly worse outcome
+     * than the vault entry the WARN is about.
+     * </p>
      */
-    private void deleteVaultKey(String tenantId, String agentId, String vaultKey, String cacheKeyStr) {
+    private void deleteVaultKey(String tenantId, String agentId, String vaultKey, String cacheKeyStr, DeleteTally tally) {
         try {
             secretProvider.delete(new SecretReference(tenantId, vaultKey));
-            privateKeyCache.remove(cacheKeyStr);
+            tally.deleted++;
         } catch (ISecretProvider.SecretNotFoundException e) {
             // Expected for every version this agent never had.
-            privateKeyCache.remove(cacheKeyStr);
         } catch (Exception e) {
-            LOGGER.warnf("Could not delete vault key '%s' for agent '%s' in tenant '%s' — it may still hold private key "
-                    + "material: %s", vaultKey, agentId, tenantId, e.getMessage());
+            tally.failed++;
+            if (tally.firstFailure == null) {
+                tally.firstFailure = vaultKey + ": " + e.getMessage();
+            }
+        } finally {
+            privateKeyCache.remove(cacheKeyStr);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/agents/CapabilityRegistryService.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/CapabilityRegistryService.java
@@ -6,11 +6,16 @@ package ai.labs.eddi.configs.agents;
 
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration.Capability;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.datastore.serialization.IDescriptorStore;
+import ai.labs.eddi.utils.RestUtilities;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.quarkus.runtime.StartupEvent;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
@@ -29,15 +34,27 @@ import java.util.stream.Collectors;
  * the registry to find agents that match a required skill. Selection strategies
  * (highest_confidence, round_robin, all) are deterministic algorithms, not LLM
  * guesses.
+ *
+ * <h3>How the index is maintained</h3> It is seeded once at startup from
+ * {@link IAgentStore} (see {@link #onStartup}), and kept current by
+ * <em>explicit</em> {@link #register}/{@link #unregister} calls from
+ * {@code RestAgentStore}'s create/update/delete. There is no observer
+ * mechanism: {@code @ConfigurationUpdate} is an interceptor binding with no
+ * interceptor behind it (AGENTS.md §4.3), and the Javadoc here used to claim
+ * otherwise — which is why agent-creating paths that bypass the REST facade
+ * (ZIP import, MCP) were written without a {@code register} call and their
+ * agents were never discoverable. Any new creation path must call
+ * {@link #register} itself.
  * <p>
- * The registry is rebuilt from {@code AgentConfiguration} on agent
- * create/update/delete via {@code @ConfigurationUpdate} observer events.
+ * The index is process-local. A cluster node learns about another node's edits
+ * only on its own restart.
  *
  * @since 6.0.0
  */
 @ApplicationScoped
 public class CapabilityRegistryService {
     private static final Logger LOGGER = Logger.getLogger(CapabilityRegistryService.class);
+    private static final String AGENT_DESCRIPTOR_TYPE = "ai.labs.agent";
 
     /**
      * Index: skill name → list of (agentId, capability) pairs. Rebuilt on agent
@@ -52,18 +69,65 @@ public class CapabilityRegistryService {
     private final Map<String, AtomicInteger> roundRobinCounters = new ConcurrentHashMap<>();
 
     private final MeterRegistry meterRegistry;
+    private final IAgentStore agentStore;
+    private final IDocumentDescriptorStore documentDescriptorStore;
     private Counter queryCounter;
     private Timer queryTimer;
 
     @Inject
-    public CapabilityRegistryService(MeterRegistry meterRegistry) {
+    public CapabilityRegistryService(MeterRegistry meterRegistry, IAgentStore agentStore,
+            IDocumentDescriptorStore documentDescriptorStore) {
         this.meterRegistry = meterRegistry;
+        this.agentStore = agentStore;
+        this.documentDescriptorStore = documentDescriptorStore;
     }
 
     @PostConstruct
     void initMetrics() {
         queryCounter = meterRegistry.counter("eddi.capability.query.count");
         queryTimer = meterRegistry.timer("eddi.capability.query.time");
+    }
+
+    /**
+     * Seeds the index from every stored agent, once, at startup.
+     *
+     * <p>
+     * This used to be a {@code @PostConstruct} on {@code RestAgentStore} — an
+     * {@code @ApplicationScoped} JAX-RS resource that ArC instantiates lazily, on
+     * first client-proxy call. Nothing eager touches that bean, so on a fresh node
+     * the index stayed EMPTY until an admin happened to open the Manager: a
+     * {@code capabilityMatch} behaviour rule simply never fired, and A2A discovery
+     * returned nothing, with no error to explain it. Observing {@link StartupEvent}
+     * on the bean that owns the index makes the seeding independent of who is
+     * injected where.
+     * </p>
+     */
+    void onStartup(@Observes StartupEvent event) {
+        populateFromStore();
+    }
+
+    void populateFromStore() {
+        try {
+            var descriptors = documentDescriptorStore.readDescriptors(AGENT_DESCRIPTOR_TYPE, null, 0, IDescriptorStore.NO_LIMIT, false);
+            int registered = 0;
+            for (var descriptor : descriptors) {
+                try {
+                    var resourceId = RestUtilities.extractResourceId(descriptor.getResource());
+                    var config = agentStore.read(resourceId.getId(), resourceId.getVersion());
+                    if (config.getCapabilities() != null && !config.getCapabilities().isEmpty()) {
+                        register(resourceId.getId(), config);
+                        registered++;
+                    }
+                } catch (Exception e) {
+                    LOGGER.debugf("Skipping capability registration for agent: %s", e.getMessage());
+                }
+            }
+            if (registered > 0) {
+                LOGGER.infof("Capability registry populated: %d agent(s) with capabilities", registered);
+            }
+        } catch (Exception e) {
+            LOGGER.warnf("Failed to populate capability registry at startup: %s", e.getMessage());
+        }
     }
 
     /**
@@ -74,7 +138,7 @@ public class CapabilityRegistryService {
      * @param config
      *            the agent's configuration containing capabilities
      */
-    public void register(String agentId, AgentConfiguration config) {
+    public synchronized void register(String agentId, AgentConfiguration config) {
         // Remove any previous entries for this agent
         unregister(agentId);
 
@@ -99,8 +163,18 @@ public class CapabilityRegistryService {
 
     /**
      * Remove all capability entries for an agent.
+     *
+     * <p>
+     * {@code synchronized}, like {@link #register}, because the two are not safe
+     * against each other on a {@code ConcurrentHashMap} alone: registering is
+     * get-list-then-add, and an interleaved {@code removeIf} could observe the
+     * freshly created EMPTY list between those two steps, drop the map entry, and
+     * leave the registering thread adding to an orphaned list — the skill silently
+     * missing from the index until the next full re-registration. These are rare
+     * admin operations, so a lock costs nothing that matters.
+     * </p>
      */
-    public void unregister(String agentId) {
+    public synchronized void unregister(String agentId) {
         skillIndex.values().forEach(entries -> entries.removeIf(e -> e.agentId().equals(agentId)));
         // Clean up empty skill entries and reset round-robin counters
         skillIndex.entrySet().removeIf(entry -> {
@@ -127,7 +201,7 @@ public class CapabilityRegistryService {
         return queryTimer.record(() -> {
             queryCounter.increment();
             String resolvedStrategy = strategy != null ? strategy.toLowerCase(Locale.ROOT) : "all";
-            meterRegistry.counter("eddi.capability.strategy.applied", "strategy", resolvedStrategy).increment();
+            meterRegistry.counter("eddi.capability.strategy.applied", "strategy", knownStrategy(resolvedStrategy)).increment();
 
             List<CapabilityMatch> matches = lookupBySkill(skill);
             if (matches.isEmpty()) {
@@ -152,7 +226,13 @@ public class CapabilityRegistryService {
         List<AgentCapabilityEntry> entries = skillIndex.getOrDefault(normalizedSkill, Collections.emptyList());
 
         if (entries.isEmpty()) {
-            meterRegistry.counter("eddi.capability.miss.count", "skill", normalizedSkill).increment();
+            // Deliberately untagged. The skill string arrives from GET /capabilities,
+            // A2A discovery, a templated capabilityMatch rule, and the LLM-invoked
+            // FindAgentsByCapabilityTool — a model that invents skill names mints an
+            // unbounded number of Meters, one per distinct miss, for the lifetime of the
+            // process. Which skill was missed belongs in a log line, not a metric label.
+            meterRegistry.counter("eddi.capability.miss.count").increment();
+            LOGGER.debugf("No agent registered for skill '%s'", normalizedSkill);
             return Collections.emptyList();
         }
 
@@ -236,6 +316,19 @@ public class CapabilityRegistryService {
                 yield shuffled;
             }
             default -> matches; // "all" — return in natural order
+        };
+    }
+
+    /**
+     * Folds an arbitrary caller-supplied strategy onto the four the switch in
+     * {@link #applyStrategy} actually understands, so the {@code strategy} meter
+     * tag has a bounded value set. Anything else behaves as "all" and is tagged
+     * {@code other}.
+     */
+    private static String knownStrategy(String strategy) {
+        return switch (strategy) {
+            case "highest_confidence", "round_robin", "random", "all" -> strategy;
+            default -> "other";
         };
     }
 

--- a/src/main/java/ai/labs/eddi/configs/agents/CapabilityRegistryService.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/CapabilityRegistryService.java
@@ -26,6 +26,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
+
 /**
  * In-memory capability registry for A2A agent discovery.
  * <p>
@@ -232,7 +234,10 @@ public class CapabilityRegistryService {
             // unbounded number of Meters, one per distinct miss, for the lifetime of the
             // process. Which skill was missed belongs in a log line, not a metric label.
             meterRegistry.counter("eddi.capability.miss.count").increment();
-            LOGGER.debugf("No agent registered for skill '%s'", normalizedSkill);
+            // Sanitized, not logged verbatim: the skill string is caller-supplied (GET
+            // /capabilities, A2A discovery, a templated capabilityMatch rule, an
+            // LLM-invoked tool), so a newline in it would forge a second log record.
+            LOGGER.debugf("No agent registered for skill '%s'", sanitize(normalizedSkill));
             return Collections.emptyList();
         }
 

--- a/src/main/java/ai/labs/eddi/configs/agents/IRestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/IRestAgentStore.java
@@ -62,7 +62,10 @@ public interface IRestAgentStore extends IRestVersionInfo {
     @Path("descriptors")
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(operationId = "readAgentDescriptorsWithWorkflow", description = "Read list of Agent descriptors including a given workflowUri.")
+    @Operation(operationId = "readAgentDescriptorsWithWorkflow", description = "Read list of Agent descriptors including a given workflowUri. "
+            + "filter, index and limit are applied to the result AFTER the reverse-reference lookup, which "
+            + "takes neither. They used to be accepted and ignored, so a client that never paged received the "
+            + "full list; with limit defaulting to 20 such a client now receives at most 20 rows per page.")
     // @formatter:off
     List<DocumentDescriptor> readAgentDescriptors(@QueryParam("filter") @DefaultValue("") String filter,
             @QueryParam("index") @DefaultValue("0") Integer index,
@@ -117,21 +120,28 @@ public interface IRestAgentStore extends IRestVersionInfo {
             + "and their extension resources (behavior sets, HTTP calls, output sets, langchains, "
             + "property setters, dictionaries). Shared resources (packages used by other agents, "
             + "extensions used by other packages) are skipped. "
-            + "Partial failures are logged but do not prevent the Agent from being deleted.")
+            + "Partial failures are logged but do not prevent the Agent from being deleted. "
+            + "With cascade=true the version must be the Agent's current one, otherwise the request is "
+            + "refused with 409 before anything is deleted.")
     @APIResponse(responseCode = "200", description = "Agent deleted successfully.")
     @APIResponse(responseCode = "404", description = "Agent not found.")
+    @APIResponse(responseCode = "409", description = "cascade=true against a version that is not the current one; nothing was deleted.")
     // @formatter:off
     Response deleteAgent(@PathParam("id") String id,
             @Parameter(name = "version", required = true, example = "1",
                     description = "Version of the Agent to delete.")
             @QueryParam("version") Integer version,
-            @Parameter(description = "If true, permanently remove from database. "
-                    + "If false (default), soft-delete only.")
+            @Parameter(description = "If true, permanently remove from database, and additionally destroy this "
+                    + "Agent's signing keys in the secrets vault — irreversibly, since no endpoint can "
+                    + "regenerate them, so an Agent restored from a backup afterwards cannot sign again. "
+                    + "If false (default), soft-delete only: the vault keys are kept so the Agent stays "
+                    + "restorable.")
             @QueryParam("permanent") @DefaultValue("false") Boolean permanent,
             @Parameter(description = "If true, also delete all packages "
                     + "and extension resources referenced by this agent. "
-                    + "Resources shared with other agents are still deleted "
-                    + "— use with care.")
+                    + "Workflows still referenced by another agent are skipped. "
+                    + "Cascaded resources are always soft-deleted, even when permanent=true, "
+                    + "so a resource shared at a different pinned version can be recovered.")
             @QueryParam("cascade") @DefaultValue("false") Boolean cascade);
     // @formatter:on
 }

--- a/src/main/java/ai/labs/eddi/configs/agents/IRestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/IRestAgentStore.java
@@ -120,28 +120,40 @@ public interface IRestAgentStore extends IRestVersionInfo {
             + "and their extension resources (behavior sets, HTTP calls, output sets, langchains, "
             + "property setters, dictionaries). Shared resources (packages used by other agents, "
             + "extensions used by other packages) are skipped. "
+            + "An agent's workflow reference is version-pinned and routinely names an older version than the one that "
+            + "exists; the cascade resolves each reference to the workflow's CURRENT version before deciding, and asks "
+            + "'is anyone else using this?' against that same version. "
             + "Partial failures are logged but do not prevent the Agent from being deleted. "
-            + "With cascade=true the version must be the Agent's current one, otherwise the request is "
-            + "refused with 409 before anything is deleted.")
+            + "The version must be the Agent's current one whenever cascade=true or permanent=true, otherwise the "
+            + "request is refused with 409 before anything is deleted. An Agent that is already soft-deleted has no "
+            + "current version to be stale against: permanent=true still purges its history and its vault keys, and "
+            + "the cascade is skipped rather than refused.")
     @APIResponse(responseCode = "200", description = "Agent deleted successfully.")
     @APIResponse(responseCode = "404", description = "Agent not found.")
-    @APIResponse(responseCode = "409", description = "cascade=true against a version that is not the current one; nothing was deleted.")
+    @APIResponse(responseCode = "409",
+                 description = "cascade=true or permanent=true against a version that is not the current one; nothing was deleted.")
     // @formatter:off
     Response deleteAgent(@PathParam("id") String id,
             @Parameter(name = "version", required = true, example = "1",
                     description = "Version of the Agent to delete.")
             @QueryParam("version") Integer version,
-            @Parameter(description = "If true, permanently remove from database, and additionally destroy this "
+            @Parameter(description = "If true, permanently remove from database — every version and every history row, "
+                    + "so the version given must be the current one or the request is refused with 409 — and "
+                    + "additionally destroy this "
                     + "Agent's signing keys in the secrets vault — irreversibly, since no endpoint can "
                     + "regenerate them, so an Agent restored from a backup afterwards cannot sign again. "
+                    + "This also purges an Agent that was already soft-deleted, keys included. "
                     + "If false (default), soft-delete only: the vault keys are kept so the Agent stays "
                     + "restorable.")
             @QueryParam("permanent") @DefaultValue("false") Boolean permanent,
             @Parameter(description = "If true, also delete all packages "
-                    + "and extension resources referenced by this agent. "
-                    + "Workflows still referenced by another agent are skipped. "
+                    + "and extension resources referenced by this agent, each at its own current version. "
+                    + "Workflows still referenced by another agent — at any version — are skipped, as are workflows "
+                    + "that have no live version left. "
                     + "Cascaded resources are always soft-deleted, even when permanent=true, "
-                    + "so a resource shared at a different pinned version can be recovered.")
+                    + "so a resource shared at a different pinned version can be recovered. "
+                    + "The workflow delete this cascades into reports its own skipped extensions in "
+                    + "X-Cascade-Skipped; that header is not propagated onto this response.")
             @QueryParam("cascade") @DefaultValue("false") Boolean cascade);
     // @formatter:on
 }

--- a/src/main/java/ai/labs/eddi/configs/agents/crypto/JacksonCanonicalizer.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/crypto/JacksonCanonicalizer.java
@@ -38,6 +38,9 @@ import java.util.TreeMap;
  */
 public final class JacksonCanonicalizer {
 
+    // ORDER_MAP_ENTRIES_BY_KEYS is deliberately kept even though sortKeys() already
+    // rebuilds every ObjectNode through a TreeMap: it also covers any Map value
+    // serialized directly, so the two are belt and braces rather than redundant.
     private static final ObjectMapper MAPPER = new ObjectMapper(
             JsonFactory.builder()
                     .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
@@ -49,7 +52,15 @@ public final class JacksonCanonicalizer {
     }
 
     /**
-     * Canonicalize a JSON string per RFC 8785.
+     * Canonicalize a JSON string: object keys sorted lexicographically (recursive),
+     * no insignificant whitespace.
+     * <p>
+     * <strong>Not RFC 8785 (JCS).</strong> Numbers keep Jackson's default
+     * serialization, so a payload containing numbers may canonicalize to different
+     * bytes than a true JCS implementation would produce — see the class-level
+     * note. This method's Javadoc used to claim RFC 8785 outright, which would send
+     * a peer implementing verification against JCS number formatting straight into
+     * failing signature checks.
      *
      * @param json
      *            the input JSON string

--- a/src/main/java/ai/labs/eddi/configs/agents/model/AgentConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/model/AgentConfiguration.java
@@ -770,10 +770,19 @@ public class AgentConfiguration {
             return summarizeTargetEntries;
         }
 
+        /**
+         * Plain assignment — the {@code >= 1} rule is enforced on the WRITE path, by
+         * {@code AgentStore.create}/{@code update}, not here.
+         * <p>
+         * Jackson calls this setter on every MongoDB read, ZIP import and instance
+         * sync, so throwing from it made any agent already stored with
+         * {@code summarizeTargetEntries: 0} — legal when it was written — permanently
+         * unreadable: not deployable, not exportable, and not even repairable by PUT,
+         * because the read happens first. See {@code AbstractResourceStore.validate}:
+         * "a document already in the database must keep loading even if the rules
+         * tightened".
+         */
         public void setSummarizeTargetEntries(int summarizeTargetEntries) {
-            if (summarizeTargetEntries < 1) {
-                throw new IllegalArgumentException("summarizeTargetEntries must be >= 1");
-            }
             this.summarizeTargetEntries = summarizeTargetEntries;
         }
 

--- a/src/main/java/ai/labs/eddi/configs/agents/mongo/AgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/mongo/AgentStore.java
@@ -46,6 +46,7 @@ public class AgentStore extends AbstractResourceStore<AgentConfiguration> implem
     public IResourceStore.IResourceId create(AgentConfiguration agentConfiguration) throws IResourceStore.ResourceStoreException {
         RuntimeUtilities.checkCollectionNoNullElements(agentConfiguration.getWorkflows(), WORKFLOWS_FIELD);
         HitlConfigValidation.validate(agentConfiguration.getHitlConfig());
+        validateUserMemoryConfig(agentConfiguration);
         return super.create(agentConfiguration);
     }
 
@@ -55,7 +56,31 @@ public class AgentStore extends AbstractResourceStore<AgentConfiguration> implem
             throws IResourceStore.ResourceStoreException, IResourceStore.ResourceModifiedException, IResourceStore.ResourceNotFoundException {
         RuntimeUtilities.checkCollectionNoNullElements(agentConfiguration.getWorkflows(), WORKFLOWS_FIELD);
         HitlConfigValidation.validate(agentConfiguration.getHitlConfig());
+        validateUserMemoryConfig(agentConfiguration);
         return super.update(id, version, agentConfiguration);
+    }
+
+    /**
+     * Write-time bound on the Dream consolidation settings.
+     * <p>
+     * This rule used to live in
+     * {@code AgentConfiguration.DreamConfig.setSummarizeTargetEntries}, which
+     * Jackson calls on every READ — so an agent stored before the rule existed
+     * became impossible to load, deploy, export or repair. Checking here rejects
+     * the same bad input at save time with a 400 (via
+     * {@code IllegalArgumentExceptionMapper}) while leaving stored documents
+     * readable.
+     */
+    private static void validateUserMemoryConfig(AgentConfiguration agentConfiguration) {
+        var userMemoryConfig = agentConfiguration.getUserMemoryConfig();
+        if (userMemoryConfig == null || userMemoryConfig.getDream() == null) {
+            return;
+        }
+        if (userMemoryConfig.getDream().getSummarizeTargetEntries() < 1) {
+            throw new IllegalArgumentException(
+                    "userMemoryConfig.dream.summarizeTargetEntries must be >= 1, got: "
+                            + userMemoryConfig.getDream().getSummarizeTargetEntries());
+        }
     }
 
     public List<DocumentDescriptor> getAgentDescriptorsContainingWorkflow(String workflowId, Integer workflowVersion, boolean includePreviousVersions)
@@ -78,7 +103,7 @@ public class AgentStore extends AbstractResourceStore<AgentConfiguration> implem
             allIds = allIds.stream().sorted(comparator).collect(Collectors.toList());
 
             for (IResourceStore.IResourceId agentId : allIds) {
-                if (agentId.getVersion() < getCurrentResourceId(agentId.getId()).getVersion()) {
+                if (isStaleReference(agentId.getId(), agentId.getVersion())) {
                     continue;
                 }
 

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.agents.rest;
 
+import ai.labs.eddi.configs.agents.AgentSigningService;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
@@ -13,20 +14,20 @@ import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.AccessLevel;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
-import ai.labs.eddi.configs.workflows.rest.RestWorkflowStore;
 import ai.labs.eddi.configs.rest.RestVersionInfo;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
-import ai.labs.eddi.datastore.serialization.IDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.utils.RestUtilities;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
@@ -53,6 +54,8 @@ public class RestAgentStore implements IRestAgentStore {
     private final IScheduleStore scheduleStore;
     private final CapabilityRegistryService capabilityRegistryService;
     private final IDeploymentStore deploymentStore;
+    private final AgentSigningService agentSigningService;
+    private final String defaultTenantId;
 
     private static final Logger log = Logger.getLogger(RestAgentStore.class);
 
@@ -60,7 +63,9 @@ public class RestAgentStore implements IRestAgentStore {
     public RestAgentStore(IAgentStore agentStore, IRestWorkflowStore restWorkflowStore, IDocumentDescriptorStore documentDescriptorStore,
             IJsonSchemaCreator jsonSchemaCreator, IScheduleStore scheduleStore, CapabilityRegistryService capabilityRegistryService,
             IDeploymentStore deploymentStore,
-            ResourceAccessGuard resourceAccessGuard) {
+            ResourceAccessGuard resourceAccessGuard,
+            AgentSigningService agentSigningService,
+            @ConfigProperty(name = "eddi.tenant.default-id", defaultValue = "default") String defaultTenantId) {
         this.resourceAccessGuard = resourceAccessGuard;
         restVersionInfo = new RestVersionInfo<>(resourceURI, agentStore, documentDescriptorStore, resourceAccessGuard);
         this.documentDescriptorStore = documentDescriptorStore;
@@ -70,34 +75,8 @@ public class RestAgentStore implements IRestAgentStore {
         this.scheduleStore = scheduleStore;
         this.capabilityRegistryService = capabilityRegistryService;
         this.deploymentStore = deploymentStore;
-    }
-
-    /**
-     * Populate the capability registry at startup from all existing agents.
-     */
-    @PostConstruct
-    void populateCapabilityRegistry() {
-        try {
-            var descriptors = documentDescriptorStore.readDescriptors("ai.labs.agent", null, 0, IDescriptorStore.NO_LIMIT, false);
-            int registered = 0;
-            for (var descriptor : descriptors) {
-                try {
-                    var resourceId = RestUtilities.extractResourceId(descriptor.getResource());
-                    var config = agentStore.read(resourceId.getId(), resourceId.getVersion());
-                    if (config.getCapabilities() != null && !config.getCapabilities().isEmpty()) {
-                        capabilityRegistryService.register(resourceId.getId(), config);
-                        registered++;
-                    }
-                } catch (Exception e) {
-                    log.debugf("Skipping capability registration for agent: %s", e.getMessage());
-                }
-            }
-            if (registered > 0) {
-                log.infof("Capability registry populated: %d agent(s) with capabilities", registered);
-            }
-        } catch (Exception e) {
-            log.warnf("Failed to populate capability registry at startup: %s", e.getMessage());
-        }
+        this.agentSigningService = agentSigningService;
+        this.defaultTenantId = defaultTenantId;
     }
 
     /**
@@ -133,7 +112,7 @@ public class RestAgentStore implements IRestAgentStore {
 
         IResourceId validatedResourceId = validateUri(containingWorkflowUri);
         if (validatedResourceId == null || !containingWorkflowUri.startsWith(WORKFLOW_URI)) {
-            return createMalFormattedResourceUriException(containingWorkflowUri);
+            throw malformedResourceUri(containingWorkflowUri);
         }
 
         try {
@@ -144,8 +123,13 @@ public class RestAgentStore implements IRestAgentStore {
             // with the full descriptor payload. The page can come back short; that is the
             // right trade for a diagnostic listing bounded by how many things reference
             // one resource.
-            return visibleOnly(agentStore.getAgentDescriptorsContainingWorkflow(validatedResourceId.getId(),
-                    validatedResourceId.getVersion(), includePreviousVersions));
+            //
+            // filter/index/limit are applied here for the same reason, and used to be
+            // accepted and then dropped: paging clients got the whole list back on every
+            // page, and a resource referenced by thousands of workflows returned all of
+            // them at once.
+            return filterAndPage(visibleOnly(agentStore.getAgentDescriptorsContainingWorkflow(validatedResourceId.getId(),
+                    validatedResourceId.getVersion(), includePreviousVersions)), filter, index, limit);
         } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
             throw sneakyThrow(e);
         }
@@ -194,7 +178,11 @@ public class RestAgentStore implements IRestAgentStore {
         if (updated) {
             return updateAgent(id, version, agentConfig);
         } else {
-            URI uri = RestUtilities.createURI(RestWorkflowStore.resourceURI, id, versionQueryParam, version);
+            // This store's own constant, qualified because the method parameter shadows
+            // it. It was RestWorkflowStore.resourceURI — copied from the workflow-store
+            // variant where it is correct — so the 400 body named a workflow URI built
+            // from an AGENT id, which no resource has.
+            URI uri = RestUtilities.createURI(IRestAgentStore.resourceURI, id, versionQueryParam, version);
             return Response.status(BAD_REQUEST).entity(uri).type(MediaType.TEXT_PLAIN).build();
         }
     }
@@ -203,8 +191,10 @@ public class RestAgentStore implements IRestAgentStore {
     public Response createAgent(AgentConfiguration agentConfiguration) {
         validateSecurityFlags(agentConfiguration);
 
-        // Use createDocument() to get IResourceId directly — Response.getLocation()
-        // returns null for eddi:// scheme URIs in CDI direct calls
+        // createDocument() because the id and version are what this method needs.
+        // NOT because Response.getLocation() is broken for eddi:// URIs — it is not;
+        // RestWorkflowStoreCrudTest.duplicateDeepCopyWithParserDictionaries proves it
+        // works with the real JAX-RS RuntimeDelegate.
         IResourceId resourceId = restVersionInfo.createDocument(agentConfiguration);
         URI createdUri = RestUtilities.createURI(resourceURI, resourceId.getId(), versionQueryParam, resourceId.getVersion());
 
@@ -221,7 +211,10 @@ public class RestAgentStore implements IRestAgentStore {
     @Override
     public Response duplicateAgent(String id, Integer version, Boolean deepCopy) {
         restVersionInfo.requireViewAccess(id);
-        restVersionInfo.validateParameters(id, version);
+        // Keep the normalised version: validateParameters maps 0 -> current, and
+        // discarding the return value left agentStore.read(id, 0) matching nothing,
+        // so the '0 means current' shorthand that PUT and DELETE accept 404'd here.
+        version = restVersionInfo.validateParameters(id, version);
         try {
             AgentConfiguration agentConfig = agentStore.read(id, version);
             validateSecurityFlags(agentConfig);
@@ -231,8 +224,6 @@ public class RestAgentStore implements IRestAgentStore {
                     URI workflowUri = packages.get(i);
                     IResourceId wfResId = RestUtilities.extractResourceId(workflowUri);
                     Response duplicateResourceResponse = restWorkflowStore.duplicateWorkflow(wfResId.getId(), wfResId.getVersion(), true);
-                    // Extract URI from X-Resource-URI entity fallback since getLocation() fails for
-                    // eddi:// URIs
                     URI newResourceLocation = extractCreatedUri(duplicateResourceResponse);
                     if (newResourceLocation == null) {
                         throw new IllegalStateException(String.format(
@@ -243,8 +234,6 @@ public class RestAgentStore implements IRestAgentStore {
                 }
             }
 
-            // Use createDocument() — bypasses broken Response.getLocation() for eddi://
-            // URIs
             IResourceId newAgentId = restVersionInfo.createDocument(agentConfig);
             URI createdUri = RestUtilities.createURI(resourceURI, newAgentId.getId(), versionQueryParam, newAgentId.getVersion());
             createDocumentDescriptorForDuplicate(documentDescriptorStore, resourceAccessGuard, id, version, createdUri);
@@ -257,8 +246,25 @@ public class RestAgentStore implements IRestAgentStore {
     }
 
     /**
-     * Extracts the created resource URI from a Response, trying multiple strategies
-     * since {@code getLocation()} returns null for {@code eddi://} scheme URIs.
+     * Extracts the created resource URI from a create/duplicate response.
+     *
+     * <p>
+     * {@code getLocation()} is the answer, and it works fine for {@code eddi://}
+     * URIs — contrary to what the comments here used to claim, and as
+     * {@code RestWorkflowStoreCrudTest.duplicateDeepCopyWithParserDictionaries}
+     * shows against the real JAX-RS {@code RuntimeDelegate}. Every production
+     * caller reaches this with a {@code Response} built by
+     * {@code RestWorkflowStore.duplicateWorkflow}, which sets it.
+     * </p>
+     *
+     * <p>
+     * The header and entity fallbacks are kept as defence for a response built
+     * without a {@code Location} — they cost nothing and this runs on a path that
+     * creates resources before it needs the answer — but they are not a workaround
+     * for a broken JAX-RS, and nothing should be written to depend on them. Note
+     * {@code RestImportService} is NOT such a caller: it uses direct CDI store
+     * calls, so no proxy ever strips anything from its responses.
+     * </p>
      */
     private URI extractCreatedUri(Response response) {
         URI location = response.getLocation();
@@ -285,7 +291,19 @@ public class RestAgentStore implements IRestAgentStore {
     public Response deleteAgent(String id, Integer version, Boolean permanent, Boolean cascade) {
         // Before the cascade, not after — see RestVersionInfo.requireOwnAccess.
         restVersionInfo.requireOwnAccess(id);
-        if (cascade) {
+
+        // Resolve '0' to the current version up front. restVersionInfo.delete() does
+        // it too, but only at the very END — so with ?version=0 the cascade read
+        // version 0, found nothing, and skipped itself with a WARN while the delete
+        // went through: cascade=true silently did not cascade.
+        version = restVersionInfo.validateParameters(id, version);
+
+        // Read BEFORE the delete — afterwards there is no current row to ask whether
+        // this Agent had signing key material to clean out of the vault. Only asked
+        // on the permanent path; see the vault cleanup below for why.
+        boolean deleteSigningKeys = Boolean.TRUE.equals(permanent) && hasSigningIdentity(id, version);
+
+        if (cascade && isCurrentVersion(id, version)) {
             // Cascade-delete all schedules for this Agent first
             try {
                 int deletedSchedules = scheduleStore.deleteSchedulesByAgentId(id);
@@ -309,7 +327,16 @@ public class RestAgentStore implements IRestAgentStore {
                             continue;
                         }
 
-                        restWorkflowStore.deleteWorkflow(resourceId.getId(), resourceId.getVersion(), permanent, true);
+                        // NEVER permanent down a cascade, whatever the request asked for.
+                        // The guard above answers a VERSION-scoped question ("who references
+                        // W?version=1?") while permanent=true performs an ID-scoped delete —
+                        // deleteAllPermanently drops every version and every history row. An
+                        // agent pinning W?version=2 is invisible to the check and loses its
+                        // workflow with nothing to recover from. Soft-deleting the pinned
+                        // version keeps the two scopes in agreement; permanently removing a
+                        // shared resource stays an explicit, non-cascading request against
+                        // that resource.
+                        restWorkflowStore.deleteWorkflow(resourceId.getId(), resourceId.getVersion(), false, true);
                         log.infof("Cascade-deleted package %s (v%d) for Agent %s", resourceId.getId(), resourceId.getVersion(), id);
                     } catch (Exception e) {
                         log.warnf("Failed to cascade-delete package %s: %s", resourceId.getId(), e.getMessage());
@@ -321,12 +348,32 @@ public class RestAgentStore implements IRestAgentStore {
                 log.warnf("Error reading Agent %s for cascade: %s", id, e.getMessage());
             }
         }
+
+        Response response = restVersionInfo.delete(id, version, permanent);
+
+        // Deliberately after the delete, which throws on a stale or unknown version.
+        // Clearing first would strip a still-live Agent of the capabilities that
+        // capabilityMatch rules and A2A discovery route on, with no error anywhere.
         capabilityRegistryService.unregister(id);
 
-        // Deliberately after the delete, which throws on a stale
-        // or unknown version. Clearing first would strip a
-        // still-live Agent of what it needs to redeploy.
-        Response response = restVersionInfo.delete(id, version, permanent);
+        // Permanent deletes ONLY, and only for Agents that actually declare key
+        // material.
+        //
+        // Deleting an Agent used to leave its Ed25519 private key in the vault
+        // forever — nothing else ever removes it, and the entry outlives the config
+        // that documented what it was for. But destroying it is irreversible in a way
+        // the config itself is not: there is no key-generation endpoint (see
+        // validateSecurityFlags), so a private key that is gone cannot be recreated,
+        // and an Agent restored from a ZIP backup would come back with a public key
+        // whose private half no longer exists — signInterAgentMessages permanently
+        // broken. A soft delete is the deliberately recoverable path and must stay
+        // recoverable, by the same rule the cascade above follows: destroying shared
+        // or unrecreatable material is an explicit request, never a side effect.
+        // The residual leak (soft-delete then never purge) is the recoverable failure
+        // of the two.
+        if (deleteSigningKeys) {
+            agentSigningService.deleteKeyPair(defaultTenantId, id);
+        }
 
         // A record left behind makes the runtime retry a
         // doomed redeploy on every startup.
@@ -340,6 +387,72 @@ public class RestAgentStore implements IRestAgentStore {
         }
 
         return response;
+    }
+
+    /**
+     * Whether this Agent declares signing key material, and therefore has a private
+     * key in the vault that its deletion must also remove.
+     *
+     * <p>
+     * Best-effort: an unreadable Agent simply reports {@code false}. Failing the
+     * delete because the key-cleanup probe could not run would be the wrong trade —
+     * a leaked vault entry is recoverable, a config that cannot be deleted is not.
+     * </p>
+     */
+    private boolean hasSigningIdentity(String id, Integer version) {
+        try {
+            AgentConfiguration config = agentStore.read(id, version);
+            var identity = config == null ? null : config.getIdentity();
+            return identity != null && ((identity.getPublicKey() != null && !identity.getPublicKey().isBlank())
+                    || (identity.getKeys() != null && !identity.getKeys().isEmpty()));
+        } catch (Exception e) {
+            // Every failure mode reports "no key material", deliberately: not found,
+            // store unreachable, an already soft-deleted Agent whose read answers null.
+            // The alternative is failing the delete on a probe, and a leaked vault entry
+            // is recoverable where a config that cannot be deleted is not.
+            log.debugf("Could not read Agent %s (v%s) to check for signing key material: %s", sanitize(id), version, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Whether {@code version} is the Agent's live version, i.e. whether a cascade
+     * addressed at it may run.
+     *
+     * <p>
+     * The cascade tears down schedules and workflows <em>before</em>
+     * {@code restVersionInfo.delete()} — the only place the version is checked —
+     * has run. {@code agentStore.read(id, staleVersion)} succeeds through the
+     * history fallback, so {@code DELETE ?version=1&cascade=true} against an Agent
+     * that is at v2 (a stale browser tab, an optimistic-lock race) deleted v1's
+     * workflows and schedules and only then answered 409: the live Agent kept its
+     * config and lost everything it pointed at. So a stale version is refused here,
+     * with nothing touched.
+     * </p>
+     *
+     * @return true when the versions match; false when the Agent has no live
+     *         version at all (already soft-deleted — the cascade is skipped so a
+     *         {@code permanent=true} purge of the remaining history still works)
+     * @throws WebApplicationException
+     *             409, carrying the current resource URI, when the Agent is live at
+     *             a different version
+     */
+    private boolean isCurrentVersion(String id, Integer version) {
+        IResourceId current;
+        try {
+            current = agentStore.getCurrentResourceId(id);
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            // No current row at all: the Agent is already soft-deleted. Skip the
+            // cascade — nothing live is left to protect — and let the delete below
+            // purge the remaining history. Dereferencing the missing id instead would
+            // NPE partway through a destructive operation.
+            return false;
+        }
+
+        if (!current.getVersion().equals(version)) {
+            throw RestUtilities.createConflictException(resourceURI, current);
+        }
+        return true;
     }
 
     @Override
@@ -359,7 +472,7 @@ public class RestAgentStore implements IRestAgentStore {
      * require an Ed25519 keypair on the agent's identity block. This validation
      * prevents enabling signing without the necessary infrastructure.
      *
-     * @throws jakarta.ws.rs.BadRequestException
+     * @throws BadRequestException
      *             if crypto is enabled without a keypair
      */
     private void validateSecurityFlags(AgentConfiguration config) {
@@ -374,19 +487,23 @@ public class RestAgentStore implements IRestAgentStore {
             return;
         }
         // Crypto is enabled — validate that a public key exists on the agent identity.
-        // Key generation is done via POST /agentstore/{id}/signing/keys, which sets
-        // the public key on the agent's identity block.
+        // There is deliberately no endpoint named here: none exists.
+        // AgentSigningService.generateKeyPair has no production caller, so the only way
+        // to satisfy this check today is to write the key material into the config
+        // yourself. Pointing at POST /agentstore/{agentId}/signing/keys — which returns
+        // 404 — sent operators looking for a route that was never built.
         var identity = config.getIdentity();
         boolean hasLegacyKey = identity != null && identity.getPublicKey() != null
                 && !identity.getPublicKey().isBlank();
         boolean hasRotatedKeys = identity != null && identity.getKeys() != null
                 && !identity.getKeys().isEmpty();
         if (!hasLegacyKey && !hasRotatedKeys) {
-            throw new jakarta.ws.rs.BadRequestException(
+            throw new BadRequestException(
                     "Cryptographic identity features require a signing key. "
-                            + "Generate one via POST /agentstore/{agentId}/signing/keys "
-                            + "before enabling signInterAgentMessages "
-                            + "or requirePeerVerification.");
+                            + "Set identity.publicKey (or identity.keys) on this agent before enabling "
+                            + "signInterAgentMessages or requirePeerVerification. "
+                            + "Note that the matching private key must also be in the secrets vault under "
+                            + "'agent-signing-key:{agentId}', or signing will fail at runtime.");
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -338,6 +338,9 @@ public class RestAgentStore implements IRestAgentStore {
             }
 
             for (IResourceId target : cascadeTargets) {
+                if (stillReferencedAfterAgentDelete(target)) {
+                    continue;
+                }
                 try {
                     // NEVER permanent down a cascade, whatever the request asked for.
                     // The guard in planCascade answers a VERSION-scoped question ("who
@@ -394,6 +397,50 @@ public class RestAgentStore implements IRestAgentStore {
         }
 
         return response;
+    }
+
+    /**
+     * Re-asks "does any Agent still reference this workflow?" immediately before
+     * the irreversible cascade delete.
+     *
+     * <p>
+     * {@link #planCascade} answers that question BEFORE this Agent is deleted — it
+     * has to, so this Agent still counts among the referrers — and an Agent
+     * created, or re-pointed at this workflow, in the window between the two would
+     * then have its newly shared workflow (and, through {@code deleteWorkflow}'s
+     * own cascade, that workflow's extensions) torn down underneath it. This Agent
+     * is gone by the time this runs, so the honest expectation is ZERO referrers
+     * rather than the {@code > 1} the plan phase used: the reverse lookup drops a
+     * soft-deleted or erased referrer (see
+     * {@code AbstractResourceStore.isStaleReference}).
+     * </p>
+     *
+     * <p>
+     * It narrows the window to the instants between this query and the delete
+     * rather than closing it, and FAILS CLOSED — a lookup that cannot answer is not
+     * a licence to delete.
+     * </p>
+     *
+     * @return true when the workflow must NOT be cascade-deleted
+     */
+    private boolean stillReferencedAfterAgentDelete(IResourceId target) {
+        List<DocumentDescriptor> referencingAgents;
+        try {
+            referencingAgents = agentStore.getAgentDescriptorsContainingWorkflow(target.getId(), target.getVersion(), true);
+        } catch (Exception e) {
+            log.warnf("Re-check of package %s after the Agent delete failed — NOT cascade-deleting it: %s", target.getId(), e.getMessage());
+            return true;
+        }
+        if (referencingAgents == null) {
+            log.warnf("Re-check of package %s after the Agent delete returned no answer — NOT cascade-deleting it", target.getId());
+            return true;
+        }
+        if (!referencingAgents.isEmpty()) {
+            log.infof("Skipping cascade-delete of package %s (v%d) — it became referenced by %d Agent(s) after the cascade was planned",
+                    target.getId(), target.getVersion(), referencingAgents.size());
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.agents.AgentSigningService;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.IRestAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
+import ai.labs.eddi.configs.agents.crypto.AgentPublicKey;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
@@ -31,6 +32,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 import static ai.labs.eddi.configs.descriptors.ResourceUtilities.*;
@@ -298,13 +300,34 @@ public class RestAgentStore implements IRestAgentStore {
         // went through: cascade=true silently did not cascade.
         version = restVersionInfo.validateParameters(id, version);
 
-        // Read BEFORE the delete — afterwards there is no current row to ask whether
-        // this Agent had signing key material to clean out of the vault. Only asked
-        // on the permanent path; see the vault cleanup below for why.
-        boolean deleteSigningKeys = Boolean.TRUE.equals(permanent) && hasSigningIdentity(id, version);
+        // Read BEFORE the delete — afterwards there is no row at all to ask whether
+        // this Agent had signing key material to clean out of the vault, nor which
+        // rotated versions it declares. Only asked on the permanent path; see the
+        // vault cleanup below for why. null means "no key material".
+        List<Integer> signingKeyVersions = Boolean.TRUE.equals(permanent) ? signingKeyVersions(id, version) : null;
 
-        if (cascade && isCurrentVersion(id, version)) {
-            // Cascade-delete all schedules for this Agent first
+        // DECIDED before the delete, EXECUTED after it — the same split, and for the
+        // same reason, as RestWorkflowStore.deleteWorkflow.
+        //
+        // isCurrentVersion() is a check-then-act. A concurrent update committing
+        // between it and restVersionInfo.delete() — a PUT, or the 10-second
+        // deployment sweep touching this Agent — left the schedules deleted and every
+        // exclusively owned workflow (plus, through deleteWorkflow's own cascade, its
+        // extensions) torn down while the delete answered 409 "nothing was deleted":
+        // the live Agent kept its config and lost everything it pointed at, and the
+        // 409 contract IRestAgentStore documents was false on this path. The store's
+        // own delete is version-checked (HistorizedResourceStore.delete raises
+        // ResourceModifiedException), so making it the gate means an Agent that moved
+        // on raises before anything it references has been touched.
+        //
+        // Deciding first is what keeps the reference guard honest: the "> 1" below
+        // counts this Agent among a workflow's referrers, which it only is while it
+        // still exists.
+        List<IResourceId> cascadeTargets = cascade && isCurrentVersion(id, version) ? planCascade(id, version) : null;
+
+        Response response = restVersionInfo.delete(id, version, permanent);
+
+        if (cascadeTargets != null) {
             try {
                 int deletedSchedules = scheduleStore.deleteSchedulesByAgentId(id);
                 if (deletedSchedules > 0) {
@@ -314,42 +337,22 @@ public class RestAgentStore implements IRestAgentStore {
                 log.warnf("Failed to cascade-delete schedules for Agent %s: %s", id, e.getMessage());
             }
 
-            try {
-                AgentConfiguration agentConfig = agentStore.read(id, version);
-                for (URI workflowUri : agentConfig.getWorkflows()) {
-                    IResourceId resourceId = RestUtilities.extractResourceId(workflowUri);
-                    try {
-                        // Check if this package is referenced by other agents
-                        var referencingAgents = agentStore.getAgentDescriptorsContainingWorkflow(resourceId.getId(), resourceId.getVersion(), false);
-                        if (referencingAgents.size() > 1) {
-                            log.infof("Skipping cascade-delete of package %s (v%d) — " + "still referenced by %d other agent(s)", resourceId.getId(),
-                                    resourceId.getVersion(), referencingAgents.size() - 1);
-                            continue;
-                        }
-
-                        // NEVER permanent down a cascade, whatever the request asked for.
-                        // The guard above answers a VERSION-scoped question ("who references
-                        // W?version=1?") while permanent=true performs an ID-scoped delete —
-                        // deleteAllPermanently drops every version and every history row. An
-                        // agent pinning W?version=2 is invisible to the check and loses its
-                        // workflow with nothing to recover from. Soft-deleting the pinned
-                        // version keeps the two scopes in agreement; permanently removing a
-                        // shared resource stays an explicit, non-cascading request against
-                        // that resource.
-                        restWorkflowStore.deleteWorkflow(resourceId.getId(), resourceId.getVersion(), false, true);
-                        log.infof("Cascade-deleted package %s (v%d) for Agent %s", resourceId.getId(), resourceId.getVersion(), id);
-                    } catch (Exception e) {
-                        log.warnf("Failed to cascade-delete package %s: %s", resourceId.getId(), e.getMessage());
-                    }
+            for (IResourceId target : cascadeTargets) {
+                try {
+                    // NEVER permanent down a cascade, whatever the request asked for.
+                    // The guard in planCascade answers a VERSION-scoped question ("who
+                    // references W?version=2?") while permanent=true performs an
+                    // ID-scoped delete — deleteAllPermanently drops every version and
+                    // every history row. Soft-deleting the current version keeps the two
+                    // scopes in agreement; permanently removing a shared resource stays
+                    // an explicit, non-cascading request against that resource.
+                    restWorkflowStore.deleteWorkflow(target.getId(), target.getVersion(), false, true);
+                    log.infof("Cascade-deleted package %s (v%d) for Agent %s", target.getId(), target.getVersion(), id);
+                } catch (Exception e) {
+                    log.warnf("Failed to cascade-delete package %s: %s", target.getId(), e.getMessage());
                 }
-            } catch (IResourceStore.ResourceNotFoundException e) {
-                log.warnf("Agent %s (v%d) not found for cascade — deleting Agent only", id, version);
-            } catch (IResourceStore.ResourceStoreException e) {
-                log.warnf("Error reading Agent %s for cascade: %s", id, e.getMessage());
             }
         }
-
-        Response response = restVersionInfo.delete(id, version, permanent);
 
         // Deliberately after the delete, which throws on a stale or unknown version.
         // Clearing first would strip a still-live Agent of the capabilities that
@@ -371,8 +374,12 @@ public class RestAgentStore implements IRestAgentStore {
         // or unrecreatable material is an explicit request, never a side effect.
         // The residual leak (soft-delete then never purge) is the recoverable failure
         // of the two.
-        if (deleteSigningKeys) {
-            agentSigningService.deleteKeyPair(defaultTenantId, id);
+        if (signingKeyVersions != null) {
+            // Bounded BY the declared versions rather than a blind 1..100 sweep — but
+            // not narrowed to exactly them: a rotation whose follow-up config write
+            // failed leaves a vault entry that no keys[] entry names. See
+            // AgentSigningService.versionsToSweep.
+            agentSigningService.deleteKeyPair(defaultTenantId, id, signingKeyVersions);
         }
 
         // A record left behind makes the runtime retry a
@@ -390,28 +397,115 @@ public class RestAgentStore implements IRestAgentStore {
     }
 
     /**
-     * Whether this Agent declares signing key material, and therefore has a private
-     * key in the vault that its deletion must also remove.
+     * Decides — before the Agent is deleted — which of its workflows the cascade
+     * may remove.
      *
      * <p>
-     * Best-effort: an unreadable Agent simply reports {@code false}. Failing the
-     * delete because the key-cleanup probe could not run would be the wrong trade —
-     * a leaked vault entry is recoverable, a config that cannot be deleted is not.
+     * Deciding and deleting are separate steps so the reference guard still counts
+     * this Agent among the referrers (hence {@code > 1}) while the Agent itself is
+     * deleted first; see {@link #deleteAgent}.
+     * </p>
+     *
+     * @return the workflows to delete, addressed at their CURRENT version — never
+     *         null, so "nothing to cascade" and "no cascade requested" stay
+     *         distinct at the call site
+     */
+    private List<IResourceId> planCascade(String id, Integer version) {
+        List<IResourceId> targets = new ArrayList<>();
+        try {
+            AgentConfiguration agentConfig = agentStore.read(id, version);
+            for (URI workflowUri : agentConfig.getWorkflows()) {
+                IResourceId pinned = RestUtilities.extractResourceId(workflowUri);
+                try {
+                    // Resolve the reference to the version that EXISTS. An agent's
+                    // workflow reference is version-pinned and is NOT re-pointed when the
+                    // workflow is edited, so an agent pinning W?version=1 while W is at v2
+                    // is the normal state. Against the pinned version both steps here were
+                    // wrong at once: the reference check asked who else pins a version
+                    // nobody may still pin, and deleteWorkflow's own isCurrentVersion()
+                    // then answered 409 — swallowed as a bare WARN. cascade=true
+                    // consequently deleted nothing for any workflow that had ever been
+                    // edited.
+                    IResourceId target = restWorkflowStore.getCurrentResourceId(pinned.getId());
+
+                    // includePreviousVersions=true, starting from the CURRENT version:
+                    // the reverse lookup walks that version down to 1, so an agent still
+                    // pinning an older version protects the workflow, and there is no
+                    // newer version above for the walk to miss.
+                    var referencingAgents = agentStore.getAgentDescriptorsContainingWorkflow(target.getId(), target.getVersion(), true);
+                    if (referencingAgents.size() > 1) {
+                        log.infof("Skipping cascade-delete of package %s (v%d) — still referenced by %d other agent(s)", target.getId(),
+                                target.getVersion(), referencingAgents.size() - 1);
+                        continue;
+                    }
+                    targets.add(target);
+                } catch (IResourceStore.ResourceNotFoundException e) {
+                    log.infof("Skipping cascade-delete of package %s — it has no live version left", pinned.getId());
+                } catch (Exception e) {
+                    // FAIL CLOSED per workflow, exactly as the workflow store's own
+                    // cascade does: a reference check that cannot answer is not a licence
+                    // to delete, and letting the throwable out here would abort the whole
+                    // request before the Agent itself had been deleted.
+                    log.warnf("Failed to plan cascade-delete of package %s: %s", pinned.getId(), e.getMessage());
+                }
+            }
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            log.warnf("Agent %s (v%d) not found for cascade — deleting Agent only", id, version);
+        } catch (IResourceStore.ResourceStoreException e) {
+            log.warnf("Error reading Agent %s for cascade: %s", id, e.getMessage());
+        }
+        return targets;
+    }
+
+    /**
+     * The rotated signing key versions this Agent declares, or {@code null} when it
+     * declares no key material at all and its deletion has no vault entry to clean
+     * up.
+     *
+     * <p>
+     * Read through {@code readIncludingDeleted}, NOT {@code read}.
+     * {@code HistorizedResourceStore.read} throws {@code ResourceNotFoundException}
+     * for a history row flagged deleted — that is, for every soft-deleted Agent —
+     * and "soft-delete first, then purge with {@code permanent=true}" is exactly
+     * the two-step flow {@link #isCurrentVersion} documents as ordinary. On that
+     * flow the probe therefore answered "no key material", {@code deleteKeyPair}
+     * never ran, and the Ed25519 private key stayed in the vault after the config
+     * and its whole history had been erased: the leak this cleanup exists to close,
+     * surviving on the only recommended path to closing it.
+     * </p>
+     *
+     * <p>
+     * An empty list means "key material, but no rotated versions" — the legacy
+     * unversioned key — and is deliberately distinct from {@code null}.
+     * </p>
+     *
+     * <p>
+     * Best-effort: an unreadable Agent reports {@code null}. Failing the delete
+     * because the key-cleanup probe could not run would be the wrong trade — a
+     * leaked vault entry is recoverable, a config that cannot be deleted is not.
      * </p>
      */
-    private boolean hasSigningIdentity(String id, Integer version) {
+    private List<Integer> signingKeyVersions(String id, Integer version) {
         try {
-            AgentConfiguration config = agentStore.read(id, version);
+            AgentConfiguration config = agentStore.readIncludingDeleted(id, version);
             var identity = config == null ? null : config.getIdentity();
-            return identity != null && ((identity.getPublicKey() != null && !identity.getPublicKey().isBlank())
-                    || (identity.getKeys() != null && !identity.getKeys().isEmpty()));
+            if (identity == null) {
+                return null;
+            }
+            boolean hasLegacyKey = identity.getPublicKey() != null && !identity.getPublicKey().isBlank();
+            List<AgentPublicKey> keys = identity.getKeys();
+            boolean hasRotatedKeys = keys != null && !keys.isEmpty();
+            if (!hasLegacyKey && !hasRotatedKeys) {
+                return null;
+            }
+            return hasRotatedKeys ? keys.stream().map(AgentPublicKey::version).toList() : List.of();
         } catch (Exception e) {
-            // Every failure mode reports "no key material", deliberately: not found,
-            // store unreachable, an already soft-deleted Agent whose read answers null.
-            // The alternative is failing the delete on a probe, and a leaked vault entry
+            // Every remaining failure mode reports "no key material", deliberately:
+            // not found, store unreachable, a document that will not deserialize. The
+            // alternative is failing the delete on a probe, and a leaked vault entry
             // is recoverable where a config that cannot be deleted is not.
             log.debugf("Could not read Agent %s (v%s) to check for signing key material: %s", sanitize(id), version, e.getMessage());
-            return false;
+            return null;
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/rest/RestAgentStore.java
@@ -204,7 +204,7 @@ public class RestAgentStore implements IRestAgentStore {
         try {
             capabilityRegistryService.register(resourceId.getId(), agentConfiguration);
         } catch (Exception e) {
-            log.debugf("Could not register capabilities for new agent: %s", e.getMessage());
+            log.debugf("Could not register capabilities for new agent: %s", sanitize(e.getMessage()));
         }
 
         return Response.created(createdUri).location(createdUri)
@@ -332,10 +332,10 @@ public class RestAgentStore implements IRestAgentStore {
             try {
                 int deletedSchedules = scheduleStore.deleteSchedulesByAgentId(id);
                 if (deletedSchedules > 0) {
-                    log.infof("Cascade-deleted %d schedule(s) for Agent %s", deletedSchedules, id);
+                    log.infof("Cascade-deleted %d schedule(s) for Agent %s", deletedSchedules, sanitize(id));
                 }
             } catch (Exception e) {
-                log.warnf("Failed to cascade-delete schedules for Agent %s: %s", id, e.getMessage());
+                log.warnf("Failed to cascade-delete schedules for Agent %s: %s", sanitize(id), sanitize(e.getMessage()));
             }
 
             for (IResourceId target : cascadeTargets) {
@@ -351,9 +351,10 @@ public class RestAgentStore implements IRestAgentStore {
                     // scopes in agreement; permanently removing a shared resource stays
                     // an explicit, non-cascading request against that resource.
                     restWorkflowStore.deleteWorkflow(target.getId(), target.getVersion(), false, true);
-                    log.infof("Cascade-deleted package %s (v%d) for Agent %s", target.getId(), target.getVersion(), id);
+                    log.infof("Cascade-deleted package %s (v%d) for Agent %s", sanitize(target.getId()), target.getVersion(),
+                            sanitize(id));
                 } catch (Exception e) {
-                    log.warnf("Failed to cascade-delete package %s: %s", target.getId(), e.getMessage());
+                    log.warnf("Failed to cascade-delete package %s: %s", sanitize(target.getId()), sanitize(e.getMessage()));
                 }
             }
         }
@@ -394,7 +395,7 @@ public class RestAgentStore implements IRestAgentStore {
                 log.infof("Cascade-deleted %d deployment record(s) for Agent %s", deletedDeployments, sanitize(id));
             }
         } catch (Exception e) {
-            log.warnf("Failed to delete deployment record(s) for Agent %s: %s", sanitize(id), e.getMessage());
+            log.warnf("Failed to delete deployment record(s) for Agent %s: %s", sanitize(id), sanitize(e.getMessage()));
         }
 
         return response;
@@ -429,16 +430,18 @@ public class RestAgentStore implements IRestAgentStore {
         try {
             referencingAgents = agentStore.getAgentDescriptorsContainingWorkflow(target.getId(), target.getVersion(), true);
         } catch (Exception e) {
-            log.warnf("Re-check of package %s after the Agent delete failed — NOT cascade-deleting it: %s", target.getId(), e.getMessage());
+            log.warnf("Re-check of package %s after the Agent delete failed — NOT cascade-deleting it: %s",
+                    sanitize(target.getId()), sanitize(e.getMessage()));
             return true;
         }
         if (referencingAgents == null) {
-            log.warnf("Re-check of package %s after the Agent delete returned no answer — NOT cascade-deleting it", target.getId());
+            log.warnf("Re-check of package %s after the Agent delete returned no answer — NOT cascade-deleting it",
+                    sanitize(target.getId()));
             return true;
         }
         if (!referencingAgents.isEmpty()) {
             log.infof("Skipping cascade-delete of package %s (v%d) — it became referenced by %d Agent(s) after the cascade was planned",
-                    target.getId(), target.getVersion(), referencingAgents.size());
+                    sanitize(target.getId()), target.getVersion(), referencingAgents.size());
             return true;
         }
         return false;
@@ -482,25 +485,25 @@ public class RestAgentStore implements IRestAgentStore {
                     // newer version above for the walk to miss.
                     var referencingAgents = agentStore.getAgentDescriptorsContainingWorkflow(target.getId(), target.getVersion(), true);
                     if (referencingAgents.size() > 1) {
-                        log.infof("Skipping cascade-delete of package %s (v%d) — still referenced by %d other agent(s)", target.getId(),
-                                target.getVersion(), referencingAgents.size() - 1);
+                        log.infof("Skipping cascade-delete of package %s (v%d) — still referenced by %d other agent(s)",
+                                sanitize(target.getId()), target.getVersion(), referencingAgents.size() - 1);
                         continue;
                     }
                     targets.add(target);
                 } catch (IResourceStore.ResourceNotFoundException e) {
-                    log.infof("Skipping cascade-delete of package %s — it has no live version left", pinned.getId());
+                    log.infof("Skipping cascade-delete of package %s — it has no live version left", sanitize(pinned.getId()));
                 } catch (Exception e) {
                     // FAIL CLOSED per workflow, exactly as the workflow store's own
                     // cascade does: a reference check that cannot answer is not a licence
                     // to delete, and letting the throwable out here would abort the whole
                     // request before the Agent itself had been deleted.
-                    log.warnf("Failed to plan cascade-delete of package %s: %s", pinned.getId(), e.getMessage());
+                    log.warnf("Failed to plan cascade-delete of package %s: %s", sanitize(pinned.getId()), sanitize(e.getMessage()));
                 }
             }
         } catch (IResourceStore.ResourceNotFoundException e) {
-            log.warnf("Agent %s (v%d) not found for cascade — deleting Agent only", id, version);
+            log.warnf("Agent %s (v%d) not found for cascade — deleting Agent only", sanitize(id), version);
         } catch (IResourceStore.ResourceStoreException e) {
-            log.warnf("Error reading Agent %s for cascade: %s", id, e.getMessage());
+            log.warnf("Error reading Agent %s for cascade: %s", sanitize(id), sanitize(e.getMessage()));
         }
         return targets;
     }
@@ -552,7 +555,8 @@ public class RestAgentStore implements IRestAgentStore {
             // not found, store unreachable, a document that will not deserialize. The
             // alternative is failing the delete on a probe, and a leaked vault entry
             // is recoverable where a config that cannot be deleted is not.
-            log.debugf("Could not read Agent %s (v%s) to check for signing key material: %s", sanitize(id), version, e.getMessage());
+            log.debugf("Could not read Agent %s (v%s) to check for signing key material: %s", sanitize(id), version,
+                    sanitize(e.getMessage()));
             return null;
         }
     }

--- a/src/main/java/ai/labs/eddi/configs/deployment/mongo/MongoDeploymentStorage.java
+++ b/src/main/java/ai/labs/eddi/configs/deployment/mongo/MongoDeploymentStorage.java
@@ -8,11 +8,15 @@ import ai.labs.eddi.configs.deployment.IDeploymentStorage;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
+import com.mongodb.MongoException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.ReplaceOptions;
 import io.quarkus.arc.DefaultBean;
 import org.bson.Document;
+import org.jboss.logging.Logger;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -28,6 +32,8 @@ import static com.mongodb.client.model.Filters.eq;
 @ApplicationScoped
 @DefaultBean
 public class MongoDeploymentStorage implements IDeploymentStorage {
+
+    private static final Logger LOGGER = Logger.getLogger(MongoDeploymentStorage.class);
 
     private static final String COLLECTION_DEPLOYMENTS = "deployments";
     private static final String FIELD_DEPLOYMENT_STATUS = "deploymentStatus";
@@ -46,18 +52,68 @@ public class MongoDeploymentStorage implements IDeploymentStorage {
         // deleteDeploymentInfos filters on agentId alone, which the index above cannot
         // serve: agentId is not one of its leading fields.
         deploymentsCollection.createIndex(Indexes.ascending(FIELD_AGENT_ID));
+        createDeploymentKeyIndex();
     }
 
+    /**
+     * Adds the uniqueness {@code PostgresDeploymentStorage} gets from its ON
+     * CONFLICT target — without refusing to start where it cannot be added.
+     *
+     * <p>
+     * The index matters because {@code deleteDeploymentInfo} deletes ONE row and
+     * {@code readDeploymentInfos} returns whatever is there: a duplicated key makes
+     * an agent list twice, survive its own undeploy, and read as 'deployed' and
+     * 'undeployed' at the same time.
+     * </p>
+     *
+     * <p>
+     * But {@code createIndex(unique)} fails with E11000 against a collection that
+     * ALREADY holds duplicates — which is exactly the state of the deployments this
+     * index exists to protect, because those duplicates are what the check-then-act
+     * {@link #setDeploymentInfo} replaced used to write. Building it
+     * unconditionally in the constructor therefore broke bean construction on
+     * precisely the installations that hit the bug, and an unconstructable
+     * {@code IDeploymentStore} takes {@code RestAgentStore},
+     * {@code RestAgentAdministration} and the startup redeploy with it. So a
+     * failure is logged with the cleanup an operator has to do, and the collection
+     * keeps working without the index: {@code replaceOne(upsert)} is the actual fix
+     * for the race, the index only its backstop.
+     * </p>
+     */
+    private void createDeploymentKeyIndex() {
+        try {
+            deploymentsCollection.createIndex(Indexes.ascending(FIELD_ENVIRONMENT, FIELD_AGENT_ID, FIELD_AGENT_VERSION),
+                    new IndexOptions().unique(true));
+        } catch (MongoException e) {
+            LOGGER.warnf("Could not create the unique deployment-key index on '%s' (%s, %s, %s): %s. "
+                    + "Deployments keep working, but duplicate rows are no longer prevented. The usual cause is "
+                    + "duplicates already in the collection: keep one row per environment/agentId/agentVersion, "
+                    + "then restart to have the index created.",
+                    COLLECTION_DEPLOYMENTS, FIELD_ENVIRONMENT, FIELD_AGENT_ID, FIELD_AGENT_VERSION, e.getMessage());
+        }
+    }
+
+    /**
+     * Upserts in ONE atomic operation.
+     *
+     * <p>
+     * This was findOneAndReplace-then-insert-if-absent: a check-then-act, so two
+     * callers racing on the same (environment, agentId, agentVersion) — a
+     * double-clicked deploy, two nodes running their startup redeploy, a deploy
+     * overlapping the 10-second {@code checkDeployments} sweep — both saw
+     * {@code null} and both inserted. {@code replaceOne(upsert)} is decided by the
+     * server, so this alone closes the race; where
+     * {@link #createDeploymentKeyIndex()} succeeded, the unique index additionally
+     * turns any residual one into a duplicate-key error rather than a second row.
+     * </p>
+     */
     @Override
     public void setDeploymentInfo(String environment, String agentId, Integer agentVersion, DeploymentInfo.DeploymentStatus deploymentStatus) {
         Document filter = createFilter(environment, agentId, agentVersion);
         Document newDeploymentInfo = new Document(filter);
         newDeploymentInfo.put(FIELD_DEPLOYMENT_STATUS, deploymentStatus.toString());
 
-        Document existing = deploymentsCollection.findOneAndReplace(filter, newDeploymentInfo);
-        if (existing == null) {
-            deploymentsCollection.insertOne(newDeploymentInfo);
-        }
+        deploymentsCollection.replaceOne(filter, newDeploymentInfo, new ReplaceOptions().upsert(true));
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/deployment/mongo/MongoDeploymentStorage.java
+++ b/src/main/java/ai/labs/eddi/configs/deployment/mongo/MongoDeploymentStorage.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.in;
 
 /**
  * MongoDB implementation of {@link IDeploymentStorage}.
@@ -40,6 +41,12 @@ public class MongoDeploymentStorage implements IDeploymentStorage {
     private static final String FIELD_ENVIRONMENT = "environment";
     private static final String FIELD_AGENT_ID = "agentId";
     private static final String FIELD_AGENT_VERSION = "agentVersion";
+    /**
+     * Aggregation-only field names used by
+     * {@link #removeDuplicateDeploymentRows()}.
+     */
+    private static final String FIELD_DUPLICATE_IDS = "duplicateIds";
+    private static final String FIELD_DUPLICATE_COUNT = "duplicateCount";
 
     private final MongoCollection<Document> deploymentsCollection;
     private final IDocumentBuilder documentBuilder;
@@ -60,37 +67,122 @@ public class MongoDeploymentStorage implements IDeploymentStorage {
      * CONFLICT target — without refusing to start where it cannot be added.
      *
      * <p>
-     * The index matters because {@code deleteDeploymentInfo} deletes ONE row and
-     * {@code readDeploymentInfos} returns whatever is there: a duplicated key makes
-     * an agent list twice, survive its own undeploy, and read as 'deployed' and
-     * 'undeployed' at the same time.
+     * The index matters because it is what actually closes the race.
+     * {@code replaceOne(upsert)} is atomic per operation, but an upsert whose
+     * filter fields are not uniquely indexed can still insert twice under
+     * concurrency: two callers whose filter matches nothing both take the insert
+     * branch. Only the unique index turns the loser into a duplicate-key error.
+     * Without it {@code deleteDeploymentInfo} (which deletes ONE row) and
+     * {@code readDeploymentInfos} (which returns whatever is there) let an agent
+     * list twice, survive its own undeploy, and read as 'deployed' and 'undeployed'
+     * at the same time.
      * </p>
      *
      * <p>
-     * But {@code createIndex(unique)} fails with E11000 against a collection that
-     * ALREADY holds duplicates — which is exactly the state of the deployments this
-     * index exists to protect, because those duplicates are what the check-then-act
-     * {@link #setDeploymentInfo} replaced used to write. Building it
-     * unconditionally in the constructor therefore broke bean construction on
-     * precisely the installations that hit the bug, and an unconstructable
-     * {@code IDeploymentStore} takes {@code RestAgentStore},
-     * {@code RestAgentAdministration} and the startup redeploy with it. So a
-     * failure is logged with the cleanup an operator has to do, and the collection
-     * keeps working without the index: {@code replaceOne(upsert)} is the actual fix
-     * for the race, the index only its backstop.
+     * {@code createIndex(unique)} fails with E11000 against a collection that
+     * ALREADY holds duplicates — exactly the state of the deployments this index
+     * exists to protect, because those duplicates are what the check-then-act
+     * {@link #setDeploymentInfo} replaced used to write. Letting that failure out
+     * broke bean construction on precisely the installations that hit the bug, and
+     * an unconstructable {@code IDeploymentStore} takes {@code RestAgentStore},
+     * {@code RestAgentAdministration} and the startup redeploy with it. So the
+     * duplicates are removed first — one row per (environment, agentId,
+     * agentVersion), the most recently written kept — and the index is retried. If
+     * even that does not get the index built, the collection keeps working and the
+     * failure is reported at ERROR: the race is then genuinely still open, which an
+     * operator has to know rather than read a comment claiming it is closed.
      * </p>
      */
     private void createDeploymentKeyIndex() {
         try {
-            deploymentsCollection.createIndex(Indexes.ascending(FIELD_ENVIRONMENT, FIELD_AGENT_ID, FIELD_AGENT_VERSION),
-                    new IndexOptions().unique(true));
+            createUniqueKeyIndex();
+            return;
         } catch (MongoException e) {
             LOGGER.warnf("Could not create the unique deployment-key index on '%s' (%s, %s, %s): %s. "
-                    + "Deployments keep working, but duplicate rows are no longer prevented. The usual cause is "
-                    + "duplicates already in the collection: keep one row per environment/agentId/agentVersion, "
-                    + "then restart to have the index created.",
-                    COLLECTION_DEPLOYMENTS, FIELD_ENVIRONMENT, FIELD_AGENT_ID, FIELD_AGENT_VERSION, e.getMessage());
+                    + "Removing duplicate rows and retrying.", COLLECTION_DEPLOYMENTS, FIELD_ENVIRONMENT, FIELD_AGENT_ID,
+                    FIELD_AGENT_VERSION, e.getMessage());
         }
+
+        int removed;
+        try {
+            removed = removeDuplicateDeploymentRows();
+        } catch (Exception e) {
+            // Nothing in this constructor may make the bean unconstructable — see
+            // above. A dedupe that cannot run leaves the collection exactly as it
+            // was, minus the index.
+            LOGGER.errorf("Could not deduplicate '%s': %s. Duplicate deployment records are NOT prevented on this "
+                    + "installation: an agent can list twice, survive its own undeploy, and read as both deployed and "
+                    + "undeployed. Keep one row per %s/%s/%s by hand, then restart.", COLLECTION_DEPLOYMENTS, e.getMessage(),
+                    FIELD_ENVIRONMENT, FIELD_AGENT_ID, FIELD_AGENT_VERSION);
+            return;
+        }
+
+        try {
+            createUniqueKeyIndex();
+            LOGGER.warnf("Removed %d duplicate deployment row(s) from '%s' and created the unique index.", removed,
+                    COLLECTION_DEPLOYMENTS);
+        } catch (Exception e) {
+            LOGGER.errorf("Removed %d duplicate deployment row(s) from '%s' but still could not create the unique index: %s. "
+                    + "Duplicate deployment records are NOT prevented on this installation.", removed, COLLECTION_DEPLOYMENTS,
+                    e.getMessage());
+        }
+    }
+
+    private void createUniqueKeyIndex() {
+        deploymentsCollection.createIndex(Indexes.ascending(FIELD_ENVIRONMENT, FIELD_AGENT_ID, FIELD_AGENT_VERSION),
+                new IndexOptions().unique(true));
+    }
+
+    /**
+     * Keeps one row per (environment, agentId, agentVersion) and removes the rest.
+     *
+     * <p>
+     * The survivor is the newest row: duplicates differ only in
+     * {@code deploymentStatus}, so the last-written one is what reflects the
+     * operator's last deploy/undeploy. Guessing is unavoidable here — the rows
+     * carry no timestamp of their own — but any single row is a consistent answer
+     * where two are not.
+     * </p>
+     *
+     * <p>
+     * "Newest" is established by the leading {@code $sort} on {@code _id}, and that
+     * stage is load-bearing rather than cosmetic. {@code $push} preserves the order
+     * the documents reach {@code $group} in, and without a sort that is the storage
+     * engine's natural order, which is not insertion order and is not stable
+     * between nodes. Two nodes deduplicating the same collection during a rolling
+     * restart could therefore each keep a DIFFERENT element and, between them,
+     * delete every row for a key — an agent that was deployed silently never
+     * redeployed by {@code checkDeployments} again. Rows are inserted without an
+     * explicit {@code _id}, so Mongo assigns an ObjectId whose leading bytes are
+     * the insert timestamp: ascending {@code _id} is insertion order, and every
+     * node computes the same survivor.
+     * </p>
+     *
+     * @return how many rows were removed
+     */
+    private int removeDuplicateDeploymentRows() {
+        List<Document> pipeline = List.of(
+                new Document("$sort", new Document("_id", 1)),
+                new Document("$group", new Document("_id",
+                        new Document(FIELD_ENVIRONMENT, "$" + FIELD_ENVIRONMENT).append(FIELD_AGENT_ID, "$" + FIELD_AGENT_ID)
+                                .append(FIELD_AGENT_VERSION, "$" + FIELD_AGENT_VERSION))
+                        .append(FIELD_DUPLICATE_IDS, new Document("$push", "$_id"))
+                        .append(FIELD_DUPLICATE_COUNT, new Document("$sum", 1))),
+                new Document("$match", new Document(FIELD_DUPLICATE_COUNT, new Document("$gt", 1))));
+
+        List<Object> doomed = new ArrayList<>();
+        for (Document group : deploymentsCollection.aggregate(pipeline)) {
+            List<Object> ids = group.getList(FIELD_DUPLICATE_IDS, Object.class);
+            if (ids == null || ids.size() < 2) {
+                continue;
+            }
+            doomed.addAll(ids.subList(0, ids.size() - 1));
+        }
+
+        if (doomed.isEmpty()) {
+            return 0;
+        }
+        return (int) deploymentsCollection.deleteMany(in("_id", doomed)).getDeletedCount();
     }
 
     /**
@@ -101,10 +193,13 @@ public class MongoDeploymentStorage implements IDeploymentStorage {
      * callers racing on the same (environment, agentId, agentVersion) — a
      * double-clicked deploy, two nodes running their startup redeploy, a deploy
      * overlapping the 10-second {@code checkDeployments} sweep — both saw
-     * {@code null} and both inserted. {@code replaceOne(upsert)} is decided by the
-     * server, so this alone closes the race; where
-     * {@link #createDeploymentKeyIndex()} succeeded, the unique index additionally
-     * turns any residual one into a duplicate-key error rather than a second row.
+     * {@code null} and both inserted. {@code replaceOne(upsert)} removes the
+     * application-side window, but it does not on its own make the write unique: an
+     * upsert whose filter matches nothing is still free to insert, and two of them
+     * running concurrently both can. The unique index from
+     * {@link #createDeploymentKeyIndex()} is what turns the second insert into a
+     * duplicate-key error — so where that index could not be built, this race stays
+     * open and is reported at ERROR rather than assumed away.
      * </p>
      */
     @Override

--- a/src/main/java/ai/labs/eddi/configs/descriptors/ResourceUtilities.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/ResourceUtilities.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -36,11 +37,82 @@ public class ResourceUtilities {
         return null;
     }
 
-    public static List<DocumentDescriptor> createMalFormattedResourceUriException(String containingResourceUri) {
+    /**
+     * The 400 for a resource URI that is not in the expected shape.
+     *
+     * <p>
+     * Returns the exception for the caller to {@code throw}, rather than being
+     * declared to return {@code List<DocumentDescriptor>} and throwing from inside
+     * — a signature that existed only so call sites could write
+     * {@code return createMalFormatted…(uri);} to satisfy the compiler, and that
+     * read as if a value came back.
+     * </p>
+     */
+    public static BadRequestException malformedResourceUri(String containingResourceUri) {
         String message = String.format(
                 "Bad resource uri. Needs to be of this format: " + "eddi://ai.labs.<type>/<path>/<ID>?version=<VERSION>" + "\n actual: '%s'",
                 containingResourceUri);
-        throw new BadRequestException(Response.status(BAD_REQUEST).entity(message).type(MediaType.TEXT_PLAIN).build());
+        return new BadRequestException(Response.status(BAD_REQUEST).entity(message).type(MediaType.TEXT_PLAIN).build());
+    }
+
+    /**
+     * Applies {@code filter}, {@code index} and {@code limit} to an
+     * already-materialised descriptor list.
+     *
+     * <p>
+     * The reverse-reference listings ("which agents contain this workflow?") answer
+     * from a store lookup that takes neither a filter nor a page, so those three
+     * REST parameters were accepted and then silently dropped: a client paging with
+     * {@code index}/{@code limit} got the whole list back on every page, and a
+     * resource referenced by thousands of workflows returned all of them at once.
+     * Post-filtering is an approximation of the store-side filter — a
+     * case-insensitive substring over the same descriptor fields the descriptor
+     * store matches on — and it is applied here rather than pushed down because
+     * there is no query to push it into.
+     * </p>
+     *
+     * @param index
+     *            page number, not offset — the same meaning the descriptor store
+     *            gives it
+     */
+    public static List<DocumentDescriptor> filterAndPage(List<DocumentDescriptor> descriptors, String filter, Integer index,
+                                                         Integer limit) {
+        if (descriptors == null || descriptors.isEmpty()) {
+            return descriptors;
+        }
+
+        List<DocumentDescriptor> matching = descriptors;
+        if (!isNullOrEmpty(filter)) {
+            String needle = filter.toLowerCase(Locale.ROOT);
+            matching = descriptors.stream().filter(descriptor -> matches(descriptor, needle)).toList();
+        }
+
+        // null or non-positive means "no page": an in-process caller may pass either,
+        // even though the REST overloads declare @DefaultValue("20"). Paging on a
+        // limit of 0 would return an empty page and silently drop every row.
+        if (limit == null || limit <= 0) {
+            return matching;
+        }
+        int page = index == null || index < 0 ? 0 : index;
+        int from = Math.min(page * limit, matching.size());
+        int to = Math.min(from + limit, matching.size());
+        return matching.subList(from, to);
+    }
+
+    /**
+     * The descriptor fields this post-filter matches on, deliberately the same set
+     * the descriptor store's own filter searches — a narrower set would make one
+     * query string select different rows depending on which listing answered it.
+     */
+    private static boolean matches(DocumentDescriptor descriptor, String needle) {
+        return containsIgnoreCase(descriptor.getName(), needle)
+                || containsIgnoreCase(descriptor.getDescription(), needle)
+                || containsIgnoreCase(descriptor.getOwnerId(), needle)
+                || (descriptor.getResource() != null && containsIgnoreCase(descriptor.getResource().toString(), needle));
+    }
+
+    private static boolean containsIgnoreCase(String value, String needle) {
+        return value != null && value.toLowerCase(Locale.ROOT).contains(needle);
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/configs/descriptors/ResourceUtilities.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/ResourceUtilities.java
@@ -93,10 +93,18 @@ public class ResourceUtilities {
         if (limit == null || limit <= 0) {
             return matching;
         }
+        // Both operands are clamped to the list BEFORE they are multiplied, and the
+        // multiply itself is done in long. index and limit come straight off the
+        // query string, so `page * limit` in int overflows on values a client can
+        // simply type ({@code index=Integer.MAX_VALUE}): the product wraps negative
+        // and subList throws IndexOutOfBoundsException — a 500 for a paging request
+        // — instead of answering the empty page that lies past the end of the list.
+        int size = matching.size();
         int page = index == null || index < 0 ? 0 : index;
-        int from = Math.min(page * limit, matching.size());
-        int to = Math.min(from + limit, matching.size());
-        return matching.subList(from, to);
+        int pageSize = Math.min(limit, size);
+        long from = Math.min((long) page * pageSize, size);
+        long to = Math.min(from + pageSize, size);
+        return matching.subList((int) from, (int) to);
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.utils.RestUtilities;
 import ai.labs.eddi.utils.RuntimeUtilities;
+import org.jboss.logging.Logger;
 
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
@@ -40,6 +41,8 @@ import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
  * @author ginccc
  */
 public class RestVersionInfo<T> implements IRestVersionInfo {
+    private static final Logger LOGGER = Logger.getLogger(RestVersionInfo.class);
+
     private final String resourceURI;
     private final IResourceStore<T> resourceStore;
     protected final IDocumentDescriptorStore documentDescriptorStore;
@@ -159,9 +162,12 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
      * Creates a new resource and returns the {@link IResourceStore.IResourceId}
      * directly, bypassing the JAX-RS {@link Response} wrapper entirely.
      * <p>
-     * Use this method for in-process callers (CDI direct calls, import service,
-     * duplicate operations) where {@code Response.getLocation()} returns
-     * {@code null} for {@code eddi://} scheme URIs.
+     * For in-process callers (CDI direct calls, import service, duplicate
+     * operations) that want the id and version, not an HTTP envelope to unwrap
+     * again. It is <em>not</em> a workaround for {@code Response.getLocation()}:
+     * that works for {@code eddi://} URIs, as
+     * {@code RestWorkflowStoreCrudTest.duplicateDeepCopyWithParserDictionaries}
+     * demonstrates against the real JAX-RS {@code RuntimeDelegate}.
      *
      * @param document
      *            the resource to create
@@ -186,6 +192,12 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
         // and sharing belong to the resource, so reading an old version of a resource
         // that was since re-shared must not be decided against stale sharing.
         requireViewAccess(id);
+
+        // After the access check, and by the same rule update/delete follow: version 0
+        // means "current". Reading it literally made GET ?version=0 a 404 while
+        // PUT ?version=0 and DELETE ?version=0 acted on the current version, so no
+        // single convention worked across the three verbs.
+        version = validateParameters(id, version);
 
         try {
             return resourceStore.read(id, version);
@@ -230,9 +242,55 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
             } else {
                 resourceStore.delete(id, version);
             }
+            markDescriptorDeleted(id, version);
             return Response.ok().build();
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceModifiedException | IResourceStore.ResourceNotFoundException e) {
             throw sneakyThrow(e);
+        }
+    }
+
+    /**
+     * Flags the resource's descriptor as deleted, here rather than only in
+     * {@code DocumentDescriptorFilter}.
+     *
+     * <p>
+     * That filter is a JAX-RS {@code ContainerResponseFilter}, so it runs for an
+     * HTTP DELETE and for nothing else. Every in-process delete — the agent
+     * cascade, the workflow cascade, the orphan purge — reaches the store through a
+     * direct CDI call and never touched a descriptor, while the store layer itself
+     * (neither {@code deleteAllPermanently} nor {@code HistorizedResourceStore
+     * .delete}) touches one either. The result: a cascade-deleted rule set kept
+     * {@code deleted=false}, so {@code readDescriptors(includeDeleted=false)} still
+     * listed it, opening it answered 404, and the orphan scan kept re-reporting
+     * resources it had already purged. Marking it at this level makes the two paths
+     * converge; the filter then repeats the same idempotent write on the HTTP path.
+     * </p>
+     *
+     * <p>
+     * The descriptor is <em>flagged</em>, never removed, even for
+     * {@code permanent=true}. {@code documentDescriptorStore.deleteAllDescriptor}
+     * would be the tidier cleanup, but on the HTTP path
+     * {@code DocumentDescriptorFilter} runs after this and reads the descriptor
+     * back — a missing row there becomes a {@code NotFoundException}, so erasing it
+     * would answer 404 to a delete that in fact succeeded.
+     * </p>
+     *
+     * <p>
+     * Best-effort by design: the resource IS gone by the time we get here, so a
+     * descriptor that cannot be updated must not turn a completed delete into an
+     * error response.
+     * </p>
+     */
+    private void markDescriptorDeleted(String id, Integer version) {
+        try {
+            DocumentDescriptor descriptor = documentDescriptorStore.readDescriptor(id, version);
+            if (descriptor != null && !descriptor.isDeleted()) {
+                descriptor.setDeleted(true);
+                documentDescriptorStore.setDescriptor(id, version, descriptor);
+            }
+        } catch (Exception e) {
+            LOGGER.warnf("Deleted %s '%s' (v%s) but could not flag its descriptor as deleted: %s", resourceTypeLabel, id, version,
+                    e.getMessage());
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.List;
 
 import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
  * The shared CRUD body behind all fifteen configuration resource types.
@@ -238,14 +239,73 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
 
         try {
             if (permanent) {
+                // A permanent delete is ID-scoped — deleteAllPermanently drops every
+                // version and every history row — while `version` used to be accepted
+                // and then ignored on this branch. That made DELETE ?version=1
+                // &permanent=true from a stale tab erase a resource that is at v2,
+                // with no 409 anywhere, which is precisely the check the soft path
+                // gets for free from HistorizedResourceStore.delete. Refuse the stale
+                // claim before anything is destroyed.
+                requireCurrentVersion(id, version);
                 resourceStore.deleteAllPermanently(id);
+                // Flagged at the DESCRIPTOR's current version, not at the version the
+                // request addressed: descriptors outlive the resource (see below), so
+                // flagging a history row left the current descriptor saying
+                // deleted=false and the listing still showing a resource whose every
+                // version had just been erased.
+                markDescriptorDeleted(id, currentDescriptorVersion(id, version));
             } else {
                 resourceStore.delete(id, version);
+                markDescriptorDeleted(id, version);
             }
-            markDescriptorDeleted(id, version);
             return Response.ok().build();
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceModifiedException | IResourceStore.ResourceNotFoundException e) {
             throw sneakyThrow(e);
+        }
+    }
+
+    /**
+     * Refuses a permanent delete addressed at anything but the resource's live
+     * version.
+     *
+     * <p>
+     * A resource with no live version at all is <em>allowed</em> through: purging
+     * the history left behind by a soft delete is the documented two-step flow, and
+     * there is no current version for the request to be stale against.
+     * </p>
+     *
+     * <p>
+     * Raises the 409 {@link RestUtilities#createConflictException} builds, carrying
+     * the current resource URI, when the resource is live at a different version.
+     * </p>
+     */
+    private void requireCurrentVersion(String id, Integer version) {
+        IResourceStore.IResourceId current;
+        try {
+            current = resourceStore.getCurrentResourceId(id);
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            return;
+        }
+        // A null answer means the same thing the exception does — no live version —
+        // and some store implementations report it that way. Dereferencing it here
+        // would NPE in the middle of a destructive operation.
+        if (current == null || current.getVersion() == null) {
+            return;
+        }
+        if (!current.getVersion().equals(version)) {
+            throw RestUtilities.createConflictException(resourceURI, current);
+        }
+    }
+
+    /**
+     * The version the resource's descriptor currently lives at, falling back to
+     * {@code addressedVersion} when there is no descriptor row to ask.
+     */
+    private Integer currentDescriptorVersion(String id, Integer addressedVersion) {
+        try {
+            return documentDescriptorStore.getCurrentResourceId(id).getVersion();
+        } catch (Exception e) {
+            return addressedVersion;
         }
     }
 
@@ -289,8 +349,11 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
                 documentDescriptorStore.setDescriptor(id, version, descriptor);
             }
         } catch (Exception e) {
-            LOGGER.warnf("Deleted %s '%s' (v%s) but could not flag its descriptor as deleted: %s", resourceTypeLabel, id, version,
-                    e.getMessage());
+            // id is a path parameter and the store message quotes it back, so both are
+            // sanitized before they reach the log: a newline in either would otherwise
+            // forge a log record (CWE-117).
+            LOGGER.warnf("Deleted %s '%s' (v%s) but could not flag its descriptor as deleted: %s", resourceTypeLabel, sanitize(id), version,
+                    sanitize(e.getMessage()));
         }
     }
 

--- a/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
+++ b/src/main/java/ai/labs/eddi/configs/rest/RestVersionInfo.java
@@ -256,7 +256,14 @@ public class RestVersionInfo<T> implements IRestVersionInfo {
                 markDescriptorDeleted(id, currentDescriptorVersion(id, version));
             } else {
                 resourceStore.delete(id, version);
-                markDescriptorDeleted(id, version);
+                // Resolved the same way as the permanent branch, and for the same
+                // reason: descriptor versions advance independently of the resource's
+                // (DocumentDescriptorFilter bumps them on metadata edits), so a
+                // resource at v2 whose descriptor has moved to v4 had its v2 descriptor
+                // row flagged while the CURRENT v4 row stayed deleted=false — the
+                // phantom listing this flagging exists to remove, surviving on the soft
+                // path because only the permanent one resolved the descriptor.
+                markDescriptorDeleted(id, currentDescriptorVersion(id, version));
             }
             return Response.ok().build();
         } catch (IResourceStore.ResourceStoreException | IResourceStore.ResourceModifiedException | IResourceStore.ResourceNotFoundException e) {

--- a/src/main/java/ai/labs/eddi/configs/schema/IJsonSchemaCreator.java
+++ b/src/main/java/ai/labs/eddi/configs/schema/IJsonSchemaCreator.java
@@ -4,6 +4,16 @@
  */
 package ai.labs.eddi.configs.schema;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 public interface IJsonSchemaCreator {
-    String generateSchema(Class<?> clazz) throws Exception;
+
+    /**
+     * The JSON schema for a configuration class.
+     * <p>
+     * Narrowed from {@code throws Exception}: the only checked failure is Jackson
+     * failing to serialize the generated schema, and the blanket declaration forced
+     * every caller through {@code sneakyThrow}.
+     */
+    String generateSchema(Class<?> clazz) throws JsonProcessingException;
 }

--- a/src/main/java/ai/labs/eddi/configs/schema/JsonSchemaCreator.java
+++ b/src/main/java/ai/labs/eddi/configs/schema/JsonSchemaCreator.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.configs.schema;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.*;
 import com.github.victools.jsonschema.module.jackson.JacksonModule;
@@ -11,10 +12,24 @@ import com.github.victools.jsonschema.module.jackson.JacksonOption;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class JsonSchemaCreator implements IJsonSchemaCreator {
     private final ObjectMapper objectMapper;
+
+    /**
+     * A class's JSON schema is a pure function of its (immutable) structure, so it
+     * is computed once per class and kept.
+     * <p>
+     * Every call used to build a fresh JacksonModule, config builder and
+     * SchemaGenerator and then reflect over the whole type graph —
+     * {@code AgentConfiguration} alone has a dozen nested classes — and the Manager
+     * hits {@code GET /{store}/jsonSchema} every time an editor opens, across
+     * fifteen sibling endpoints.
+     */
+    private final Map<Class<?>, String> schemaCache = new ConcurrentHashMap<>();
 
     @Inject
     public JsonSchemaCreator(ObjectMapper objectMapper) {
@@ -22,7 +37,21 @@ public class JsonSchemaCreator implements IJsonSchemaCreator {
     }
 
     @Override
-    public String generateSchema(Class<?> clazz) throws Exception {
+    public String generateSchema(Class<?> clazz) throws JsonProcessingException {
+        String cached = schemaCache.get(clazz);
+        if (cached != null) {
+            return cached;
+        }
+
+        // Generated outside computeIfAbsent: reflecting over a large type graph while
+        // holding a ConcurrentHashMap bin lock would block unrelated schema requests,
+        // and a lost race only means the same schema was built twice.
+        String schema = buildSchema(clazz);
+        String raced = schemaCache.putIfAbsent(clazz, schema);
+        return raced != null ? raced : schema;
+    }
+
+    private String buildSchema(Class<?> clazz) throws JsonProcessingException {
         JacksonModule jacksonModule = new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_ORDER, JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
                 JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE);
 

--- a/src/main/java/ai/labs/eddi/configs/shared/RetryConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/shared/RetryConfiguration.java
@@ -6,10 +6,20 @@ package ai.labs.eddi.configs.shared;
 import ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException;
 
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.exception.NonRetriableException;
+import dev.langchain4j.exception.RetriableException;
+import jakarta.ws.rs.WebApplicationException;
 import org.jboss.logging.Logger;
 
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 /**
  * Shared retry configuration and execution utility.
@@ -21,6 +31,19 @@ import java.util.concurrent.TimeoutException;
  */
 public class RetryConfiguration {
     private static final Logger LOGGER = Logger.getLogger(RetryConfiguration.class);
+
+    /**
+     * Engine-level ceilings on what an agent's {@code retry} block can ask a
+     * pipeline thread to do. Config chooses a policy within these; it does not get
+     * to exceed them.
+     */
+    public static final int MAX_ATTEMPTS_CEILING = 10;
+    static final long MAX_BACKOFF_CEILING_MS = 30_000L;
+    static final long MAX_TOTAL_BACKOFF_MS = 60_000L;
+
+    /** Distinct clamped values already reported; see {@link #warnClamped}. */
+    private static final Set<String> CLAMP_WARNINGS = ConcurrentHashMap.newKeySet();
+    private static final int MAX_CLAMP_WARNINGS = 32;
 
     private Integer maxAttempts = 3;
     private Long backoffDelayMs = 1000L;
@@ -68,6 +91,14 @@ public class RetryConfiguration {
      * {@code maxBackoffDelayMs}. Retryable errors are identified by walking the
      * exception cause chain for known transient error types (timeout, connection,
      * rate limit, HTTP 429/502/503/504).
+     * <p>
+     * Config alone cannot hold a pipeline thread indefinitely: attempts are clamped
+     * to {@value #MAX_ATTEMPTS_CEILING}, one backoff to
+     * {@value #MAX_BACKOFF_CEILING_MS} ms, and the summed backoff of a single call
+     * to {@value #MAX_TOTAL_BACKOFF_MS} ms. Without these, {@code {"maxAttempts":
+     * 50, "maxBackoffDelayMs": 60000}} in one agent's {@code retry} block parked a
+     * worker for the best part of an hour per turn, against AGENTS.md §4.1 rule 5
+     * ("must not block for extended periods").
      *
      * @param action
      *            the action to execute
@@ -90,13 +121,16 @@ public class RetryConfiguration {
             retryConfig = new RetryConfiguration();
         }
 
-        int maxAttempts = retryConfig.getMaxAttempts() != null ? retryConfig.getMaxAttempts() : 3;
+        int maxAttempts = effectiveMaxAttempts(retryConfig);
         long backoffDelay = retryConfig.getBackoffDelayMs() != null ? retryConfig.getBackoffDelayMs() : 1000L;
         double backoffMultiplier = retryConfig.getBackoffMultiplier() != null ? retryConfig.getBackoffMultiplier() : 2.0;
-        long maxBackoffDelay = retryConfig.getMaxBackoffDelayMs() != null ? retryConfig.getMaxBackoffDelayMs() : 10000L;
+        long maxBackoffDelay = effectiveMaxBackoffMs(retryConfig);
 
         int attempt = 0;
-        long currentBackoff = backoffDelay;
+        // Never negative: a negative backoffDelayMs would otherwise reach
+        // Thread.sleep() and throw IllegalArgumentException.
+        long currentBackoff = Math.max(0L, Math.min(backoffDelay, maxBackoffDelay));
+        long totalBackoff = 0L;
         Exception lastException = null;
 
         while (attempt < maxAttempts) {
@@ -107,7 +141,13 @@ public class RetryConfiguration {
 
                 T result = action.call();
 
-                LOGGER.info(actionDescription + " succeeded on attempt " + attempt);
+                // INFO only when a retry actually rescued the call — at INFO for every
+                // success this fired once per LLM and MCP call in production.
+                if (attempt > 1) {
+                    LOGGER.info(actionDescription + " succeeded on attempt " + attempt);
+                } else {
+                    LOGGER.debug(actionDescription + " succeeded on attempt " + attempt);
+                }
                 return result;
 
             } catch (Exception e) {
@@ -122,15 +162,23 @@ public class RetryConfiguration {
 
                 if (attempt < maxAttempts) {
                     if (isRetryableError(e)) {
+                        long sleepFor = budgetedSleep(currentBackoff, totalBackoff);
+                        if (sleepFor < 0) {
+                            LOGGER.warn(actionDescription + " exhausted its " + MAX_TOTAL_BACKOFF_MS
+                                    + "ms retry budget after " + attempt + " attempt(s); giving up");
+                            break;
+                        }
+
                         LOGGER.warn(actionDescription + " failed (attempt " + attempt + "/" + maxAttempts
-                                + "), retrying after " + currentBackoff + "ms: " + e.getMessage());
+                                + "), retrying after " + sleepFor + "ms: " + e.getMessage());
 
                         try {
-                            Thread.sleep(currentBackoff);
+                            Thread.sleep(sleepFor);
                         } catch (InterruptedException ie) {
                             Thread.currentThread().interrupt();
                             throw new LifecycleException("Retry interrupted", ie);
                         }
+                        totalBackoff += sleepFor;
 
                         currentBackoff = Math.min((long) (currentBackoff * backoffMultiplier), maxBackoffDelay);
                     } else {
@@ -143,7 +191,104 @@ public class RetryConfiguration {
             }
         }
 
-        throw new LifecycleException(actionDescription + " failed after " + maxAttempts + " attempts", lastException);
+        // The attempts actually made, not the attempts configured: breaking out on a
+        // spent budget reported "failed after 10 attempts" for a call that made two.
+        throw new LifecycleException(actionDescription + " failed after " + attempt + " attempts", lastException);
+    }
+
+    /**
+     * How long the next retry may sleep, or {@code -1} when the total backoff
+     * budget for this call is spent.
+     *
+     * <p>
+     * The budget is what bounds a whole {@code executeWithRetry} call, and only the
+     * budget: a zero (or negative) {@code backoffDelayMs} is a legitimate "retry
+     * immediately" policy, not an exhausted budget. Deciding both with one
+     * {@code sleepFor <= 0} test conflated them, so {@code {"maxAttempts": 5,
+     * "backoffDelayMs": 0}} broke out of the loop after its FIRST retryable failure
+     * — retries silently off, with a warning blaming a 60s budget that had not been
+     * touched.
+     * </p>
+     *
+     * @param currentBackoff
+     *            the backoff this attempt would like, already clamped to
+     *            {@code maxBackoffDelayMs}
+     * @param totalBackoff
+     *            what this call has already slept
+     * @see #MAX_TOTAL_BACKOFF_MS
+     */
+    static long budgetedSleep(long currentBackoff, long totalBackoff) {
+        long remainingBudget = MAX_TOTAL_BACKOFF_MS - totalBackoff;
+        if (remainingBudget <= 0) {
+            return -1L;
+        }
+        return Math.max(0L, Math.min(currentBackoff, remainingBudget));
+    }
+
+    /**
+     * How many attempts config actually gets, after the engine ceiling.
+     *
+     * @see #MAX_ATTEMPTS_CEILING
+     */
+    static int effectiveMaxAttempts(RetryConfiguration retryConfig) {
+        int configured = retryConfig != null && retryConfig.getMaxAttempts() != null ? retryConfig.getMaxAttempts() : 3;
+        return clampAttempts(configured);
+    }
+
+    /**
+     * The engine ceiling on an attempt count, for retry loops that live outside
+     * {@link #executeWithRetry} — the streaming path runs its own.
+     *
+     * <p>
+     * Public so that ceiling is uniform: while the streaming executor read
+     * {@code getMaxAttempts()} directly, {@code {"maxAttempts": 50}} was clamped on
+     * the tool-loop path and unbounded on the streaming one, for the same agent and
+     * the same config block.
+     * </p>
+     *
+     * @see #MAX_ATTEMPTS_CEILING
+     */
+    public static int clampAttempts(int configured) {
+        if (configured <= MAX_ATTEMPTS_CEILING) {
+            return configured;
+        }
+        warnClamped("maxAttempts", configured, MAX_ATTEMPTS_CEILING);
+        return MAX_ATTEMPTS_CEILING;
+    }
+
+    /**
+     * How long a single backoff may last, after the engine ceiling.
+     *
+     * @see #MAX_BACKOFF_CEILING_MS
+     */
+    static long effectiveMaxBackoffMs(RetryConfiguration retryConfig) {
+        long configured = retryConfig != null && retryConfig.getMaxBackoffDelayMs() != null ? retryConfig.getMaxBackoffDelayMs() : 10000L;
+        if (configured <= MAX_BACKOFF_CEILING_MS) {
+            return configured;
+        }
+        warnClamped("maxBackoffDelayMs", configured, MAX_BACKOFF_CEILING_MS);
+        return MAX_BACKOFF_CEILING_MS;
+    }
+
+    /**
+     * Says once, per distinct clamped value, that a configured retry setting is not
+     * being honoured as written.
+     *
+     * <p>
+     * The ceilings exist to stop one agent's {@code retry} block from parking a
+     * pipeline thread (AGENTS.md §4.1 rule 5), but silently overriding a number an
+     * author deliberately typed is its own trap — an agent set to 20 attempts that
+     * stops at 10 looks like a bug in the engine. Deduplicated because this is on
+     * the path of every LLM and MCP call, and bounded because a log-key set that
+     * grows with config values is a leak of its own.
+     * </p>
+     */
+    private static void warnClamped(String setting, long configured, long ceiling) {
+        String key = setting + "=" + configured;
+        if (CLAMP_WARNINGS.size() < MAX_CLAMP_WARNINGS && CLAMP_WARNINGS.add(key)) {
+            LOGGER.warn("retry." + setting + " is configured as " + configured + " but the engine caps it at " + ceiling
+                    + "; the extra is ignored. Lower the configured value to make the effective policy explicit.");
+        }
     }
 
     /**
@@ -156,7 +301,7 @@ public class RetryConfiguration {
         }
         long baseDelay = retryConfig.getBackoffDelayMs() != null ? retryConfig.getBackoffDelayMs() : 1000L;
         double multiplier = retryConfig.getBackoffMultiplier() != null ? retryConfig.getBackoffMultiplier() : 2.0;
-        long maxDelay = retryConfig.getMaxBackoffDelayMs() != null ? retryConfig.getMaxBackoffDelayMs() : 10000L;
+        long maxDelay = effectiveMaxBackoffMs(retryConfig);
 
         int exponent = Math.max(0, attempt - 1);
         long delay = Math.min((long) (baseDelay * Math.pow(multiplier, exponent)), maxDelay);
@@ -171,41 +316,69 @@ public class RetryConfiguration {
     // ==========================
 
     /**
-     * Determines if an error is retryable by checking:
-     * <ol>
-     * <li>Known exception types (timeout, connection)</li>
-     * <li>HTTP status codes from HttpException or WebApplicationException (429,
-     * 502, 503, 504)</li>
-     * <li>Message string patterns (fallback for wrapped/untyped exceptions)</li>
-     * </ol>
+     * Transient-failure signatures in an exception message — the last resort, for
+     * providers that surface a failure only as prose.
+     * <p>
+     * The union of what the two previous implementations matched.
+     * {@code CascadingModelExecutor} had its own regex that additionally caught
+     * bare status numbers, so the same provider failure was retried on the cascade
+     * path and not on the tool-loop path (or vice versa) depending purely on how
+     * the message happened to be worded. Word boundaries keep {@code 429} from
+     * matching inside an id or a token count.
+     */
+    private static final Pattern RETRYABLE_MESSAGE = Pattern.compile(
+            "timeout|rate limit|too many requests|connection refused|connection reset"
+                    + "|service unavailable|bad gateway|gateway timeout|\\b429\\b|\\b50[234]\\b",
+            Pattern.CASE_INSENSITIVE);
+
+    private static final Set<Integer> RETRYABLE_STATUS_CODES = Set.of(429, 502, 503, 504);
+
+    /**
+     * The single retryable-error verdict for the whole codebase — LLM tool loop,
+     * MCP calls and the model cascade all route here.
+     *
+     * <p>
+     * Order matters. langchain4j's own classification is checked FIRST, because it
+     * is what {@code chatModel.chat()} actually throws and it is authoritative:
+     * {@link RetriableException} (rate limit, provider timeout, 5xx) means retry,
+     * {@link NonRetriableException} (bad request, auth, unknown model) means stop —
+     * and stopping early matters, since a wrapped auth failure whose message merely
+     * mentions a timeout would otherwise be retried until the attempts run out.
+     * Untyped transport exceptions come next, then HTTP status codes, and only then
+     * the message-text fallback.
+     * </p>
      */
     public static boolean isRetryableError(Exception e) {
         Throwable current = e;
 
         while (current != null) {
-            // 1. Typed exception matching
-            if (current instanceof java.net.SocketTimeoutException
+            // 1. langchain4j's typed verdict — authoritative, in both directions
+            if (current instanceof RetriableException) {
+                return true;
+            }
+            if (current instanceof NonRetriableException) {
+                return false;
+            }
+
+            // 2. Untyped transport failures
+            if (current instanceof SocketTimeoutException
                     || current instanceof TimeoutException
-                    || current instanceof java.net.ConnectException
-                    || current instanceof java.net.UnknownHostException) {
+                    || current instanceof ConnectException
+                    || current instanceof UnknownHostException) {
                 return true;
             }
 
-            // 2. HTTP status code matching from typed exceptions
-            if (current instanceof jakarta.ws.rs.WebApplicationException wae) {
-                int status = wae.getResponse().getStatus();
-                if (status == 429 || status == 502 || status == 503 || status == 504) {
-                    return true;
-                }
+            // 3. HTTP status code matching from typed exceptions
+            if (current instanceof HttpException httpException && RETRYABLE_STATUS_CODES.contains(httpException.statusCode())) {
+                return true;
+            }
+            if (current instanceof WebApplicationException wae && RETRYABLE_STATUS_CODES.contains(wae.getResponse().getStatus())) {
+                return true;
             }
 
-            // 3. String-based fallback for wrapped exceptions (conservative matching)
-            String message = current.getMessage() != null ? current.getMessage().toLowerCase() : "";
-
-            if (message.contains("timeout") || message.contains("rate limit") || message.contains("too many requests")
-                    || message.contains("connection refused") || message.contains("connection reset")
-                    || message.contains("service unavailable") || message.contains("bad gateway")
-                    || message.contains("gateway timeout")) {
+            // 4. String-based fallback for wrapped/untyped exceptions
+            String message = current.getMessage();
+            if (message != null && RETRYABLE_MESSAGE.matcher(message).find()) {
                 return true;
             }
 

--- a/src/main/java/ai/labs/eddi/configs/shared/RetryConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/shared/RetryConfiguration.java
@@ -292,10 +292,37 @@ public class RetryConfiguration {
     }
 
     /**
-     * Sleeps for the appropriate backoff duration for the given attempt. Useful for
-     * callers that manage their own retry loop (e.g., streaming).
+     * Sleeps one backoff for the given attempt, with no accumulated budget to
+     * spend. Equivalent to {@code backoff(attempt, retryConfig, 0L)}.
      */
     public static void backoff(int attempt, RetryConfiguration retryConfig) {
+        backoff(attempt, retryConfig, 0L);
+    }
+
+    /**
+     * Sleeps the backoff for {@code attempt}, trimmed to what is left of this
+     * execution's total-backoff budget. For callers that manage their own retry
+     * loop (the streaming executor) rather than going through
+     * {@link #executeWithRetry}.
+     *
+     * <p>
+     * The per-sleep ceiling alone does not bound such a loop, and this method used
+     * to enforce only that: at {@link #MAX_ATTEMPTS_CEILING} attempts with a
+     * configured 30-second delay the streaming path could sleep nine times — 270
+     * seconds of a blocked pipeline thread, against the very
+     * {@value #MAX_TOTAL_BACKOFF_MS} ms budget {@code executeWithRetry} applies to
+     * every other retry loop in the engine. Passing the running total back in is
+     * what makes the two paths agree.
+     * </p>
+     *
+     * @param totalBackoffMs
+     *            what this execution has already slept
+     * @return how long this call actually slept, to be added to
+     *         {@code totalBackoffMs}, or {@code -1} when the budget is spent and
+     *         the caller must stop retrying (nothing was slept)
+     * @see #budgetedSleep(long, long)
+     */
+    public static long backoff(int attempt, RetryConfiguration retryConfig, long totalBackoffMs) {
         if (retryConfig == null) {
             retryConfig = new RetryConfiguration();
         }
@@ -305,11 +332,16 @@ public class RetryConfiguration {
 
         int exponent = Math.max(0, attempt - 1);
         long delay = Math.min((long) (baseDelay * Math.pow(multiplier, exponent)), maxDelay);
+        long sleepFor = budgetedSleep(delay, totalBackoffMs);
+        if (sleepFor < 0) {
+            return -1L;
+        }
         try {
-            Thread.sleep(delay);
+            Thread.sleep(sleepFor);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+        return sleepFor;
     }
 
     // ========================== Retryable Error Detection
@@ -349,17 +381,26 @@ public class RetryConfiguration {
      * </p>
      */
     public static boolean isRetryableError(Exception e) {
-        Throwable current = e;
-
-        while (current != null) {
-            // 1. langchain4j's typed verdict — authoritative, in both directions
+        // Pass 1: langchain4j's typed verdict, over the WHOLE chain, before any
+        // fallback gets a say.
+        //
+        // Running the four signals interleaved down one walk did not implement the
+        // order above — it implemented "outermost exception wins", and the weakest
+        // signal is the one most likely to be present on the outermost wrapper.
+        // new RuntimeException("timeout", new AuthenticationException(...)) matched
+        // the message fallback on the wrapper and returned true, never reaching the
+        // NonRetriableException underneath: precisely the wrapped auth failure this
+        // ordering was written to stop from burning the retry budget.
+        for (Throwable current = e; current != null; current = current.getCause()) {
             if (current instanceof RetriableException) {
                 return true;
             }
             if (current instanceof NonRetriableException) {
                 return false;
             }
+        }
 
+        for (Throwable current = e; current != null; current = current.getCause()) {
             // 2. Untyped transport failures
             if (current instanceof SocketTimeoutException
                     || current instanceof TimeoutException
@@ -381,8 +422,6 @@ public class RetryConfiguration {
             if (message != null && RETRYABLE_MESSAGE.matcher(message).find()) {
                 return true;
             }
-
-            current = current.getCause();
         }
 
         return false;

--- a/src/main/java/ai/labs/eddi/configs/workflows/IRestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/IRestWorkflowStore.java
@@ -50,7 +50,10 @@ public interface IRestWorkflowStore extends IRestVersionInfo {
     @Path("descriptors")
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(operationId = "readWorkflowDescriptorsWithResource", description = "Read list of workflow descriptors including a given resourceUri.")
+    @Operation(operationId = "readWorkflowDescriptorsWithResource", description = "Read list of workflow descriptors including a given resourceUri. "
+            + "filter, index and limit are applied to the result AFTER the reverse-reference lookup, which "
+            + "takes neither. They used to be accepted and ignored, so a client that never paged received the "
+            + "full list; with limit defaulting to 20 such a client now receives at most 20 rows per page.")
     List<DocumentDescriptor> readWorkflowDescriptors(@QueryParam("filter")
     @DefaultValue("") String filter,
                                                      @QueryParam("index")
@@ -104,21 +107,27 @@ public interface IRestWorkflowStore extends IRestVersionInfo {
     @Operation(summary = "Delete package", description = "Delete a workflow configuration. When cascade=true, also deletes extension "
             + "resources referenced by this package: behavior sets, HTTP calls, output sets, "
             + "LLM configs, property setters, and parser dictionaries. " + "Shared resources (used by other packages) are skipped. "
-            + "Partial failures are logged but do not prevent the workflow from being deleted.")
+            + "Partial failures are logged but do not prevent the workflow from being deleted. "
+            + "With cascade=true the version must be the workflow's current one, otherwise the request is "
+            + "refused with 409 before anything is deleted.")
     @APIResponse(responseCode = "200", description = "Workflow deleted successfully.")
     @APIResponse(responseCode = "404", description = "Workflow not found.")
+    @APIResponse(responseCode = "409", description = "cascade=true against a version that is not the current one; nothing was deleted.")
     // @formatter:off
     Response deleteWorkflow(@PathParam("id") String id,
             @Parameter(name = "version", required = true, example = "1",
-                    description = "Version of the workflow to delete.")
+                    description = "Version of the workflow to delete. 0 means the current version.")
             @QueryParam("version") Integer version,
-            @Parameter(description = "If true, permanently remove from database. "
-                    + "If false (default), soft-delete only.")
+            @Parameter(description = "If true, permanently remove this workflow from the database. "
+                    + "If false (default), soft-delete only. It never applies to cascaded resources — "
+                    + "see cascade.")
             @QueryParam("permanent") @DefaultValue("false") Boolean permanent,
             @Parameter(description = "If true, also delete all extension resources "
                     + "referenced by this package (behavior, httpcalls, "
                     + "output, langchain, propertysetter, parser "
-                    + "dictionaries).")
+                    + "dictionaries). Extensions still referenced by another workflow are skipped, and "
+                    + "cascaded resources are always soft-deleted even when permanent=true, so an "
+                    + "extension shared at a different pinned version can be recovered.")
             @QueryParam("cascade") @DefaultValue("false") Boolean cascade);
     // @formatter:on
 }

--- a/src/main/java/ai/labs/eddi/configs/workflows/IRestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/IRestWorkflowStore.java
@@ -107,27 +107,35 @@ public interface IRestWorkflowStore extends IRestVersionInfo {
     @Operation(summary = "Delete package", description = "Delete a workflow configuration. When cascade=true, also deletes extension "
             + "resources referenced by this package: behavior sets, HTTP calls, output sets, "
             + "LLM configs, property setters, and parser dictionaries. " + "Shared resources (used by other packages) are skipped. "
+            + "A step's reference is version-pinned and routinely names an older version than the one that exists; "
+            + "the cascade resolves every reference to the resource's CURRENT version before deciding, and both the "
+            + "'is anyone else using this?' check and the delete are made against that same version. "
+            + "Resources the cascade left alone — still referenced, not routable, or a delete that failed — are counted "
+            + "in the X-Cascade-Skipped response header, which is absent when nothing was skipped. "
             + "Partial failures are logged but do not prevent the workflow from being deleted. "
-            + "With cascade=true the version must be the workflow's current one, otherwise the request is "
-            + "refused with 409 before anything is deleted.")
+            + "The version must be the workflow's current one whenever cascade=true or permanent=true, otherwise the "
+            + "request is refused with 409 before anything is deleted. An already soft-deleted workflow has no current "
+            + "version to be stale against: permanent=true still purges its history, and the cascade is skipped rather "
+            + "than refused.")
     @APIResponse(responseCode = "200", description = "Workflow deleted successfully.")
     @APIResponse(responseCode = "404", description = "Workflow not found.")
-    @APIResponse(responseCode = "409", description = "cascade=true against a version that is not the current one; nothing was deleted.")
+    @APIResponse(responseCode = "409",
+                 description = "cascade=true or permanent=true against a version that is not the current one; nothing was deleted.")
     // @formatter:off
     Response deleteWorkflow(@PathParam("id") String id,
             @Parameter(name = "version", required = true, example = "1",
                     description = "Version of the workflow to delete. 0 means the current version.")
             @QueryParam("version") Integer version,
-            @Parameter(description = "If true, permanently remove this workflow from the database. "
-                    + "If false (default), soft-delete only. It never applies to cascaded resources — "
-                    + "see cascade.")
+            @Parameter(description = "If true, permanently remove this workflow from the database — every version and "
+                    + "every history row, so the version given must be the current one or the request is refused with "
+                    + "409. If false (default), soft-delete only. It never applies to cascaded resources — see cascade.")
             @QueryParam("permanent") @DefaultValue("false") Boolean permanent,
             @Parameter(description = "If true, also delete all extension resources "
                     + "referenced by this package (behavior, httpcalls, "
                     + "output, langchain, propertysetter, parser "
-                    + "dictionaries). Extensions still referenced by another workflow are skipped, and "
-                    + "cascaded resources are always soft-deleted even when permanent=true, so an "
-                    + "extension shared at a different pinned version can be recovered.")
+                    + "dictionaries), each at its own current version. Extensions still referenced by another workflow "
+                    + "are skipped, and cascaded resources are always soft-deleted even when permanent=true, so an "
+                    + "extension shared at a different pinned version can be recovered. See X-Cascade-Skipped.")
             @QueryParam("cascade") @DefaultValue("false") Boolean cascade);
     // @formatter:on
 }

--- a/src/main/java/ai/labs/eddi/configs/workflows/model/WorkflowConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/model/WorkflowConfiguration.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.configs.workflows.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+
 import java.net.URI;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -58,7 +60,7 @@ public class WorkflowConfiguration {
     // schemas (ZIP files / MongoDB)
     // where the property was natively named "workflowExtensions" instead of
     // "workflowSteps".
-    @com.fasterxml.jackson.annotation.JsonAlias("workflowExtensions")
+    @JsonAlias("workflowExtensions")
     public void setWorkflowSteps(List<WorkflowStep> workflowSteps) {
         this.workflowSteps = workflowSteps;
     }

--- a/src/main/java/ai/labs/eddi/configs/workflows/model/WorkflowConfiguration.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/model/WorkflowConfiguration.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import com.fasterxml.jackson.annotation.JsonAlias;
 
 /**
  * @author ginccc

--- a/src/main/java/ai/labs/eddi/configs/workflows/mongo/WorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/mongo/WorkflowStore.java
@@ -17,6 +17,7 @@ import ai.labs.eddi.utils.RuntimeUtilities;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.net.URI;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -42,6 +43,7 @@ public class WorkflowStore extends AbstractResourceStore<WorkflowConfiguration> 
      */
     public static final String WORKFLOW_EXTENSIONS_CONFIG_URI_FIELD = "workflowSteps.config.uri";
     public static final String WORKFLOW_EXTENSIONS_DICTIONARIES_CONFIG_URI_FIELD = "workflowSteps.extensions.dictionaries.config.uri";
+    private static final String VERSION_QUERY_PARAM = "?version=";
 
     private final IDocumentDescriptorStore documentDescriptorStore;
 
@@ -72,9 +74,20 @@ public class WorkflowStore extends AbstractResourceStore<WorkflowConfiguration> 
 
         List<DocumentDescriptor> ret = new LinkedList<>();
 
-        int startIndexVersion = resourceURI.lastIndexOf("=") + 1;
-        var version = Integer.parseInt(resourceURI.substring(startIndexVersion));
-        var resourceURIPart = resourceURI.substring(0, startIndexVersion);
+        // Parsed, not scraped. The previous "everything after the last '='" split
+        // threw NumberFormatException — undeclared by this interface — for any URI
+        // without a version query or with a second query parameter, and callers such
+        // as RestWorkflowStore.deleteResourceSafely feed step config.uri values in
+        // verbatim. There the throw is caught and logged as "reference check failed",
+        // so one unversioned reference turned cascade cleanup into a permanent no-op.
+        URI parsedResourceUri = parseResourceUri(resourceURI);
+        String resourceURIPart = RestUtilities.pathWithoutVersionQuery(parsedResourceUri);
+        Integer version = resourceURIPart == null ? null : RestUtilities.extractResourceId(parsedResourceUri).getVersion();
+        if (resourceURIPart == null || version == null || version < 1) {
+            throw new IResourceStore.ResourceStoreException(
+                    "Reverse lookup requires a versioned resource URI ('...?version=<n>' with n >= 1), got: " + resourceURI);
+        }
+        resourceURIPart = resourceURIPart + VERSION_QUERY_PARAM;
 
         do {
             resourceURI = resourceURIPart + version;
@@ -96,7 +109,7 @@ public class WorkflowStore extends AbstractResourceStore<WorkflowConfiguration> 
             allIds = allIds.stream().sorted(comparator).collect(Collectors.toList());
 
             for (IResourceStore.IResourceId workflowId : allIds) {
-                if (workflowId.getVersion() < getCurrentResourceId(workflowId.getId()).getVersion()) {
+                if (isStaleReference(workflowId.getId(), workflowId.getVersion())) {
                     continue;
                 }
 
@@ -120,5 +133,21 @@ public class WorkflowStore extends AbstractResourceStore<WorkflowConfiguration> 
         } while (includePreviousVersions && version >= 1);
 
         return ret;
+    }
+
+    /**
+     * {@code URI.create} on a caller-supplied string, with its unchecked
+     * {@link IllegalArgumentException} turned into {@code null} so the single
+     * validation branch above reports every malformed input the same way.
+     */
+    private static URI parseResourceUri(String resourceURI) {
+        if (resourceURI == null || resourceURI.isBlank()) {
+            return null;
+        }
+        try {
+            return URI.create(resourceURI);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
@@ -91,7 +91,7 @@ public class RestWorkflowStore implements IRestWorkflowStore {
                                                             Boolean includePreviousVersions) {
 
         if (validateUri(containingResourceUri) == null) {
-            return createMalFormattedResourceUriException(containingResourceUri);
+            throw malformedResourceUri(containingResourceUri);
         }
 
         try {
@@ -102,7 +102,14 @@ public class RestWorkflowStore implements IRestWorkflowStore {
             // with the full descriptor payload. The page can come back short; that is the
             // right trade for a diagnostic listing bounded by how many things reference
             // one resource.
-            return visibleOnly(workflowStore.getWorkflowDescriptorsContainingResource(containingResourceUri, includePreviousVersions));
+            //
+            // filter/index/limit are applied here for the same reason, and used to be
+            // accepted and then dropped: paging clients got the whole list back on every
+            // page, and a resource referenced by thousands of workflows returned all of
+            // them at once.
+            return filterAndPage(
+                    visibleOnly(workflowStore.getWorkflowDescriptorsContainingResource(containingResourceUri, includePreviousVersions)), filter,
+                    index, limit);
         } catch (IResourceStore.ResourceNotFoundException | IResourceStore.ResourceStoreException e) {
             throw sneakyThrow(e);
         }
@@ -139,14 +146,24 @@ public class RestWorkflowStore implements IRestWorkflowStore {
                 updated = true;
             }
 
+            // Pattern-matched rather than blind-cast (as RestOrphanAdmin already walks
+            // the same shape). A stored step with "extensions": null, or an extension
+            // value that is an object rather than an array, turned this endpoint into a
+            // 500 — and this is the endpoint the re-point cascade walks for every config
+            // edit, so one malformed step blocked re-pointing the whole workflow.
             Map<String, Object> extensions = workflowStep.getExtensions();
-            for (String extensionKey : extensions.keySet()) {
-                @SuppressWarnings("unchecked")
-                var extensionElements = (List<Map<String, Object>>) extensions.get(extensionKey);
-                for (Map<String, Object> extensionElement : extensionElements) {
-                    if (extensionElement.containsKey(KEY_CONFIG)) {
+            if (extensions == null) {
+                continue;
+            }
+            for (Object extensionValue : extensions.values()) {
+                if (!(extensionValue instanceof List<?> extensionElements)) {
+                    continue;
+                }
+                for (Object extensionElement : extensionElements) {
+                    if (extensionElement instanceof Map<?, ?> elementMap
+                            && elementMap.get(KEY_CONFIG) instanceof Map<?, ?> configMap) {
                         @SuppressWarnings("unchecked")
-                        var config = (Map<String, Object>) extensionElement.get(KEY_CONFIG);
+                        var config = (Map<String, Object>) configMap;
                         if (updateResourceURI(resourceURI, resourceURIWithoutVersion, config)) {
                             updated = true;
                         }
@@ -164,13 +181,16 @@ public class RestWorkflowStore implements IRestWorkflowStore {
     }
 
     private boolean updateResourceURI(URI resourceURI, String resourceURIWithoutVersion, Map<String, Object> config) {
-        if (config.containsKey(KEY_URI)) {
-            Object uri = config.get(KEY_URI);
-            if (uri.toString().startsWith(resourceURIWithoutVersion)) {
-                // found resource URI to update
-                config.put(KEY_URI, resourceURI);
-                return true;
-            }
+        // Null-tolerant on both sides: a step may have no config at all, and a
+        // present-but-null "uri" (JSON `"uri": null`) used to NPE on uri.toString().
+        if (config == null) {
+            return false;
+        }
+        Object uri = config.get(KEY_URI);
+        if (uri != null && uri.toString().startsWith(resourceURIWithoutVersion)) {
+            // found resource URI to update
+            config.put(KEY_URI, resourceURI);
+            return true;
         }
 
         return false;
@@ -186,14 +206,20 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         // Before the cascade, not after: restVersionInfo.delete() checks at the end,
         // by which point the referenced resources would already be gone.
         restVersionInfo.requireOwnAccess(id);
-        if (cascade) {
+
+        // '0' means current, and resolving it here rather than only inside
+        // restVersionInfo.delete() is what makes ?version=0&cascade=true cascade at
+        // all — the read below would otherwise match nothing and skip silently.
+        version = restVersionInfo.validateParameters(id, version);
+
+        if (cascade && isCurrentVersion(id, version)) {
             try {
                 WorkflowConfiguration workflowConfig = workflowStore.read(id, version);
                 for (var workflowStep : workflowConfig.getWorkflowSteps()) {
                     // Delete parser dictionaries
                     URI type = workflowStep.getType();
                     if (type != null && "ai.labs.parser".equals(type.getHost())) {
-                        deleteParserDictionaries(workflowStep, permanent);
+                        deleteParserDictionaries(workflowStep);
                     }
 
                     // Delete main extension resource (via config.uri)
@@ -201,7 +227,7 @@ public class RestWorkflowStore implements IRestWorkflowStore {
                     if (!isNullOrEmpty(config)) {
                         Object resourceUriObj = config.get(KEY_URI);
                         if (!isNullOrEmpty(resourceUriObj)) {
-                            deleteResourceSafely(URI.create(resourceUriObj.toString()), permanent);
+                            deleteResourceSafely(URI.create(resourceUriObj.toString()));
                         }
                     }
                 }
@@ -214,9 +240,48 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         return restVersionInfo.delete(id, version, permanent);
     }
 
+    /**
+     * Whether {@code version} is the workflow's live version, i.e. whether a
+     * cascade addressed at it may run.
+     *
+     * <p>
+     * Same ordering hazard as the agent store: {@code workflowStore.read} falls
+     * back to history, so a stale version's extension resources were torn down
+     * before {@code restVersionInfo.delete()} rejected the request. Refuse first,
+     * touch nothing.
+     * </p>
+     *
+     * @return true when the versions match; false when the workflow has no live
+     *         version (already soft-deleted), so a {@code permanent=true} purge of
+     *         the remaining history still works
+     */
+    private boolean isCurrentVersion(String id, Integer version) {
+        IResourceStore.IResourceId current;
+        try {
+            current = workflowStore.getCurrentResourceId(id);
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            // Already soft-deleted: no live version to protect, so skip the cascade
+            // and let the delete below purge whatever history is left.
+            return false;
+        }
+
+        if (!current.getVersion().equals(version)) {
+            throw RestUtilities.createConflictException(resourceURI, current);
+        }
+        return true;
+    }
+
     @SuppressWarnings("unchecked")
-    private void deleteParserDictionaries(WorkflowStep workflowStep, boolean permanent) {
-        var dictionaries = (List<Map<String, Object>>) workflowStep.getExtensions().get("dictionaries");
+    private void deleteParserDictionaries(WorkflowStep workflowStep) {
+        // A parser step with no extensions block at all is legal stored data (Jackson
+        // leaves it null for an absent or explicitly null "extensions"). This runs on
+        // the destructive cascade, where an NPE aborts it mid-way — after some
+        // resources have already been deleted — so the step is skipped, not thrown on.
+        Map<String, Object> extensions = workflowStep.getExtensions();
+        if (extensions == null) {
+            return;
+        }
+        var dictionaries = (List<Map<String, Object>>) extensions.get("dictionaries");
         if (!isNullOrEmpty(dictionaries)) {
             for (var dictionary : dictionaries) {
                 var dictType = dictionary.get("type");
@@ -225,7 +290,7 @@ public class RestWorkflowStore implements IRestWorkflowStore {
                     if (!isNullOrEmpty(config)) {
                         Object dictionaryUriObj = config.get(KEY_URI);
                         if (!isNullOrEmpty(dictionaryUriObj)) {
-                            deleteResourceSafely(URI.create(dictionaryUriObj.toString()), permanent);
+                            deleteResourceSafely(URI.create(dictionaryUriObj.toString()));
                         }
                     }
                 }
@@ -233,7 +298,21 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         }
     }
 
-    private void deleteResourceSafely(URI resourceUri, boolean permanent) {
+    /**
+     * Soft-deletes a referenced resource, if nothing else still references it.
+     *
+     * <p>
+     * The cascade never deletes permanently, whatever the request asked for. The
+     * guard below is VERSION-scoped — it asks who references
+     * {@code R?version=<pinned>} — while a permanent delete is ID-scoped:
+     * {@code deleteAllPermanently} drops every version and every history row. A
+     * workflow pinning a different version of the same rule set is invisible to the
+     * guard and would lose it outright, unrecoverably. Soft-deleting the pinned
+     * version keeps guard and effect on the same scope; erasing a shared resource
+     * stays an explicit, non-cascading request against that resource.
+     * </p>
+     */
+    private void deleteResourceSafely(URI resourceUri) {
         List<DocumentDescriptor> referencingWorkflows;
         try {
             // Is this resource still referenced by other workflows?
@@ -263,7 +342,7 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         }
 
         try {
-            resourceClientLibrary.deleteResource(resourceUri, permanent);
+            resourceClientLibrary.deleteResource(resourceUri, false);
             log.infof("Cascade-deleted resource %s", resourceUri);
         } catch (Exception e) {
             log.warnf("Failed to cascade-delete resource %s: %s", resourceUri, e.getMessage());
@@ -273,13 +352,21 @@ public class RestWorkflowStore implements IRestWorkflowStore {
     @Override
     public Response duplicateWorkflow(String id, Integer version, Boolean deepCopy) {
         restVersionInfo.requireViewAccess(id);
-        restVersionInfo.validateParameters(id, version);
+        // Keep the normalised version — validateParameters maps 0 -> current, and
+        // discarding it left workflowStore.read(id, 0) matching nothing, so the
+        // documented '0 means current' shorthand 404'd here while PUT and DELETE
+        // honoured it.
+        version = restVersionInfo.validateParameters(id, version);
         try {
             WorkflowConfiguration workflowConfig = workflowStore.read(id, version);
             if (deepCopy) {
                 for (var workflowStep : workflowConfig.getWorkflowSteps()) {
+                    // Guarded exactly as deleteWorkflow guards it: a stored step without a
+                    // type is accepted by WorkflowStore.create, and an unguarded getHost()
+                    // made ?deepCopy=true a bare NPE/500 — after sub-resources earlier in
+                    // the loop had already been created and persisted.
                     URI type = workflowStep.getType();
-                    if ("ai.labs.parser".equals(type.getHost())) {
+                    if (type != null && "ai.labs.parser".equals(type.getHost())) {
                         duplicateDictionaryInParser(workflowStep);
                     }
 
@@ -294,8 +381,12 @@ public class RestWorkflowStore implements IRestWorkflowStore {
                 }
             }
 
-            // Use createDocument() — bypasses broken Response.getLocation() for eddi://
-            // URIs
+            // createDocument() because the id and version are what this method needs;
+            // wrapping them in a Response only to unwrap it again would be the detour.
+            // NOT because Response.getLocation() is broken for eddi:// URIs — it is not,
+            // and duplicateResource() below depends on it working
+            // (RestWorkflowStoreCrudTest.duplicateDeepCopyWithParserDictionaries pins
+            // that with the real JAX-RS RuntimeDelegate).
             IResourceStore.IResourceId resourceId = restVersionInfo.createDocument(workflowConfig);
             URI createdUri = RestUtilities.createURI(resourceURI, resourceId.getId(), versionQueryParam, resourceId.getVersion());
             createDocumentDescriptorForDuplicate(documentDescriptorStore, resourceAccessGuard, id, version, createdUri);
@@ -309,12 +400,24 @@ public class RestWorkflowStore implements IRestWorkflowStore {
     }
 
     private void duplicateDictionaryInParser(WorkflowStep workflowStep) throws ServiceException {
-        URI type;
+        // Same guard as deleteParserDictionaries: a stored parser step may carry no
+        // extensions block at all, and a deep copy that NPEs leaves the sub-resources
+        // it already created behind.
+        Map<String, Object> extensions = workflowStep.getExtensions();
+        if (extensions == null) {
+            return;
+        }
         @SuppressWarnings("unchecked")
-        var dictionaries = (List<Map<String, Object>>) workflowStep.getExtensions().get("dictionaries");
+        var dictionaries = (List<Map<String, Object>>) extensions.get("dictionaries");
         if (!isNullOrEmpty(dictionaries)) {
             for (var dictionary : dictionaries) {
-                type = URI.create(dictionary.get("type").toString());
+                // Same null guard as deleteParserDictionaries — the two walked the same
+                // stored shape but disagreed about whether "type" may be absent.
+                var dictTypeObj = dictionary.get("type");
+                if (dictTypeObj == null) {
+                    continue;
+                }
+                URI type = URI.create(dictTypeObj.toString());
                 if ("ai.labs.parser.dictionaries.regular".equals(type.getHost())) {
                     @SuppressWarnings("unchecked")
                     var config = (Map<String, URI>) dictionary.get("config");
@@ -350,7 +453,8 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         }
 
         if (isNullOrEmpty(newResourceLocation)) {
-            String errorMsg = String.format("New resource for %s could not be created. " + "Mission Location Header.", resourceUriObj);
+            String errorMsg = String.format("New resource for %s could not be created: the duplicate response carried no Location header.",
+                    resourceUriObj);
             throw new ServiceException(errorMsg);
         }
 

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
@@ -238,6 +238,10 @@ public class RestWorkflowStore implements IRestWorkflowStore {
 
         int skipped = plan.skipped();
         for (URI candidate : plan.toDelete()) {
+            if (stillReferencedAfterParentDelete(candidate)) {
+                skipped++;
+                continue;
+            }
             if (!deleteCascadedResource(candidate)) {
                 skipped++;
             }
@@ -471,6 +475,54 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         String raw = resourceUri.toString();
         int queryStart = raw.indexOf('?');
         return URI.create((queryStart >= 0 ? raw.substring(0, queryStart) : raw) + versionQueryParam + version);
+    }
+
+    /**
+     * Re-asks "is anyone still using this?" immediately before the irreversible
+     * child delete.
+     *
+     * <p>
+     * {@link #planCascade} answers that question BEFORE the parent workflow is
+     * deleted — it has to, so the parent still counts among the referrers — and a
+     * workflow created, or re-pointed at this resource, in the window between the
+     * two would then have its newly shared configuration soft-deleted underneath
+     * it. The parent is gone by the time this runs, so the honest expectation here
+     * is ZERO referrers, not the {@code > 1} the plan phase used: the reverse
+     * lookup drops a soft-deleted or erased referrer (see
+     * {@code AbstractResourceStore.isStaleReference}).
+     * </p>
+     *
+     * <p>
+     * This narrows the window to the instants between this query and the delete; it
+     * does not close it. Closing it needs a deployment-wide lock over reference
+     * writes, which would serialise configuration editing against every cascade.
+     * </p>
+     *
+     * <p>
+     * FAILS CLOSED, like the plan-phase check it repeats: a lookup that throws or
+     * answers null has told us nothing, and "nothing" is not a licence to delete.
+     * </p>
+     *
+     * @return true when the resource must NOT be deleted
+     */
+    private boolean stillReferencedAfterParentDelete(URI currentUri) {
+        List<DocumentDescriptor> referencingWorkflows;
+        try {
+            referencingWorkflows = workflowStore.getWorkflowDescriptorsContainingResource(currentUri.toString(), true);
+        } catch (Exception e) {
+            log.errorf(e, "Re-check of %s after the workflow delete failed — NOT cascade-deleting it", currentUri);
+            return true;
+        }
+        if (referencingWorkflows == null) {
+            log.warnf("Re-check of %s after the workflow delete returned no answer — NOT cascade-deleting it", currentUri);
+            return true;
+        }
+        if (!referencingWorkflows.isEmpty()) {
+            log.infof("Skipping cascade-delete of %s — it became referenced by %d workflow(s) after the cascade was planned",
+                    currentUri, referencingWorkflows.size());
+            return true;
+        }
+        return false;
     }
 
     /** @return true when the resource was actually deleted */

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
@@ -36,6 +36,7 @@ import static ai.labs.eddi.configs.descriptors.ResourceUtilities.*;
 import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
 import static ai.labs.eddi.utils.RuntimeUtilities.isNullOrEmpty;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 @ApplicationScoped
 public class RestWorkflowStore implements IRestWorkflowStore {
@@ -341,9 +342,9 @@ public class RestWorkflowStore implements IRestWorkflowStore {
                 }
             }
         } catch (IResourceStore.ResourceNotFoundException e) {
-            log.warnf("Workflow %s (v%d) not found for cascade — deleting workflow only", id, version);
+            log.warnf("Workflow %s (v%d) not found for cascade — deleting workflow only", sanitize(id), version);
         } catch (IResourceStore.ResourceStoreException e) {
-            log.warnf("Error reading workflow %s for cascade: %s", id, e.getMessage());
+            log.warnf("Error reading workflow %s for cascade: %s", sanitize(id), sanitize(e.getMessage()));
         }
         return new CascadePlan(toDelete, skipped[0]);
     }

--- a/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
+++ b/src/main/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStore.java
@@ -26,8 +26,11 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static ai.labs.eddi.configs.descriptors.ResourceUtilities.*;
 import static ai.labs.eddi.engine.exception.SneakyThrow.sneakyThrow;
@@ -38,6 +41,15 @@ import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 public class RestWorkflowStore implements IRestWorkflowStore {
     private static final String KEY_CONFIG = "config";
     private static final String KEY_URI = "uri";
+    private static final String KEY_TYPE = "type";
+    private static final String KEY_DICTIONARIES = "dictionaries";
+    private static final String DICTIONARY_TYPE_HOST = "ai.labs.parser.dictionaries.regular";
+    /**
+     * How many resources a cascade deliberately did not delete (still referenced,
+     * not routable, or the delete itself failed). Absent when the cascade removed
+     * everything it walked.
+     */
+    private static final String CASCADE_SKIPPED_HEADER = "X-Cascade-Skipped";
     private final IWorkflowStore workflowStore;
     private final ResourceClientLibrary resourceClientLibrary;
     private final IJsonSchemaCreator jsonSchemaCreator;
@@ -212,32 +224,31 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         // all — the read below would otherwise match nothing and skip silently.
         version = restVersionInfo.validateParameters(id, version);
 
-        if (cascade && isCurrentVersion(id, version)) {
-            try {
-                WorkflowConfiguration workflowConfig = workflowStore.read(id, version);
-                for (var workflowStep : workflowConfig.getWorkflowSteps()) {
-                    // Delete parser dictionaries
-                    URI type = workflowStep.getType();
-                    if (type != null && "ai.labs.parser".equals(type.getHost())) {
-                        deleteParserDictionaries(workflowStep);
-                    }
+        CascadePlan plan = cascade && isCurrentVersion(id, version) ? planCascade(id, version) : CascadePlan.empty();
 
-                    // Delete main extension resource (via config.uri)
-                    Map<String, Object> config = workflowStep.getConfig();
-                    if (!isNullOrEmpty(config)) {
-                        Object resourceUriObj = config.get(KEY_URI);
-                        if (!isNullOrEmpty(resourceUriObj)) {
-                            deleteResourceSafely(URI.create(resourceUriObj.toString()));
-                        }
-                    }
-                }
-            } catch (IResourceStore.ResourceNotFoundException e) {
-                log.warnf("Workflow %s (v%d) not found for cascade — deleting workflow only", id, version);
-            } catch (IResourceStore.ResourceStoreException e) {
-                log.warnf("Error reading workflow %s for cascade: %s", id, e.getMessage());
+        // The workflow itself is deleted FIRST, its referenced resources only once
+        // that succeeded. isCurrentVersion() above is a check-then-act: a concurrent
+        // update committing between it and the delete left the extension resources
+        // torn down while the delete answered 409 for a stale version — the exact
+        // destructive outcome the version check exists to prevent. The store's own
+        // delete is version-checked (HistorizedResourceStore.delete raises
+        // ResourceModifiedException), so a workflow that moved on in the meantime
+        // now raises before anything it references has been touched.
+        Response response = restVersionInfo.delete(id, version, permanent);
+
+        int skipped = plan.skipped();
+        for (URI candidate : plan.toDelete()) {
+            if (!deleteCascadedResource(candidate)) {
+                skipped++;
             }
         }
-        return restVersionInfo.delete(id, version, permanent);
+        if (skipped > 0) {
+            // The operator's only feedback is this response: a cascade that skipped
+            // half the graph used to answer exactly like one that deleted all of it,
+            // with the difference visible only in the server log.
+            return Response.fromResponse(response).header(CASCADE_SKIPPED_HEADER, skipped).build();
+        }
+        return response;
     }
 
     /**
@@ -245,9 +256,9 @@ public class RestWorkflowStore implements IRestWorkflowStore {
      * cascade addressed at it may run.
      *
      * <p>
-     * Same ordering hazard as the agent store: {@code workflowStore.read} falls
-     * back to history, so a stale version's extension resources were torn down
-     * before {@code restVersionInfo.delete()} rejected the request. Refuse first,
+     * {@code workflowStore.read} falls back to history, so without this a stale
+     * version's extension resources were collected and deleted for a request that
+     * {@code restVersionInfo.delete()} was going to reject anyway. Refuse first,
      * touch nothing.
      * </p>
      *
@@ -271,52 +282,160 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         return true;
     }
 
-    @SuppressWarnings("unchecked")
-    private void deleteParserDictionaries(WorkflowStep workflowStep) {
-        // A parser step with no extensions block at all is legal stored data (Jackson
-        // leaves it null for an absent or explicitly null "extensions"). This runs on
-        // the destructive cascade, where an NPE aborts it mid-way — after some
-        // resources have already been deleted — so the step is skipped, not thrown on.
-        Map<String, Object> extensions = workflowStep.getExtensions();
-        if (extensions == null) {
-            return;
+    /**
+     * What a cascade will delete, and how many referenced resources it decided to
+     * leave alone.
+     *
+     * <p>
+     * {@code toDelete} is a SET, and deliberately: two workflow steps may name the
+     * same resource (two httpcalls steps on one apicalls config is ordinary), and
+     * the second delete of one resource finds it already soft-deleted,
+     * {@code HistorizedResourceStore.delete} raises
+     * {@code ResourceNotFoundException}, and the delete loop counted that as a
+     * skip. A cascade that removed everything it walked then answered
+     * {@code X-Cascade-Skipped: 1} — the header exists to stop the response lying
+     * about the cascade, so it must not lie the other way either.
+     * </p>
+     */
+    private record CascadePlan(Collection<URI> toDelete, int skipped) {
+        static CascadePlan empty() {
+            return new CascadePlan(Set.of(), 0);
         }
-        var dictionaries = (List<Map<String, Object>>) extensions.get("dictionaries");
-        if (!isNullOrEmpty(dictionaries)) {
-            for (var dictionary : dictionaries) {
-                var dictType = dictionary.get("type");
-                if (dictType != null && "ai.labs.parser.dictionaries.regular".equals(URI.create(dictType.toString()).getHost())) {
-                    var config = (Map<String, Object>) dictionary.get("config");
-                    if (!isNullOrEmpty(config)) {
-                        Object dictionaryUriObj = config.get(KEY_URI);
-                        if (!isNullOrEmpty(dictionaryUriObj)) {
-                            deleteResourceSafely(URI.create(dictionaryUriObj.toString()));
-                        }
+    }
+
+    /**
+     * Decides — before anything is deleted — which of this workflow's referenced
+     * resources the cascade may remove.
+     *
+     * <p>
+     * Deciding and deleting are separate steps so that the reference guard still
+     * counts this workflow among the referrers (hence {@code > 1} below) while the
+     * workflow is deleted first; see {@link #deleteWorkflow}.
+     * </p>
+     */
+    private CascadePlan planCascade(String id, Integer version) {
+        // LinkedHashSet: de-duplicated (see CascadePlan) while keeping the traversal
+        // order, so the delete order stays the workflow's own step order.
+        Set<URI> toDelete = new LinkedHashSet<>();
+        int[] skipped = {0};
+        try {
+            WorkflowConfiguration workflowConfig = workflowStore.read(id, version);
+            for (var workflowStep : workflowConfig.getWorkflowSteps()) {
+                // Parser dictionaries
+                URI type = workflowStep.getType();
+                if (type != null && "ai.labs.parser".equals(type.getHost())) {
+                    collectParserDictionaries(workflowStep, toDelete, skipped);
+                }
+
+                // Main extension resource (via config.uri)
+                Map<String, Object> config = workflowStep.getConfig();
+                if (!isNullOrEmpty(config)) {
+                    Object resourceUriObj = config.get(KEY_URI);
+                    if (!isNullOrEmpty(resourceUriObj)) {
+                        collectCascadeCandidate(URI.create(resourceUriObj.toString()), toDelete, skipped);
                     }
                 }
+            }
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            log.warnf("Workflow %s (v%d) not found for cascade — deleting workflow only", id, version);
+        } catch (IResourceStore.ResourceStoreException e) {
+            log.warnf("Error reading workflow %s for cascade: %s", id, e.getMessage());
+        }
+        return new CascadePlan(toDelete, skipped[0]);
+    }
+
+    private void collectParserDictionaries(WorkflowStep workflowStep, Set<URI> toDelete, int[] skipped) {
+        // A parser step with no extensions block at all is legal stored data (Jackson
+        // leaves it null for an absent or explicitly null "extensions"). This runs on
+        // the destructive cascade, where an exception aborts it mid-way — after some
+        // resources have already been deleted — so a step that does not have the
+        // expected shape is skipped, not thrown on. Pattern-matched rather than
+        // cast for exactly that reason: a stored '"dictionaries": {}' or a list
+        // holding anything but objects is a ClassCastException on a blind cast, and
+        // updateResourceInWorkflow already walks this shape defensively.
+        Map<String, Object> extensions = workflowStep.getExtensions();
+        if (extensions == null || !(extensions.get(KEY_DICTIONARIES) instanceof List<?> dictionaries)) {
+            return;
+        }
+        for (Object entry : dictionaries) {
+            if (!(entry instanceof Map<?, ?> dictionary)) {
+                continue;
+            }
+            var dictType = dictionary.get(KEY_TYPE);
+            if (dictType == null || !DICTIONARY_TYPE_HOST.equals(URI.create(dictType.toString()).getHost())) {
+                continue;
+            }
+            if (!(dictionary.get(KEY_CONFIG) instanceof Map<?, ?> config)) {
+                continue;
+            }
+            Object dictionaryUriObj = config.get(KEY_URI);
+            if (!isNullOrEmpty(dictionaryUriObj)) {
+                collectCascadeCandidate(URI.create(dictionaryUriObj.toString()), toDelete, skipped);
             }
         }
     }
 
     /**
-     * Soft-deletes a referenced resource, if nothing else still references it.
+     * Adds a referenced resource to the cascade, if nothing else still references
+     * it.
      *
      * <p>
-     * The cascade never deletes permanently, whatever the request asked for. The
-     * guard below is VERSION-scoped — it asks who references
-     * {@code R?version=<pinned>} — while a permanent delete is ID-scoped:
-     * {@code deleteAllPermanently} drops every version and every history row. A
-     * workflow pinning a different version of the same rule set is invisible to the
-     * guard and would lose it outright, unrecoverably. Soft-deleting the pinned
-     * version keeps guard and effect on the same scope; erasing a shared resource
-     * stays an explicit, non-cascading request against that resource.
+     * The reference is resolved to the version that EXISTS before either question
+     * is asked. A stored step keeps pinning {@code ?version=1} after the rule set
+     * it names has been edited to v2 — the normal state, not an edge case — and
+     * both halves of this guard used to run against the pinned version: the
+     * reference check asked who else pins a version nobody may still pin, and the
+     * delete was then rejected as stale by the store and swallowed as a WARN. So
+     * {@code cascade=true} quietly deleted nothing at all for every resource that
+     * had ever been edited, while the API description said it had soft-deleted
+     * them.
+     * </p>
+     *
+     * <p>
+     * The cascade never deletes permanently, whatever the request asked for.
+     * {@code deleteAllPermanently} is ID-scoped — every version and every history
+     * row — while this guard can only ever speak for the versions it can see.
+     * Soft-deleting the current version keeps guard and effect on the same scope;
+     * erasing a shared resource stays an explicit, non-cascading request against
+     * that resource.
      * </p>
      */
-    private void deleteResourceSafely(URI resourceUri) {
+    private void collectCascadeCandidate(URI pinnedUri, Set<URI> toDelete, int[] skipped) {
+        IResourceStore.IResourceId current;
+        try {
+            current = resourceClientLibrary.getCurrentResourceId(pinnedUri);
+        } catch (Exception e) {
+            // Fails closed PER RESOURCE, like the reference check below, rather than
+            // letting the throwable out of planCascade. getCurrentResourceId only
+            // absorbs ResourceNotFoundException: the Mongo store's getCurrentVersion
+            // does `new ObjectId(id)`, which raises IllegalArgumentException for the
+            // 18-23 char hex and UUID-shaped ids RestUtilities.isValidId accepts, and
+            // a transport failure surfaces as MongoException. Uncaught, ONE
+            // hand-written or imported step reference turned the whole
+            // cascade=true delete into a 500 — before the workflow itself was
+            // deleted, so the workflow became undeletable-with-cascade until someone
+            // edited the stray reference out.
+            log.errorf(e, "Could not resolve %s to a live version — NOT cascade-deleting it", pinnedUri);
+            skipped[0]++;
+            return;
+        }
+        if (current == null) {
+            // Either the type is not one this cascade can route, or the resource has
+            // no live version left. Both mean "nothing here to delete", and neither
+            // is a reason to guess at the pinned version.
+            log.infof("Skipping cascade-delete of %s — no live version to delete, or its type is not routable", pinnedUri);
+            skipped[0]++;
+            return;
+        }
+
+        URI currentUri = withVersion(pinnedUri, current.getVersion());
         List<DocumentDescriptor> referencingWorkflows;
         try {
-            // Is this resource still referenced by other workflows?
-            referencingWorkflows = workflowStore.getWorkflowDescriptorsContainingResource(resourceUri.toString(), false);
+            // includePreviousVersions=true: the reverse lookup walks the resource's
+            // versions from this one down to 1, so a workflow still pinning an OLDER
+            // version protects it. Starting from the CURRENT version means there is
+            // no newer version above it for the walk to miss.
+            referencingWorkflows = workflowStore.getWorkflowDescriptorsContainingResource(currentUri.toString(), true);
         } catch (Exception e) {
             // FAIL CLOSED. A cascade-delete is irreversible and this is the only
             // thing standing between it and a config another workflow still uses —
@@ -326,26 +445,43 @@ public class RestWorkflowStore implements IRestWorkflowStore {
             // answers this way for EVERY resource, which silently turns cascade
             // delete into a permanent no-op. That must be loud, and the cause must
             // be in the log — hence the throwable rather than just its message.
-            log.errorf(e, "Reference check for %s failed — NOT cascade-deleting it", resourceUri);
+            log.errorf(e, "Reference check for %s failed — NOT cascade-deleting it", currentUri);
+            skipped[0]++;
             return;
         }
 
         if (referencingWorkflows == null) {
-            log.warnf("Reference check for %s returned no answer — NOT cascade-deleting it", resourceUri);
+            log.warnf("Reference check for %s returned no answer — NOT cascade-deleting it", currentUri);
+            skipped[0]++;
             return;
         }
 
         if (referencingWorkflows.size() > 1) {
-            log.infof("Skipping cascade-delete of resource %s — still referenced by %d other workflow(s)", resourceUri,
+            log.infof("Skipping cascade-delete of resource %s — still referenced by %d other workflow(s)", currentUri,
                     referencingWorkflows.size() - 1);
+            skipped[0]++;
             return;
         }
 
+        toDelete.add(currentUri);
+    }
+
+    /** The same resource, addressed at {@code version}. */
+    private static URI withVersion(URI resourceUri, Integer version) {
+        String raw = resourceUri.toString();
+        int queryStart = raw.indexOf('?');
+        return URI.create((queryStart >= 0 ? raw.substring(0, queryStart) : raw) + versionQueryParam + version);
+    }
+
+    /** @return true when the resource was actually deleted */
+    private boolean deleteCascadedResource(URI resourceUri) {
         try {
             resourceClientLibrary.deleteResource(resourceUri, false);
             log.infof("Cascade-deleted resource %s", resourceUri);
+            return true;
         } catch (Exception e) {
             log.warnf("Failed to cascade-delete resource %s: %s", resourceUri, e.getMessage());
+            return false;
         }
     }
 
@@ -403,31 +539,32 @@ public class RestWorkflowStore implements IRestWorkflowStore {
         // Same guard as deleteParserDictionaries: a stored parser step may carry no
         // extensions block at all, and a deep copy that NPEs leaves the sub-resources
         // it already created behind.
+        // Pattern-matched, not cast, for the same reason collectParserDictionaries
+        // is: a stored '"dictionaries": {}' or a list element that is not an object
+        // makes a blind (List<Map<…>>) cast throw, here after earlier steps of the
+        // deep copy have already created and persisted sub-resources.
         Map<String, Object> extensions = workflowStep.getExtensions();
-        if (extensions == null) {
+        if (extensions == null || !(extensions.get(KEY_DICTIONARIES) instanceof List<?> dictionaries)) {
             return;
         }
-        @SuppressWarnings("unchecked")
-        var dictionaries = (List<Map<String, Object>>) extensions.get("dictionaries");
-        if (!isNullOrEmpty(dictionaries)) {
-            for (var dictionary : dictionaries) {
-                // Same null guard as deleteParserDictionaries — the two walked the same
-                // stored shape but disagreed about whether "type" may be absent.
-                var dictTypeObj = dictionary.get("type");
-                if (dictTypeObj == null) {
-                    continue;
-                }
-                URI type = URI.create(dictTypeObj.toString());
-                if ("ai.labs.parser.dictionaries.regular".equals(type.getHost())) {
-                    @SuppressWarnings("unchecked")
-                    var config = (Map<String, URI>) dictionary.get("config");
-                    if (!isNullOrEmpty(config)) {
-                        Object dictionaryUriObj = config.get(KEY_URI);
-                        if (!isNullOrEmpty(dictionaryUriObj)) {
-                            var newDictionaryLocation = duplicateResource(dictionaryUriObj);
-                            config.put(KEY_URI, newDictionaryLocation);
-                        }
-                    }
+        for (Object entry : dictionaries) {
+            if (!(entry instanceof Map<?, ?> dictionary)) {
+                continue;
+            }
+            // Same null guard as collectParserDictionaries — the two walked the same
+            // stored shape but disagreed about whether "type" may be absent.
+            var dictTypeObj = dictionary.get(KEY_TYPE);
+            if (dictTypeObj == null) {
+                continue;
+            }
+            URI type = URI.create(dictTypeObj.toString());
+            if (DICTIONARY_TYPE_HOST.equals(type.getHost()) && dictionary.get(KEY_CONFIG) instanceof Map<?, ?> configMap) {
+                @SuppressWarnings("unchecked")
+                var config = (Map<String, Object>) configMap;
+                Object dictionaryUriObj = config.get(KEY_URI);
+                if (!isNullOrEmpty(dictionaryUriObj)) {
+                    var newDictionaryLocation = duplicateResource(dictionaryUriObj);
+                    config.put(KEY_URI, newDictionaryLocation);
                 }
             }
         }

--- a/src/main/java/ai/labs/eddi/datastore/AbstractResourceStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/AbstractResourceStore.java
@@ -118,4 +118,29 @@ public abstract class AbstractResourceStore<T> implements IResourceStore<T> {
     public IResourceId getCurrentResourceId(String id) throws ResourceNotFoundException {
         return resourceStore.getCurrentResourceId(id);
     }
+
+    /**
+     * Whether a hit from a reverse-reference lookup should be ignored because it
+     * does not describe the resource as it stands today.
+     * <p>
+     * Reverse lookups union the current collection with history, so they return two
+     * kinds of stale hit: an older version of a resource that still exists, and a
+     * version of a resource that has since been soft-deleted (the current row is
+     * gone, the history row still matches). Only the first is a comparison —
+     * {@link #getCurrentResourceId(String)} <em>throws</em> for the second, and an
+     * unguarded call turns one soft-deleted referrer into a 404 for the whole
+     * listing and a permanently swallowed cascade-delete.
+     *
+     * @return true when {@code id} has no current version, or when {@code version}
+     *         is older than it
+     */
+    protected boolean isStaleReference(String id, Integer version) {
+        try {
+            return version < getCurrentResourceId(id).getVersion();
+        } catch (ResourceNotFoundException e) {
+            // No current row: the resource was soft-deleted, so every history hit
+            // for it is stale by definition.
+            return true;
+        }
+    }
 }

--- a/src/main/java/ai/labs/eddi/datastore/mongo/MongoResourceStorage.java
+++ b/src/main/java/ai/labs/eddi/datastore/mongo/MongoResourceStorage.java
@@ -40,6 +40,15 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
     private static final String DELETED_FIELD = "_deleted";
 
     private static final String HISTORY_POSTFIX = ".history";
+
+    /**
+     * A history row's {@code _id} is the embedded document
+     * <code>{_id: ObjectId, _version: int}</code>, so its parts are addressed by
+     * these dotted paths. Named once because both the filter and the index that has
+     * to serve it must agree.
+     */
+    static final String HISTORY_NESTED_ID_FIELD = ID_FIELD + "." + ID_FIELD;
+    static final String HISTORY_NESTED_VERSION_FIELD = ID_FIELD + "." + VERSION_FIELD;
     private final Class<T> documentType;
 
     protected MongoCollection<Document> currentCollection;
@@ -60,6 +69,14 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
         this.documentBuilder = documentBuilder;
 
         ensureIndex(currentCollection, Indexes.ascending(ID_FIELD, VERSION_FIELD), true);
+        // History rows are addressed by the NESTED id, not by a range over the
+        // composite _id (see historyRowsOf). MongoDB's built-in _id index covers the
+        // whole embedded subdocument and cannot serve a dotted path into it, so
+        // without this index removeAllPermanently and readHistoryLatest are a
+        // COLLSCAN of the history collection. That is not academic: descriptors.history
+        // holds one row per conversation, and GdprComplianceService's erasure loop
+        // calls deleteAllDescriptor once per conversation.
+        ensureIndex(historyCollection, Indexes.ascending(HISTORY_NESTED_ID_FIELD, HISTORY_NESTED_VERSION_FIELD), false);
 
         Arrays.stream(indexes).forEach(index -> {
             ensureIndex(currentCollection, Indexes.ascending(index), false);
@@ -272,24 +289,32 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
         }
     }
 
+    /**
+     * Every history row of a resource, addressed by the nested id rather than by a
+     * range over the composite {@code _id}.
+     * <p>
+     * A history row's {@code _id} is the embedded document {@code {_id: ObjectId,
+     * _version: int}} (see {@link #newHistoryResourceFor(IResource, boolean)}), and
+     * BSON compares embedded documents field by field. The previous {@code $gt
+     * {_id, _version: 0}} bound therefore compared EQUAL to — and so excluded —
+     * every row archived at version 0, which is exactly the version conversation
+     * descriptors are created at. Those tombstones (carrying {@code userId})
+     * survived both permanent delete and GDPR erasure, and nothing else in the
+     * codebase deletes history rows. Matching the nested field covers every
+     * version, including 0 and negative ones, and matches
+     * {@code PostgresResourceStorage}, which deletes by id alone.
+     * <p>
+     * The dotted path needs its own index — the built-in {@code _id} index is on
+     * the whole subdocument and cannot serve it — which the constructor creates.
+     */
+    private static Document historyRowsOf(String id) {
+        return new Document(HISTORY_NESTED_ID_FIELD, new ObjectId(id));
+    }
+
     @Override
     public void removeAllPermanently(String id) {
         remove(id);
-
-        Document beginId = new Document();
-        beginId.put(ID_FIELD, new ObjectId(id));
-        beginId.put(VERSION_FIELD, 0);
-
-        Document endId = new Document();
-        endId.put(ID_FIELD, new ObjectId(id));
-        endId.put(VERSION_FIELD, Integer.MAX_VALUE);
-
-        Document query = new Document();
-        query.put("$gt", beginId);
-        query.put("$lt", endId);
-        Document idQuery = new Document();
-        idQuery.put(ID_FIELD, query);
-        historyCollection.deleteMany(idQuery);
+        historyCollection.deleteMany(historyRowsOf(id));
     }
 
     @Override
@@ -304,27 +329,16 @@ public class MongoResourceStorage<T> implements IResourceStorage<T> {
         return new HistoryResource(doc);
     }
 
+    /** @see #historyRowsOf(String) for why this is a nested-field match. */
     @Override
     public IHistoryResource<T> readHistoryLatest(String id) {
-        Document beginId = new Document();
-        beginId.put(ID_FIELD, new ObjectId(id));
-        beginId.put(VERSION_FIELD, 0);
+        Document query = historyRowsOf(id);
 
-        Document endId = new Document();
-        endId.put(ID_FIELD, new ObjectId(id));
-        endId.put(VERSION_FIELD, Integer.MAX_VALUE);
-
-        Document query = new Document();
-        query.put("$gt", beginId);
-        query.put("$lt", endId);
-        Document object = new Document();
-        object.put(ID_FIELD, query);
-
-        if (historyCollection.countDocuments(object) == 0) {
+        if (historyCollection.countDocuments(query) == 0) {
             return null;
         }
 
-        Document doc = historyCollection.find(object).sort(new Document(ID_FIELD, -1)).limit(1).first();
+        Document doc = historyCollection.find(query).sort(new Document(HISTORY_NESTED_VERSION_FIELD, -1)).limit(1).first();
         if (doc == null) {
             return null;
         }

--- a/src/main/java/ai/labs/eddi/engine/runtime/client/configuration/IResourceClientLibrary.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/client/configuration/IResourceClientLibrary.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.runtime.client.configuration;
 
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.service.ServiceException;
 
 import jakarta.ws.rs.core.Response;
@@ -20,6 +21,25 @@ public interface IResourceClientLibrary {
     Response duplicateResource(URI uri) throws ServiceException;
 
     Response deleteResource(URI uri, boolean permanent) throws ServiceException;
+
+    /**
+     * The live version of the resource a reference names, regardless of which
+     * version the reference itself pins.
+     *
+     * <p>
+     * References are version-pinned and are <em>not</em> re-pointed when the
+     * resource they name is edited, so "the version in the URI" and "the version
+     * that exists" routinely disagree. A cascade delete has to ask both questions
+     * against the same version — who else references this resource, and which row
+     * am I about to remove — or it guards one version and deletes another (or, as
+     * it did, guards a version nobody references and then has its delete rejected
+     * as stale, cascading nothing at all).
+     * </p>
+     *
+     * @return the current id and version, or {@code null} when the type is not
+     *         registered or the resource has no live version left
+     */
+    IResourceStore.IResourceId getCurrentResourceId(URI uri);
 
     class ResourceClientLibraryException extends RuntimeException {
         public ResourceClientLibraryException(String message, Exception e) {

--- a/src/main/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibrary.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibrary.java
@@ -26,7 +26,6 @@ import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.service.ServiceException;
 import ai.labs.eddi.utils.RestUtilities;
 import ai.labs.eddi.utils.RuntimeUtilities;
-import org.jboss.logging.Logger;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -90,8 +89,6 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
     private final IRestRagStore restRagStore;
 
     private Map<String, IResourceService> resourceServices;
-
-    private static final Logger log = Logger.getLogger(ResourceClientLibrary.class);
 
     @Inject
     public ResourceClientLibrary(IParserStore parserStore, IDictionaryStore dictionaryStore, IRuleSetStore ruleSetStore,
@@ -342,13 +339,26 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
         return proxy.duplicate(resourceId.getId(), resourceId.getVersion());
     }
 
+    /**
+     * Deletes the resource a reference names.
+     *
+     * <p>
+     * An unregistered type is an error, not a silent skip. Returning
+     * {@code Response.ok()} here made {@code RestOrphanAdmin.purgeOrphans} count
+     * every unhandled orphan as "purged" — the whole {@code ai.labs.workflow}
+     * category, which is the largest one, since a deleted agent is exactly what
+     * leaves workflows unreferenced. The operator got a converged-looking report
+     * for an operation that had deleted nothing, forever. Matching
+     * {@link #duplicateResource}'s behaviour means a caller either deletes or is
+     * told it did not.
+     * </p>
+     */
     @Override
     public Response deleteResource(URI uri, boolean permanent) throws ServiceException {
         String type = uri.getHost();
         IResourceService proxy = resourceServices.get(type);
         if (RuntimeUtilities.isNullOrEmpty(proxy)) {
-            log.warnf("Could not find proxy for type '%s' in uri '%s' — skipping delete", type, uri);
-            return Response.ok().build();
+            throw new ServiceException(String.format("Could not find proxy for type '%s' in uri '%s' — nothing was deleted", type, uri));
         }
 
         IResourceId resourceId = RestUtilities.extractResourceId(uri);

--- a/src/main/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibrary.java
+++ b/src/main/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibrary.java
@@ -89,6 +89,18 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
     private final IRestRagStore restRagStore;
 
     private Map<String, IResourceService> resourceServices;
+    /**
+     * The same types {@link #resourceServices} registers, resolved to the store
+     * rather than to the REST facade.
+     * <p>
+     * Version resolution is a READ, so it belongs on the store side of the split
+     * described in this class's Javadoc: a cascade must not have to own a
+     * configuration in order to ask which version of it currently exists. Keep this
+     * map in step with {@code resourceServices} — a type registered there and
+     * missing here answers {@code null} from {@link #getCurrentResourceId(URI)},
+     * which callers must treat as "cannot resolve", never as "no live version".
+     */
+    private Map<String, IResourceStore<?>> resourceStores;
 
     @Inject
     public ResourceClientLibrary(IParserStore parserStore, IDictionaryStore dictionaryStore, IRuleSetStore ruleSetStore,
@@ -123,6 +135,23 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
     @Override
     public void init() throws ResourceClientLibraryException {
         this.resourceServices = new HashMap<>();
+        this.resourceStores = new HashMap<>();
+
+        // Same keys as resourceServices below, including the two-host aliases, so a
+        // reference written with the legacy authority resolves its version the same
+        // way it resolves its content.
+        resourceStores.put("ai.labs.parser", parserStore);
+        resourceStores.put("ai.labs.regulardictionary", dictionaryStore);
+        resourceStores.put("ai.labs.dictionary", dictionaryStore);
+        resourceStores.put("ai.labs.behavior", ruleSetStore);
+        resourceStores.put("ai.labs.rules", ruleSetStore);
+        resourceStores.put("ai.labs.httpcalls", apiCallsStore);
+        resourceStores.put("ai.labs.apicalls", apiCallsStore);
+        resourceStores.put("ai.labs.llm", llmStore);
+        resourceStores.put("ai.labs.output", outputStore);
+        resourceStores.put("ai.labs.property", propertySetterStore);
+        resourceStores.put("ai.labs.mcpcalls", mcpCallsStore);
+        resourceStores.put("ai.labs.rag", ragStore);
 
         resourceServices.put("ai.labs.parser", new IResourceService() {
             @Override
@@ -363,6 +392,23 @@ public class ResourceClientLibrary implements IResourceClientLibrary {
 
         IResourceId resourceId = RestUtilities.extractResourceId(uri);
         return proxy.delete(resourceId.getId(), resourceId.getVersion(), permanent);
+    }
+
+    @Override
+    public IResourceId getCurrentResourceId(URI uri) {
+        if (uri == null) {
+            return null;
+        }
+        IResourceStore<?> store = resourceStores.get(uri.getHost());
+        IResourceId resourceId = RestUtilities.extractResourceId(uri);
+        if (store == null || resourceId == null || resourceId.getId() == null) {
+            return null;
+        }
+        try {
+            return store.getCurrentResourceId(resourceId.getId());
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            return null;
+        }
     }
 
     private interface IResourceService {

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutor.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.modules.llm.impl;
 
 import ai.labs.eddi.configs.hitl.model.ToolApprovalsConfig;
+import ai.labs.eddi.configs.shared.RetryConfiguration;
 import ai.labs.eddi.configs.variables.GlobalVariableResolver;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
 import ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException;
@@ -32,7 +33,6 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -894,27 +894,22 @@ class CascadingModelExecutor {
         return s == null || s.isBlank();
     }
 
-    // Retryable transient-failure signatures in an exception message.
-    private static final Pattern RETRYABLE_MESSAGE = Pattern.compile("timeout|rate limit|too many requests|429|50[234]", Pattern.CASE_INSENSITIVE);
-
     /**
-     * Check if an error is retryable (transient network / throttling errors). Same
-     * intent as {@code AgentExecutionHelper}.
+     * Check if an error is retryable (transient network / throttling errors).
+     *
+     * <p>
+     * Delegates to {@link RetryConfiguration#isRetryableError} instead of keeping a
+     * second copy. The two had drifted: this one matched bare
+     * {@code 429}/{@code 50x} in a message but ignored
+     * {@code WebApplicationException} status codes, while the other did the
+     * opposite — and neither knew langchain4j's typed {@code RetriableException} /
+     * {@code NonRetriableException}, which is what {@code chatModel.chat()}
+     * actually throws. The same provider failure was therefore retried on one path
+     * and not the other, decided by the wording of a message.
+     * </p>
      */
     private static boolean isRetryableError(Exception e) {
-        Throwable current = e;
-        while (current != null) {
-            if (current instanceof java.net.SocketTimeoutException || current instanceof TimeoutException
-                    || current instanceof java.net.ConnectException || current instanceof java.net.UnknownHostException) {
-                return true;
-            }
-            String message = current.getMessage();
-            if (message != null && RETRYABLE_MESSAGE.matcher(message).find()) {
-                return true;
-            }
-            current = current.getCause();
-        }
-        return false;
+        return RetryConfiguration.isRetryableError(e);
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/StreamingLegacyChatExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/StreamingLegacyChatExecutor.java
@@ -165,15 +165,26 @@ class StreamingLegacyChatExecutor {
     }
 
     /**
-     * Resolve the attempt count from the task's retry config, clamped to at least
-     * one: {@code maxAttempts <= 0} means "don't retry", not "never call the
-     * model". Without the clamp the retry loop body never runs and the caller gets
-     * a null response indistinguishable from silence.
+     * Resolve the attempt count from the task's retry config, bounded at both ends.
+     *
+     * <p>
+     * At least one: {@code maxAttempts <= 0} means "don't retry", not "never call
+     * the model". Without that the retry loop body never runs and the caller gets a
+     * null response indistinguishable from silence.
+     * </p>
+     *
+     * <p>
+     * And at most {@code RetryConfiguration.MAX_ATTEMPTS_CEILING}. This used to
+     * read {@code getMaxAttempts()} raw, so the engine ceiling that bounds the tool
+     * loop did not apply here: the identical {@code retry} block was capped on one
+     * path and unbounded on the other, and a streaming task could hold its worker
+     * for as many attempts as the config asked for.
+     * </p>
      */
     private static int resolveMaxAttempts(LlmConfiguration.Task task) {
         RetryConfiguration retryConfig = task != null ? task.getRetry() : null;
         int configured = retryConfig != null && retryConfig.getMaxAttempts() != null ? retryConfig.getMaxAttempts() : 1;
-        return Math.max(1, configured);
+        return Math.max(1, RetryConfiguration.clampAttempts(configured));
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/StreamingLegacyChatExecutor.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/StreamingLegacyChatExecutor.java
@@ -345,6 +345,11 @@ class StreamingLegacyChatExecutor {
 
         Map<String, Object> metadata = new HashMap<>();
         String responseText = null;
+        // Carried across attempts so this loop honours the same total-backoff
+        // budget executeWithRetry applies. The per-sleep ceiling alone does not
+        // bound it: ten attempts at a configured 30s delay is 270s of blocked
+        // pipeline thread.
+        long totalBackoffMs = 0L;
 
         for (int attempt = 1; attempt <= maxAttempts; attempt++) {
             // Each attempt reports its own outcome. Without this reset, a
@@ -499,11 +504,16 @@ class StreamingLegacyChatExecutor {
                 }
                 // No response at all — treat as retryable failure
                 if (attempt < maxAttempts) {
-                    LOGGER.warnf("Streaming timed out with empty response, retrying (attempt %d/%d)", attempt, maxAttempts);
-                    RetryConfiguration.backoff(attempt, retryConfig);
-                    continue;
+                    long slept = RetryConfiguration.backoff(attempt, retryConfig, totalBackoffMs);
+                    if (slept >= 0) {
+                        totalBackoffMs += slept;
+                        LOGGER.warnf("Streaming timed out with empty response, retrying (attempt %d/%d)", attempt, maxAttempts);
+                        continue;
+                    }
+                    LOGGER.warnf("Streaming timed out with empty response and the retry backoff budget is spent after %d attempt(s)",
+                            attempt);
                 }
-                LOGGER.errorf("Streaming timed out with empty response after %d attempts", maxAttempts);
+                LOGGER.errorf("Streaming timed out with empty response after %d attempt(s)", attempt);
                 return new StreamingResult("", metadata);
             }
 
@@ -518,15 +528,20 @@ class StreamingLegacyChatExecutor {
                 // Nothing salvageable (no content, or the caller wants errors
                 // propagated) — retry if possible
                 if (attempt < maxAttempts) {
-                    LOGGER.warnf("Streaming error with empty response, retrying (attempt %d/%d): %s",
-                            attempt, maxAttempts, errorRef.get().getMessage());
                     synchronized (streamLock) {
                         abandoned.set(true);
                     }
-                    RetryConfiguration.backoff(attempt, retryConfig);
-                    continue;
+                    long slept = RetryConfiguration.backoff(attempt, retryConfig, totalBackoffMs);
+                    if (slept >= 0) {
+                        totalBackoffMs += slept;
+                        LOGGER.warnf("Streaming error with empty response, retrying (attempt %d/%d): %s",
+                                attempt, maxAttempts, errorRef.get().getMessage());
+                        continue;
+                    }
+                    LOGGER.warnf("Streaming error with empty response and the retry backoff budget is spent after %d attempt(s): %s",
+                            attempt, errorRef.get().getMessage());
                 }
-                LOGGER.errorf("Streaming chat error after %d attempts: %s", maxAttempts, errorRef.get().getMessage());
+                LOGGER.errorf("Streaming chat error after %d attempt(s): %s", attempt, errorRef.get().getMessage());
                 throw new RuntimeException("Streaming chat failed", errorRef.get());
             }
 

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.backup.impl;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.backup.IZipArchive;
 import ai.labs.eddi.backup.model.ImportPreview;
+import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
@@ -37,6 +38,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -70,6 +72,8 @@ import static org.mockito.Mockito.when;
 class RestImportServiceRollbackAndCleanupTest {
 
     private static final String AGENT_ORIGIN_ID = "aaaa11112222333344445555";
+    private static final String SECOND_AGENT_ORIGIN_ID = "ffff11112222333344445555";
+    private static final String NEW_AGENT_ID = "dddd11112222333344445555";
     private static final String WORKFLOW_ORIGIN_ID = "bbbb11112222333344445555";
     private static final String NEW_WORKFLOW_ID = "cccc11112222333344445555";
     private static final String NEW_SNIPPET_ID = "eeee11112222333344445555";
@@ -221,6 +225,42 @@ class RestImportServiceRollbackAndCleanupTest {
             }
         }
 
+        /**
+         * Import creates Agents through the store directly, so it registers their
+         * skills itself — and the capability index is a process-local map that nothing
+         * else prunes. A ZIP that landed one Agent and then failed therefore deleted
+         * the Agent row while leaving its skills behind, so {@code findBySkill} and A2A
+         * discovery kept answering with an agent id that no longer existed, until the
+         * next restart.
+         */
+        @Test
+        @DisplayName("a rolled-back Agent is taken back out of the capability index")
+        void rolledBackAgentIsUnregisteredFromTheCapabilityIndex() throws Exception {
+            var workflowStore = mock(IWorkflowStore.class);
+            var agentStore = mock(IAgentStore.class);
+            var capabilityRegistry = mock(CapabilityRegistryService.class);
+            stubTwoCapableAgentsZip();
+
+            when(workflowStore.create(any())).thenReturn(resourceId(NEW_WORKFLOW_ID, 1));
+            // The first Agent lands and is registered; the second blows up, so
+            // everything this ZIP created so far is rolled back.
+            when(agentStore.create(any()))
+                    .thenReturn(resourceId(NEW_AGENT_ID, 1))
+                    .thenThrow(new IResourceStore.ResourceStoreException("agent store unavailable"));
+
+            try (MockedStatic<CDI> cdiMock = mockStatic(CDI.class)) {
+                stubCdi(cdiMock, workflowStore, agentStore, capabilityRegistry);
+
+                assertThrows(InternalServerErrorException.class,
+                        () -> importService.importAgent(
+                                new ByteArrayInputStream(new byte[0]), "create", null, null, null));
+
+                verify(capabilityRegistry).register(eq(NEW_AGENT_ID), any());
+                verify(agentStore).deleteAllPermanently(NEW_AGENT_ID);
+                verify(capabilityRegistry).unregister(NEW_AGENT_ID);
+            }
+        }
+
         @Test
         @DisplayName("a successful import deletes nothing")
         void successfulImportDoesNotRollBack() throws Exception {
@@ -365,6 +405,36 @@ class RestImportServiceRollbackAndCleanupTest {
     }
 
     /**
+     * A ZIP holding TWO capability-declaring agents over one workflow — the shape
+     * that makes a half-imported ZIP reachable: the first agent is created (and
+     * registered) before the second one fails. Both files deserialize to the same
+     * configuration, so the assertions do not depend on the order
+     * {@code Files.newDirectoryStream} happens to return them in.
+     */
+    private void stubTwoCapableAgentsZip() throws Exception {
+        URI workflowUri = URI.create(
+                "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ORIGIN_ID + "?version=1");
+
+        doAnswer(inv -> {
+            File dir = inv.getArgument(1);
+            dir.mkdirs();
+            Files.writeString(new File(dir, AGENT_ORIGIN_ID + ".agent.json").toPath(), "AGENTJSON");
+            Files.writeString(new File(dir, SECOND_AGENT_ORIGIN_ID + ".agent.json").toPath(), "AGENTJSON");
+            File workflowDir = new File(new File(dir, WORKFLOW_ORIGIN_ID), "1");
+            workflowDir.mkdirs();
+            Files.writeString(new File(workflowDir, WORKFLOW_ORIGIN_ID + ".workflow.json").toPath(), "WORKFLOWJSON");
+            return null;
+        }).when(zipArchive).unzip(any(InputStream.class), any(File.class));
+
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of(workflowUri));
+        agentConfig.setCapabilities(List.of(new AgentConfiguration.Capability("translation", Map.of(), "high")));
+        when(jsonSerialization.deserialize(eq("AGENTJSON"), eq(AgentConfiguration.class))).thenReturn(agentConfig);
+        when(jsonSerialization.deserialize(eq("WORKFLOWJSON"), eq(WorkflowConfiguration.class)))
+                .thenReturn(new WorkflowConfiguration());
+    }
+
+    /**
      * Same ZIP as {@link #stubAgentWithOneWorkflowZip()} plus a {@code snippets/}
      * directory holding one snippet — the layout {@code findSnippetsDir} looks for
      * directly under the unzipped root.
@@ -422,6 +492,25 @@ class RestImportServiceRollbackAndCleanupTest {
         Instance<IAgentStore> agentInstance = mock(Instance.class);
         when(cdi.select(IAgentStore.class)).thenReturn(agentInstance);
         when(agentInstance.get()).thenReturn(agentStore);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void stubCdi(MockedStatic<CDI> cdiMock, IWorkflowStore workflowStore, IAgentStore agentStore,
+                                CapabilityRegistryService capabilityRegistry) {
+        CDI cdi = mock(CDI.class);
+        cdiMock.when(CDI::current).thenReturn(cdi);
+
+        Instance<IWorkflowStore> workflowInstance = mock(Instance.class);
+        when(cdi.select(IWorkflowStore.class)).thenReturn(workflowInstance);
+        when(workflowInstance.get()).thenReturn(workflowStore);
+
+        Instance<IAgentStore> agentInstance = mock(Instance.class);
+        when(cdi.select(IAgentStore.class)).thenReturn(agentInstance);
+        when(agentInstance.get()).thenReturn(agentStore);
+
+        Instance<CapabilityRegistryService> registryInstance = mock(Instance.class);
+        when(cdi.select(CapabilityRegistryService.class)).thenReturn(registryInstance);
+        when(registryInstance.get()).thenReturn(capabilityRegistry);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
+++ b/src/test/java/ai/labs/eddi/backup/impl/RestImportServiceRollbackAndCleanupTest.java
@@ -261,6 +261,79 @@ class RestImportServiceRollbackAndCleanupTest {
             }
         }
 
+        /**
+         * Adding an imported Agent to the discovery index is best-effort: the Agent row
+         * is already written by the time it happens, so a registry that cannot be
+         * updated must not turn a completed import into a 500 — and must certainly not
+         * trigger the rollback, which would delete an Agent the caller was about to be
+         * told it had.
+         */
+        @Test
+        @DisplayName("a capability index that refuses the registration does not fail the import")
+        void registrationFailureDoesNotFailTheImport() throws Exception {
+            var workflowStore = mock(IWorkflowStore.class);
+            var agentStore = mock(IAgentStore.class);
+            var capabilityRegistry = mock(CapabilityRegistryService.class);
+            stubOneCapableAgentZip();
+
+            when(workflowStore.create(any())).thenReturn(resourceId(NEW_WORKFLOW_ID, 1));
+            when(agentStore.create(any())).thenReturn(resourceId(NEW_AGENT_ID, 1));
+            doThrow(new IllegalStateException("registry unavailable"))
+                    .when(capabilityRegistry).register(anyString(), any());
+
+            try (MockedStatic<CDI> cdiMock = mockStatic(CDI.class)) {
+                stubCdi(cdiMock, workflowStore, agentStore, capabilityRegistry);
+
+                Response response = importService.importAgent(
+                        new ByteArrayInputStream(new byte[0]), "create", null, null, null);
+
+                // An imported Agent's skills must be offered to the index at all —
+                // import creates Agents through the store directly, so without this
+                // call they stayed invisible to capabilityMatch rules and to A2A
+                // discovery until the node restarted, with no error to explain it.
+                verify(capabilityRegistry).register(eq(NEW_AGENT_ID), any());
+                assertEquals(201, response.getStatus(), "the Agent was written; a discovery-index failure is not the caller's problem");
+                verify(agentStore, never()).deleteAllPermanently(anyString());
+                verify(workflowStore, never()).deleteAllPermanently(anyString());
+            }
+        }
+
+        /**
+         * The rollback's own steps are each guarded so one failure cannot mask the
+         * original error or abandon the resources it has not reached yet. An
+         * unreachable capability index while unwinding must still leave every created
+         * resource deleted.
+         */
+        @Test
+        @DisplayName("a capability index that refuses the unregistration does not abandon the rest of the rollback")
+        void unregistrationFailureDoesNotAbandonTheRollback() throws Exception {
+            var workflowStore = mock(IWorkflowStore.class);
+            var agentStore = mock(IAgentStore.class);
+            var capabilityRegistry = mock(CapabilityRegistryService.class);
+            stubTwoCapableAgentsZip();
+
+            when(workflowStore.create(any())).thenReturn(resourceId(NEW_WORKFLOW_ID, 1));
+            when(agentStore.create(any()))
+                    .thenReturn(resourceId(NEW_AGENT_ID, 1))
+                    .thenThrow(new IResourceStore.ResourceStoreException("agent store unavailable"));
+            doThrow(new IllegalStateException("registry unavailable"))
+                    .when(capabilityRegistry).unregister(anyString());
+
+            try (MockedStatic<CDI> cdiMock = mockStatic(CDI.class)) {
+                stubCdi(cdiMock, workflowStore, agentStore, capabilityRegistry);
+
+                assertThrows(InternalServerErrorException.class,
+                        () -> importService.importAgent(
+                                new ByteArrayInputStream(new byte[0]), "create", null, null, null));
+
+                verify(capabilityRegistry).unregister(NEW_AGENT_ID);
+                verify(agentStore).deleteAllPermanently(NEW_AGENT_ID);
+                // Rolled back newest first, so this one comes AFTER the failing
+                // unregistration — it is the proof the loop was not abandoned.
+                verify(workflowStore).deleteAllPermanently(NEW_WORKFLOW_ID);
+            }
+        }
+
         @Test
         @DisplayName("a successful import deletes nothing")
         void successfulImportDoesNotRollBack() throws Exception {
@@ -402,6 +475,24 @@ class RestImportServiceRollbackAndCleanupTest {
         when(jsonSerialization.deserialize(eq("AGENTJSON"), eq(AgentConfiguration.class))).thenReturn(agentConfig);
         when(jsonSerialization.deserialize(eq("WORKFLOWJSON"), eq(WorkflowConfiguration.class)))
                 .thenReturn(new WorkflowConfiguration());
+    }
+
+    /**
+     * As {@link #stubAgentWithOneWorkflowZip()}, but the single agent declares a
+     * skill — so the import reaches the capability registration at all. One agent,
+     * not two, because a second agent re-reads the workflow directory under its
+     * already-remapped id and fails for a reason that has nothing to do with this
+     * test.
+     */
+    private void stubOneCapableAgentZip() throws Exception {
+        stubAgentWithOneWorkflowZip();
+
+        URI workflowUri = URI.create(
+                "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ORIGIN_ID + "?version=1");
+        var agentConfig = new AgentConfiguration();
+        agentConfig.setWorkflows(List.of(workflowUri));
+        agentConfig.setCapabilities(List.of(new AgentConfiguration.Capability("translation", Map.of(), "high")));
+        when(jsonSerialization.deserialize(eq("AGENTJSON"), eq(AgentConfiguration.class))).thenReturn(agentConfig);
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/configs/admin/model/OrphanReportTest.java
+++ b/src/test/java/ai/labs/eddi/configs/admin/model/OrphanReportTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.configs.admin.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The scan-completeness flag has to survive the wire.
+ *
+ * <p>
+ * {@code GET /administration/orphans} is the operator's review surface for an
+ * irreversible deletion, and a partial scan lists resources that are still in
+ * use as "orphans". A flag that the server sets but that never reaches — or
+ * never reads back out of — the JSON body is indistinguishable from a clean
+ * scan, which is exactly the failure it was added to remove.
+ * </p>
+ */
+@DisplayName("OrphanReport — scan completeness on the wire")
+class OrphanReportTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static OrphanInfo orphan() {
+        return new OrphanInfo(URI.create("eddi://ai.labs.rules/rulestore/rulesets/aabbccddeeff112233445566?version=1"), "ai.labs.rules",
+                "an-unreferenced-ruleset", false);
+    }
+
+    @Test
+    @DisplayName("an incomplete scan round-trips its flag and its reason")
+    void incompleteScanRoundTrips() throws Exception {
+        var report = new OrphanReport(1, 0, List.of(orphan()), false, "could not enumerate Agent/workflow descriptors: boom");
+
+        var restored = MAPPER.readValue(MAPPER.writeValueAsString(report), OrphanReport.class);
+
+        assertFalse(restored.isScanComplete(), "a partial scan must still read as partial after serialization");
+        assertEquals("could not enumerate Agent/workflow descriptors: boom", restored.getScanWarning());
+        assertEquals(1, restored.getTotalOrphans());
+        assertEquals(0, restored.getDeletedCount());
+        assertEquals(1, restored.getOrphans().size());
+    }
+
+    /**
+     * The default matters as much as the flag: a body written by an older node — or
+     * by the three-argument constructor the purge still uses — carries no
+     * {@code scanComplete}, and must not read back as "the scan failed".
+     */
+    @Test
+    @DisplayName("a body without the flag reads as a complete scan, not a failed one")
+    void absentFlagDefaultsToComplete() throws Exception {
+        var restored = MAPPER.readValue("{\"totalOrphans\":2,\"deletedCount\":2,\"orphans\":[]}", OrphanReport.class);
+
+        assertTrue(restored.isScanComplete());
+        assertNull(restored.getScanWarning());
+        assertEquals(2, restored.getTotalOrphans());
+    }
+
+    @Test
+    @DisplayName("the three-argument constructor reports a complete scan")
+    void threeArgConstructorIsComplete() {
+        var report = new OrphanReport(3, 3, List.of(orphan()));
+
+        assertTrue(report.isScanComplete());
+        assertNull(report.getScanWarning());
+        assertEquals(3, report.getDeletedCount());
+    }
+}

--- a/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminBranchTest.java
+++ b/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminBranchTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration.WorkflowStep;
@@ -39,13 +40,15 @@ class RestOrphanAdminBranchTest {
     private IDocumentDescriptorStore documentDescriptorStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
+    @Mock
+    private IRestWorkflowStore restWorkflowStore;
 
     private RestOrphanAdmin restOrphanAdmin;
 
     @BeforeEach
     void setUp() {
         openMocks(this);
-        restOrphanAdmin = new RestOrphanAdmin(agentStore, workflowStore, documentDescriptorStore, resourceClientLibrary);
+        restOrphanAdmin = new RestOrphanAdmin(agentStore, workflowStore, documentDescriptorStore, resourceClientLibrary, restWorkflowStore);
     }
 
     // =========================================================

--- a/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminBranchTest.java
+++ b/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminBranchTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.configs.admin.rest;
 import ai.labs.eddi.configs.admin.model.OrphanReport;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
@@ -42,13 +43,16 @@ class RestOrphanAdminBranchTest {
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
     private IRestWorkflowStore restWorkflowStore;
+    @Mock
+    private IDeploymentStore deploymentStore;
 
     private RestOrphanAdmin restOrphanAdmin;
 
     @BeforeEach
     void setUp() {
         openMocks(this);
-        restOrphanAdmin = new RestOrphanAdmin(agentStore, workflowStore, documentDescriptorStore, resourceClientLibrary, restWorkflowStore);
+        restOrphanAdmin = new RestOrphanAdmin(agentStore, workflowStore, documentDescriptorStore, resourceClientLibrary, restWorkflowStore,
+                deploymentStore);
     }
 
     // =========================================================

--- a/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminSafetyTest.java
+++ b/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminSafetyTest.java
@@ -9,11 +9,13 @@ import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,9 +24,13 @@ import org.mockito.Mock;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -73,13 +79,15 @@ class RestOrphanAdminSafetyTest {
     private IDocumentDescriptorStore documentDescriptorStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
+    @Mock
+    private IRestWorkflowStore restWorkflowStore;
 
     private RestOrphanAdmin restOrphanAdmin;
 
     @BeforeEach
     void setUp() {
         openMocks(this);
-        restOrphanAdmin = new RestOrphanAdmin(agentStore, workflowStore, documentDescriptorStore, resourceClientLibrary);
+        restOrphanAdmin = new RestOrphanAdmin(agentStore, workflowStore, documentDescriptorStore, resourceClientLibrary, restWorkflowStore);
     }
 
     private static DocumentDescriptor descriptor(URI resource, String name) {
@@ -87,6 +95,12 @@ class RestOrphanAdminSafetyTest {
         descriptor.setResource(resource);
         descriptor.setName(name);
         return descriptor;
+    }
+
+    private static WorkflowConfiguration emptyWorkflow() {
+        WorkflowConfiguration config = new WorkflowConfiguration();
+        config.setWorkflowSteps(List.of());
+        return config;
     }
 
     private static List<DocumentDescriptor> fullPage(String type) {
@@ -291,6 +305,251 @@ class RestOrphanAdminSafetyTest {
 
             assertEquals(0, report.getTotalOrphans(), "a referenced workflow must never be purged");
             verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
+
+        /**
+         * The version-skew case, which is the NORMAL state rather than an edge case:
+         * {@code DocumentDescriptorFilter} rewrites a descriptor's {@code resource} to
+         * the new version on every PUT, while references stay pinned where they were.
+         * So one edit of a rule set leaves the descriptor saying {@code ?version=2} and
+         * every un-re-pointed workflow still saying {@code ?version=1}. A literal
+         * string compare called that rule set an orphan, and the purge — which deletes
+         * every version and all history — destroyed a config a live workflow was still
+         * resolving.
+         */
+        @Test
+        @DisplayName("a resource referenced at an older pinned version is not an orphan")
+        void referenceAtOlderVersionProtectsCurrentVersion() throws Exception {
+            String ruleSetId = "aabbccddeeff11223344556a";
+            URI pinnedByWorkflow = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+            URI currentDescriptorResource = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=2");
+            String workflowId = "aabbccddeeff112233445569";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            AgentConfiguration agentConfig = new AgentConfiguration();
+            agentConfig.setWorkflows(List.of(workflowUri));
+
+            WorkflowConfiguration workflowConfig = new WorkflowConfiguration();
+            WorkflowConfiguration.WorkflowStep rulesStep = new WorkflowConfiguration.WorkflowStep();
+            rulesStep.setType(URI.create("eddi://ai.labs.behavior"));
+            rulesStep.setConfig(new HashMap<>(Map.of("uri", pinnedByWorkflow.toString())));
+            workflowConfig.setWorkflowSteps(List.of(rulesStep));
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.agent"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(AGENT_URI, "live-agent")));
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "live-workflow")));
+            // The rule set's descriptor points at v2 — the version the last PUT created.
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(currentDescriptorResource, "edited-ruleset")));
+            when(agentStore.read(eq(AGENT_ID), any())).thenReturn(agentConfig);
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(workflowConfig);
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(true);
+
+            assertEquals(0, report.getTotalOrphans(), "any referenced version must protect the resource");
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
+    }
+
+    @Nested
+    @DisplayName("the report tells the operator what actually happened")
+    class ReportHonesty {
+
+        /**
+         * {@code ResourceClientLibrary} registers no {@code ai.labs.workflow} proxy,
+         * and {@code deleteResource} used to answer {@code Response.ok()} for an
+         * unknown type. So every orphaned workflow — the largest category, since a
+         * deleted agent is exactly what leaves workflows unreferenced — was counted as
+         * purged and logged as purged while nothing was deleted, forever.
+         */
+        @Test
+        @DisplayName("an orphaned workflow is deleted through the workflow store, not the (unregistered) proxy")
+        void orphanedWorkflowIsActuallyDeleted() throws Exception {
+            String workflowId = "aabbccddeeff11223344556b";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "unreferenced-workflow")));
+            // The workflow itself resolves — it simply is not referenced by any Agent.
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(emptyWorkflow());
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenReturn(Response.ok().build());
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getTotalOrphans());
+            assertEquals(1, report.getDeletedCount());
+            // permanent=true (that is what a purge means); cascade=false, because every
+            // resource the workflow references is itself enumerated by this same scan.
+            verify(restWorkflowStore).deleteWorkflow(workflowId, 1, true, false);
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("a workflow delete that fails is not counted as purged")
+        void failedWorkflowDeleteIsNotCounted() throws Exception {
+            String workflowId = "aabbccddeeff11223344556c";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "stuck-workflow")));
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(emptyWorkflow());
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenThrow(new IllegalStateException("still deployed"));
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getTotalOrphans());
+            assertEquals(0, report.getDeletedCount(), "deletedCount must count deletions, not attempts");
+        }
+
+        /**
+         * The GET is the operator's review surface for an irreversible operation, and a
+         * transient store failure drops that document's references from the set —
+         * promoting everything only it referenced to "orphan". The purge refuses in
+         * that case; the read-only scan answers, so it has to say the list is partial.
+         */
+        @Test
+        @DisplayName("an incomplete reference scan is reported as such, with a reason")
+        void incompleteScanIsFlagged() throws Exception {
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.agent"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(AGENT_URI, "broken-agent")));
+            when(agentStore.read(eq(AGENT_ID), any())).thenThrow(new IResourceStore.ResourceStoreException("mongo down"));
+
+            OrphanReport report = restOrphanAdmin.scanOrphans(false);
+
+            assertFalse(report.isScanComplete(), "a partial scan must not look like a clean one");
+            assertTrue(report.getScanWarning() != null && report.getScanWarning().contains("mongo down"),
+                    "the warning must name the cause, got: " + report.getScanWarning());
+        }
+
+        @Test
+        @DisplayName("a clean scan reports scanComplete=true and no warning")
+        void completeScanIsFlagged() throws Exception {
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+
+            OrphanReport report = restOrphanAdmin.scanOrphans(false);
+
+            assertTrue(report.isScanComplete());
+            assertNull(report.getScanWarning());
+        }
+
+        /**
+         * {@code deletedCount} is the operator's only feedback for an irreversible
+         * operation, so every way a workflow delete can fail to happen must leave it
+         * uncounted. These are the three that do not raise on their own: a URI with no
+         * usable resource id, a null Response, and a non-2xx answer.
+         */
+        @Test
+        @DisplayName("a workflow URI with no usable resource id is not counted as purged")
+        void workflowUriWithoutResourceIdIsNotCounted() throws Exception {
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/not-a-hex-id?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "unidentifiable-workflow")));
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getTotalOrphans());
+            assertEquals(0, report.getDeletedCount(), "nothing was deleted, so nothing may be counted");
+            verify(restWorkflowStore, never()).deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("a null delete response is not counted as purged")
+        void nullDeleteResponseIsNotCounted() throws Exception {
+            String workflowId = "aabbccddeeff11223344556d";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "silent-workflow")));
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(emptyWorkflow());
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(null);
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getTotalOrphans());
+            assertEquals(0, report.getDeletedCount(), "a delete that answered nothing is not a deletion");
+        }
+
+        @Test
+        @DisplayName("a non-2xx delete response is not counted as purged")
+        void nonSuccessDeleteResponseIsNotCounted() throws Exception {
+            String workflowId = "aabbccddeeff11223344556e";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "conflicted-workflow")));
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(emptyWorkflow());
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenReturn(Response.status(409).build());
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getTotalOrphans());
+            assertEquals(0, report.getDeletedCount(), "a 409 is a refusal, not a deletion");
+        }
+    }
+
+    /**
+     * A workflow step whose {@code uri} is not a parsable URI. Recording it
+     * verbatim protects nothing, which is the documented trade — but the reference
+     * traversal must survive it, because an exception here is caught per workflow
+     * and costs the scan every OTHER reference that workflow holds, which is what
+     * turns live resources into "orphans".
+     */
+    @Nested
+    @DisplayName("a malformed step URI does not derail the reference scan")
+    class MalformedStepUri {
+
+        @Test
+        @DisplayName("the rest of the workflow's references are still collected, and the scan stays complete")
+        void malformedUriIsRecordedAndTheScanContinues() throws Exception {
+            String workflowId = "aabbccddeeff11223344556f";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+            String ruleSetId = "aabbccddeeff112233445570";
+            URI ruleSetUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+
+            var malformedStep = new WorkflowConfiguration.WorkflowStep();
+            malformedStep.setType(URI.create("eddi://ai.labs.output"));
+            malformedStep.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.output/outputstore/output sets/x?version=1")));
+
+            var goodStep = new WorkflowConfiguration.WorkflowStep();
+            goodStep.setType(URI.create("eddi://ai.labs.behavior"));
+            goodStep.setConfig(new HashMap<>(Map.of("uri", ruleSetUri.toString())));
+
+            var workflowConfig = new WorkflowConfiguration();
+            workflowConfig.setWorkflowSteps(List.of(malformedStep, goodStep));
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "workflow-with-a-typo")));
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(ruleSetUri, "still-referenced-ruleset")));
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(workflowConfig);
+
+            OrphanReport report = restOrphanAdmin.scanOrphans(false);
+
+            assertTrue(report.isScanComplete(), "a malformed reference is not a scan failure, got: " + report.getScanWarning());
+            assertTrue(report.getOrphans().stream().noneMatch(o -> ruleSetUri.equals(o.getResourceUri())),
+                    "the reference AFTER the malformed one must still protect its resource");
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminSafetyTest.java
+++ b/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminSafetyTest.java
@@ -7,6 +7,8 @@ package ai.labs.eddi.configs.admin.rest;
 import ai.labs.eddi.configs.admin.model.OrphanReport;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.deployment.IDeploymentStore;
+import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
@@ -14,6 +16,7 @@ import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
+import ai.labs.eddi.utils.RestUtilities;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +42,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -81,13 +85,16 @@ class RestOrphanAdminSafetyTest {
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
     private IRestWorkflowStore restWorkflowStore;
+    @Mock
+    private IDeploymentStore deploymentStore;
 
     private RestOrphanAdmin restOrphanAdmin;
 
     @BeforeEach
     void setUp() {
         openMocks(this);
-        restOrphanAdmin = new RestOrphanAdmin(agentStore, workflowStore, documentDescriptorStore, resourceClientLibrary, restWorkflowStore);
+        restOrphanAdmin = new RestOrphanAdmin(agentStore, workflowStore, documentDescriptorStore, resourceClientLibrary, restWorkflowStore,
+                deploymentStore);
     }
 
     private static DocumentDescriptor descriptor(URI resource, String name) {
@@ -95,6 +102,20 @@ class RestOrphanAdminSafetyTest {
         descriptor.setResource(resource);
         descriptor.setName(name);
         return descriptor;
+    }
+
+    private static IResourceStore.IResourceId resourceId(String id, Integer version) {
+        return new IResourceStore.IResourceId() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return version;
+            }
+        };
     }
 
     private static WorkflowConfiguration emptyWorkflow() {
@@ -355,6 +376,332 @@ class RestOrphanAdminSafetyTest {
     }
 
     @Nested
+    @DisplayName("the purge converges and respects what is live right now")
+    class PurgeConvergence {
+
+        /**
+         * {@code RestVersionInfo.markDescriptorDeleted} only FLAGS descriptors — it has
+         * to, because on the HTTP path the descriptor filter reads one back after the
+         * delete and a missing row answers 404 to a delete that succeeded. But a
+         * flagged descriptor whose resource is gone is exactly what
+         * {@code readDescriptors(includeDeleted=true)} selects, so every purged
+         * resource came back as an orphan on the next {@code includeDeleted=true}
+         * sweep, {@code deleteAllPermanently} on a non-existent id answered silently,
+         * and {@code deletedCount} counted it again — forever. That filter does not run
+         * for {@code /administration/orphans}, so erasing the row here is both safe and
+         * what makes the sweep converge.
+         */
+        @Test
+        @DisplayName("a purged resource's descriptor is removed, so the next sweep does not re-report it")
+        void purgeRemovesTheDescriptorSoTheSweepConverges() throws Exception {
+            String ruleSetId = "aabbccddeeff11223344557a";
+            URI orphan = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(orphan, "already-soft-deleted-ruleset")));
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(true);
+
+            assertEquals(1, report.getDeletedCount());
+            verify(resourceClientLibrary).deleteResource(orphan, true);
+            verify(documentDescriptorStore).deleteAllDescriptor(ruleSetId);
+        }
+
+        @Test
+        @DisplayName("an orphaned workflow's descriptor is removed too")
+        void purgingAWorkflowAlsoRemovesItsDescriptor() throws Exception {
+            String workflowId = "aabbccddeeff11223344557b";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "unreferenced-workflow")));
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(emptyWorkflow());
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
+
+            restOrphanAdmin.purgeOrphans(true);
+
+            verify(documentDescriptorStore).deleteAllDescriptor(workflowId);
+        }
+
+        /**
+         * A permanent delete is now refused unless it is addressed at the resource's
+         * CURRENT version ({@code RestVersionInfo.requireCurrentVersion}), so the purge
+         * must resolve the version rather than trust the descriptor's. Descriptor
+         * versions go stale routinely: {@code DocumentDescriptorFilter} advances them
+         * only on an HTTP PUT/PATCH, so every in-process update path — MCP's injected
+         * facades, ZIP import, the upgrade executor — leaves the descriptor at v1 while
+         * the resource is at v2, the skew {@code resourceKey}'s Javadoc calls normal.
+         * Addressed at the descriptor's version, every such orphan failed with a caught
+         * 409 on every run and was never purged: the non-convergence this endpoint
+         * exists to remove.
+         */
+        @Test
+        @DisplayName("an orphan whose descriptor lags the resource is deleted at the LIVE version, not the descriptor's")
+        void purgeAddressesTheLiveVersionNotTheDescriptorsStaleOne() throws Exception {
+            String ruleSetId = "aabbccddeeff11223344558a";
+            URI staleDescriptorUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+            URI liveUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=2");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(staleDescriptorUri, "edited-through-mcp")));
+            // Edited in-process, so the resource moved to v2 and the descriptor did not.
+            when(resourceClientLibrary.getCurrentResourceId(staleDescriptorUri)).thenReturn(resourceId(ruleSetId, 2));
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(true);
+
+            verify(resourceClientLibrary).deleteResource(liveUri, true);
+            verify(resourceClientLibrary, never()).deleteResource(eq(staleDescriptorUri), anyBoolean());
+            assertEquals(1, report.getDeletedCount(), "the orphan must actually be purged, not 409 on every run for ever");
+        }
+
+        /**
+         * The workflow arm of the same defect: {@code deleteWorkflow} routes to
+         * {@code RestVersionInfo.delete} exactly as the extension facades do.
+         */
+        @Test
+        @DisplayName("an orphaned workflow whose descriptor lags is deleted at the live version too")
+        void purgeAddressesTheLiveWorkflowVersion() throws Exception {
+            String workflowId = "aabbccddeeff11223344558b";
+            URI staleDescriptorUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(staleDescriptorUri, "edited-through-import")));
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(emptyWorkflow());
+            when(workflowStore.getCurrentResourceId(workflowId)).thenReturn(resourceId(workflowId, 4));
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
+
+            restOrphanAdmin.purgeOrphans(true);
+
+            verify(restWorkflowStore).deleteWorkflow(workflowId, 4, true, false);
+            verify(restWorkflowStore, never()).deleteWorkflow(eq(workflowId), eq(1), anyBoolean(), anyBoolean());
+        }
+
+        /**
+         * The re-check and the delete must ask about the SAME version. Both reverse
+         * lookups take {@code includePreviousVersions=true}, which walks from the
+         * version given DOWN to 1, so a referrer pinning a version ABOVE the one asked
+         * about is invisible. Asked at a stale descriptor's v1, a workflow that started
+         * referencing this rule set at v2 in the mark/sweep window would be missed —
+         * and now that the delete is addressed at the live version it would actually
+         * succeed, permanently erasing a resource in use. (Before the version was
+         * resolved at all, that delete answered 409 and the gap was closed only by
+         * accident.)
+         */
+        @Test
+        @DisplayName("the pre-delete re-check asks at the live version, so a referrer at a newer version still protects the resource")
+        void recheckAsksAtTheLiveVersionNotTheDescriptorsStaleOne() throws Exception {
+            String ruleSetId = "aabbccddeeff11223344558d";
+            URI staleDescriptorUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+            URI liveUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=2");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(staleDescriptorUri, "edited-through-mcp")));
+            when(resourceClientLibrary.getCurrentResourceId(staleDescriptorUri)).thenReturn(resourceId(ruleSetId, 2));
+            // A workflow started referencing it at v2 after the scan. The walk from v1
+            // downwards cannot see that; the walk from v2 can.
+            when(workflowStore.getWorkflowDescriptorsContainingResource(liveUri.toString(), true))
+                    .thenReturn(List.of(descriptor(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/"
+                            + "aabbccddeeff11223344558e?version=1"), "a-workflow-that-uses-it")));
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(true);
+
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+            assertEquals(0, report.getDeletedCount(), "a resource referenced at its live version must never be purged");
+        }
+
+        /**
+         * The soft-deleted case, which {@code requireCurrentVersion} deliberately
+         * admits: there is no live version for the request to be stale against, so the
+         * two-step "soft delete, then purge the history" flow must keep working. The
+         * descriptor's version is the only address available, and it has to be used.
+         */
+        @Test
+        @DisplayName("a resource with no live version left is still purged at the descriptor's version")
+        void purgeFallsBackToTheDescriptorVersionWhenNothingIsLive() throws Exception {
+            String ruleSetId = "aabbccddeeff11223344558c";
+            URI orphan = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(orphan, "already-soft-deleted-ruleset")));
+            when(resourceClientLibrary.getCurrentResourceId(orphan)).thenReturn(null);
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(true);
+
+            verify(resourceClientLibrary).deleteResource(orphan, true);
+            assertEquals(1, report.getDeletedCount());
+        }
+
+        /**
+         * Mark and sweep are separated by however long the scan takes. A workflow that
+         * starts referencing a candidate in that window makes it live again, and the
+         * purge would erase every version of something in use. The re-check is a fresh
+         * reverse lookup taken immediately before the delete; it narrows the window
+         * rather than closing it, and it fails closed.
+         */
+        @Test
+        @DisplayName("a candidate that became referenced after the scan is not purged")
+        void aCandidateThatBecameReferencedIsSkipped() throws Exception {
+            URI orphan = URI.create("eddi://ai.labs.rules/rulestore/rulesets/aabbccddeeff11223344557c?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(orphan, "just-became-referenced")));
+            // The scan saw nothing referencing it; by the time the purge runs, a
+            // workflow does.
+            when(workflowStore.getWorkflowDescriptorsContainingResource(eq(orphan.toString()), eq(true)))
+                    .thenReturn(List.of(descriptor(orphan, "referring-workflow")));
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(true);
+
+            assertEquals(1, report.getTotalOrphans());
+            assertEquals(0, report.getDeletedCount());
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("a re-check that cannot answer fails closed")
+        void aFailedRecheckFailsClosed() throws Exception {
+            URI orphan = URI.create("eddi://ai.labs.rules/rulestore/rulesets/aabbccddeeff11223344557d?version=1");
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(orphan, "unanswerable")));
+            when(workflowStore.getWorkflowDescriptorsContainingResource(anyString(), anyBoolean()))
+                    .thenThrow(new IResourceStore.ResourceStoreException("index unavailable"));
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(true);
+
+            assertEquals(0, report.getDeletedCount(), "a permanent delete must never be decided on an unanswered query");
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
+    }
+
+    @Nested
+    @DisplayName("what counts as a reference")
+    class ReferenceIdentity {
+
+        /**
+         * Deployments are version-pinned: {@code checkDeployments} reads
+         * {@code (agentId, agentVersion)} out of the deployment store and redeploys
+         * exactly that version on every startup. Only each agent's CURRENT version used
+         * to contribute references, so editing a deployed agent to point at a new
+         * workflow made the old one look unreferenced — and purging it left the
+         * still-deployed version unable to resolve its own workflow, history rows gone
+         * and no recovery path.
+         */
+        @Test
+        @DisplayName("a workflow referenced only by a DEPLOYED older agent version is not an orphan")
+        void deployedOlderAgentVersionProtectsItsWorkflow() throws Exception {
+            String workflowId = "aabbccddeeff11223344558a";
+            URI oldWorkflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            // The agent's CURRENT version (v2) has dropped that workflow entirely.
+            AgentConfiguration currentAgent = new AgentConfiguration();
+            currentAgent.setWorkflows(List.of());
+            // The DEPLOYED version (v1) still points at it.
+            AgentConfiguration deployedAgent = new AgentConfiguration();
+            deployedAgent.setWorkflows(List.of(oldWorkflowUri));
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.agent"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(URI.create("eddi://ai.labs.agent/agentstore/agents/" + AGENT_ID + "?version=2"),
+                            "edited-agent")));
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(oldWorkflowUri, "still-deployed-workflow")));
+            when(agentStore.read(AGENT_ID, 2)).thenReturn(currentAgent);
+            when(agentStore.read(AGENT_ID, 1)).thenReturn(deployedAgent);
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(emptyWorkflow());
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed))
+                    .thenReturn(List.of(deployment(AGENT_ID, 1)));
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(0, report.getTotalOrphans(), "a deployed agent version's workflow must never be purged");
+            verify(restWorkflowStore, never()).deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("a deployment store that cannot be read makes the scan incomplete and refuses the purge")
+        void unreadableDeploymentStoreRefusesThePurge() throws Exception {
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed))
+                    .thenThrow(new IResourceStore.ResourceStoreException("mongo down"));
+
+            WebApplicationException thrown = assertThrows(WebApplicationException.class, () -> restOrphanAdmin.purgeOrphans(false));
+
+            assertEquals(409, thrown.getResponse().getStatus());
+            assertFalse(restOrphanAdmin.scanOrphans(false).isScanComplete(), "the read-only scan must say so as well");
+        }
+
+        /**
+         * {@code ResourceClientLibrary.init()} registers three stores under two
+         * authorities each, so a workflow step written through REST or MCP with the
+         * legacy authority resolves perfectly at runtime — while the descriptor always
+         * carries the canonical one {@code RestVersionInfo.create} writes. Only ZIP
+         * import normalises. A literal compare therefore reported a rule set a live
+         * workflow still references as unreferenced, and the purge erased it.
+         */
+        @Test
+        @DisplayName("a reference through a legacy authority protects the canonical resource")
+        void legacyAuthorityReferenceProtectsTheCanonicalResource() throws Exception {
+            String ruleSetId = "aabbccddeeff11223344558b";
+            URI legacyReference = URI.create("eddi://ai.labs.behavior/behaviorstore/behaviorsets/" + ruleSetId + "?version=1");
+            URI canonicalDescriptorResource = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=2");
+            String workflowId = "aabbccddeeff11223344558c";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            AgentConfiguration agentConfig = new AgentConfiguration();
+            agentConfig.setWorkflows(List.of(workflowUri));
+
+            WorkflowConfiguration workflowConfig = new WorkflowConfiguration();
+            WorkflowConfiguration.WorkflowStep rulesStep = new WorkflowConfiguration.WorkflowStep();
+            rulesStep.setType(URI.create("eddi://ai.labs.behavior"));
+            rulesStep.setConfig(new HashMap<>(Map.of("uri", legacyReference.toString())));
+            workflowConfig.setWorkflowSteps(List.of(rulesStep));
+
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.agent"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(AGENT_URI, "live-agent")));
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "live-workflow")));
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(canonicalDescriptorResource, "ruleset-referenced-by-legacy-uri")));
+            when(agentStore.read(eq(AGENT_ID), any())).thenReturn(agentConfig);
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(workflowConfig);
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(0, report.getTotalOrphans(), "a legacy-authority reference names the same resource the runtime resolves");
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
+    }
+
+    private static DeploymentInfo deployment(String agentId, int agentVersion) {
+        DeploymentInfo info = new DeploymentInfo();
+        info.setAgentId(agentId);
+        info.setAgentVersion(agentVersion);
+        info.setDeploymentStatus(DeploymentInfo.DeploymentStatus.deployed);
+        return info;
+    }
+
+    @Nested
     @DisplayName("the report tells the operator what actually happened")
     class ReportHonesty {
 
@@ -550,6 +897,297 @@ class RestOrphanAdminSafetyTest {
             assertTrue(report.isScanComplete(), "a malformed reference is not a scan failure, got: " + report.getScanWarning());
             assertTrue(report.getOrphans().stream().noneMatch(o -> ruleSetUri.equals(o.getResourceUri())),
                     "the reference AFTER the malformed one must still protect its resource");
+        }
+    }
+
+    /**
+     * The deployment sweep and the purge's own bookkeeping.
+     *
+     * <p>
+     * Two properties are pinned here, and they pull in opposite directions. A
+     * deployment row that protects nothing — no agent id, no workflows, an agent
+     * version already gone from the store — must NOT make the scan incomplete, or
+     * the purge is permanently refused on any installation with a stale deployment
+     * row. A deployment or workflow that cannot be READ must, because everything
+     * that version protects would otherwise be reported as an orphan and erased.
+     * </p>
+     */
+    @Nested
+    @DisplayName("deployment sweep and purge bookkeeping")
+    class DeploymentSweepAndBookkeeping {
+
+        private static final String DEPLOYED_AGENT_ID = "aabbccddeeff112233445580";
+        private static final String DEPLOYED_WORKFLOW_ID = "aabbccddeeff112233445581";
+        private static final URI DEPLOYED_WORKFLOW_URI = URI
+                .create("eddi://ai.labs.workflow/workflowstore/workflows/" + DEPLOYED_WORKFLOW_ID + "?version=3");
+
+        private void noDescriptors() throws Exception {
+            when(documentDescriptorStore.readDescriptors(anyString(), anyString(), anyInt(), anyInt(), anyBoolean()))
+                    .thenReturn(List.of());
+        }
+
+        @Test
+        @DisplayName("deployment rows that protect nothing leave the scan complete")
+        void harmlessDeploymentRowsDoNotBlockThePurge() throws Exception {
+            noDescriptors();
+
+            DeploymentInfo noAgentId = new DeploymentInfo();
+            noAgentId.setAgentVersion(1);
+            DeploymentInfo noVersion = new DeploymentInfo();
+            noVersion.setAgentId(DEPLOYED_AGENT_ID);
+
+            String workflowlessAgentId = "aabbccddeeff112233445582";
+            String goneAgentId = "aabbccddeeff112233445583";
+
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed))
+                    .thenReturn(List.of(noAgentId, noVersion, deployment(workflowlessAgentId, 1), deployment(goneAgentId, 7)));
+            // Declares no workflows at all. Explicitly null, which is what a stored
+            // document without the field deserializes to — the field defaults to an
+            // empty list, so only this reaches the null branch.
+            AgentConfiguration workflowless = new AgentConfiguration();
+            workflowless.setWorkflows(null);
+            when(agentStore.read(workflowlessAgentId, 1)).thenReturn(workflowless);
+            // The deployed version is already gone from the store: it protects nothing,
+            // and that is not an incomplete scan.
+            when(agentStore.read(goneAgentId, 7)).thenThrow(new IResourceStore.ResourceNotFoundException("purged"));
+
+            OrphanReport report = restOrphanAdmin.scanOrphans(false);
+
+            assertTrue(report.isScanComplete(), "a stale deployment row must not veto the purge, got: " + report.getScanWarning());
+            assertNull(report.getScanWarning());
+        }
+
+        @Test
+        @DisplayName("a deployed Agent that cannot be read makes the scan incomplete and names it")
+        void unreadableDeployedAgentMakesTheScanIncomplete() throws Exception {
+            noDescriptors();
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed))
+                    .thenReturn(List.of(deployment(DEPLOYED_AGENT_ID, 4)));
+            when(agentStore.read(DEPLOYED_AGENT_ID, 4)).thenThrow(new IResourceStore.ResourceStoreException("mongo down"));
+
+            OrphanReport report = restOrphanAdmin.scanOrphans(false);
+
+            assertFalse(report.isScanComplete());
+            assertTrue(report.getScanWarning().contains(DEPLOYED_AGENT_ID),
+                    "the warning must name the Agent whose references are missing, got: " + report.getScanWarning());
+            assertEquals(409, assertThrows(WebApplicationException.class, () -> restOrphanAdmin.purgeOrphans(false))
+                    .getResponse().getStatus());
+        }
+
+        @Test
+        @DisplayName("a deployed workflow that no longer exists leaves the scan complete")
+        void missingDeployedWorkflowLeavesTheScanComplete() throws Exception {
+            noDescriptors();
+            AgentConfiguration deployedAgent = new AgentConfiguration();
+            deployedAgent.setWorkflows(List.of(DEPLOYED_WORKFLOW_URI));
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed))
+                    .thenReturn(List.of(deployment(DEPLOYED_AGENT_ID, 1)));
+            when(agentStore.read(DEPLOYED_AGENT_ID, 1)).thenReturn(deployedAgent);
+            when(workflowStore.read(DEPLOYED_WORKFLOW_ID, 3)).thenThrow(new IResourceStore.ResourceNotFoundException("gone"));
+
+            OrphanReport report = restOrphanAdmin.scanOrphans(false);
+
+            assertTrue(report.isScanComplete(), "a workflow that is already gone protects nothing, got: " + report.getScanWarning());
+        }
+
+        @Test
+        @DisplayName("a deployed workflow reference with no usable version is skipped, not fatal")
+        void unversionedDeployedWorkflowReferenceIsSkipped() throws Exception {
+            noDescriptors();
+            AgentConfiguration deployedAgent = new AgentConfiguration();
+            deployedAgent.setWorkflows(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + DEPLOYED_WORKFLOW_ID)));
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed))
+                    .thenReturn(List.of(deployment(DEPLOYED_AGENT_ID, 1)));
+            when(agentStore.read(DEPLOYED_AGENT_ID, 1)).thenReturn(deployedAgent);
+
+            OrphanReport report = restOrphanAdmin.scanOrphans(false);
+
+            assertTrue(report.isScanComplete(), "an unusable reference is not a read failure, got: " + report.getScanWarning());
+            verify(workflowStore, never()).read(eq(DEPLOYED_WORKFLOW_ID), anyInt());
+        }
+
+        @Test
+        @DisplayName("a deployed workflow that cannot be read makes the scan incomplete and names it")
+        void unreadableDeployedWorkflowMakesTheScanIncomplete() throws Exception {
+            noDescriptors();
+            AgentConfiguration deployedAgent = new AgentConfiguration();
+            deployedAgent.setWorkflows(List.of(DEPLOYED_WORKFLOW_URI));
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed))
+                    .thenReturn(List.of(deployment(DEPLOYED_AGENT_ID, 1)));
+            when(agentStore.read(DEPLOYED_AGENT_ID, 1)).thenReturn(deployedAgent);
+            when(workflowStore.read(DEPLOYED_WORKFLOW_ID, 3)).thenThrow(new IResourceStore.ResourceStoreException("mongo down"));
+
+            OrphanReport report = restOrphanAdmin.scanOrphans(false);
+
+            assertFalse(report.isScanComplete(), "its extension references are missing from the set");
+            assertTrue(report.getScanWarning().contains(DEPLOYED_WORKFLOW_ID),
+                    "the warning must name the workflow, got: " + report.getScanWarning());
+        }
+
+        /**
+         * The purge re-checks each candidate immediately before the irreversible
+         * delete. A candidate it cannot even address — no version to ask about — is not
+         * a licence to delete: fail closed, exactly as the reference check does.
+         */
+        @Test
+        @DisplayName("an orphan with no usable version is not purged")
+        void orphanWithoutAUsableVersionIsNotPurged() throws Exception {
+            String ruleSetId = "aabbccddeeff112233445584";
+            URI unversioned = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId);
+
+            noDescriptors();
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(unversioned, "unversioned-orphan")));
+            // No live version either, so nothing supplies one.
+            when(resourceClientLibrary.getCurrentResourceId(unversioned)).thenReturn(null);
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getTotalOrphans());
+            assertEquals(0, report.getDeletedCount(), "a candidate that cannot be re-checked must not be counted as purged");
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
+
+        /**
+         * A descriptor whose URI carries no {@code ?version=} at all — hand-written, or
+         * imported from an older export. Once the live version is known, both the
+         * re-check and the delete must be addressed AT that version.
+         *
+         * <p>
+         * The reverse-lookup stub below is the real {@code WorkflowStore} contract, not
+         * a convenience: {@code WorkflowStore.getWorkflowDescriptorsContainingResource}
+         * throws {@code ResourceStoreException("Reverse lookup requires a versioned
+         * resource URI")} for exactly the query-less string, and
+         * {@code ResourceClientLibrary.deleteResource} reads the version straight out
+         * of the URI it is handed. So a test that stubs the lookup with
+         * {@code anyString()} certifies a purge the deployment cannot perform: in
+         * production {@code isReferencedNow} catches, logs "NOT purging it" and answers
+         * true, and the orphan is re-listed by every scan for ever. Pinning the
+         * VERSIONED URI on both calls is what makes this test able to fail.
+         * </p>
+         */
+        @Test
+        @DisplayName("an unversioned descriptor URI is re-addressed at the live version before it is purged")
+        void unversionedDescriptorUriIsPurgedVerbatim() throws Exception {
+            String ruleSetId = "aabbccddeeff112233445585";
+            URI unversioned = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId);
+            URI atLiveVersion = URI.create(unversioned + "?version=4");
+
+            noDescriptors();
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(unversioned, "live-but-unreferenced")));
+            when(resourceClientLibrary.getCurrentResourceId(unversioned)).thenReturn(resourceId(ruleSetId, 4));
+            // The real store's contract: a versioned URI is answered, anything else is
+            // refused.
+            when(workflowStore.getWorkflowDescriptorsContainingResource(anyString(), anyBoolean()))
+                    .thenAnswer(invocation -> {
+                        String uri = invocation.getArgument(0);
+                        if (RestUtilities.pathWithoutVersionQuery(URI.create(uri)) == null) {
+                            throw new IResourceStore.ResourceStoreException(
+                                    "Reverse lookup requires a versioned resource URI ('...?version=<n>' with n >= 1), got: " + uri);
+                        }
+                        return List.of();
+                    });
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getDeletedCount(), "a resolvable, unreferenced orphan must actually converge");
+            verify(workflowStore).getWorkflowDescriptorsContainingResource(atLiveVersion.toString(), true);
+            verify(resourceClientLibrary).deleteResource(atLiveVersion, true);
+            verify(resourceClientLibrary, never()).deleteResource(eq(unversioned), anyBoolean());
+            verify(documentDescriptorStore).deleteAllDescriptor(ruleSetId);
+        }
+
+        /**
+         * {@code IWorkflowStore} reports "no live version" by exception where
+         * {@code ResourceClientLibrary} reports it by null. The purge has to read both
+         * as the same thing, or an already soft-deleted workflow whose history is being
+         * purged throws out of the loop instead of being addressed at the version its
+         * descriptor carries.
+         */
+        @Test
+        @DisplayName("a workflow with no live version falls back to the descriptor's version")
+        void workflowWithoutALiveVersionFallsBackToTheDescriptor() throws Exception {
+            String workflowId = "aabbccddeeff112233445586";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=2");
+
+            noDescriptors();
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "soft-deleted-workflow")));
+            when(workflowStore.read(eq(workflowId), anyInt())).thenReturn(emptyWorkflow());
+            when(workflowStore.getCurrentResourceId(workflowId)).thenThrow(new IResourceStore.ResourceNotFoundException("soft-deleted"));
+            when(agentStore.getAgentDescriptorsContainingWorkflow(workflowId, 2, true)).thenReturn(List.of());
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(true);
+
+            assertEquals(1, report.getDeletedCount());
+            verify(restWorkflowStore).deleteWorkflow(workflowId, 2, true, false);
+        }
+
+        /**
+         * The resource IS gone by the time the descriptor is removed, so a descriptor
+         * that cannot be deleted must not turn a completed purge into a failure — it
+         * only means this resource will be re-reported on the next sweep, which the
+         * WARN says.
+         */
+        @Test
+        @DisplayName("a descriptor that cannot be removed does not un-count a completed purge")
+        void descriptorRemovalFailureDoesNotUncountThePurge() throws Exception {
+            String ruleSetId = "aabbccddeeff112233445587";
+            URI ruleSetUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+
+            noDescriptors();
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(ruleSetUri, "orphan-ruleset")));
+            when(resourceClientLibrary.getCurrentResourceId(ruleSetUri)).thenReturn(resourceId(ruleSetId, 1));
+            when(workflowStore.getWorkflowDescriptorsContainingResource(anyString(), anyBoolean())).thenReturn(List.of());
+            doThrow(new IllegalStateException("descriptor store down"))
+                    .when(documentDescriptorStore).deleteAllDescriptor(ruleSetId);
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getDeletedCount(), "the resource was deleted; the descriptor is bookkeeping");
+            verify(resourceClientLibrary).deleteResource(ruleSetUri, true);
+        }
+
+        /**
+         * A descriptor whose resource URI carries no authority at all cannot be keyed
+         * by canonical type; it is compared verbatim instead. That protects nothing —
+         * but it must not throw, and a workflow step written the same way must still
+         * match it, or the scan promotes a referenced resource to "orphan".
+         */
+        @Test
+        @DisplayName("a hostless resource URI is compared verbatim rather than throwing")
+        void hostlessResourceUriIsComparedVerbatim() throws Exception {
+            String ruleSetId = "aabbccddeeff112233445588";
+            URI hostless = URI.create("rulestore/rulesets/" + ruleSetId + "?version=1");
+            String workflowId = "aabbccddeeff112233445589";
+            URI workflowUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + workflowId + "?version=1");
+
+            WorkflowConfiguration workflowConfig = new WorkflowConfiguration();
+            WorkflowConfiguration.WorkflowStep step = new WorkflowConfiguration.WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.behavior"));
+            step.setConfig(new HashMap<>(Map.of("uri", hostless.toString())));
+            workflowConfig.setWorkflowSteps(List.of(step));
+
+            noDescriptors();
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.workflow"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(workflowUri, "workflow-with-a-relative-reference")));
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.agent"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(AGENT_URI, "live-agent")));
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(hostless, "referenced-by-a-relative-uri")));
+            AgentConfiguration agentConfig = new AgentConfiguration();
+            agentConfig.setWorkflows(List.of(workflowUri));
+            when(agentStore.read(eq(AGENT_ID), any())).thenReturn(agentConfig);
+            when(workflowStore.read(eq(workflowId), any())).thenReturn(workflowConfig);
+
+            OrphanReport report = restOrphanAdmin.scanOrphans(false);
+
+            assertTrue(report.isScanComplete(), "a hostless URI is not a scan failure, got: " + report.getScanWarning());
+            assertTrue(report.getOrphans().stream().noneMatch(o -> hostless.equals(o.getResourceUri())),
+                    "the verbatim key must still match the step that references it, got: " + report.getOrphans());
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminSafetyTest.java
+++ b/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminSafetyTest.java
@@ -1189,5 +1189,114 @@ class RestOrphanAdminSafetyTest {
             assertTrue(report.getOrphans().stream().noneMatch(o -> hostless.equals(o.getResourceUri())),
                     "the verbatim key must still match the step that references it, got: " + report.getOrphans());
         }
+
+        /**
+         * The mark scan counts every version a deployment record pins; the
+         * per-candidate re-check has to count them too.
+         *
+         * <p>
+         * Both reverse lookups the re-check uses skip a referrer that is not a
+         * resource's current version ({@code AbstractResourceStore.isStaleReference}),
+         * so they speak only for current Agents and current workflows. A deployment
+         * record that starts pinning an older Agent version in the mark/sweep window is
+         * therefore invisible to them — and the purge would erase the extension (or
+         * workflow) that the still-deployed version resolves, with every version and
+         * every history row gone and no recovery path.
+         * </p>
+         *
+         * <p>
+         * The deployment store answers empty on the mark scan and non-empty afterwards,
+         * which IS the window: the rule set really is unreferenced when it is
+         * classified, and really is referenced when it is about to be deleted.
+         * </p>
+         */
+        @Test
+        @DisplayName("a deployed version that starts referencing an orphan between scan and purge stops the delete")
+        void deployedVersionThatAppearsDuringThePurgeStopsTheDelete() throws Exception {
+            String ruleSetId = "aabbccddeeff112233445590";
+            URI ruleSetUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+
+            WorkflowConfiguration deployedWorkflow = new WorkflowConfiguration();
+            WorkflowConfiguration.WorkflowStep step = new WorkflowConfiguration.WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.rules"));
+            step.setConfig(new HashMap<>(Map.of("uri", ruleSetUri.toString())));
+            deployedWorkflow.setWorkflowSteps(List.of(step));
+
+            AgentConfiguration deployedAgent = new AgentConfiguration();
+            deployedAgent.setWorkflows(List.of(DEPLOYED_WORKFLOW_URI));
+
+            noDescriptors();
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(ruleSetUri, "orphan-at-scan-time")));
+            when(resourceClientLibrary.getCurrentResourceId(ruleSetUri)).thenReturn(resourceId(ruleSetId, 1));
+            // No CURRENT workflow references it — the only question the version-scoped
+            // re-check can ask.
+            when(workflowStore.getWorkflowDescriptorsContainingResource(anyString(), anyBoolean())).thenReturn(List.of());
+            // Empty during the mark scan, so the rule set is genuinely classified as an
+            // orphan; the deployment record appears before the delete.
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed))
+                    .thenReturn(List.of(), List.of(deployment(DEPLOYED_AGENT_ID, 2)));
+            when(agentStore.read(DEPLOYED_AGENT_ID, 2)).thenReturn(deployedAgent);
+            when(workflowStore.read(DEPLOYED_WORKFLOW_ID, 3)).thenReturn(deployedWorkflow);
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getTotalOrphans(), "it was an orphan when the scan classified it");
+            assertEquals(0, report.getDeletedCount(), "a deployed Agent version references it now, so it must not be erased");
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+            verify(documentDescriptorStore, never()).deleteAllDescriptor(anyString());
+        }
+
+        /**
+         * The counterpart: with no deployment record in the window the same candidate
+         * still converges. Without it the test above would pass equally against a purge
+         * that had simply stopped deleting.
+         */
+        @Test
+        @DisplayName("no deployed version appears, so the orphan is still purged")
+        void unreferencedOrphanIsStillPurgedWhenNoDeploymentAppears() throws Exception {
+            String ruleSetId = "aabbccddeeff112233445591";
+            URI ruleSetUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+
+            noDescriptors();
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(ruleSetUri, "orphan-ruleset")));
+            when(resourceClientLibrary.getCurrentResourceId(ruleSetUri)).thenReturn(resourceId(ruleSetId, 1));
+            when(workflowStore.getWorkflowDescriptorsContainingResource(anyString(), anyBoolean())).thenReturn(List.of());
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed)).thenReturn(List.of());
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(1, report.getDeletedCount());
+            verify(resourceClientLibrary).deleteResource(ruleSetUri, true);
+        }
+
+        /**
+         * The deployed-version re-check fails CLOSED like every other guard on this
+         * path: a deployment store that cannot answer has told us nothing, and nothing
+         * is not a licence for a permanent delete. The mark scan runs before the
+         * failure starts, so this cannot be mistaken for the incomplete-scan refusal —
+         * the purge is entered, and stops at the candidate.
+         */
+        @Test
+        @DisplayName("a deployment store that fails during the purge stops the delete rather than guessing")
+        void deploymentReadFailureDuringThePurgeStopsTheDelete() throws Exception {
+            String ruleSetId = "aabbccddeeff112233445592";
+            URI ruleSetUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + ruleSetId + "?version=1");
+
+            noDescriptors();
+            when(documentDescriptorStore.readDescriptors(eq("ai.labs.rules"), anyString(), eq(0), anyInt(), anyBoolean()))
+                    .thenReturn(List.of(descriptor(ruleSetUri, "orphan-ruleset")));
+            when(resourceClientLibrary.getCurrentResourceId(ruleSetUri)).thenReturn(resourceId(ruleSetId, 1));
+            when(workflowStore.getWorkflowDescriptorsContainingResource(anyString(), anyBoolean())).thenReturn(List.of());
+            when(deploymentStore.readDeploymentInfos(DeploymentInfo.DeploymentStatus.deployed))
+                    .thenReturn(List.of())
+                    .thenThrow(new IResourceStore.ResourceStoreException("mongo down"));
+
+            OrphanReport report = restOrphanAdmin.purgeOrphans(false);
+
+            assertEquals(0, report.getDeletedCount(), "the re-check could not answer, so nothing may be erased");
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminTest.java
+++ b/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.IWorkflowStore;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.client.configuration.IResourceClientLibrary;
@@ -33,6 +34,8 @@ class RestOrphanAdminTest {
     private IDocumentDescriptorStore descriptorStore;
     @Mock
     private IResourceClientLibrary resourceClientLibrary;
+    @Mock
+    private IRestWorkflowStore restWorkflowStore;
 
     private RestOrphanAdmin admin;
     private AutoCloseable mocks;
@@ -40,7 +43,7 @@ class RestOrphanAdminTest {
     @BeforeEach
     void setUp() {
         mocks = openMocks(this);
-        admin = new RestOrphanAdmin(agentStore, workflowStore, descriptorStore, resourceClientLibrary);
+        admin = new RestOrphanAdmin(agentStore, workflowStore, descriptorStore, resourceClientLibrary, restWorkflowStore);
     }
 
     @AfterEach

--- a/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminTest.java
+++ b/src/test/java/ai/labs/eddi/configs/admin/rest/RestOrphanAdminTest.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.configs.admin.rest;
 import ai.labs.eddi.configs.admin.model.OrphanReport;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
+import ai.labs.eddi.configs.deployment.IDeploymentStore;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
@@ -36,6 +37,8 @@ class RestOrphanAdminTest {
     private IResourceClientLibrary resourceClientLibrary;
     @Mock
     private IRestWorkflowStore restWorkflowStore;
+    @Mock
+    private IDeploymentStore deploymentStore;
 
     private RestOrphanAdmin admin;
     private AutoCloseable mocks;
@@ -43,7 +46,7 @@ class RestOrphanAdminTest {
     @BeforeEach
     void setUp() {
         mocks = openMocks(this);
-        admin = new RestOrphanAdmin(agentStore, workflowStore, descriptorStore, resourceClientLibrary, restWorkflowStore);
+        admin = new RestOrphanAdmin(agentStore, workflowStore, descriptorStore, resourceClientLibrary, restWorkflowStore, deploymentStore);
     }
 
     @AfterEach

--- a/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
@@ -12,8 +12,11 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -268,8 +271,114 @@ class AgentSigningServiceTest {
                 () -> signingService.sign("tenant-1", "agent-1", "payload"));
     }
 
+    /**
+     * A rotated agent has no legacy unversioned key, and the vault answers
+     * {@code SecretNotFoundException} for it. That exception used to escape into
+     * the method-wide catch, so the versioned scan below it never ran at all and
+     * every rotated key stayed in the vault forever — the exact leak this method
+     * exists to prevent, on the agents most likely to have one.
+     */
+    @Test
+    void deleteKeyPair_deletesVersionedKeysWhenNoLegacyKeyExists() throws Exception {
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 1);
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 2);
+
+        signingService.deleteKeyPair("tenant-1", "agent-1");
+
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v1"),
+                "v1 was left in the vault: the absent legacy key aborted the versioned scan");
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v2"),
+                "v2 was left in the vault: the absent legacy key aborted the versioned scan");
+    }
+
+    /**
+     * {@code rotateKey} takes an arbitrary version number from its caller, so
+     * versions can be sparse. Stopping the scan at the first missing version left
+     * every key past the gap behind.
+     */
+    @Test
+    void deleteKeyPair_deletesVersionsPastAGap() throws Exception {
+        signingService.generateKeyPair("tenant-1", "agent-1");
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 1);
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 3);
+
+        signingService.deleteKeyPair("tenant-1", "agent-1");
+
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v3"),
+                "v3 was left in the vault: the scan stopped at the missing v2");
+    }
+
+    /**
+     * The scan is deliberately exhaustive rather than stopping at the first gap, so
+     * the cost of one permanent agent delete is fixed and worth pinning: the legacy
+     * key plus every version in {@code 1..MAX_KEY_VERSION_SCAN}, once each. An
+     * early {@code break} leaks the keys past a rotation gap; a wider or unbounded
+     * loop turns one delete into an unbounded number of vault round trips.
+     */
+    @Test
+    void deleteKeyPair_scansTheLegacyKeyAndTheWholeVersionRangeExactlyOnce() {
+        signingService.deleteKeyPair("tenant-1", "agent-1");
+
+        assertEquals(AgentSigningService.MAX_KEY_VERSION_SCAN + 1, secretProvider.deleteAttempts.size(),
+                "one delete per version, plus the legacy key; attempted: " + secretProvider.deleteAttempts.size());
+        assertTrue(secretProvider.deleteAttempts.contains("tenant-1:agent-signing-key:agent-1"), "the legacy key must be attempted");
+        assertTrue(secretProvider.deleteAttempts.contains("tenant-1:agent-signing-key:agent-1:v1"));
+        assertTrue(
+                secretProvider.deleteAttempts
+                        .contains("tenant-1:agent-signing-key:agent-1:v" + AgentSigningService.MAX_KEY_VERSION_SCAN),
+                "the last version in the documented range must be attempted");
+        assertFalse(
+                secretProvider.deleteAttempts
+                        .contains("tenant-1:agent-signing-key:agent-1:v" + (AgentSigningService.MAX_KEY_VERSION_SCAN + 1)),
+                "the scan must stay inside its documented bound");
+    }
+
+    /**
+     * "Absent" and "vault unreachable" are different, and only the first is
+     * expected. A vault error on one key must be reported and stepped over, not
+     * abandon the keys after it — a failure mid-scan is the same leak this method
+     * exists to prevent, wearing a success message.
+     */
+    @Test
+    void deleteKeyPair_continuesPastAVaultFailureOnOneKey() throws Exception {
+        signingService.generateKeyPair("tenant-1", "agent-1");
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 1);
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 2);
+        // The vault answers for everything except the legacy key, which is the first
+        // thing the scan touches.
+        secretProvider.failDeleteFor("tenant-1:agent-signing-key:agent-1");
+
+        assertDoesNotThrow(() -> signingService.deleteKeyPair("tenant-1", "agent-1"));
+
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v1"),
+                "a vault error on an earlier key must not abandon the rest of the scan");
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v2"),
+                "a vault error on an earlier key must not abandon the rest of the scan");
+    }
+
     // ==================== sign error path with SecretNotFoundException
     // ====================
+
+    /**
+     * The envelope path and the plain path used to report the identical failure
+     * differently: {@code sign} said "No signing key found", {@code signEnvelope}
+     * said "Envelope signing failed … InvalidKeySpecException". Only the exception
+     * TYPE was asserted, so the two were free to drift apart again.
+     */
+    @Test
+    void signEnvelope_reportsAMissingKeyTheSameWaySignDoes() {
+        var envelope = SignedEnvelope.forSigning("agent-1", "agent-2", Map.of("data", "test"));
+
+        var envelopeFailure = assertThrows(AgentSigningService.AgentSigningException.class,
+                () -> signingService.signEnvelope("t1", "nonexistent", envelope, 0));
+        var plainFailure = assertThrows(AgentSigningService.AgentSigningException.class,
+                () -> signingService.sign("t1", "nonexistent", "payload"));
+
+        assertEquals("No signing key found for agent nonexistent", envelopeFailure.getMessage());
+        assertEquals(plainFailure.getMessage(), envelopeFailure.getMessage(), "the two signing paths must not drift apart again");
+        assertInstanceOf(ISecretProvider.SecretNotFoundException.class, envelopeFailure.getCause(),
+                "the original cause must survive the unwrapping");
+    }
 
     @Test
     void sign_throwsWithSecretNotFoundCauseMessage() {
@@ -284,6 +393,24 @@ class AgentSigningServiceTest {
      */
     private static class InMemorySecretProvider implements ISecretProvider {
         private final ConcurrentHashMap<String, String> store = new ConcurrentHashMap<>();
+
+        /** Every key a delete was attempted for, in order — for pinning the scan. */
+        private final List<String> deleteAttempts = new ArrayList<>();
+
+        /**
+         * Keys whose delete reports the vault as unreachable, not the key as absent.
+         */
+        private final Set<String> unreachable = new HashSet<>();
+
+        /** Whether a key is still in the vault — for asserting what a delete left. */
+        boolean contains(String tenantId, String keyName) {
+            return store.containsKey(tenantId + ":" + keyName);
+        }
+
+        /** Makes {@code delete} answer {@code SecretProviderException} for this key. */
+        void failDeleteFor(String fullKey) {
+            unreachable.add(fullKey);
+        }
 
         /**
          * Reversible obfuscation, not encryption — this is a test double, and the
@@ -325,8 +452,12 @@ class AgentSigningServiceTest {
         }
 
         @Override
-        public void delete(SecretReference reference) throws SecretNotFoundException {
+        public void delete(SecretReference reference) throws SecretNotFoundException, SecretProviderException {
             String key = reference.tenantId() + ":" + reference.keyName();
+            deleteAttempts.add(key);
+            if (unreachable.contains(key)) {
+                throw new SecretProviderException("Vault unreachable for: " + key);
+            }
             if (store.remove(key) == null) {
                 throw new SecretNotFoundException("Secret not found: " + key);
             }

--- a/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
@@ -13,8 +13,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -334,6 +339,236 @@ class AgentSigningServiceTest {
     }
 
     /**
+     * The blind sweep is the FALLBACK, for callers that do not know which versions
+     * exist. The agent's configuration lists them, and the caller has already read
+     * it to decide whether there is anything to clean up at all — so an agent whose
+     * highest declared version is 3 must cost four vault round trips, not 101. On a
+     * vault-less dev instance those 101 were also 101 "may still hold private key
+     * material" WARNs for versions that never existed.
+     *
+     * <p>
+     * The declared versions BOUND the sweep; they do not enumerate it. See
+     * {@link #deleteKeyPair_withKnownVersions_stillRemovesAnUndeclaredKeyBelowTheHighest}
+     * for why.
+     * </p>
+     */
+    @Test
+    void deleteKeyPair_withKnownVersions_staysWithinTheHighestDeclaredVersion() throws Exception {
+        signingService.generateKeyPair("tenant-1", "agent-1");
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 1);
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 3);
+
+        signingService.deleteKeyPair("tenant-1", "agent-1", List.of(3, 1));
+
+        assertEquals(4, secretProvider.deleteAttempts.size(),
+                "the legacy key plus 1..3, and nothing above the highest declared version; attempted: " + secretProvider.deleteAttempts);
+        assertTrue(secretProvider.deleteAttempts.contains("tenant-1:agent-signing-key:agent-1"));
+        assertTrue(secretProvider.deleteAttempts.contains("tenant-1:agent-signing-key:agent-1:v1"));
+        assertTrue(secretProvider.deleteAttempts.contains("tenant-1:agent-signing-key:agent-1:v3"));
+        assertFalse(secretProvider.deleteAttempts.contains("tenant-1:agent-signing-key:agent-1:v4"),
+                "nothing above the highest declared version may be attempted — that is what keeps this off the 101-call path");
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v1"));
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v3"));
+    }
+
+    /**
+     * A vault key can exist at a version {@code identity.keys} does not list.
+     * {@code rotateKey} writes the vault entry and returns; adding the version to
+     * {@code keys[]} is a SEPARATE config write by the caller, which can fail after
+     * the vault write succeeded — and {@code keys[]} is operator-editable JSON that
+     * nothing prunes. Sweeping only the listed versions left that private key in
+     * the vault forever after a permanent delete, while the tally reported "Deleted
+     * N signing key(s)": the leak wearing a success message, on a narrower path
+     * than the blanket-catch one the tally was written to close.
+     */
+    @Test
+    void deleteKeyPair_withKnownVersions_stillRemovesAnUndeclaredKeyBelowTheHighest() throws Exception {
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 1);
+        // v2 exists in the vault but the follow-up config write never landed, so
+        // identity.keys names only v1 and v3.
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 2);
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 3);
+
+        signingService.deleteKeyPair("tenant-1", "agent-1", List.of(1, 3));
+
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v2"),
+                "v2 was left in the vault: a private key that keys[] does not list is still a private key");
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v1"));
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v3"));
+    }
+
+    /**
+     * The cap is on the RANGE, which is a guess, not on the declared versions,
+     * which are known to exist. A stored version far above the cap must still be
+     * attempted — otherwise the one key we are certain about is the one we skip —
+     * while the range it implies stays bounded at {@code MAX_KEY_VERSION_SCAN}.
+     */
+    @Test
+    void deleteKeyPair_withAVersionAboveTheCap_attemptsItWithoutUnboundingTheSweep() throws Exception {
+        int aboveCap = AgentSigningService.MAX_KEY_VERSION_SCAN + 5;
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", aboveCap);
+
+        signingService.deleteKeyPair("tenant-1", "agent-1", List.of(aboveCap));
+
+        assertTrue(secretProvider.deleteAttempts.contains("tenant-1:agent-signing-key:agent-1:v" + aboveCap),
+                "a declared version is known to exist and must be attempted whatever the range cap says");
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v" + aboveCap));
+        assertEquals(AgentSigningService.MAX_KEY_VERSION_SCAN + 2, secretProvider.deleteAttempts.size(),
+                "the legacy key, the capped range 1..MAX, and the one declared version above it; attempted: "
+                        + secretProvider.deleteAttempts.size());
+    }
+
+    @Test
+    void deleteKeyPair_withNoDeclaredVersions_stillRemovesTheLegacyKey() throws Exception {
+        signingService.generateKeyPair("tenant-1", "agent-1");
+
+        signingService.deleteKeyPair("tenant-1", "agent-1", List.of());
+
+        assertEquals(1, secretProvider.deleteAttempts.size(), "attempted: " + secretProvider.deleteAttempts);
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1"));
+    }
+
+    @Test
+    void deleteKeyPair_withNullVersions_fallsBackToTheBlindSweep() {
+        signingService.deleteKeyPair("tenant-1", "agent-1", null);
+
+        assertEquals(AgentSigningService.MAX_KEY_VERSION_SCAN + 1, secretProvider.deleteAttempts.size(),
+                "null means the versions are unknown, so the whole documented range must still be swept");
+    }
+
+    /**
+     * {@code identity.keys} is operator-editable JSON, so it can carry a null entry
+     * or a zero/negative version. {@code rotateKey} rejects those, meaning they
+     * name no vault entry at all — and letting one set the upper bound of the sweep
+     * would either widen it needlessly or, for a null, throw out of a delete.
+     */
+    @Test
+    void deleteKeyPair_ignoresNullAndNonPositiveDeclaredVersions() throws Exception {
+        signingService.generateKeyPair("tenant-1", "agent-1");
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 2);
+
+        signingService.deleteKeyPair("tenant-1", "agent-1", Arrays.asList(null, 0, -3, 2));
+
+        assertEquals(3, secretProvider.deleteAttempts.size(),
+                "the legacy key plus versions 1..2 — nothing more; attempted: " + secretProvider.deleteAttempts);
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1"));
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v2"));
+    }
+
+    /**
+     * A vault outage fails every key in the sweep. The sweep must not stop at the
+     * first one — the keys it has not reached yet are exactly the private key
+     * material this method exists to remove — and the tally must keep the FIRST
+     * failure rather than being overwritten by whichever key was swept last.
+     */
+    @Test
+    void deleteKeyPair_keepsSweepingAfterAVaultFailure() throws Exception {
+        signingService.generateKeyPair("tenant-1", "agent-1");
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 1);
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 2);
+        secretProvider.failDeleteFor("tenant-1:agent-signing-key:agent-1");
+        secretProvider.failDeleteFor("tenant-1:agent-signing-key:agent-1:v1");
+
+        signingService.deleteKeyPair("tenant-1", "agent-1", List.of(2));
+
+        assertEquals(3, secretProvider.deleteAttempts.size(),
+                "every key must still be attempted; attempted: " + secretProvider.deleteAttempts);
+        assertTrue(secretProvider.contains("tenant-1", "agent-signing-key:agent-1"), "the failed delete left this key behind");
+        assertTrue(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v1"), "the failed delete left this key behind");
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v2"),
+                "a vault outage on earlier keys must not stop the sweep");
+    }
+
+    /**
+     * The private key is cached after the first load, so a second signature must
+     * not go back to the vault. Pinned by removing the vault entry out from under
+     * it: the cached key has to carry the second signature on its own.
+     */
+    @Test
+    void sign_usesTheCachedPrivateKeyOnTheSecondCall() throws Exception {
+        String publicKey = signingService.generateKeyPair("tenant-1", "agent-1");
+        signingService.sign("tenant-1", "agent-1", "first");
+
+        secretProvider.forget("tenant-1:agent-signing-key:agent-1");
+        String second = signingService.sign("tenant-1", "agent-1", "second");
+
+        assertTrue(signingService.verify(publicKey, "second", second),
+                "the second signature must come from the cached key, not from a vault round trip");
+    }
+
+    /**
+     * A vault delete that fails leaves the private key in the vault — but leaving
+     * the loaded key in the in-process cache as well would let this node keep
+     * SIGNING as the deleted agent from memory, for as long as it lives. That is
+     * strictly worse than the vault entry the WARN is about, so the cache line goes
+     * regardless of what the vault answered.
+     */
+    @Test
+    void deleteKeyPair_evictsTheCacheEvenWhenTheVaultDeleteFails() throws Exception {
+        signingService.generateKeyPair("tenant-1", "agent-1");
+        // Populate the private-key cache.
+        signingService.sign("tenant-1", "agent-1", "message");
+        secretProvider.failDeleteFor("tenant-1:agent-signing-key:agent-1");
+
+        signingService.deleteKeyPair("tenant-1", "agent-1", List.of());
+
+        // The key is still in the vault (the delete failed), so a cached entry would
+        // otherwise keep signing working. Signing must now go back to the vault, and
+        // this proves it did: the vault answer is removed out from under it.
+        secretProvider.forget("tenant-1:agent-signing-key:agent-1");
+        assertThrows(AgentSigningService.AgentSigningException.class,
+                () -> signingService.sign("tenant-1", "agent-1", "message"),
+                "the private key survived in the cache, so this process can still sign as a deleted agent");
+    }
+
+    /**
+     * The closing line used to read "Deleted signing keys for agent … (cache
+     * evicted)" unconditionally — after a vault outage that left every key behind,
+     * and equally after deleting nothing at all. That is the leak wearing a success
+     * message this method's own Javadoc warns about, so the line has to report what
+     * actually happened.
+     */
+    @Test
+    void deleteKeyPair_doesNotReportSuccessWhenTheVaultRefusedEveryKey() throws Exception {
+        signingService.generateKeyPair("tenant-1", "agent-1");
+        secretProvider.failDeleteFor("tenant-1:agent-signing-key:agent-1");
+
+        List<String> captured = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                captured.add(String.valueOf(record.getMessage()));
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        // logging.properties turns the whole ai.labs.eddi namespace OFF for plain unit
+        // tests, so this logger has to be opened explicitly to see anything.
+        Logger julLogger = Logger.getLogger(AgentSigningService.class.getName());
+        Level previousLevel = julLogger.getLevel();
+        julLogger.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+        try {
+            signingService.deleteKeyPair("tenant-1", "agent-1", List.of());
+        } finally {
+            julLogger.removeHandler(handler);
+            julLogger.setLevel(previousLevel);
+        }
+
+        assertTrue(captured.stream().anyMatch(m -> m.contains("could NOT be deleted")),
+                "a vault outage must be reported, not summarised as a success; captured: " + captured);
+        assertTrue(captured.stream().noneMatch(m -> m.startsWith("Deleted ")),
+                "nothing was deleted, so nothing may claim it was; captured: " + captured);
+    }
+
+    /**
      * "Absent" and "vault unreachable" are different, and only the first is
      * expected. A vault error on one key must be reported and stepped over, not
      * abandon the keys after it — a failure mid-scan is the same leak this method
@@ -410,6 +645,14 @@ class AgentSigningServiceTest {
         /** Makes {@code delete} answer {@code SecretProviderException} for this key. */
         void failDeleteFor(String fullKey) {
             unreachable.add(fullKey);
+        }
+
+        /**
+         * Drops a key without going through {@link #delete} — for proving a cache
+         * eviction.
+         */
+        void forget(String fullKey) {
+            store.remove(fullKey);
         }
 
         /**

--- a/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
@@ -424,8 +424,36 @@ class AgentSigningServiceTest {
 
         signingService.deleteKeyPair("tenant-1", "agent-1", List.of());
 
-        assertEquals(1, secretProvider.deleteAttempts.size(), "attempted: " + secretProvider.deleteAttempts);
         assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1"));
+    }
+
+    /**
+     * An empty declared-version list is not evidence that no versioned key exists,
+     * so it bounds nothing and has to fall back to the blind sweep.
+     *
+     * <p>
+     * {@code rotateKey} writes the vault entry and returns; adding the version to
+     * {@code identity.keys} is a SEPARATE config write by the caller. A first
+     * rotation whose config write failed therefore leaves v1 in the vault with
+     * {@code keys[]} still empty — and an operator can prune {@code keys[]} by hand
+     * to the same shape. Treating that as "no rotated versions, nothing to sweep"
+     * left an Ed25519 private key in the vault after a PERMANENT delete, while the
+     * tally reported a clean "Deleted 1 signing key(s)".
+     * </p>
+     */
+    @Test
+    void deleteKeyPair_withNoDeclaredVersions_stillRemovesAnUndeclaredRotatedKey() throws Exception {
+        signingService.generateKeyPair("tenant-1", "agent-1");
+        // The rotation reached the vault; the config write that would have added it to
+        // identity.keys did not.
+        signingService.generateKeyPairVersioned("tenant-1", "agent-1", 1);
+
+        signingService.deleteKeyPair("tenant-1", "agent-1", List.of());
+
+        assertFalse(secretProvider.contains("tenant-1", "agent-signing-key:agent-1:v1"),
+                "a rotated key that no keys[] entry names is exactly the private key material a permanent delete must not leave behind");
+        assertEquals(AgentSigningService.MAX_KEY_VERSION_SCAN + 1, secretProvider.deleteAttempts.size(),
+                "an empty list bounds nothing, so the whole documented range is swept; attempted: " + secretProvider.deleteAttempts.size());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/AgentSigningServiceTest.java
@@ -24,6 +24,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static ai.labs.eddi.utils.LogCaptureSupport.FORGED_RECORD;
+import static ai.labs.eddi.utils.LogCaptureSupport.assertNoForgedRecordBoundary;
+import static ai.labs.eddi.utils.LogCaptureSupport.captureLogsOf;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AgentSigningServiceTest {
@@ -649,6 +652,74 @@ class AgentSigningServiceTest {
         var ex = assertThrows(AgentSigningService.AgentSigningException.class,
                 () -> signingService.sign("t1", "missing-agent", "payload"));
         assertTrue(ex.getMessage().contains("No signing key found") || ex.getMessage().contains("Failed to load"));
+    }
+
+    // ==================== log injection (CWE-117) ====================
+
+    /**
+     * CWE-117. {@code agentId} and {@code tenantId} arrive from the REST path and
+     * from deployment configuration, and {@code firstFailure} quotes the vault key
+     * built out of {@code agentId}, so all three carry caller text into the WARN
+     * that reports a cleanup the operator is meant to act on. A newline in any of
+     * them forges a record that reads as the server's own.
+     */
+    @Test
+    void deleteKeyPair_vaultFailure_cannotForgeALogRecordThroughTheAgentId() throws Exception {
+        String poisonedAgent = "agent-1" + FORGED_RECORD;
+        String poisonedTenant = "tenant-1" + FORGED_RECORD;
+        signingService.generateKeyPair(poisonedTenant, poisonedAgent);
+        secretProvider.failDeleteFor(poisonedTenant + ":agent-signing-key:" + poisonedAgent);
+
+        List<String> captured = captureLogsOf(AgentSigningService.class,
+                () -> signingService.deleteKeyPair(poisonedTenant, poisonedAgent, List.of(1)));
+
+        assertFalse(captured.isEmpty(),
+                "nothing was captured, so this test proves nothing — the logger was not open, or the WARN branch did not run");
+        assertTrue(captured.stream().anyMatch(value -> value.contains("could NOT be deleted")),
+                "the vault-failure WARN is the line under test and it did not fire; captured: " + captured);
+        assertNoForgedRecordBoundary(captured, "AgentSigningService.deleteKeyPair's vault-failure WARN");
+    }
+
+    /**
+     * CWE-117, the success branch of the same tally. It reports a different line
+     * with the same caller-controlled identifiers, so it needs its own sanitising
+     * and its own pin.
+     */
+    @Test
+    void deleteKeyPair_success_cannotForgeALogRecordThroughTheAgentId() throws Exception {
+        String poisonedAgent = "agent-1" + FORGED_RECORD;
+        String poisonedTenant = "tenant-1" + FORGED_RECORD;
+        signingService.generateKeyPair(poisonedTenant, poisonedAgent);
+
+        List<String> captured = captureLogsOf(AgentSigningService.class,
+                () -> signingService.deleteKeyPair(poisonedTenant, poisonedAgent, List.of(1)));
+
+        assertFalse(captured.isEmpty(),
+                "nothing was captured, so this test proves nothing — the logger was not open, or the INFO branch did not run");
+        assertTrue(captured.stream().anyMatch(value -> value.contains("signing key(s) for agent")),
+                "the successful-cleanup INFO is the line under test and it did not fire; captured: " + captured);
+        assertNoForgedRecordBoundary(captured, "AgentSigningService.deleteKeyPair's successful-cleanup INFO");
+    }
+
+    /**
+     * CWE-117, the third branch: an agent that never had key material at all. It is
+     * DEBUG rather than WARN, which changes nothing — a forged record is forged at
+     * any level, and this is the branch an attacker reaches without needing the
+     * vault to fail or the agent to exist.
+     */
+    @Test
+    void deleteKeyPair_noKeys_cannotForgeALogRecordThroughTheAgentId() {
+        String poisonedAgent = "agent-1" + FORGED_RECORD;
+        String poisonedTenant = "tenant-1" + FORGED_RECORD;
+
+        List<String> captured = captureLogsOf(AgentSigningService.class,
+                () -> signingService.deleteKeyPair(poisonedTenant, poisonedAgent, List.of(1)));
+
+        assertFalse(captured.isEmpty(),
+                "nothing was captured, so this test proves nothing — the logger was not open, or the DEBUG branch did not run");
+        assertTrue(captured.stream().anyMatch(value -> value.contains("No signing keys found in the vault")),
+                "the nothing-to-clean DEBUG is the line under test and it did not fire; captured: " + captured);
+        assertNoForgedRecordBoundary(captured, "AgentSigningService.deleteKeyPair's nothing-to-clean DEBUG");
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/configs/agents/CapabilityRegistryServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/CapabilityRegistryServiceTest.java
@@ -7,25 +7,55 @@ package ai.labs.eddi.configs.agents;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService.CapabilityMatch;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration.Capability;
+import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
+import ai.labs.eddi.datastore.IResourceStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class CapabilityRegistryServiceTest {
 
     private CapabilityRegistryService service;
 
+    /**
+     * The store arguments are only used by the startup seeding, which these tests
+     * do not exercise, so plain mocks suffice. They used to be {@code null}, which
+     * forced a null guard into {@code populateFromStore} for two
+     * constructor-injected CDI beans that can never be null in production —
+     * production code shaped by a test. {@code StartupSeeding} builds its own
+     * stubbed stores.
+     */
+    private static CapabilityRegistryService newService(MeterRegistry registry) {
+        var service = new CapabilityRegistryService(registry, mock(IAgentStore.class), mock(IDocumentDescriptorStore.class));
+        service.initMetrics();
+        return service;
+    }
+
     @BeforeEach
     void setUp() {
-        service = new CapabilityRegistryService(new SimpleMeterRegistry());
-        service.initMetrics();
+        service = newService(new SimpleMeterRegistry());
     }
 
     @Test
@@ -267,20 +297,24 @@ class CapabilityRegistryServiceTest {
     @Test
     void findBySkill_missMetricIncrementsOnNoResults() {
         var registry = new SimpleMeterRegistry();
-        var svc = new CapabilityRegistryService(registry);
-        svc.initMetrics();
+        var svc = newService(registry);
 
         svc.findBySkill("nonexistent-skill", "all");
 
-        double missCount = registry.counter("eddi.capability.miss.count", "skill", "nonexistent-skill").count();
-        assertEquals(1.0, missCount);
+        // Counted in aggregate, NOT tagged with the skill. This assertion used to read
+        // counter(name, "skill", "nonexistent-skill"), which pinned an unbounded meter
+        // cardinality: the skill string comes from HTTP query params, A2A discovery and
+        // an LLM-invoked tool, so every invented name minted a Meter for the lifetime
+        // of the process.
+        assertEquals(1.0, registry.counter("eddi.capability.miss.count").count());
+        assertTrue(registry.find("eddi.capability.miss.count").counters().stream()
+                .allMatch(c -> c.getId().getTag("skill") == null), "the miss counter must carry no per-skill tag");
     }
 
     @Test
     void findBySkill_strategyMetricIncrementsOnEachCall() {
         var registry = new SimpleMeterRegistry();
-        var svc = new CapabilityRegistryService(registry);
-        svc.initMetrics();
+        var svc = newService(registry);
 
         svc.findBySkill("anything", "highest_confidence");
         svc.findBySkill("anything", "highest_confidence");
@@ -290,11 +324,31 @@ class CapabilityRegistryServiceTest {
         assertEquals(1.0, registry.counter("eddi.capability.strategy.applied", "strategy", "round_robin").count());
     }
 
+    /**
+     * The {@code strategy} tag came straight from the caller — a query parameter on
+     * {@code GET /capabilities}, or whatever an LLM-invoked tool passed — so an
+     * unrecognised value minted a Meter that lives for the process, exactly the
+     * unbounded cardinality the untagged miss counter fixes on the other side.
+     * Folding onto the four the strategy switch understands bounds the tag set.
+     */
+    @Test
+    void findBySkill_unknownStrategyIsFoldedOntoABoundedTagSet() {
+        var registry = new SimpleMeterRegistry();
+        var svc = newService(registry);
+
+        svc.findBySkill("anything", "invented-by-a-model-42");
+        svc.findBySkill("anything", "another-invention");
+
+        assertEquals(2.0, registry.counter("eddi.capability.strategy.applied", "strategy", "other").count());
+        Set<String> tags = registry.find("eddi.capability.strategy.applied").counters().stream()
+                .map(counter -> counter.getId().getTag("strategy")).collect(Collectors.toSet());
+        assertEquals(Set.of("other"), tags, "an unrecognised strategy must not mint its own meter");
+    }
+
     @Test
     void findBySkill_nullStrategyDefaultsToAll() {
         var registry = new SimpleMeterRegistry();
-        var svc = new CapabilityRegistryService(registry);
-        svc.initMetrics();
+        var svc = newService(registry);
 
         svc.findBySkill("anything", null);
 
@@ -304,8 +358,7 @@ class CapabilityRegistryServiceTest {
     @Test
     void findBySkill_missMetricNotIncrementedWhenSkillExists() {
         var registry = new SimpleMeterRegistry();
-        var svc = new CapabilityRegistryService(registry);
-        svc.initMetrics();
+        var svc = newService(registry);
 
         var config = new AgentConfiguration();
         config.setCapabilities(List.of(new Capability("existing-skill", Map.of(), "high")));
@@ -366,5 +419,111 @@ class CapabilityRegistryServiceTest {
 
         var matches = service.findBySkillAndAttributes("skill-y", Map.of(), "all");
         assertEquals(1, matches.size());
+    }
+
+    /**
+     * Seeding at startup, moved here from {@code RestAgentStoreExpandedTest} along
+     * with the code: it was a {@code @PostConstruct} on {@code RestAgentStore}, an
+     * {@code @ApplicationScoped} JAX-RS bean ArC only instantiates on first use —
+     * so on a fresh node nothing ran it and the index stayed empty until an admin
+     * happened to open the Manager.
+     */
+    @Nested
+    @DisplayName("startup seeding")
+    class StartupSeeding {
+
+        private static final String AGENT_ID = "aabbccddeeff112233445566";
+
+        private DocumentDescriptor agentDescriptor() {
+            var descriptor = new DocumentDescriptor();
+            descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + AGENT_ID + "?version=1"));
+            return descriptor;
+        }
+
+        @Test
+        @DisplayName("registers agents that declare capabilities")
+        void registersCapabilities() throws Exception {
+            var agentStore = mock(IAgentStore.class);
+            var descriptorStore = mock(IDocumentDescriptorStore.class);
+            when(descriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false)).thenReturn(List.of(agentDescriptor()));
+
+            var config = new AgentConfiguration();
+            config.setCapabilities(List.of(new Capability("greeting", Map.of(), "medium"),
+                    new Capability("farewell", Map.of(), "medium")));
+            when(agentStore.read(AGENT_ID, 1)).thenReturn(config);
+
+            var svc = new CapabilityRegistryService(new SimpleMeterRegistry(), agentStore, descriptorStore);
+            svc.initMetrics();
+            svc.onStartup(null);
+
+            assertEquals(Set.of("greeting", "farewell"), svc.getAllSkills());
+            assertEquals(1, svc.findBySkill("greeting", "all").size());
+        }
+
+        @Test
+        @DisplayName("skips agents without capabilities")
+        void skipsNonCapableAgents() throws Exception {
+            var agentStore = mock(IAgentStore.class);
+            var descriptorStore = mock(IDocumentDescriptorStore.class);
+            when(descriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false)).thenReturn(List.of(agentDescriptor()));
+            when(agentStore.read(AGENT_ID, 1)).thenReturn(new AgentConfiguration());
+
+            var svc = new CapabilityRegistryService(new SimpleMeterRegistry(), agentStore, descriptorStore);
+            svc.initMetrics();
+            svc.onStartup(null);
+
+            assertTrue(svc.getAllSkills().isEmpty());
+        }
+
+        @Test
+        @DisplayName("one unreadable agent does not abort the seeding")
+        void individualAgentFailure() throws Exception {
+            var agentStore = mock(IAgentStore.class);
+            var descriptorStore = mock(IDocumentDescriptorStore.class);
+            when(descriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false)).thenReturn(List.of(agentDescriptor()));
+            when(agentStore.read(anyString(), any())).thenThrow(new IResourceStore.ResourceNotFoundException("not found"));
+
+            var svc = new CapabilityRegistryService(new SimpleMeterRegistry(), agentStore, descriptorStore);
+            svc.initMetrics();
+
+            assertDoesNotThrow(() -> svc.onStartup(null));
+            assertTrue(svc.getAllSkills().isEmpty());
+        }
+
+        @Test
+        @DisplayName("an unreachable store does not break startup")
+        void totalFailure() throws Exception {
+            var descriptorStore = mock(IDocumentDescriptorStore.class);
+            when(descriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false)).thenThrow(new RuntimeException("db error"));
+
+            var svc = new CapabilityRegistryService(new SimpleMeterRegistry(), mock(IAgentStore.class), descriptorStore);
+            svc.initMetrics();
+
+            assertDoesNotThrow(() -> svc.onStartup(null));
+            assertTrue(svc.getAllSkills().isEmpty(), "an unreachable store must leave the index empty, not half-built");
+        }
+
+        /**
+         * The other three tests call {@code onStartup} by hand, which proves what the
+         * seeding does but not that anything ever calls it — and "nothing calls it" is
+         * exactly the defect this change fixes. Nothing in the runnable unit suite
+         * boots ArC, so the wiring is asserted structurally instead: the bean is
+         * {@code @ApplicationScoped} and the method takes an {@code @Observes}
+         * {@code StartupEvent}, which is what makes ArC create the bean eagerly and
+         * fire it. (Whether the new IAgentStore/IDocumentDescriptorStore injection
+         * points resolve without a CDI cycle is still only provable at boot, i.e. in
+         * CI.)
+         */
+        @Test
+        @DisplayName("the seeding is wired as a StartupEvent observer on an @ApplicationScoped bean")
+        void seedingIsAStartupObserver() throws Exception {
+            assertTrue(CapabilityRegistryService.class.isAnnotationPresent(ApplicationScoped.class),
+                    "a StartupEvent observer only fires on a CDI bean");
+
+            Method onStartup = CapabilityRegistryService.class.getDeclaredMethod("onStartup", StartupEvent.class);
+            Annotation[] parameterAnnotations = onStartup.getParameterAnnotations()[0];
+            assertTrue(Stream.of(parameterAnnotations).anyMatch(a -> a.annotationType() == Observes.class),
+                    "without @Observes this is an ordinary method nothing calls, and the index stays empty on a fresh node");
+        }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/agents/CapabilityRegistryServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/CapabilityRegistryServiceTest.java
@@ -23,16 +23,24 @@ import org.junit.jupiter.api.Test;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class CapabilityRegistryServiceTest {
@@ -475,6 +483,72 @@ class CapabilityRegistryServiceTest {
             assertTrue(svc.getAllSkills().isEmpty());
         }
 
+        /**
+         * An empty {@code capabilities} array is what the Manager leaves behind when an
+         * author adds the block and then removes every entry. Registering it would put
+         * an agent id in the index under no skill at all — an entry no skill-keyed
+         * lookup can ever reach or clean up.
+         *
+         * <p>
+         * {@code getAllSkills().isEmpty()} alone cannot see the guard:
+         * {@code register()} on an empty list is itself a no-op, so the index looks
+         * identical with and without {@code && !config.getCapabilities().isEmpty()}.
+         * What the guard actually decides is whether this agent is <em>counted</em> as
+         * seeded — so the two observable consequences are asserted instead: the
+         * registry is never asked to register it, and the seeding does not report a
+         * populated registry. Drop the {@code isEmpty()} half of the guard and
+         * {@code registered} becomes 1, which logs "Capability registry populated: 1
+         * agent(s)" for an index that holds nothing.
+         * </p>
+         */
+        @Test
+        @DisplayName("skips an agent whose capabilities array is present but empty")
+        void skipsAgentWithEmptyCapabilities() throws Exception {
+            var agentStore = mock(IAgentStore.class);
+            var descriptorStore = mock(IDocumentDescriptorStore.class);
+            when(descriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false)).thenReturn(List.of(agentDescriptor()));
+
+            var config = new AgentConfiguration();
+            config.setCapabilities(List.of());
+            when(agentStore.read(AGENT_ID, 1)).thenReturn(config);
+
+            var svc = spy(new CapabilityRegistryService(new SimpleMeterRegistry(), agentStore, descriptorStore));
+            svc.initMetrics();
+
+            List<String> captured = captureLogsOf(CapabilityRegistryService.class, () -> svc.onStartup(null));
+
+            assertTrue(svc.getAllSkills().isEmpty());
+            verify(svc, never()).register(anyString(), any(AgentConfiguration.class));
+            assertTrue(captured.stream().noneMatch(value -> value.contains("Capability registry populated")),
+                    "an agent that was skipped must not be counted as seeded; captured: " + captured);
+        }
+
+        /**
+         * The complement of {@link #skipsAgentWithEmptyCapabilities}: an agent that
+         * DOES declare capabilities must be registered and counted, so the assertions
+         * above cannot be satisfied by a guard that rejects everything.
+         */
+        @Test
+        @DisplayName("an agent with capabilities is registered and counted as seeded")
+        void capableAgentIsRegisteredAndCounted() throws Exception {
+            var agentStore = mock(IAgentStore.class);
+            var descriptorStore = mock(IDocumentDescriptorStore.class);
+            when(descriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false)).thenReturn(List.of(agentDescriptor()));
+
+            var config = new AgentConfiguration();
+            config.setCapabilities(List.of(new Capability("greeting", Map.of(), "medium")));
+            when(agentStore.read(AGENT_ID, 1)).thenReturn(config);
+
+            var svc = spy(new CapabilityRegistryService(new SimpleMeterRegistry(), agentStore, descriptorStore));
+            svc.initMetrics();
+
+            List<String> captured = captureLogsOf(CapabilityRegistryService.class, () -> svc.onStartup(null));
+
+            verify(svc).register(AGENT_ID, config);
+            assertTrue(captured.stream().anyMatch(value -> value.contains("Capability registry populated")),
+                    "a seeded agent must be counted; captured: " + captured);
+        }
+
         @Test
         @DisplayName("one unreadable agent does not abort the seeding")
         void individualAgentFailure() throws Exception {
@@ -525,5 +599,74 @@ class CapabilityRegistryServiceTest {
             assertTrue(Stream.of(parameterAnnotations).anyMatch(a -> a.annotationType() == Observes.class),
                     "without @Observes this is an ordinary method nothing calls, and the index stays empty on a fresh node");
         }
+    }
+
+    /**
+     * CWE-117. The skill string reaches this lookup from GET /capabilities, from
+     * A2A discovery, from a templated {@code capabilityMatch} rule and from the
+     * LLM-invoked {@code FindAgentsByCapabilityTool} — all caller-controlled — and
+     * a newline in it forges a second log record that reads as the server's own.
+     * {@code LogSanitizer} is the sanitiser the rest of the codebase uses; this
+     * pins that this site uses it too.
+     */
+    @Test
+    @DisplayName("a miss logs the requested skill sanitized, so it cannot forge a log record")
+    void aMissedSkillIsLoggedSanitized() {
+        String poisonedSkill = "translation\nERROR [io.quarkus] forged log line";
+
+        List<String> captured = captureLogsOf(CapabilityRegistryService.class,
+                () -> assertTrue(service.findBySkill(poisonedSkill, "all").isEmpty()));
+
+        // lower-cased because the lookup normalises the skill before logging it; the
+        // point is the newline became '_' rather than a record boundary.
+        assertTrue(captured.stream().anyMatch(value -> value.contains("translation_error")),
+                "the miss must have been captured with the skill sanitized in place; captured: " + captured);
+        assertTrue(captured.stream().noneMatch(value -> value.contains("\n")),
+                "a newline reached the log, so a caller can forge log records; captured: " + captured);
+    }
+
+    /**
+     * Runs {@code body} with a JUL handler attached to {@code loggerClass}'s logger
+     * and returns every message and message parameter it emitted.
+     *
+     * <p>
+     * {@code logging.properties} turns the whole {@code ai.labs.eddi} namespace OFF
+     * for plain unit tests, so the logger has to be opened explicitly to see
+     * anything; the previous level is always put back.
+     * </p>
+     */
+    static List<String> captureLogsOf(Class<?> loggerClass, Runnable body) {
+        List<String> captured = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                captured.add(String.valueOf(record.getMessage()));
+                if (record.getParameters() != null) {
+                    for (Object parameter : record.getParameters()) {
+                        captured.add(String.valueOf(parameter));
+                    }
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        Logger julLogger = Logger.getLogger(loggerClass.getName());
+        Level previousLevel = julLogger.getLevel();
+        julLogger.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+        try {
+            body.run();
+        } finally {
+            julLogger.removeHandler(handler);
+            julLogger.setLevel(previousLevel);
+        }
+        return captured;
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/agents/CapabilityRegistryServiceTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/CapabilityRegistryServiceTest.java
@@ -23,17 +23,13 @@ import org.junit.jupiter.api.Test;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
+import static ai.labs.eddi.utils.LogCaptureSupport.captureLogsOf;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -623,50 +619,5 @@ class CapabilityRegistryServiceTest {
                 "the miss must have been captured with the skill sanitized in place; captured: " + captured);
         assertTrue(captured.stream().noneMatch(value -> value.contains("\n")),
                 "a newline reached the log, so a caller can forge log records; captured: " + captured);
-    }
-
-    /**
-     * Runs {@code body} with a JUL handler attached to {@code loggerClass}'s logger
-     * and returns every message and message parameter it emitted.
-     *
-     * <p>
-     * {@code logging.properties} turns the whole {@code ai.labs.eddi} namespace OFF
-     * for plain unit tests, so the logger has to be opened explicitly to see
-     * anything; the previous level is always put back.
-     * </p>
-     */
-    static List<String> captureLogsOf(Class<?> loggerClass, Runnable body) {
-        List<String> captured = new ArrayList<>();
-        Handler handler = new Handler() {
-            @Override
-            public void publish(LogRecord record) {
-                captured.add(String.valueOf(record.getMessage()));
-                if (record.getParameters() != null) {
-                    for (Object parameter : record.getParameters()) {
-                        captured.add(String.valueOf(parameter));
-                    }
-                }
-            }
-
-            @Override
-            public void flush() {
-            }
-
-            @Override
-            public void close() {
-            }
-        };
-
-        Logger julLogger = Logger.getLogger(loggerClass.getName());
-        Level previousLevel = julLogger.getLevel();
-        julLogger.setLevel(Level.ALL);
-        julLogger.addHandler(handler);
-        try {
-            body.run();
-        } finally {
-            julLogger.removeHandler(handler);
-            julLogger.setLevel(previousLevel);
-        }
-        return captured;
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/agents/mongo/AgentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/mongo/AgentStoreTest.java
@@ -303,6 +303,108 @@ class AgentStoreTest {
 
             assertEquals(2, result.size());
         }
+
+        /**
+         * A soft-deleted Agent keeps a history row that still contains the workflow
+         * URI, so the history search returns it — but it has no current row, and
+         * {@code getCurrentVersion} answers -1, which made {@code getCurrentResourceId}
+         * throw. The throw was unguarded, so ONE soft-deleted Agent turned this whole
+         * listing into a 404 and made {@code DELETE ?cascade=true} on any other Agent
+         * stop cascading, silently (the caller swallows the exception and logs "Failed
+         * to cascade-delete").
+         */
+        @Test
+        @DisplayName("a soft-deleted Agent in the history hits is skipped, not fatal")
+        @SuppressWarnings("unchecked")
+        void skipsHistoryOnlyAgentsWithNoCurrentVersion() throws Exception {
+            String workflowUri = "eddi://ai.labs.workflow/workflowstore/workflows/" + WORKFLOW_ID + "?version=1";
+
+            doReturn(List.of(createResourceId(AGENT_ID_2, 1))).when(resourceStorage)
+                    .findResourceIdsContaining("workflows", workflowUri);
+            // AGENT_ID_1 was soft-deleted: history still matches, no current row.
+            doReturn(List.of(createResourceId(AGENT_ID_1, 1))).when(resourceStorage)
+                    .findHistoryResourceIdsContaining("workflows", workflowUri);
+            doReturn(-1).when(resourceStorage).getCurrentVersion(AGENT_ID_1);
+            doReturn(1).when(resourceStorage).getCurrentVersion(AGENT_ID_2);
+
+            var descriptor = new DocumentDescriptor();
+            descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + AGENT_ID_2 + "?version=1"));
+            when(documentDescriptorStore.readDescriptor(AGENT_ID_2, 1)).thenReturn(descriptor);
+
+            var result = agentStore.getAgentDescriptorsContainingWorkflow(WORKFLOW_ID, 1, false);
+
+            assertEquals(1, result.size());
+            assertSame(descriptor, result.get(0));
+            verify(documentDescriptorStore, never()).readDescriptor(eq(AGENT_ID_1), anyInt());
+        }
+    }
+
+    @Nested
+    @DisplayName("userMemoryConfig validation")
+    class UserMemoryConfigValidation {
+
+        /**
+         * The {@code >= 1} rule used to live in the Jackson setter, which runs on every
+         * READ — so an agent stored before the rule existed could no longer be loaded,
+         * deployed, exported or even repaired by PUT. It belongs on the write path.
+         *
+         * <p>
+         * The config is built OUTSIDE {@code assertThrows} deliberately. Built inside
+         * the lambda, the old setter's own throw satisfied the assertion, so the test
+         * passed whether or not {@code create} validated anything at all — it pinned
+         * the defect rather than the fix. Out here, a setter that still throws fails
+         * the test before {@code create} is ever reached.
+         * </p>
+         */
+        @Test
+        @DisplayName("create rejects summarizeTargetEntries < 1")
+        void createRejectsZeroTargetEntries() {
+            AgentConfiguration config = configWithTargetEntries(0);
+
+            assertThrows(IllegalArgumentException.class, () -> agentStore.create(config));
+        }
+
+        @Test
+        @DisplayName("update rejects summarizeTargetEntries < 1")
+        void updateRejectsZeroTargetEntries() {
+            AgentConfiguration config = configWithTargetEntries(0);
+
+            assertThrows(IllegalArgumentException.class, () -> agentStore.update("aabbccdd11223344eeff5566", 1, config));
+        }
+
+        @Test
+        @DisplayName("create accepts a value inside the bound")
+        @SuppressWarnings("unchecked")
+        void acceptsValidTargetEntries() throws Exception {
+            AgentConfiguration config = configWithTargetEntries(1);
+            IResourceStorage.IResource<AgentConfiguration> mockResource = mock(IResourceStorage.IResource.class);
+            when(mockResource.getId()).thenReturn("aabbccdd11223344eeff5566");
+            when(mockResource.getVersion()).thenReturn(1);
+            doReturn(mockResource).when(resourceStorage).newResource(any());
+
+            assertDoesNotThrow(() -> agentStore.create(config));
+        }
+
+        @Test
+        @DisplayName("a document already stored with 0 still deserializes")
+        void storedZeroStillLoads() {
+            // The setter must be a plain assignment: Jackson calls it on every MongoDB
+            // read, ZIP import and instance sync.
+            var dream = new AgentConfiguration.DreamConfig();
+            assertDoesNotThrow(() -> dream.setSummarizeTargetEntries(0));
+            assertEquals(0, dream.getSummarizeTargetEntries());
+        }
+
+        private AgentConfiguration configWithTargetEntries(int targetEntries) {
+            var config = new AgentConfiguration();
+            config.setWorkflows(new ArrayList<>());
+            var userMemory = new AgentConfiguration.UserMemoryConfig();
+            var dream = new AgentConfiguration.DreamConfig();
+            dream.setSummarizeTargetEntries(targetEntries);
+            userMemory.setDream(dream);
+            config.setUserMemoryConfig(userMemory);
+            return config;
+        }
     }
 
     private IResourceStore.IResourceId createResourceId(String id, int version) {

--- a/src/test/java/ai/labs/eddi/configs/agents/mongo/AgentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/mongo/AgentStoreTest.java
@@ -385,6 +385,82 @@ class AgentStoreTest {
             assertDoesNotThrow(() -> agentStore.create(config));
         }
 
+        /**
+         * The write-time check has to bound the update in BOTH directions, and one test
+         * asserts both because either half alone is satisfied by code that does not
+         * implement the rule.
+         *
+         * <p>
+         * A legal config must reach the store: only the rejecting cases were pinned at
+         * first, so a guard that refused every update — or one wired before the wrong
+         * call — would have looked exactly as green while every agent edit in the
+         * product failed with a 400.
+         * </p>
+         *
+         * <p>
+         * And an illegal one must be refused <em>before the store is touched at
+         * all</em> — not read, not versioned, not written. That is what
+         * {@code validateUserMemoryConfig(agentConfiguration)} sitting ahead of
+         * {@code super.update} buys: drop that call and the out-of-bounds config below
+         * is persisted as the next version like any other. Asserting only "a valid
+         * value is stored" cannot see that, because a valid value is stored either way.
+         * </p>
+         */
+        @Test
+        @DisplayName("update stores a value inside the bound and refuses one outside it before writing")
+        @SuppressWarnings("unchecked")
+        void updateAcceptsValidTargetEntries() throws Exception {
+            AgentConfiguration config = configWithTargetEntries(5);
+
+            IResourceStorage.IResource<AgentConfiguration> stored = mock(IResourceStorage.IResource.class);
+            when(stored.getId()).thenReturn("aabbccdd11223344eeff5566");
+            when(stored.getVersion()).thenReturn(2);
+            doReturn(stored).when(resourceStorage).read("aabbccdd11223344eeff5566", 2);
+
+            IResourceStorage.IResource<AgentConfiguration> successor = mock(IResourceStorage.IResource.class);
+            doReturn(successor).when(resourceStorage).newResource("aabbccdd11223344eeff5566", 3, config);
+
+            Integer newVersion = agentStore.update("aabbccdd11223344eeff5566", 2, config);
+
+            assertEquals(3, newVersion, "a valid update must be persisted as the next version");
+            verify(resourceStorage).storeHistoryAndUpdate(any(), eq(successor), eq(2));
+
+            // Same store, same id, same live version — only the value moves out of
+            // bounds. Nothing about this second call may reach the storage layer.
+            clearInvocations(resourceStorage);
+            AgentConfiguration outOfBounds = configWithTargetEntries(0);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> agentStore.update("aabbccdd11223344eeff5566", 2, outOfBounds));
+
+            verifyNoInteractions(resourceStorage);
+        }
+
+        /**
+         * The Dream block is optional at both levels. An Agent that configures user
+         * memory without configuring Dream consolidation must not be rejected by a rule
+         * about a field it never set.
+         */
+        @Test
+        @DisplayName("a userMemoryConfig without a dream block is accepted")
+        @SuppressWarnings("unchecked")
+        void userMemoryWithoutDreamIsAccepted() throws Exception {
+            var config = new AgentConfiguration();
+            config.setWorkflows(new ArrayList<>());
+            var userMemory = new AgentConfiguration.UserMemoryConfig();
+            // Explicitly absent, which is what `"dream": null` in stored JSON produces —
+            // the field defaults to an instance, so only this reaches the null branch.
+            userMemory.setDream(null);
+            config.setUserMemoryConfig(userMemory);
+
+            IResourceStorage.IResource<AgentConfiguration> mockResource = mock(IResourceStorage.IResource.class);
+            when(mockResource.getId()).thenReturn("aabbccdd11223344eeff5566");
+            when(mockResource.getVersion()).thenReturn(1);
+            doReturn(mockResource).when(resourceStorage).newResource(any());
+
+            assertDoesNotThrow(() -> agentStore.create(config));
+        }
+
         @Test
         @DisplayName("a document already stored with 0 still deserializes")
         void storedZeroStillLoads() {

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExpandedTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import ai.labs.eddi.engine.security.spaces.AccessScope;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.configs.agents.AgentSigningService;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
@@ -66,7 +67,15 @@ class RestAgentStoreExpandedTest {
         deploymentStore = mock(IDeploymentStore.class);
 
         sut = new RestAgentStore(agentStore, restWorkflowStore, documentDescriptorStore,
-                jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore, permissiveGuard());
+                jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore, permissiveGuard(),
+                mock(AgentSigningService.class), "default");
+        try {
+            // The Agent is live at v1. A cascade only runs against the CURRENT version —
+            // it tears workflows and schedules down before the delete's own version check.
+            when(agentStore.getCurrentResourceId(AGENT_ID)).thenReturn(dummyResourceId(AGENT_ID, 1));
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     private IResourceStore.IResourceId dummyResourceId(String id, int version) {
@@ -141,7 +150,7 @@ class RestAgentStoreExpandedTest {
         @Test
         @DisplayName("should reject non-workflow URI")
         void nonWorkflowUri() {
-            // Not a workflow URI — createMalFormattedResourceUriException throws
+            // Not a workflow URI — malformedResourceUri is thrown
             // BadRequestException
             assertThrows(BadRequestException.class, () -> sut.readAgentDescriptors("", 0, 20,
                     "eddi://ai.labs.rules/rulestore/rulesets/abc?version=1", false));
@@ -150,7 +159,7 @@ class RestAgentStoreExpandedTest {
         @Test
         @DisplayName("should reject malformed URI")
         void malformedUri() {
-            // Malformed URI — createMalFormattedResourceUriException throws
+            // Malformed URI — malformedResourceUri is thrown
             // BadRequestException
             assertThrows(BadRequestException.class, () -> sut.readAgentDescriptors("", 0, 20, "not-a-valid-uri", false));
         }
@@ -459,70 +468,10 @@ class RestAgentStoreExpandedTest {
         }
     }
 
-    // ─── populateCapabilityRegistry ────────────────────────────────────────────
-
-    @Nested
-    @DisplayName("populateCapabilityRegistry (@PostConstruct)")
-    class CapabilityRegistryInit {
-
-        @Test
-        @DisplayName("should register agents with capabilities on startup")
-        void registersCapabilities() throws Exception {
-            var descriptor = new DocumentDescriptor();
-            descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + AGENT_ID + "?version=1"));
-            when(documentDescriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false))
-                    .thenReturn(List.of(descriptor));
-
-            var config = new AgentConfiguration();
-            config.setCapabilities(List.of(
-                    new AgentConfiguration.Capability("greeting", Map.of(), "medium"),
-                    new AgentConfiguration.Capability("farewell", Map.of(), "medium")));
-            when(agentStore.read(AGENT_ID, 1)).thenReturn(config);
-
-            sut.populateCapabilityRegistry();
-
-            verify(capabilityRegistryService).register(AGENT_ID, config);
-        }
-
-        @Test
-        @DisplayName("should skip agents without capabilities")
-        void skipsNonCapableAgents() throws Exception {
-            var descriptor = new DocumentDescriptor();
-            descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + AGENT_ID + "?version=1"));
-            when(documentDescriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false))
-                    .thenReturn(List.of(descriptor));
-
-            var config = new AgentConfiguration();
-            // No capabilities set
-            when(agentStore.read(AGENT_ID, 1)).thenReturn(config);
-
-            sut.populateCapabilityRegistry();
-
-            verify(capabilityRegistryService, never()).register(anyString(), any());
-        }
-
-        @Test
-        @DisplayName("should handle individual agent read failure gracefully")
-        void individualAgentFailure() throws Exception {
-            var descriptor = new DocumentDescriptor();
-            descriptor.setResource(URI.create("eddi://ai.labs.agent/agentstore/agents/" + AGENT_ID + "?version=1"));
-            when(documentDescriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false))
-                    .thenReturn(List.of(descriptor));
-            when(agentStore.read(AGENT_ID, 1))
-                    .thenThrow(new IResourceStore.ResourceNotFoundException("not found"));
-
-            assertDoesNotThrow(() -> sut.populateCapabilityRegistry());
-        }
-
-        @Test
-        @DisplayName("should handle complete registry population failure gracefully")
-        void totalFailure() throws Exception {
-            when(documentDescriptorStore.readDescriptors("ai.labs.agent", null, 0, 0, false))
-                    .thenThrow(new RuntimeException("db error"));
-
-            assertDoesNotThrow(() -> sut.populateCapabilityRegistry());
-        }
-    }
+    // Capability-registry seeding used to be a @PostConstruct on this class and is
+    // now an @Observes StartupEvent on CapabilityRegistryService itself (a lazily
+    // instantiated JAX-RS bean never ran it, so a fresh node had an empty index).
+    // Its tests moved with it — see CapabilityRegistryServiceTest.StartupSeeding.
 
     /**
      * A guard that admits everything. {@code visibleOnly} filters with

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreExtendedTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.agents.rest;
 
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.configs.agents.AgentSigningService;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.model.AgentConfiguration;
@@ -62,11 +63,14 @@ class RestAgentStoreExtendedTest {
     private RestAgentStore restAgentStore;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         openMocks(this);
         restAgentStore = new RestAgentStore(agentStore, restWorkflowStore,
                 documentDescriptorStore, jsonSchemaCreator, scheduleStore, capabilityRegistryService, deploymentStore,
-                permissiveGuard());
+                permissiveGuard(), mock(AgentSigningService.class), "default");
+        // The Agent is live at v1. A cascade only runs against the CURRENT version —
+        // it tears workflows and schedules down before the delete's own version check.
+        when(agentStore.getCurrentResourceId(AGENT_ID)).thenReturn(createResourceId(AGENT_ID, 1));
     }
 
     // ==================== readJsonSchema ====================
@@ -121,6 +125,45 @@ class RestAgentStoreExtendedTest {
 
             assertEquals(1, result.size());
         }
+
+        /**
+         * {@code filter}, {@code index} and {@code limit} are declared on this POST
+         * overload (with {@code @DefaultValue("20")} on limit, advertising paging) and
+         * were then never referenced: a client paging through got the whole list back
+         * on every page.
+         */
+        @Test
+        @DisplayName("index and limit actually page the result")
+        void pagesTheResult() throws Exception {
+            String wfUri = "eddi://ai.labs.workflow/workflowstore/workflows/" + WF1_ID + "?version=1";
+            when(agentStore.getAgentDescriptorsContainingWorkflow(WF1_ID, 1, false))
+                    .thenReturn(List.of(named("a"), named("b"), named("c"), named("d"), named("e")));
+
+            assertEquals(List.of("a", "b"), names(restAgentStore.readAgentDescriptors(null, 0, 2, wfUri, false)));
+            assertEquals(List.of("c", "d"), names(restAgentStore.readAgentDescriptors(null, 1, 2, wfUri, false)));
+            assertEquals(List.of("e"), names(restAgentStore.readAgentDescriptors(null, 2, 2, wfUri, false)));
+            assertTrue(restAgentStore.readAgentDescriptors(null, 9, 2, wfUri, false).isEmpty(), "past the end must be empty, not the full list");
+        }
+
+        @Test
+        @DisplayName("filter narrows the result")
+        void filtersTheResult() throws Exception {
+            String wfUri = "eddi://ai.labs.workflow/workflowstore/workflows/" + WF1_ID + "?version=1";
+            when(agentStore.getAgentDescriptorsContainingWorkflow(WF1_ID, 1, false))
+                    .thenReturn(List.of(named("support agent"), named("Sales Agent"), named("triage")));
+
+            assertEquals(List.of("Sales Agent"), names(restAgentStore.readAgentDescriptors("sales", 0, 20, wfUri, false)));
+        }
+
+        private DocumentDescriptor named(String name) {
+            DocumentDescriptor descriptor = new DocumentDescriptor();
+            descriptor.setName(name);
+            return descriptor;
+        }
+
+        private List<String> names(List<DocumentDescriptor> descriptors) {
+            return descriptors.stream().map(DocumentDescriptor::getName).toList();
+        }
     }
 
     // ==================== updateResourceInAgent ====================
@@ -157,6 +200,29 @@ class RestAgentStoreExtendedTest {
             Response response = restAgentStore.updateResourceInAgent(AGENT_ID, 1, newUri);
 
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        }
+
+        /**
+         * The 400 body names the resource that was not updated, and this is the AGENT
+         * store: the constant was copy-pasted from the workflow-store twin, so the body
+         * came back as {@code eddi://ai.labs.workflow/workflowstore/workflows/} built
+         * from an AGENT id — a URI no resource has, which callers that parse the entity
+         * (UpgradeExecutor, the Manager) read as the wrong resource type. Only the
+         * status code was asserted, so the wrong URI went unnoticed.
+         */
+        @Test
+        @DisplayName("the 400 body names this agent, not a workflow")
+        void nonMatchingUriReportsTheAgentUri() throws Exception {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(new ArrayList<>(List.of(
+                    URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + WF1_ID + "?version=1"))));
+            when(agentStore.read(AGENT_ID, 1)).thenReturn(config);
+
+            URI newUri = URI.create("eddi://ai.labs.workflow/workflowstore/workflows/differentId?version=2");
+            Response response = restAgentStore.updateResourceInAgent(AGENT_ID, 1, newUri);
+
+            assertEquals(URI.create("eddi://ai.labs.agent/agentstore/agents/" + AGENT_ID + "?version=1"),
+                    response.getEntity());
         }
     }
 
@@ -304,6 +370,33 @@ class RestAgentStoreExtendedTest {
             assertNotNull(response);
             assertEquals(201, response.getStatus());
             verify(restWorkflowStore, never()).duplicateWorkflow(anyString(), anyInt(), anyBoolean());
+        }
+
+        /**
+         * {@code ?version=0} is the documented "current version" shorthand that PUT and
+         * DELETE honour. {@code validateParameters} maps it, but its return value was
+         * discarded here, so {@code agentStore.read(id, 0)} matched nothing — neither
+         * the current row nor the history fallback — and duplicating the current
+         * version answered 404.
+         */
+        @Test
+        @DisplayName("version=0 duplicates the current version instead of 404")
+        void versionZeroDuplicatesCurrent() throws Exception {
+            AgentConfiguration sourceConfig = new AgentConfiguration();
+            sourceConfig.setSecurity(null);
+            sourceConfig.setWorkflows(new ArrayList<>());
+            when(agentStore.getCurrentResourceId(AGENT_ID)).thenReturn(createResourceId(AGENT_ID, 3));
+            when(agentStore.read(AGENT_ID, 3)).thenReturn(sourceConfig);
+            when(agentStore.create(any())).thenReturn(createResourceId("newagent1122334455", 1));
+
+            var oldDescriptor = new DocumentDescriptor();
+            oldDescriptor.setName("Original Agent");
+            when(documentDescriptorStore.readDescriptor(AGENT_ID, 3)).thenReturn(oldDescriptor);
+
+            Response response = restAgentStore.duplicateAgent(AGENT_ID, 0, false);
+
+            assertEquals(201, response.getStatus());
+            verify(agentStore).read(AGENT_ID, 3);
         }
 
         @Test
@@ -471,6 +564,9 @@ class RestAgentStoreExtendedTest {
         ResourceAccessGuard guard = mock(ResourceAccessGuard.class);
         lenient().when(guard.seesEverything()).thenReturn(true);
         lenient().when(guard.canAccess(any(), any())).thenReturn(true);
+        // Without this the bare mock returns null from redactForCaller and visibleOnly
+        // hands back a list of nulls — which every size-only assertion passes anyway.
+        lenient().when(guard.redactForCaller(any())).thenAnswer(invocation -> invocation.getArgument(0));
         return guard;
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.configs.agents.rest;
 
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.configs.agents.AgentSigningService;
 import ai.labs.eddi.configs.agents.IAgentStore;
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.agents.crypto.AgentPublicKey;
@@ -16,6 +17,8 @@ import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
 import ai.labs.eddi.datastore.IResourceStore;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -53,14 +56,34 @@ class RestAgentStoreTest {
     private CapabilityRegistryService capabilityRegistryService;
     @Mock
     private IDeploymentStore deploymentStore;
+    @Mock
+    private AgentSigningService agentSigningService;
 
     private RestAgentStore restAgentStore;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         openMocks(this);
         restAgentStore = new RestAgentStore(AgentStore, restWorkflowStore, documentDescriptorStore, jsonSchemaCreator, scheduleStore,
-                capabilityRegistryService, deploymentStore, mock(ResourceAccessGuard.class));
+                capabilityRegistryService, deploymentStore, mock(ResourceAccessGuard.class), agentSigningService, "default");
+        // The Agent is live at v1: a cascade is only allowed against the CURRENT
+        // version, since it tears down workflows and schedules before the delete —
+        // the only place the version used to be checked — has run.
+        when(AgentStore.getCurrentResourceId(AGENT_ID)).thenReturn(resourceId(AGENT_ID, 1));
+    }
+
+    static IResourceStore.IResourceId resourceId(String id, int version) {
+        return new IResourceStore.IResourceId() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return version;
+            }
+        };
     }
 
     /** Helper to create a dummy DocumentDescriptor for reference-count mocking */
@@ -128,8 +151,14 @@ class RestAgentStoreTest {
 
             restAgentStore.deleteAgent(AGENT_ID, 1, true, true);
 
-            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 2, true, true);
-            verify(restWorkflowStore).deleteWorkflow(PKG2_ID, 1, true, true);
+            // permanent=false on the cascaded workflows even though the request said
+            // permanent=true. These two assertions used to read `true` and so pinned the
+            // defect: the reference guard above asks a VERSION-scoped question
+            // ("who references W?version=2?") while a permanent delete is ID-scoped and
+            // drops every version plus all history. The Agent itself is still erased
+            // permanently — that is what the caller asked for and owns.
+            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 2, false, true);
+            verify(restWorkflowStore).deleteWorkflow(PKG2_ID, 1, false, true);
             verify(AgentStore).deleteAllPermanently(AGENT_ID);
         }
 
@@ -164,7 +193,7 @@ class RestAgentStoreTest {
 
             // Only PKG2 should be deleted — PKG1 is shared
             verify(restWorkflowStore, never()).deleteWorkflow(eq(PKG1_ID), anyInt(), anyBoolean(), anyBoolean());
-            verify(restWorkflowStore).deleteWorkflow(PKG2_ID, 1, true, true);
+            verify(restWorkflowStore).deleteWorkflow(PKG2_ID, 1, false, true);
             verify(AgentStore).deleteAllPermanently(AGENT_ID);
         }
 
@@ -177,13 +206,13 @@ class RestAgentStoreTest {
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             // both packages only referenced by this agent
             when(AgentStore.getAgentDescriptorsContainingWorkflow(anyString(), anyInt(), eq(false))).thenReturn(List.of(dummyDescriptor()));
-            when(restWorkflowStore.deleteWorkflow(PKG1_ID, 1, true, true)).thenThrow(new RuntimeException("Workflow in use"));
-            when(restWorkflowStore.deleteWorkflow(PKG2_ID, 1, true, true)).thenReturn(Response.ok().build());
+            when(restWorkflowStore.deleteWorkflow(PKG1_ID, 1, false, true)).thenThrow(new RuntimeException("Workflow in use"));
+            when(restWorkflowStore.deleteWorkflow(PKG2_ID, 1, false, true)).thenReturn(Response.ok().build());
 
             assertDoesNotThrow(() -> restAgentStore.deleteAgent(AGENT_ID, 1, true, true));
 
-            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 1, true, true);
-            verify(restWorkflowStore).deleteWorkflow(PKG2_ID, 1, true, true);
+            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 1, false, true);
+            verify(restWorkflowStore).deleteWorkflow(PKG2_ID, 1, false, true);
             verify(AgentStore).deleteAllPermanently(AGENT_ID);
         }
 
@@ -212,6 +241,169 @@ class RestAgentStoreTest {
         }
     }
 
+    @Nested
+    @DisplayName("deleteAgent — cascade version guard")
+    class CascadeVersionGuard {
+
+        /**
+         * The cascade used to run against whatever version the request named, because
+         * {@code agentStore.read} falls back to history for a superseded version and
+         * the only version check lived in {@code restVersionInfo.delete()} — at the
+         * very end. A stale tab deleting v1 of an Agent that is at v2 therefore
+         * destroyed v1's workflows and schedules and only then answered 409.
+         */
+        @Test
+        @DisplayName("refuses a stale version with 409 before touching workflows or schedules")
+        void staleVersionRefusedBeforeAnyDeletion() throws Exception {
+            when(AgentStore.getCurrentResourceId(AGENT_ID)).thenReturn(resourceId(AGENT_ID, 2));
+
+            var thrown = assertThrows(WebApplicationException.class,
+                    () -> restAgentStore.deleteAgent(AGENT_ID, 1, false, true));
+
+            assertEquals(Response.Status.CONFLICT.getStatusCode(), thrown.getResponse().getStatus());
+            verify(scheduleStore, never()).deleteSchedulesByAgentId(anyString());
+            verify(restWorkflowStore, never()).deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean());
+            verify(AgentStore, never()).delete(anyString(), anyInt());
+            verify(AgentStore, never()).deleteAllPermanently(anyString());
+        }
+
+        /**
+         * {@code ?version=0} is the documented "current version" shorthand. It used to
+         * be resolved only inside {@code restVersionInfo.delete()}, so the cascade read
+         * version 0, found nothing, and skipped itself with a WARN while the delete
+         * went through — {@code cascade=true} silently did not cascade.
+         */
+        @Test
+        @DisplayName("version=0 resolves to the current version and does cascade")
+        void versionZeroCascades() throws Exception {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 1, false)).thenReturn(List.of(dummyDescriptor()));
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
+
+            restAgentStore.deleteAgent(AGENT_ID, 0, false, true);
+
+            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 1, false, true);
+            verify(AgentStore).delete(AGENT_ID, 1);
+        }
+
+        /**
+         * The ordinary "purge what I already soft-deleted" flow:
+         * {@code ?permanent=true&cascade=true} against an Agent with no current row.
+         * {@code getCurrentResourceId} throws for it, and the documented contract is to
+         * skip the cascade and still purge the history — so the guard has to answer
+         * false rather than propagate, and must not dereference the missing current id,
+         * which on this path would NPE partway through a destructive operation.
+         */
+        @Test
+        @DisplayName("an already soft-deleted Agent skips the cascade and still purges")
+        void softDeletedAgentSkipsCascadeButStillPurges() throws Exception {
+            when(AgentStore.getCurrentResourceId(AGENT_ID))
+                    .thenThrow(new IResourceStore.ResourceNotFoundException("no current version"));
+
+            assertDoesNotThrow(() -> restAgentStore.deleteAgent(AGENT_ID, 1, true, true));
+
+            verify(scheduleStore, never()).deleteSchedulesByAgentId(anyString());
+            verify(restWorkflowStore, never()).deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean());
+            verify(AgentStore).deleteAllPermanently(AGENT_ID);
+        }
+
+        /**
+         * The capability index feeds {@code capabilityMatch} behaviour rules and A2A
+         * discovery. Clearing it before the delete stripped a still-live Agent of what
+         * it routes on when the delete then answered 409.
+         */
+        @Test
+        @DisplayName("keeps the capability registration when the delete itself fails")
+        void capabilityRegistrationSurvivesAFailedDelete() throws Exception {
+            doThrow(new IResourceStore.ResourceModifiedException("not the latest version")).when(AgentStore).delete(AGENT_ID, 1);
+
+            assertThrows(IResourceStore.ResourceModifiedException.class, () -> restAgentStore.deleteAgent(AGENT_ID, 1, false, false));
+
+            verify(capabilityRegistryService, never()).unregister(anyString());
+        }
+
+        @Test
+        @DisplayName("clears the capability registration once the delete succeeded")
+        void capabilityRegistrationClearedAfterDelete() throws Exception {
+            restAgentStore.deleteAgent(AGENT_ID, 1, false, false);
+
+            verify(capabilityRegistryService).unregister(AGENT_ID);
+        }
+
+        /**
+         * Nothing else in the codebase removes an agent's private key, and the vault
+         * entry outlives the config that documented what it was for. This assertion
+         * used to pass {@code permanent=false} — see
+         * {@link #keepsSigningKeyPairOnASoftDelete()} for why that was wrong.
+         */
+        @Test
+        @DisplayName("removes the signing key from the vault when the Agent is permanently deleted")
+        void deletesSigningKeyPair() throws Exception {
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(agentWithSigningIdentity());
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, true, false);
+
+            verify(agentSigningService).deleteKeyPair("default", AGENT_ID);
+        }
+
+        /**
+         * A soft delete is the deliberately recoverable path, and the Ed25519 private
+         * key is the one thing about an Agent that cannot be recreated: no endpoint
+         * generates one (see {@code validateSecurityFlags}), so an Agent restored from
+         * a ZIP backup would come back with a public key whose private half is gone and
+         * {@code signInterAgentMessages} permanently broken. The vault cleanup was
+         * briefly unconditional, which made every recoverable delete irreversible for
+         * key material.
+         */
+        @Test
+        @DisplayName("keeps the signing key in the vault on a soft delete")
+        void keepsSigningKeyPairOnASoftDelete() throws Exception {
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(agentWithSigningIdentity());
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, false, false);
+
+            verify(AgentStore).delete(AGENT_ID, 1);
+            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("does not probe the vault for an Agent with no key material")
+        void skipsVaultForAgentWithoutIdentity() throws Exception {
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(new AgentConfiguration());
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, true, false);
+
+            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString());
+        }
+
+        /**
+         * The key-cleanup probe is best-effort by design: an Agent that cannot be read
+         * reports "no key material" rather than failing the delete. A leaked vault
+         * entry is recoverable; a config that cannot be deleted is not — so the probe
+         * must never decide whether the delete happens.
+         */
+        @Test
+        @DisplayName("an unreadable Agent is still deleted, with the vault probe answering no")
+        void unreadableAgentDoesNotBlockThePermanentDelete() throws Exception {
+            when(AgentStore.read(AGENT_ID, 1)).thenThrow(new IResourceStore.ResourceStoreException("mongo down"));
+
+            assertDoesNotThrow(() -> restAgentStore.deleteAgent(AGENT_ID, 1, true, false));
+
+            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString());
+            verify(AgentStore).deleteAllPermanently(AGENT_ID);
+        }
+
+        private AgentConfiguration agentWithSigningIdentity() {
+            var config = new AgentConfiguration();
+            var identity = new AgentConfiguration.AgentIdentity();
+            identity.setPublicKey("MCowBQYDK2VwAyEA-not-a-real-key");
+            config.setIdentity(identity);
+            return config;
+        }
+    }
+
     // --- Wave 3: Security flag validation ---
 
     @Nested
@@ -226,7 +418,7 @@ class RestAgentStoreTest {
             security.setSignInterAgentMessages(true);
             config.setSecurity(security);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.createAgent(config));
         }
 
@@ -238,7 +430,7 @@ class RestAgentStoreTest {
             security.setRequirePeerVerification(true);
             config.setSecurity(security);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.createAgent(config));
         }
 
@@ -296,7 +488,7 @@ class RestAgentStoreTest {
             security.setSignInterAgentMessages(true);
             config.setSecurity(security);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.updateAgent(AGENT_ID, 1, config));
         }
 
@@ -312,7 +504,7 @@ class RestAgentStoreTest {
 
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(sourceConfig);
 
-            assertThrows(jakarta.ws.rs.BadRequestException.class,
+            assertThrows(BadRequestException.class,
                     () -> restAgentStore.duplicateAgent(AGENT_ID, 1, false));
         }
 

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
@@ -32,6 +32,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.ws.rs.BadRequestException;
+import static ai.labs.eddi.utils.LogCaptureSupport.FORGED_RECORD;
+import static ai.labs.eddi.utils.LogCaptureSupport.assertNoForgedRecordBoundary;
+import static ai.labs.eddi.utils.LogCaptureSupport.captureLogsOf;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -821,6 +824,158 @@ class RestAgentStoreTest {
             });
 
             assertDoesNotThrow(() -> restAgentStore.createAgent(config));
+        }
+    }
+    /**
+     * CWE-117 (log injection). Every identifier below reaches a {@code log.warnf}
+     * or {@code log.infof} from outside the process — {@code id} is the DELETE path
+     * parameter, the workflow id and the exception messages come back out of the
+     * store — and a CR/LF in any of them closes the real record and lets the
+     * remainder read as a second line the server wrote itself.
+     *
+     * <p>
+     * These assert the CONTRACT, not the call: drive a forged record through the
+     * real path and require that nothing carrying a record boundary reached the
+     * log. Removing any {@code sanitize(...)} on the pinned line fails them.
+     * </p>
+     */
+    @Nested
+    @DisplayName("deleteAgent — log injection (CWE-117)")
+    class LogInjection {
+
+        /** The Agent id as an attacker supplies it on the DELETE path. */
+        private static final String POISONED_AGENT_ID = AGENT_ID + FORGED_RECORD;
+
+        private static final String PKG1_URI = "eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=2";
+
+        /**
+         * The Agent is live at v1 under its poisoned id, so the cascade is allowed to
+         * run and reach the lines under test.
+         */
+        @BeforeEach
+        void agentIsLiveUnderThePoisonedId() throws Exception {
+            when(AgentStore.getCurrentResourceId(POISONED_AGENT_ID)).thenReturn(resourceId(POISONED_AGENT_ID, 1));
+        }
+
+        private AgentConfiguration configReferencing(String workflowUri) {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(new ArrayList<>(List.of(URI.create(workflowUri))));
+            return config;
+        }
+
+        @Test
+        @DisplayName("a CR/LF Agent id cannot forge a record through the schedule-cascade INFO")
+        void schedulesCascadeDeleted() throws Exception {
+            when(AgentStore.read(POISONED_AGENT_ID, 1)).thenReturn(configReferencing(PKG1_URI));
+            when(scheduleStore.deleteSchedulesByAgentId(POISONED_AGENT_ID)).thenReturn(3);
+
+            List<String> captured = captureLogsOf(RestAgentStore.class,
+                    () -> assertDoesNotThrow(() -> restAgentStore.deleteAgent(POISONED_AGENT_ID, 1, false, true)));
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing — the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("Cascade-deleted %d schedule(s)")
+                    || value.contains("schedule(s) for Agent")),
+                    "the line under test did not fire; captured: " + captured);
+            assertNoForgedRecordBoundary(captured, "RestAgentStore.deleteAgent's schedule-cascade INFO");
+        }
+
+        @Test
+        @DisplayName("a CR/LF Agent id and store message cannot forge a record through the schedule-cascade WARN")
+        void schedulesCascadeFails() throws Exception {
+            when(AgentStore.read(POISONED_AGENT_ID, 1)).thenReturn(configReferencing(PKG1_URI));
+            when(scheduleStore.deleteSchedulesByAgentId(POISONED_AGENT_ID))
+                    .thenThrow(new IllegalStateException("scheduler unreachable" + FORGED_RECORD));
+
+            List<String> captured = captureLogsOf(RestAgentStore.class,
+                    () -> assertDoesNotThrow(() -> restAgentStore.deleteAgent(POISONED_AGENT_ID, 1, false, true)));
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing — the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("Failed to cascade-delete schedules")),
+                    "the line under test did not fire; captured: " + captured);
+            assertNoForgedRecordBoundary(captured, "RestAgentStore.deleteAgent's schedule-cascade WARN");
+        }
+
+        @Test
+        @DisplayName("a CR/LF Agent id cannot forge a record through the not-found-for-cascade WARN")
+        void agentNotFoundForCascade() throws Exception {
+            when(AgentStore.read(POISONED_AGENT_ID, 1)).thenThrow(new IResourceStore.ResourceNotFoundException("not found"));
+
+            List<String> captured = captureLogsOf(RestAgentStore.class,
+                    () -> assertDoesNotThrow(() -> restAgentStore.deleteAgent(POISONED_AGENT_ID, 1, false, true)));
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing — the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("not found for cascade")),
+                    "the line under test did not fire; captured: " + captured);
+            assertNoForgedRecordBoundary(captured, "RestAgentStore.planCascade's Agent-not-found WARN");
+        }
+
+        @Test
+        @DisplayName("a CR/LF store error message cannot forge a record through the read-failed WARN")
+        void agentReadFailsForCascade() throws Exception {
+            when(AgentStore.read(POISONED_AGENT_ID, 1))
+                    .thenThrow(new IResourceStore.ResourceStoreException("index unavailable" + FORGED_RECORD));
+
+            List<String> captured = captureLogsOf(RestAgentStore.class,
+                    () -> assertDoesNotThrow(() -> restAgentStore.deleteAgent(POISONED_AGENT_ID, 1, false, true)));
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing — the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("Error reading Agent")),
+                    "the line under test did not fire; captured: " + captured);
+            assertNoForgedRecordBoundary(captured, "RestAgentStore.planCascade's read-failed WARN");
+        }
+
+        @Test
+        @DisplayName("a CR/LF store error message cannot forge a record through the plan-failed WARN")
+        void planningOneWorkflowFails() throws Exception {
+            when(AgentStore.read(POISONED_AGENT_ID, 1)).thenReturn(configReferencing(PKG1_URI));
+            // The reference check cannot answer — the cascade fails closed for this
+            // workflow and reports why, quoting the store's message back.
+            when(restWorkflowStore.getCurrentResourceId(PKG1_ID)).thenThrow(new RuntimeException("lookup failed" + FORGED_RECORD));
+
+            List<String> captured = captureLogsOf(RestAgentStore.class,
+                    () -> assertDoesNotThrow(() -> restAgentStore.deleteAgent(POISONED_AGENT_ID, 1, false, true)));
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing — the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("Failed to plan cascade-delete of package")),
+                    "the line under test did not fire; captured: " + captured);
+            assertNoForgedRecordBoundary(captured, "RestAgentStore.planCascade's plan-failed WARN");
+        }
+
+        @Test
+        @DisplayName("a CR/LF Agent id or workflow id cannot forge a record through the cascade-deleted INFO")
+        void cascadeDeletedPackage() throws Exception {
+            String poisonedWorkflowId = PKG1_ID + FORGED_RECORD;
+            when(AgentStore.read(POISONED_AGENT_ID, 1)).thenReturn(configReferencing(PKG1_URI));
+            when(restWorkflowStore.getCurrentResourceId(PKG1_ID)).thenReturn(resourceId(poisonedWorkflowId, 2));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(poisonedWorkflowId, 2, true)).thenAnswer(invocation -> referrers(1));
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
+
+            List<String> captured = captureLogsOf(RestAgentStore.class,
+                    () -> assertDoesNotThrow(() -> restAgentStore.deleteAgent(POISONED_AGENT_ID, 1, false, true)));
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing — the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("Cascade-deleted package")),
+                    "the line under test did not fire; captured: " + captured);
+            assertNoForgedRecordBoundary(captured, "RestAgentStore.deleteAgent's cascade-deleted INFO");
+        }
+
+        @Test
+        @DisplayName("a CR/LF workflow id or failure message cannot forge a record through the cascade-failed WARN")
+        void cascadeDeleteOfOnePackageFails() throws Exception {
+            String poisonedWorkflowId = PKG1_ID + FORGED_RECORD;
+            when(AgentStore.read(POISONED_AGENT_ID, 1)).thenReturn(configReferencing(PKG1_URI));
+            when(restWorkflowStore.getCurrentResourceId(PKG1_ID)).thenReturn(resourceId(poisonedWorkflowId, 2));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(poisonedWorkflowId, 2, true)).thenAnswer(invocation -> referrers(1));
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenThrow(new RuntimeException("workflow in use" + FORGED_RECORD));
+
+            List<String> captured = captureLogsOf(RestAgentStore.class,
+                    () -> assertDoesNotThrow(() -> restAgentStore.deleteAgent(POISONED_AGENT_ID, 1, false, true)));
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing — the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("Failed to cascade-delete package")),
+                    "the line under test did not fire; captured: " + captured);
+            assertNoForgedRecordBoundary(captured, "RestAgentStore.deleteAgent's cascade-failed WARN");
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
@@ -70,6 +70,11 @@ class RestAgentStoreTest {
         // version, since it tears down workflows and schedules before the delete —
         // the only place the version used to be checked — has run.
         when(AgentStore.getCurrentResourceId(AGENT_ID)).thenReturn(resourceId(AGENT_ID, 1));
+        // A workflow reference is version-pinned and is NOT re-pointed when the
+        // workflow is edited, so the cascade resolves each one to the version that
+        // EXISTS before it asks who else uses it or deletes anything.
+        when(restWorkflowStore.getCurrentResourceId(PKG1_ID)).thenReturn(resourceId(PKG1_ID, 2));
+        when(restWorkflowStore.getCurrentResourceId(PKG2_ID)).thenReturn(resourceId(PKG2_ID, 1));
     }
 
     static IResourceStore.IResourceId resourceId(String id, int version) {
@@ -145,8 +150,8 @@ class RestAgentStoreTest {
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG2_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             // Each package is only referenced by this one agent
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, false)).thenReturn(List.of(dummyDescriptor()));
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, false)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenReturn(List.of(dummyDescriptor()));
             when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
 
             restAgentStore.deleteAgent(AGENT_ID, 1, true, true);
@@ -168,7 +173,7 @@ class RestAgentStoreTest {
             AgentConfiguration config = new AgentConfiguration();
             config.setWorkflows(new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 1, false)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor()));
             when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
 
             restAgentStore.deleteAgent(AGENT_ID, 1, true, true);
@@ -184,9 +189,9 @@ class RestAgentStoreTest {
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG2_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             // PKG1 is shared with 2 agents — should be SKIPPED
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, false)).thenReturn(List.of(dummyDescriptor(), dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor(), dummyDescriptor()));
             // PKG2 is only in this Agent — should be deleted
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, false)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenReturn(List.of(dummyDescriptor()));
             when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
 
             restAgentStore.deleteAgent(AGENT_ID, 1, true, true);
@@ -205,13 +210,13 @@ class RestAgentStoreTest {
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG2_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             // both packages only referenced by this agent
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(anyString(), anyInt(), eq(false))).thenReturn(List.of(dummyDescriptor()));
-            when(restWorkflowStore.deleteWorkflow(PKG1_ID, 1, false, true)).thenThrow(new RuntimeException("Workflow in use"));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(anyString(), anyInt(), eq(true))).thenReturn(List.of(dummyDescriptor()));
+            when(restWorkflowStore.deleteWorkflow(PKG1_ID, 2, false, true)).thenThrow(new RuntimeException("Workflow in use"));
             when(restWorkflowStore.deleteWorkflow(PKG2_ID, 1, false, true)).thenReturn(Response.ok().build());
 
             assertDoesNotThrow(() -> restAgentStore.deleteAgent(AGENT_ID, 1, true, true));
 
-            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 1, false, true);
+            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 2, false, true);
             verify(restWorkflowStore).deleteWorkflow(PKG2_ID, 1, false, true);
             verify(AgentStore).deleteAllPermanently(AGENT_ID);
         }
@@ -279,12 +284,12 @@ class RestAgentStoreTest {
             AgentConfiguration config = new AgentConfiguration();
             config.setWorkflows(new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 1, false)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor()));
             when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
 
             restAgentStore.deleteAgent(AGENT_ID, 0, false, true);
 
-            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 1, false, true);
+            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 2, false, true);
             verify(AgentStore).delete(AGENT_ID, 1);
         }
 
@@ -341,11 +346,38 @@ class RestAgentStoreTest {
         @Test
         @DisplayName("removes the signing key from the vault when the Agent is permanently deleted")
         void deletesSigningKeyPair() throws Exception {
-            when(AgentStore.read(AGENT_ID, 1)).thenReturn(agentWithSigningIdentity());
+            when(AgentStore.readIncludingDeleted(AGENT_ID, 1)).thenReturn(agentWithSigningIdentity());
 
             restAgentStore.deleteAgent(AGENT_ID, 1, true, false);
 
-            verify(agentSigningService).deleteKeyPair("default", AGENT_ID);
+            // An EMPTY version list, not null: this Agent carries the legacy
+            // unversioned key and no rotated ones, and null is what asks for the
+            // blind 1..100 sweep.
+            verify(agentSigningService).deleteKeyPair("default", AGENT_ID, List.of());
+        }
+
+        /**
+         * The two-step purge the API documents as ordinary: soft-delete an Agent, then
+         * come back and {@code DELETE ?permanent=true}. The probe used to read through
+         * {@code agentStore.read}, which throws {@code ResourceNotFoundException} for a
+         * history row flagged deleted — i.e. for EVERY soft-deleted Agent — so it
+         * answered "no key material" and the Ed25519 private key stayed in the vault
+         * after the config and all of its history had been erased. That is the leak
+         * this cleanup exists to close, surviving on the only recommended path to
+         * closing it.
+         */
+        @Test
+        @DisplayName("purging an already soft-deleted Agent still removes its vault keys")
+        void purgingASoftDeletedAgentStillRemovesItsKeys() throws Exception {
+            when(AgentStore.getCurrentResourceId(AGENT_ID))
+                    .thenThrow(new IResourceStore.ResourceNotFoundException("no current version"));
+            when(AgentStore.read(AGENT_ID, 1)).thenThrow(new IResourceStore.ResourceNotFoundException("soft-deleted"));
+            when(AgentStore.readIncludingDeleted(AGENT_ID, 1)).thenReturn(agentWithRotatedKeys());
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, true, false);
+
+            verify(agentSigningService).deleteKeyPair("default", AGENT_ID, List.of(1, 3));
+            verify(AgentStore).deleteAllPermanently(AGENT_ID);
         }
 
         /**
@@ -360,22 +392,22 @@ class RestAgentStoreTest {
         @Test
         @DisplayName("keeps the signing key in the vault on a soft delete")
         void keepsSigningKeyPairOnASoftDelete() throws Exception {
-            when(AgentStore.read(AGENT_ID, 1)).thenReturn(agentWithSigningIdentity());
+            when(AgentStore.readIncludingDeleted(AGENT_ID, 1)).thenReturn(agentWithSigningIdentity());
 
             restAgentStore.deleteAgent(AGENT_ID, 1, false, false);
 
             verify(AgentStore).delete(AGENT_ID, 1);
-            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString());
+            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString(), any());
         }
 
         @Test
         @DisplayName("does not probe the vault for an Agent with no key material")
         void skipsVaultForAgentWithoutIdentity() throws Exception {
-            when(AgentStore.read(AGENT_ID, 1)).thenReturn(new AgentConfiguration());
+            when(AgentStore.readIncludingDeleted(AGENT_ID, 1)).thenReturn(new AgentConfiguration());
 
             restAgentStore.deleteAgent(AGENT_ID, 1, true, false);
 
-            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString());
+            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString(), any());
         }
 
         /**
@@ -387,11 +419,138 @@ class RestAgentStoreTest {
         @Test
         @DisplayName("an unreadable Agent is still deleted, with the vault probe answering no")
         void unreadableAgentDoesNotBlockThePermanentDelete() throws Exception {
-            when(AgentStore.read(AGENT_ID, 1)).thenThrow(new IResourceStore.ResourceStoreException("mongo down"));
+            when(AgentStore.readIncludingDeleted(AGENT_ID, 1)).thenThrow(new IResourceStore.ResourceStoreException("mongo down"));
 
             assertDoesNotThrow(() -> restAgentStore.deleteAgent(AGENT_ID, 1, true, false));
 
-            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString());
+            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString(), any());
+            verify(AgentStore).deleteAllPermanently(AGENT_ID);
+        }
+
+        /**
+         * The pre-cascade version check is a check-then-act, exactly as it was in
+         * {@code RestWorkflowStore.deleteWorkflow}. A concurrent update committing
+         * between it and {@code restVersionInfo.delete()} — a PUT, or the 10-second
+         * deployment sweep touching this Agent — used to leave the schedules deleted
+         * and every exclusively owned workflow (and, through deleteWorkflow's own
+         * cascade, its extensions) torn down while the delete answered 409 "nothing was
+         * deleted". The live Agent kept its config and lost everything it pointed at,
+         * and the 409 contract {@code IRestAgentStore} documents was false on this
+         * path. Deleting the Agent FIRST makes the store's own version check the gate.
+         */
+        @Test
+        @DisplayName("an Agent that moved on between the guard and the delete loses neither workflows nor schedules")
+        void concurrentUpdateBetweenGuardAndDeleteCascadesNothing() throws Exception {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(
+                    new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor()));
+            // The guard saw v1; by the time the delete runs the Agent is at v2.
+            doThrow(new IResourceStore.ResourceModifiedException("not the latest version")).when(AgentStore).delete(AGENT_ID, 1);
+
+            assertThrows(IResourceStore.ResourceModifiedException.class, () -> restAgentStore.deleteAgent(AGENT_ID, 1, false, true));
+
+            verify(restWorkflowStore, never()).deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean());
+            verify(scheduleStore, never()).deleteSchedulesByAgentId(anyString());
+        }
+
+        /**
+         * The other half of the reordering: DECIDING still happens before the delete,
+         * so the reference guard counts this Agent among a workflow's referrers (hence
+         * the {@code > 1} test). Were the reverse lookup moved after the delete, the
+         * Agent would no longer count itself, a workflow shared with exactly one other
+         * Agent would come back as size 1, and the cascade would delete a workflow that
+         * is still in use.
+         */
+        @Test
+        @DisplayName("a workflow shared with another Agent survives the cascade")
+        void sharedWorkflowIsNotCascadeDeleted() throws Exception {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(
+                    new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
+            // This Agent plus one other — the guard must read that as "still referenced".
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true))
+                    .thenReturn(List.of(dummyDescriptor(), dummyDescriptor()));
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, false, true);
+
+            verify(AgentStore).delete(AGENT_ID, 1);
+            verify(restWorkflowStore, never()).deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean());
+        }
+
+        /**
+         * A reference to a workflow that has no live version left is nothing to cascade
+         * at — there is no version to address the delete at, and guessing the pinned
+         * one would resurrect the very stale-version delete the guard exists to refuse.
+         * It is skipped, and the workflows after it in the list are still planned: one
+         * dangling reference must not disarm the whole cascade.
+         */
+        @Test
+        @DisplayName("a workflow with no live version left is skipped, and the rest of the cascade still runs")
+        void workflowWithNoLiveVersionIsSkipped() throws Exception {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(new ArrayList<>(List.of(
+                    URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"),
+                    URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG2_ID + "?version=1"))));
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
+            when(restWorkflowStore.getCurrentResourceId(PKG1_ID))
+                    .thenThrow(new IResourceStore.ResourceNotFoundException("already soft-deleted"));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenReturn(List.of(dummyDescriptor()));
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, false, true);
+
+            verify(restWorkflowStore, never()).deleteWorkflow(eq(PKG1_ID), anyInt(), anyBoolean(), anyBoolean());
+            verify(restWorkflowStore).deleteWorkflow(PKG2_ID, 1, false, true);
+            verify(AgentStore).delete(AGENT_ID, 1);
+        }
+
+        /**
+         * FAIL CLOSED per workflow. A reference check that cannot answer is not a
+         * licence to delete, and letting the throwable out of the planning step would
+         * abort the request before the Agent itself had been deleted — leaving the
+         * Agent undeletable for as long as the store misbehaves.
+         */
+        @Test
+        @DisplayName("a reference check that blows up skips that workflow and still deletes the Agent")
+        void referenceCheckFailureSkipsOnlyThatWorkflow() throws Exception {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(new ArrayList<>(List.of(
+                    URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"),
+                    URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG2_ID + "?version=1"))));
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true))
+                    .thenThrow(new IResourceStore.ResourceStoreException("reverse lookup broken"));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenReturn(List.of(dummyDescriptor()));
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, false, true);
+
+            verify(restWorkflowStore, never()).deleteWorkflow(eq(PKG1_ID), anyInt(), anyBoolean(), anyBoolean());
+            verify(restWorkflowStore).deleteWorkflow(PKG2_ID, 1, false, true);
+            verify(AgentStore).delete(AGENT_ID, 1);
+        }
+
+        /**
+         * An {@code identity} block is not by itself key material: an Agent can carry
+         * one for its name or metadata with neither a legacy {@code publicKey} nor any
+         * rotated {@code keys}. Destroying vault entries is irreversible — there is no
+         * key-generation endpoint — so the cleanup must only run for an Agent that
+         * actually declares a key.
+         */
+        @Test
+        @DisplayName("an identity block with no key material does not trigger the vault cleanup")
+        void identityWithoutKeysDoesNotTriggerVaultCleanup() throws Exception {
+            var config = new AgentConfiguration();
+            var identity = new AgentConfiguration.AgentIdentity();
+            identity.setPublicKey("   ");
+            identity.setKeys(new ArrayList<>());
+            config.setIdentity(identity);
+            when(AgentStore.readIncludingDeleted(AGENT_ID, 1)).thenReturn(config);
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, true, false);
+
+            verify(agentSigningService, never()).deleteKeyPair(anyString(), anyString(), any());
             verify(AgentStore).deleteAllPermanently(AGENT_ID);
         }
 
@@ -399,6 +558,18 @@ class RestAgentStoreTest {
             var config = new AgentConfiguration();
             var identity = new AgentConfiguration.AgentIdentity();
             identity.setPublicKey("MCowBQYDK2VwAyEA-not-a-real-key");
+            config.setIdentity(identity);
+            return config;
+        }
+
+        /**
+         * A rotated identity whose declared versions skip a number, as rotateKey
+         * allows.
+         */
+        private AgentConfiguration agentWithRotatedKeys() {
+            var config = new AgentConfiguration();
+            var identity = new AgentConfiguration.AgentIdentity();
+            identity.setKeys(new ArrayList<>(List.of(AgentPublicKey.createCurrent(1, "k1"), AgentPublicKey.createCurrent(3, "k3"))));
             config.setIdentity(identity);
             return config;
         }

--- a/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/agents/rest/RestAgentStoreTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -75,6 +76,16 @@ class RestAgentStoreTest {
         // EXISTS before it asks who else uses it or deletes anything.
         when(restWorkflowStore.getCurrentResourceId(PKG1_ID)).thenReturn(resourceId(PKG1_ID, 2));
         when(restWorkflowStore.getCurrentResourceId(PKG2_ID)).thenReturn(resourceId(PKG2_ID, 1));
+        // The Agent stops being a referrer of its own workflows the moment it is
+        // deleted; see referrers().
+        doAnswer(invocation -> {
+            agentDeleted.set(true);
+            return null;
+        }).when(AgentStore).delete(anyString(), anyInt());
+        doAnswer(invocation -> {
+            agentDeleted.set(true);
+            return null;
+        }).when(AgentStore).deleteAllPermanently(anyString());
     }
 
     static IResourceStore.IResourceId resourceId(String id, int version) {
@@ -94,6 +105,32 @@ class RestAgentStoreTest {
     /** Helper to create a dummy DocumentDescriptor for reference-count mocking */
     private DocumentDescriptor dummyDescriptor() {
         return new DocumentDescriptor();
+    }
+
+    /**
+     * Whether the Agent under test has been deleted yet; see {@link #referrers}.
+     */
+    private final AtomicBoolean agentDeleted = new AtomicBoolean();
+
+    /**
+     * The reverse lookup's answer, as the real store gives it: {@code total} counts
+     * the Agent being deleted among a workflow's referrers, and that one disappears
+     * once the Agent has been deleted — {@code AbstractResourceStore
+     * .isStaleReference} drops a referrer that has no current row.
+     *
+     * <p>
+     * Modelling that is what lets the post-delete re-check in {@code deleteAgent}
+     * mean anything: against a stub frozen at its pre-delete answer, "only this
+     * Agent used it" and "another Agent has picked it up since" look identical.
+     * </p>
+     */
+    private List<DocumentDescriptor> referrers(int total) {
+        int remaining = agentDeleted.get() ? total - 1 : total;
+        List<DocumentDescriptor> descriptors = new ArrayList<>();
+        for (int i = 0; i < remaining; i++) {
+            descriptors.add(dummyDescriptor());
+        }
+        return descriptors;
     }
 
     @Nested
@@ -150,8 +187,8 @@ class RestAgentStoreTest {
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG2_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             // Each package is only referenced by this one agent
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor()));
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenAnswer(invocation -> referrers(1));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenAnswer(invocation -> referrers(1));
             when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
 
             restAgentStore.deleteAgent(AGENT_ID, 1, true, true);
@@ -173,7 +210,7 @@ class RestAgentStoreTest {
             AgentConfiguration config = new AgentConfiguration();
             config.setWorkflows(new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenAnswer(invocation -> referrers(1));
             when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
 
             restAgentStore.deleteAgent(AGENT_ID, 1, true, true);
@@ -189,9 +226,9 @@ class RestAgentStoreTest {
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG2_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             // PKG1 is shared with 2 agents — should be SKIPPED
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor(), dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenAnswer(invocation -> referrers(2));
             // PKG2 is only in this Agent — should be deleted
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenAnswer(invocation -> referrers(1));
             when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
 
             restAgentStore.deleteAgent(AGENT_ID, 1, true, true);
@@ -210,7 +247,7 @@ class RestAgentStoreTest {
                     URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG2_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             // both packages only referenced by this agent
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(anyString(), anyInt(), eq(true))).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(anyString(), anyInt(), eq(true))).thenAnswer(invocation -> referrers(1));
             when(restWorkflowStore.deleteWorkflow(PKG1_ID, 2, false, true)).thenThrow(new RuntimeException("Workflow in use"));
             when(restWorkflowStore.deleteWorkflow(PKG2_ID, 1, false, true)).thenReturn(Response.ok().build());
 
@@ -284,7 +321,7 @@ class RestAgentStoreTest {
             AgentConfiguration config = new AgentConfiguration();
             config.setWorkflows(new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenAnswer(invocation -> referrers(1));
             when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
 
             restAgentStore.deleteAgent(AGENT_ID, 0, false, true);
@@ -445,7 +482,7 @@ class RestAgentStoreTest {
             config.setWorkflows(
                     new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenAnswer(invocation -> referrers(1));
             // The guard saw v1; by the time the delete runs the Agent is at v2.
             doThrow(new IResourceStore.ResourceModifiedException("not the latest version")).when(AgentStore).delete(AGENT_ID, 1);
 
@@ -472,12 +509,62 @@ class RestAgentStoreTest {
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             // This Agent plus one other — the guard must read that as "still referenced".
             when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true))
-                    .thenReturn(List.of(dummyDescriptor(), dummyDescriptor()));
+                    .thenAnswer(invocation -> referrers(2));
 
             restAgentStore.deleteAgent(AGENT_ID, 1, false, true);
 
             verify(AgentStore).delete(AGENT_ID, 1);
             verify(restWorkflowStore, never()).deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean());
+        }
+
+        /**
+         * The window the ordering leaves open: the workflow was judged exclusive BEFORE
+         * this Agent was deleted, and another Agent can be created — or re-pointed at
+         * it — between that decision and the cascade delete. Nothing downstream
+         * re-asks: {@code deleteWorkflow} only checks WORKFLOW referrers, not Agent
+         * ones. So the newly shared workflow (and, through that delete's own cascade,
+         * its rule sets, output sets and dictionaries) was torn down under a live
+         * Agent. The re-check runs after this Agent is gone, so anything the reverse
+         * lookup still returns is a referrer that must stop the delete.
+         */
+        @Test
+        @DisplayName("a workflow another Agent picks up during the cascade is not deleted")
+        void workflowThatBecomesSharedDuringTheCascadeIsSkipped() throws Exception {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(
+                    new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
+            // One referrer at both moments, but not the SAME one: when the cascade is
+            // planned it is this Agent (so the workflow is a candidate), and by the time
+            // the cascade delete runs this Agent is gone and the one referrer is an
+            // Agent that has just been pointed at the workflow.
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenReturn(List.of(dummyDescriptor()));
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, false, true);
+
+            verify(AgentStore).delete(AGENT_ID, 1);
+            verify(restWorkflowStore, never()).deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean());
+        }
+
+        /**
+         * The counterpart to
+         * {@link #workflowThatBecomesSharedDuringTheCascadeIsSkipped} — without it,
+         * that test would pass equally against a cascade that had simply stopped
+         * deleting anything.
+         */
+        @Test
+        @DisplayName("a workflow nobody picks up during the cascade is still deleted")
+        void workflowThatStaysExclusiveIsStillCascadeDeleted() throws Exception {
+            AgentConfiguration config = new AgentConfiguration();
+            config.setWorkflows(
+                    new ArrayList<>(List.of(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/" + PKG1_ID + "?version=1"))));
+            when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true)).thenAnswer(invocation -> referrers(1));
+            when(restWorkflowStore.deleteWorkflow(anyString(), anyInt(), anyBoolean(), anyBoolean())).thenReturn(Response.ok().build());
+
+            restAgentStore.deleteAgent(AGENT_ID, 1, false, true);
+
+            verify(restWorkflowStore).deleteWorkflow(PKG1_ID, 2, false, true);
         }
 
         /**
@@ -497,7 +584,7 @@ class RestAgentStoreTest {
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             when(restWorkflowStore.getCurrentResourceId(PKG1_ID))
                     .thenThrow(new IResourceStore.ResourceNotFoundException("already soft-deleted"));
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenAnswer(invocation -> referrers(1));
 
             restAgentStore.deleteAgent(AGENT_ID, 1, false, true);
 
@@ -522,7 +609,7 @@ class RestAgentStoreTest {
             when(AgentStore.read(AGENT_ID, 1)).thenReturn(config);
             when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG1_ID, 2, true))
                     .thenThrow(new IResourceStore.ResourceStoreException("reverse lookup broken"));
-            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenReturn(List.of(dummyDescriptor()));
+            when(AgentStore.getAgentDescriptorsContainingWorkflow(PKG2_ID, 1, true)).thenAnswer(invocation -> referrers(1));
 
             restAgentStore.deleteAgent(AGENT_ID, 1, false, true);
 

--- a/src/test/java/ai/labs/eddi/configs/deployment/mongo/MongoDeploymentStorageTest.java
+++ b/src/test/java/ai/labs/eddi/configs/deployment/mongo/MongoDeploymentStorageTest.java
@@ -7,15 +7,20 @@ package ai.labs.eddi.configs.deployment.mongo;
 import ai.labs.eddi.configs.deployment.model.DeploymentInfo;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCommandException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.ReplaceOptions;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.util.List;
@@ -43,24 +48,73 @@ class MongoDeploymentStorageTest {
 
     // ==================== setDeploymentInfo ====================
 
+    /**
+     * These replace a pair that pinned the old check-then-act (findOneAndReplace,
+     * then insertOne when it came back null). Two concurrent deploys of the same
+     * agent/version both saw null and both inserted, so those assertions described
+     * the defect rather than the requirement.
+     */
     @Test
-    @DisplayName("setDeploymentInfo — replaces when existing")
-    void setDeploymentInfoReplace() {
-        Document existing = new Document("environment", "production");
-        when(collection.findOneAndReplace(any(Document.class), any(Document.class))).thenReturn(existing);
+    @DisplayName("setDeploymentInfo — one atomic upsert, never a check-then-act")
+    void setDeploymentInfoUpserts() {
+        ArgumentCaptor<Document> filterCaptor = ArgumentCaptor.forClass(Document.class);
+        ArgumentCaptor<Document> docCaptor = ArgumentCaptor.forClass(Document.class);
+        ArgumentCaptor<ReplaceOptions> optionsCaptor = ArgumentCaptor.forClass(ReplaceOptions.class);
 
         storage.setDeploymentInfo("production", "agent-1", 1, DeploymentInfo.DeploymentStatus.deployed);
-        verify(collection).findOneAndReplace(any(Document.class), any(Document.class));
+
+        verify(collection).replaceOne(filterCaptor.capture(), docCaptor.capture(), optionsCaptor.capture());
+        verify(collection, never()).findOneAndReplace(any(Document.class), any(Document.class));
         verify(collection, never()).insertOne(any(Document.class));
+
+        assertTrue(optionsCaptor.getValue().isUpsert(), "the replace must upsert, or the first deploy writes nothing");
+        assertEquals("production", filterCaptor.getValue().get("environment"));
+        assertEquals("agent-1", filterCaptor.getValue().get("agentId"));
+        assertEquals(1, filterCaptor.getValue().get("agentVersion"));
+        assertEquals("deployed", docCaptor.getValue().get("deploymentStatus"));
     }
 
     @Test
-    @DisplayName("setDeploymentInfo — inserts when not existing")
-    void setDeploymentInfoInsert() {
-        when(collection.findOneAndReplace(any(Document.class), any(Document.class))).thenReturn(null);
+    @DisplayName("a unique index on (environment, agentId, agentVersion) backs the upsert")
+    void uniqueIndexOnDeploymentKey() {
+        ArgumentCaptor<Bson> keyCaptor = ArgumentCaptor.forClass(Bson.class);
+        ArgumentCaptor<IndexOptions> optionsCaptor = ArgumentCaptor.forClass(IndexOptions.class);
 
-        storage.setDeploymentInfo("production", "agent-1", 1, DeploymentInfo.DeploymentStatus.deployed);
-        verify(collection).insertOne(any(Document.class));
+        verify(collection).createIndex(keyCaptor.capture(), optionsCaptor.capture());
+
+        assertEquals(Boolean.TRUE, optionsCaptor.getValue().isUnique());
+        String key = keyCaptor.getValue().toBsonDocument(Document.class, MongoClientSettings.getDefaultCodecRegistry()).toString();
+        assertTrue(key.contains("environment") && key.contains("agentId") && key.contains("agentVersion"),
+                "unexpected unique index key: " + key);
+    }
+
+    /**
+     * A unique index cannot be built over a collection that already holds
+     * duplicates — which is exactly the state of the deployments this index exists
+     * to protect, since those duplicates are what the check-then-act upsert used to
+     * write. Letting the E11000 out of the constructor made the bean
+     * unconstructable on precisely those installations, and an unconstructable
+     * {@code IDeploymentStore} takes {@code RestAgentStore},
+     * {@code RestAgentAdministration} and the startup redeploy with it: the fix
+     * bricked the deployments that had the bug.
+     */
+    @Test
+    @DisplayName("a duplicate-key failure building the unique index does not break construction")
+    void duplicateRowsDoNotBreakConstruction() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        MongoCollection<Document> failingCollection = mock(MongoCollection.class);
+        when(database.getCollection("deployments")).thenReturn(failingCollection);
+        when(failingCollection.createIndex(any(Bson.class), any(IndexOptions.class)))
+                .thenThrow(mock(MongoCommandException.class));
+
+        MongoDeploymentStorage constructed = assertDoesNotThrow(
+                () -> new MongoDeploymentStorage(database, documentBuilder),
+                "duplicate rows must not make the deployment store unconstructable");
+
+        // and the store stays usable: the atomic upsert is what actually closes the
+        // race, the index is only its backstop.
+        constructed.setDeploymentInfo("production", "agent-1", 1, DeploymentInfo.DeploymentStatus.deployed);
+        verify(failingCollection).replaceOne(any(Document.class), any(Document.class), any(ReplaceOptions.class));
     }
 
     // ==================== readDeploymentInfo ====================

--- a/src/test/java/ai/labs/eddi/configs/deployment/mongo/MongoDeploymentStorageTest.java
+++ b/src/test/java/ai/labs/eddi/configs/deployment/mongo/MongoDeploymentStorageTest.java
@@ -9,18 +9,21 @@ import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
+import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.result.DeleteResult;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.IOException;
 import java.util.List;
@@ -106,15 +109,181 @@ class MongoDeploymentStorageTest {
         when(database.getCollection("deployments")).thenReturn(failingCollection);
         when(failingCollection.createIndex(any(Bson.class), any(IndexOptions.class)))
                 .thenThrow(mock(MongoCommandException.class));
+        stubAggregate(failingCollection, List.of());
 
         MongoDeploymentStorage constructed = assertDoesNotThrow(
                 () -> new MongoDeploymentStorage(database, documentBuilder),
                 "duplicate rows must not make the deployment store unconstructable");
 
-        // and the store stays usable: the atomic upsert is what actually closes the
-        // race, the index is only its backstop.
+        // and the store stays usable — but the race is genuinely still open on such an
+        // installation, which is why that failure is now reported at ERROR instead of
+        // being described as fixed. See dedupesThenRetriesTheUniqueIndex.
         constructed.setDeploymentInfo("production", "agent-1", 1, DeploymentInfo.DeploymentStatus.deployed);
         verify(failingCollection).replaceOne(any(Document.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    /**
+     * {@code replaceOne(upsert)} is atomic per operation, but an upsert whose
+     * filter fields carry no unique constraint can still insert twice under
+     * concurrency: two callers that both match nothing both take the insert branch.
+     * Only the unique index turns the loser into a duplicate-key error — so giving
+     * up on the index leaves the race open on exactly the installations that
+     * already demonstrated it. Removing the duplicates and retrying is what closes
+     * it.
+     */
+    @Test
+    @DisplayName("duplicate rows are removed and the unique index is retried, not given up on")
+    void dedupesThenRetriesTheUniqueIndex() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        MongoCollection<Document> duplicated = mock(MongoCollection.class);
+        when(database.getCollection("deployments")).thenReturn(duplicated);
+        // Fails while duplicates are present, succeeds once they are gone.
+        when(duplicated.createIndex(any(Bson.class), any(IndexOptions.class)))
+                .thenThrow(mock(MongoCommandException.class))
+                .thenReturn("environment_1_agentId_1_agentVersion_1");
+
+        Document duplicateGroup = new Document("duplicateIds", List.of("id-old", "id-new")).append("duplicateCount", 2);
+        stubAggregate(duplicated, List.of(duplicateGroup));
+        DeleteResult deleteResult = mock(DeleteResult.class);
+        when(deleteResult.getDeletedCount()).thenReturn(1L);
+        when(duplicated.deleteMany(any(Bson.class))).thenReturn(deleteResult);
+
+        assertDoesNotThrow(() -> new MongoDeploymentStorage(database, documentBuilder));
+
+        ArgumentCaptor<Bson> deleteFilter = ArgumentCaptor.forClass(Bson.class);
+        verify(duplicated).deleteMany(deleteFilter.capture());
+        String filter = deleteFilter.getValue().toBsonDocument(Document.class, MongoClientSettings.getDefaultCodecRegistry()).toString();
+        assertTrue(filter.contains("id-old"), "the older duplicate must be removed, got: " + filter);
+        assertFalse(filter.contains("id-new"), "exactly one row per key must survive, got: " + filter);
+
+        // Twice: once before the dedupe (which failed) and once after it.
+        verify(duplicated, times(2)).createIndex(any(Bson.class), any(IndexOptions.class));
+    }
+
+    /**
+     * The survivor is picked as the LAST element of the {@code $push} array, so the
+     * array's order is the whole correctness argument — and {@code $push} only
+     * preserves an order the pipeline actually established. Without a leading
+     * {@code $sort} the input order is the storage engine's natural order, which is
+     * neither insertion order nor stable across nodes: two nodes deduplicating
+     * during a rolling restart can each keep a different element and, between them,
+     * delete every row for a key, leaving a deployed agent silently un-redeployed.
+     *
+     * <p>
+     * This asserts the pipeline the code actually sends, because the mock in
+     * {@link #dedupesThenRetriesTheUniqueIndex} supplies the array order itself and
+     * so can never notice that the server was never asked for one.
+     * </p>
+     */
+    @Test
+    @DisplayName("the dedupe pipeline sorts by _id before grouping, so every node keeps the same row")
+    void dedupePipelineSortsBeforeGrouping() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        MongoCollection<Document> duplicated = mock(MongoCollection.class);
+        when(database.getCollection("deployments")).thenReturn(duplicated);
+        when(duplicated.createIndex(any(Bson.class), any(IndexOptions.class)))
+                .thenThrow(mock(MongoCommandException.class))
+                .thenReturn("environment_1_agentId_1_agentVersion_1");
+        stubAggregate(duplicated, List.of());
+
+        assertDoesNotThrow(() -> new MongoDeploymentStorage(database, documentBuilder));
+
+        ArgumentCaptor<List<Document>> pipeline = ArgumentCaptor.forClass(List.class);
+        verify(duplicated).aggregate(pipeline.capture());
+        List<Document> stages = pipeline.getValue();
+
+        int sortStage = indexOfStage(stages, "$sort");
+        int groupStage = indexOfStage(stages, "$group");
+        assertTrue(sortStage >= 0, "the dedupe pipeline must sort before it groups, got: " + stages);
+        assertTrue(groupStage >= 0, "the dedupe pipeline must group, got: " + stages);
+        assertTrue(sortStage < groupStage, "the $sort must precede the $group or $push order is undefined, got: " + stages);
+        assertEquals(new Document("_id", 1), stages.get(sortStage).get("$sort"),
+                "sorting must be ascending by _id — an ObjectId's leading bytes are the insert timestamp, so that is insertion order");
+    }
+
+    /**
+     * The dedupe is the recovery path, so its own failure must not become the thing
+     * it was recovering from. Nothing in this constructor may make the bean
+     * unconstructable: an unconstructable {@code IDeploymentStore} takes
+     * {@code RestAgentStore}, {@code RestAgentAdministration} and the startup
+     * redeploy down with it. The collection is left exactly as it was — no delete
+     * is attempted on an aggregation that never answered — and the index is not
+     * retried, because nothing changed.
+     */
+    @Test
+    @DisplayName("a dedupe that itself fails leaves the store constructible and deletes nothing")
+    void dedupeFailureDoesNotBreakConstructionOrDeleteAnything() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        MongoCollection<Document> broken = mock(MongoCollection.class);
+        when(database.getCollection("deployments")).thenReturn(broken);
+        when(broken.createIndex(any(Bson.class), any(IndexOptions.class))).thenThrow(mock(MongoCommandException.class));
+        when(broken.aggregate(anyList())).thenThrow(mock(MongoCommandException.class));
+
+        MongoDeploymentStorage constructed = assertDoesNotThrow(() -> new MongoDeploymentStorage(database, documentBuilder),
+                "a failing dedupe must not make the deployment store unconstructable");
+
+        verify(broken, never()).deleteMany(any(Bson.class));
+        // Once, not twice: the retry is only earned by a dedupe that actually ran.
+        verify(broken).createIndex(any(Bson.class), any(IndexOptions.class));
+
+        // The collection stays usable.
+        constructed.setDeploymentInfo("production", "agent-1", 1, DeploymentInfo.DeploymentStatus.deployed);
+        verify(broken).replaceOne(any(Document.class), any(Document.class), any(ReplaceOptions.class));
+    }
+
+    /**
+     * A group the {@code $match} let through but that carries fewer than two ids
+     * describes no duplicate, so nothing may be deleted for it. The guard is what
+     * stops {@code ids.subList(0, ids.size() - 1)} on a one-element (or absent)
+     * array from turning a bad aggregation result into data loss.
+     */
+    @Test
+    @DisplayName("a group with fewer than two ids deletes nothing")
+    void groupWithoutARealDuplicateDeletesNothing() {
+        MongoDatabase database = mock(MongoDatabase.class);
+        MongoCollection<Document> odd = mock(MongoCollection.class);
+        when(database.getCollection("deployments")).thenReturn(odd);
+        when(odd.createIndex(any(Bson.class), any(IndexOptions.class)))
+                .thenThrow(mock(MongoCommandException.class))
+                .thenReturn("environment_1_agentId_1_agentVersion_1");
+        stubAggregate(odd, List.of(new Document("duplicateIds", List.of("only-one")).append("duplicateCount", 2),
+                new Document("duplicateCount", 2)));
+
+        assertDoesNotThrow(() -> new MongoDeploymentStorage(database, documentBuilder));
+
+        verify(odd, never()).deleteMany(any(Bson.class));
+        // The index is still retried — the dedupe ran, it simply found nothing to do.
+        verify(odd, times(2)).createIndex(any(Bson.class), any(IndexOptions.class));
+    }
+
+    private static int indexOfStage(List<Document> stages, String stageName) {
+        for (int i = 0; i < stages.size(); i++) {
+            if (stages.get(i).containsKey(stageName)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void stubAggregate(MongoCollection<Document> collection, List<Document> groups) {
+        AggregateIterable<Document> iterable = mock(AggregateIterable.class);
+        when(collection.aggregate(anyList())).thenReturn(iterable);
+        MongoCursor<Document> cursor = mock(MongoCursor.class);
+        doReturn(cursor).when(iterable).iterator();
+
+        OngoingStubbing<Boolean> hasNext = when(cursor.hasNext());
+        for (int i = 0; i < groups.size(); i++) {
+            hasNext = hasNext.thenReturn(true);
+        }
+        hasNext.thenReturn(false);
+
+        if (!groups.isEmpty()) {
+            OngoingStubbing<Document> next = when(cursor.next());
+            for (Document group : groups) {
+                next = next.thenReturn(group);
+            }
+        }
     }
 
     // ==================== readDeploymentInfo ====================

--- a/src/test/java/ai/labs/eddi/configs/descriptors/ResourceUtilitiesTest.java
+++ b/src/test/java/ai/labs/eddi/configs/descriptors/ResourceUtilitiesTest.java
@@ -6,9 +6,12 @@ package ai.labs.eddi.configs.descriptors;
 
 import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.engine.memory.descriptor.model.ConversationDescriptor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -69,5 +72,106 @@ class ResourceUtilitiesTest {
         assertEquals(ConversationDescriptor.ViewState.UNSEEN, descriptor.getViewState());
         assertNotNull(descriptor.getCreatedOn());
         assertNull(descriptor.getCreatedBy());
+    }
+
+    // ==================== filterAndPage ====================
+
+    /**
+     * The reverse-reference listings post-filter with this helper because the store
+     * lookup behind them takes neither a filter nor a page. Its Javadoc claims it
+     * approximates "the same descriptor fields the descriptor store matches on", so
+     * which fields it actually matches is the contract — a narrower set silently
+     * disagrees with the store-side filter for the same query string.
+     */
+    @Nested
+    @DisplayName("filterAndPage")
+    class FilterAndPage {
+
+        private DocumentDescriptor descriptor(String name, String description, String ownerId, String resource) {
+            var descriptor = new DocumentDescriptor();
+            descriptor.setName(name);
+            descriptor.setDescription(description);
+            descriptor.setOwnerId(ownerId);
+            if (resource != null) {
+                descriptor.setResource(URI.create(resource));
+            }
+            return descriptor;
+        }
+
+        private List<String> names(List<DocumentDescriptor> descriptors) {
+            return descriptors.stream().map(DocumentDescriptor::getName).toList();
+        }
+
+        private List<DocumentDescriptor> fixture() {
+            return List.of(
+                    descriptor("alpha", "the first one", "owner-a", "eddi://ai.labs.agent/agentstore/agents/111?version=1"),
+                    descriptor("beta", "second, tagged", "owner-b", "eddi://ai.labs.agent/agentstore/agents/222?version=1"),
+                    descriptor("gamma", "third, tagged", "owner-c", "eddi://ai.labs.agent/agentstore/agents/333?version=1"));
+        }
+
+        @Test
+        @DisplayName("matches the description, not only the name")
+        void matchesDescription() {
+            assertEquals(List.of("alpha"), names(ResourceUtilities.filterAndPage(fixture(), "FIRST", 0, 20)));
+        }
+
+        @Test
+        @DisplayName("matches the owner id")
+        void matchesOwnerId() {
+            assertEquals(List.of("beta"), names(ResourceUtilities.filterAndPage(fixture(), "owner-b", 0, 20)));
+        }
+
+        @Test
+        @DisplayName("matches the resource uri")
+        void matchesResourceUri() {
+            assertEquals(List.of("gamma"), names(ResourceUtilities.filterAndPage(fixture(), "agents/333", 0, 20)));
+        }
+
+        @Test
+        @DisplayName("a descriptor with null fields is skipped, not an NPE")
+        void tolerantOfNullFields() {
+            var incomplete = List.of(descriptor(null, null, null, null));
+
+            assertTrue(ResourceUtilities.filterAndPage(incomplete, "anything", 0, 20).isEmpty());
+        }
+
+        /**
+         * {@code limit} arrives from the REST layer, where the POST overloads declare
+         * {@code @DefaultValue("20")} but an in-process caller may pass null or 0. Both
+         * mean "no page", i.e. return everything — truncating instead would silently
+         * drop rows.
+         */
+        @Test
+        @DisplayName("a null or non-positive limit returns everything")
+        void noLimitReturnsEverything() {
+            assertEquals(List.of("alpha", "beta", "gamma"), names(ResourceUtilities.filterAndPage(fixture(), null, 0, null)));
+            assertEquals(List.of("alpha", "beta", "gamma"), names(ResourceUtilities.filterAndPage(fixture(), null, 0, 0)));
+            assertEquals(List.of("alpha", "beta", "gamma"), names(ResourceUtilities.filterAndPage(fixture(), null, 0, -1)));
+        }
+
+        @Test
+        @DisplayName("index is a page number, and a negative one is the first page")
+        void indexIsAPageNumber() {
+            assertEquals(List.of("alpha", "beta"), names(ResourceUtilities.filterAndPage(fixture(), null, 0, 2)));
+            assertEquals(List.of("gamma"), names(ResourceUtilities.filterAndPage(fixture(), null, 1, 2)));
+            assertEquals(List.of("alpha", "beta"), names(ResourceUtilities.filterAndPage(fixture(), null, -3, 2)));
+            assertEquals(List.of("alpha", "beta"), names(ResourceUtilities.filterAndPage(fixture(), null, null, 2)));
+            assertTrue(ResourceUtilities.filterAndPage(fixture(), null, 9, 2).isEmpty(), "past the end must be empty, not the full list");
+        }
+
+        @Test
+        @DisplayName("filter and page compose: the page is taken from the matches, not the input")
+        void filterThenPage() {
+            assertEquals(List.of("beta"), names(ResourceUtilities.filterAndPage(fixture(), "tagged", 0, 1)));
+            assertEquals(List.of("gamma"), names(ResourceUtilities.filterAndPage(fixture(), "tagged", 1, 1)));
+            assertTrue(ResourceUtilities.filterAndPage(fixture(), "tagged", 2, 1).isEmpty());
+        }
+
+        @Test
+        @DisplayName("null and empty inputs are handed straight back")
+        void nullAndEmptyInputs() {
+            assertNull(ResourceUtilities.filterAndPage(null, "x", 0, 20));
+            assertTrue(ResourceUtilities.filterAndPage(List.of(), "x", 0, 20).isEmpty());
+        }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/descriptors/ResourceUtilitiesTest.java
+++ b/src/test/java/ai/labs/eddi/configs/descriptors/ResourceUtilitiesTest.java
@@ -173,5 +173,24 @@ class ResourceUtilitiesTest {
             assertNull(ResourceUtilities.filterAndPage(null, "x", 0, 20));
             assertTrue(ResourceUtilities.filterAndPage(List.of(), "x", 0, 20).isEmpty());
         }
+
+        /**
+         * index and limit arrive straight off the query string. Multiplied as int,
+         * {@code page * limit} wraps negative for values a client can simply type, and
+         * {@code subList} then throws IndexOutOfBoundsException — a 500 for a paging
+         * request, instead of the empty page that lies past the end of the list.
+         */
+        @Test
+        @DisplayName("an index or limit near Integer.MAX_VALUE answers an empty page, it does not overflow")
+        void hugeIndexAndLimitDoNotOverflow() {
+            assertTrue(ResourceUtilities.filterAndPage(fixture(), null, Integer.MAX_VALUE, 20).isEmpty(),
+                    "page Integer.MAX_VALUE is past the end of a 3-row list");
+            assertTrue(ResourceUtilities.filterAndPage(fixture(), null, Integer.MAX_VALUE, Integer.MAX_VALUE).isEmpty());
+            assertTrue(ResourceUtilities.filterAndPage(fixture(), null, 1_000_000, 1_000_000).isEmpty());
+
+            // A limit past the end of the list is still the whole list on page 0 — the
+            // clamp must not turn a large limit into a short page.
+            assertEquals(List.of("alpha", "beta", "gamma"), names(ResourceUtilities.filterAndPage(fixture(), null, 0, Integer.MAX_VALUE)));
+        }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoTest.java
@@ -6,13 +6,18 @@ package ai.labs.eddi.configs.rest;
 
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.configs.descriptors.IDocumentDescriptorStore;
+import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.IResourceStore.IResourceId;
 import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 /**
@@ -104,5 +109,92 @@ class RestVersionInfoTest {
         // Assert
         assertEquals(3, resolvedVersion);
         verifyNoInteractions(resourceStore);
+    }
+
+    /**
+     * {@code read} took the version literally while {@code update} and
+     * {@code delete} both routed it through {@code validateParameters}, so
+     * {@code GET ?version=0} was a 404 while {@code PUT ?version=0} and
+     * {@code DELETE ?version=0} acted on the current version — no single convention
+     * worked across the three verbs.
+     */
+    @Test
+    void read_versionZero_readsTheCurrentVersion() throws Exception {
+        IResourceId currentResourceId = mock(IResourceId.class);
+        when(currentResourceId.getVersion()).thenReturn(5);
+        when(resourceStore.getCurrentResourceId(TEST_ID)).thenReturn(currentResourceId);
+        Object document = new Object();
+        when(resourceStore.read(TEST_ID, 5)).thenReturn(document);
+
+        assertSame(document, restVersionInfo.read(TEST_ID, 0));
+        verify(resourceStore).read(TEST_ID, 5);
+    }
+
+    /**
+     * Only {@code DocumentDescriptorFilter} — a JAX-RS response filter — used to
+     * flag a descriptor deleted, so it ran for an HTTP DELETE and for nothing else.
+     * Every in-process delete (the agent cascade, the workflow cascade, the orphan
+     * purge) left {@code deleted=false}, so the resource stayed in every listing,
+     * answered 404 when opened, and kept being re-reported by the orphan scan.
+     */
+    @Test
+    void delete_marksTheDescriptorDeleted() throws Exception {
+        var descriptor = new DocumentDescriptor();
+        when(documentDescriptorStore.readDescriptor(TEST_ID, 2)).thenReturn(descriptor);
+
+        restVersionInfo.delete(TEST_ID, 2, false);
+
+        assertTrue(descriptor.isDeleted());
+        verify(documentDescriptorStore).setDescriptor(TEST_ID, 2, descriptor);
+    }
+
+    /**
+     * Four classes used to assert in comments that {@code Response.getLocation()}
+     * returns null for {@code eddi://} scheme URIs, and a parallel creation API
+     * plus a three-strategy URI extractor were built around that belief. It is
+     * false, and this pins it against the real JAX-RS {@code RuntimeDelegate} on
+     * the Response {@code create} actually builds — so the next author does not
+     * reintroduce the workaround.
+     */
+    @Test
+    void create_locationHeaderCarriesTheEddiUri() throws Exception {
+        IResourceId created = mock(IResourceId.class);
+        when(created.getId()).thenReturn(TEST_ID);
+        when(created.getVersion()).thenReturn(1);
+        when(resourceStore.create(any())).thenReturn(created);
+
+        var response = restVersionInfo.create(new Object());
+
+        assertEquals(201, response.getStatus());
+        assertEquals(URI.create(RESOURCE_URI + TEST_ID + "?version=1"), response.getLocation());
+    }
+
+    /**
+     * Even a permanent delete only FLAGS the descriptor. Erasing the row would be
+     * tidier, but on the HTTP path {@code DocumentDescriptorFilter} runs after this
+     * and reads the descriptor back — a missing row there becomes a 404 answer to a
+     * delete that in fact succeeded.
+     */
+    @Test
+    void delete_permanent_flagsTheDescriptorRatherThanErasingIt() throws Exception {
+        var descriptor = new DocumentDescriptor();
+        when(documentDescriptorStore.readDescriptor(TEST_ID, 2)).thenReturn(descriptor);
+
+        restVersionInfo.delete(TEST_ID, 2, true);
+
+        assertTrue(descriptor.isDeleted());
+        verify(documentDescriptorStore).setDescriptor(TEST_ID, 2, descriptor);
+        verify(documentDescriptorStore, never()).deleteAllDescriptor(anyString());
+    }
+
+    @Test
+    void delete_descriptorFailureDoesNotFailTheDelete() throws Exception {
+        // The resource IS gone by then — a descriptor that cannot be updated must not
+        // turn a completed delete into an error response.
+        when(documentDescriptorStore.readDescriptor(TEST_ID, 2))
+                .thenThrow(new ResourceNotFoundException("no descriptor"));
+
+        assertEquals(200, restVersionInfo.delete(TEST_ID, 2, false).getStatus());
+        verify(resourceStore).delete(TEST_ID, 2);
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoTest.java
@@ -13,11 +13,20 @@ import ai.labs.eddi.datastore.IResourceStore.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import jakarta.ws.rs.WebApplicationException;
+
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -177,6 +186,12 @@ class RestVersionInfoTest {
      */
     @Test
     void delete_permanent_flagsTheDescriptorRatherThanErasingIt() throws Exception {
+        IResourceId current = mock(IResourceId.class);
+        when(current.getId()).thenReturn(TEST_ID);
+        when(current.getVersion()).thenReturn(2);
+        when(resourceStore.getCurrentResourceId(TEST_ID)).thenReturn(current);
+        when(documentDescriptorStore.getCurrentResourceId(TEST_ID)).thenReturn(current);
+
         var descriptor = new DocumentDescriptor();
         when(documentDescriptorStore.readDescriptor(TEST_ID, 2)).thenReturn(descriptor);
 
@@ -185,6 +200,147 @@ class RestVersionInfoTest {
         assertTrue(descriptor.isDeleted());
         verify(documentDescriptorStore).setDescriptor(TEST_ID, 2, descriptor);
         verify(documentDescriptorStore, never()).deleteAllDescriptor(anyString());
+    }
+
+    /**
+     * A permanent delete is ID-scoped — {@code deleteAllPermanently} drops every
+     * version and every history row — while {@code version} was accepted and then
+     * ignored on that branch, so a stale browser tab issuing
+     * {@code DELETE ?version=1&permanent=true} against a resource that is at v2
+     * erased all of it with no 409 anywhere. The soft path gets this check for free
+     * from {@code HistorizedResourceStore.delete}; the permanent one has to ask.
+     */
+    @Test
+    void delete_permanent_refusesAStaleVersionBeforeErasingAnything() throws Exception {
+        IResourceId current = mock(IResourceId.class);
+        when(current.getId()).thenReturn(TEST_ID);
+        when(current.getVersion()).thenReturn(2);
+        when(resourceStore.getCurrentResourceId(TEST_ID)).thenReturn(current);
+
+        var thrown = assertThrows(WebApplicationException.class, () -> restVersionInfo.delete(TEST_ID, 1, true));
+
+        assertEquals(409, thrown.getResponse().getStatus());
+        verify(resourceStore, never()).deleteAllPermanently(anyString());
+        verify(documentDescriptorStore, never()).setDescriptor(anyString(), any(), any());
+    }
+
+    /**
+     * The two-step purge: a resource that is already soft-deleted has no current
+     * version to be stale against, so purging its remaining history must still
+     * work. Refusing here would make the documented flow impossible.
+     */
+    @Test
+    void delete_permanent_allowsAnAlreadySoftDeletedResource() throws Exception {
+        when(resourceStore.getCurrentResourceId(TEST_ID)).thenThrow(new ResourceNotFoundException("no current version"));
+
+        assertEquals(200, restVersionInfo.delete(TEST_ID, 1, true).getStatus());
+        verify(resourceStore).deleteAllPermanently(TEST_ID);
+    }
+
+    /**
+     * Some store implementations report "no live version" by answering {@code null}
+     * rather than by throwing. That must mean the same thing here — the purge is
+     * allowed — and above all must not be dereferenced: an NPE in the middle of a
+     * destructive operation leaves the caller with no idea what was erased.
+     */
+    @Test
+    void delete_permanent_treatsANullCurrentIdAsNoLiveVersion() throws Exception {
+        when(resourceStore.getCurrentResourceId(TEST_ID)).thenReturn(null);
+
+        assertEquals(200, restVersionInfo.delete(TEST_ID, 1, true).getStatus());
+
+        IResourceId versionless = mock(IResourceId.class);
+        when(versionless.getVersion()).thenReturn(null);
+        when(resourceStore.getCurrentResourceId(TEST_ID)).thenReturn(versionless);
+
+        assertEquals(200, restVersionInfo.delete(TEST_ID, 1, true).getStatus());
+        verify(resourceStore, times(2)).deleteAllPermanently(TEST_ID);
+    }
+
+    /**
+     * Descriptors outlive the resource — they are flagged, never removed — so
+     * flagging the version the request happened to address left the CURRENT
+     * descriptor row saying {@code deleted=false}. The listing then kept showing a
+     * resource whose every version had just been erased, opening it answered 404,
+     * and the orphan scan reported it as a live orphan: the phantom this branch set
+     * out to remove, on the path it claimed had converged.
+     */
+    @Test
+    void delete_permanent_flagsTheDescriptorAtItsCurrentVersion() throws Exception {
+        IResourceId currentResource = mock(IResourceId.class);
+        when(currentResource.getId()).thenReturn(TEST_ID);
+        when(currentResource.getVersion()).thenReturn(2);
+        when(resourceStore.getCurrentResourceId(TEST_ID)).thenReturn(currentResource);
+
+        // The descriptor has moved on to v4 while the resource is at v2 — the two are
+        // versioned independently, so the descriptor's own current version is the one
+        // to flag.
+        IResourceId currentDescriptor = mock(IResourceId.class);
+        when(currentDescriptor.getId()).thenReturn(TEST_ID);
+        when(currentDescriptor.getVersion()).thenReturn(4);
+        when(documentDescriptorStore.getCurrentResourceId(TEST_ID)).thenReturn(currentDescriptor);
+
+        var descriptor = new DocumentDescriptor();
+        when(documentDescriptorStore.readDescriptor(TEST_ID, 4)).thenReturn(descriptor);
+
+        restVersionInfo.delete(TEST_ID, 2, true);
+
+        assertTrue(descriptor.isDeleted());
+        verify(documentDescriptorStore).setDescriptor(TEST_ID, 4, descriptor);
+        verify(documentDescriptorStore, never()).setDescriptor(eq(TEST_ID), eq(2), any());
+    }
+
+    /**
+     * CWE-117. The id is a path parameter and the store's message quotes it back,
+     * so a newline in either forges a second log record — a fabricated WARN or
+     * ERROR line that an operator (or a log-based alert) reads as the server's own.
+     * {@code LogSanitizer} is the sanitiser the rest of the codebase already uses;
+     * this pins that this site uses it too.
+     */
+    @Test
+    void delete_descriptorFailureLogsTheIdSanitized() throws Exception {
+        String poisonedId = "resource-id\nERROR [io.quarkus] forged log line";
+        List<String> captured = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                captured.add(String.valueOf(record.getMessage()));
+                if (record.getParameters() != null) {
+                    for (Object parameter : record.getParameters()) {
+                        captured.add(String.valueOf(parameter));
+                    }
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        // logging.properties turns the whole ai.labs.eddi namespace OFF for plain
+        // unit tests, so this logger has to be opened explicitly to see anything.
+        Logger julLogger = Logger.getLogger(RestVersionInfo.class.getName());
+        Level previousLevel = julLogger.getLevel();
+        julLogger.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+        try {
+            when(documentDescriptorStore.readDescriptor(eq(poisonedId), any()))
+                    .thenThrow(new ResourceNotFoundException("no descriptor"));
+
+            restVersionInfo.delete(poisonedId, 2, false);
+        } finally {
+            julLogger.removeHandler(handler);
+            julLogger.setLevel(previousLevel);
+        }
+
+        assertTrue(captured.stream().anyMatch(value -> value.contains("resource-id_ERROR")),
+                "the WARN must have been captured with the id sanitized in place; captured: " + captured);
+        assertTrue(captured.stream().noneMatch(value -> value.contains("\n")),
+                "a newline reached the log, so a caller can forge log records; captured: " + captured);
     }
 
     @Test
@@ -196,5 +352,44 @@ class RestVersionInfoTest {
 
         assertEquals(200, restVersionInfo.delete(TEST_ID, 2, false).getStatus());
         verify(resourceStore).delete(TEST_ID, 2);
+    }
+
+    /**
+     * The store's optimistic-lock failure must reach the caller, not be turned into
+     * a 200 by the surrounding best-effort descriptor handling. This is the check
+     * the cascades rely on to abort before they touch anything a still-live
+     * resource references, so swallowing it here would silently re-open every one
+     * of them.
+     *
+     * <p>
+     * And the descriptor flagging this branch adds to the soft path has to sit
+     * <em>after</em> the store call, not beside it: a live descriptor is supplied
+     * below precisely so a flag written before the refused delete would be visible.
+     * Mark first and a resource that is still at v2 disappears from every listing
+     * ({@code readDescriptors(includeDeleted=false)} drops it) while the delete
+     * that was supposed to remove it answered 409 — a resource nobody can find and
+     * nobody deleted. The descriptor object is asserted directly rather than only
+     * through {@code setDescriptor}, because {@code markDescriptorDeleted} mutates
+     * the instance it read before it tries to store it.
+     * </p>
+     */
+    @Test
+    void delete_soft_propagatesAConcurrentModificationInsteadOfAnsweringOk() throws Exception {
+        var liveDescriptor = new DocumentDescriptor();
+        liveDescriptor.setDeleted(false);
+        when(documentDescriptorStore.readDescriptor(TEST_ID, 2)).thenReturn(liveDescriptor);
+        doThrow(new IResourceStore.ResourceModifiedException("someone else moved it to v3"))
+                .when(resourceStore).delete(TEST_ID, 2);
+
+        var thrown = assertThrows(IResourceStore.ResourceModifiedException.class,
+                () -> restVersionInfo.delete(TEST_ID, 2, false));
+
+        assertEquals("someone else moved it to v3", thrown.getMessage());
+        // Nothing may claim the delete happened — neither in the descriptor store nor
+        // on the descriptor itself.
+        verify(documentDescriptorStore, never()).setDescriptor(anyString(), any(), any());
+        verify(documentDescriptorStore, never()).readDescriptor(anyString(), any());
+        assertFalse(liveDescriptor.isDeleted(),
+                "a refused delete must leave the descriptor exactly as it found it");
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoTest.java
+++ b/src/test/java/ai/labs/eddi/configs/rest/RestVersionInfoTest.java
@@ -158,6 +158,33 @@ class RestVersionInfoTest {
     }
 
     /**
+     * The soft path had the same descriptor-version bug the permanent path was
+     * fixed for, and only the permanent one was pinned. Descriptor versions advance
+     * independently of the resource's — {@code DocumentDescriptorFilter} bumps them
+     * on metadata edits — so a resource at v2 whose descriptor has moved to v4 had
+     * its v2 descriptor row flagged while the CURRENT v4 row kept saying
+     * {@code deleted=false}: the listing still showed a resource that had just been
+     * deleted, which is the phantom this flagging exists to remove.
+     */
+    @Test
+    void delete_soft_flagsTheDescriptorAtItsCurrentVersion() throws Exception {
+        IResourceId currentDescriptor = mock(IResourceId.class);
+        when(currentDescriptor.getId()).thenReturn(TEST_ID);
+        when(currentDescriptor.getVersion()).thenReturn(4);
+        when(documentDescriptorStore.getCurrentResourceId(TEST_ID)).thenReturn(currentDescriptor);
+
+        var descriptor = new DocumentDescriptor();
+        when(documentDescriptorStore.readDescriptor(TEST_ID, 4)).thenReturn(descriptor);
+
+        restVersionInfo.delete(TEST_ID, 2, false);
+
+        verify(resourceStore).delete(TEST_ID, 2);
+        assertTrue(descriptor.isDeleted());
+        verify(documentDescriptorStore).setDescriptor(TEST_ID, 4, descriptor);
+        verify(documentDescriptorStore, never()).setDescriptor(eq(TEST_ID), eq(2), any());
+    }
+
+    /**
      * Four classes used to assert in comments that {@code Response.getLocation()}
      * returns null for {@code eddi://} scheme URIs, and a parallel creation API
      * plus a three-strategy URI extractor were built around that belief. It is

--- a/src/test/java/ai/labs/eddi/configs/schema/JsonSchemaCreatorTest.java
+++ b/src/test/java/ai/labs/eddi/configs/schema/JsonSchemaCreatorTest.java
@@ -107,4 +107,20 @@ public class JsonSchemaCreatorTest {
         assertTrue(properties.has("targetServerUrl"), "ApiCallsConfiguration schema must have 'targetServerUrl' property");
         assertTrue(properties.has("httpCalls"), "ApiCallsConfiguration schema must have 'httpCalls' property");
     }
+
+    /**
+     * A class's schema is a pure function of its structure, and the Manager hits
+     * {@code GET /{store}/jsonSchema} on every editor open, across fifteen sibling
+     * endpoints. Each call used to build a fresh generator and reflect over the
+     * whole type graph — {@code AgentConfiguration} alone has a dozen nested
+     * classes.
+     */
+    @Test
+    void generateSchema_isCachedPerClass() throws Exception {
+        String first = schemaCreator.generateSchema(AgentConfiguration.class);
+        String second = schemaCreator.generateSchema(AgentConfiguration.class);
+
+        assertSame(first, second, "the same class must return the cached schema instance");
+        assertNotSame(first, schemaCreator.generateSchema(WorkflowConfiguration.class), "each class caches its own schema");
+    }
 }

--- a/src/test/java/ai/labs/eddi/configs/shared/RetryConfigurationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/shared/RetryConfigurationTest.java
@@ -5,6 +5,11 @@
 package ai.labs.eddi.configs.shared;
 
 import ai.labs.eddi.engine.lifecycle.exceptions.LifecycleException;
+import dev.langchain4j.exception.AuthenticationException;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.exception.InternalServerException;
+import dev.langchain4j.exception.InvalidRequestException;
+import dev.langchain4j.exception.RateLimitException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.DisplayName;
@@ -223,6 +228,209 @@ class RetryConfigurationTest {
             var doubleWrapped = new Exception("outer", wrapped);
 
             assertTrue(RetryConfiguration.isRetryableError(doubleWrapped));
+        }
+
+        /**
+         * langchain4j's own classification is what {@code chatModel.chat()} actually
+         * throws, and neither of the two previous copies of this method knew about it —
+         * a provider timeout was only retried because its message happened to embed the
+         * cause class name.
+         */
+        @Test
+        @DisplayName("langchain4j RetriableException is retryable on its type alone")
+        void langchain4jRetriable() {
+            assertTrue(RetryConfiguration.isRetryableError(new RateLimitException("slow down")));
+            assertTrue(RetryConfiguration.isRetryableError(new InternalServerException("upstream blew up")));
+        }
+
+        /**
+         * And it must short-circuit in the other direction too: an auth failure whose
+         * message merely mentions a timeout would otherwise burn every attempt.
+         */
+        @Test
+        @DisplayName("langchain4j NonRetriableException stops immediately, even with a retryable-looking message")
+        void langchain4jNonRetriable() {
+            assertFalse(RetryConfiguration.isRetryableError(new AuthenticationException("invalid key after timeout")));
+            assertFalse(RetryConfiguration.isRetryableError(new InvalidRequestException("bad request")));
+        }
+
+        /**
+         * {@code CascadingModelExecutor} had a second copy of this method whose regex
+         * matched bare status numbers while this one only looked at
+         * {@code WebApplicationException} — so the same provider failure was retried on
+         * one path and not the other, decided by message wording. One implementation
+         * now answers for both; these are the cases only the other copy used to catch.
+         */
+        @Test
+        @DisplayName("bare status numbers in a message are retryable (the cascade copy's rule)")
+        void bareStatusNumbersInMessage() {
+            assertTrue(RetryConfiguration.isRetryableError(new RuntimeException("provider returned 429")));
+            assertTrue(RetryConfiguration.isRetryableError(new RuntimeException("HTTP 503 from upstream")));
+        }
+
+        @Test
+        @DisplayName("a status-like number inside a larger token is not a match")
+        void statusNumbersNeedWordBoundaries() {
+            assertFalse(RetryConfiguration.isRetryableError(new RuntimeException("used 4290 tokens")));
+            assertFalse(RetryConfiguration.isRetryableError(new RuntimeException("request id 5031abc")));
+        }
+
+        /**
+         * {@code HttpException} is what several langchain4j HTTP clients actually
+         * throw, and it is neither {@code RetriableException} nor
+         * {@code NonRetriableException} — its {@code statusCode()} is the only signal
+         * it carries. The messages here deliberately contain no transient wording, so
+         * only the status-code branch can classify them: with a wrong accessor or a
+         * wrong status set these would fall through to the text fallback and answer
+         * false.
+         */
+        @Test
+        @DisplayName("langchain4j HttpException is classified by its status code, not its text")
+        void langchain4jHttpExceptionStatusCodes() {
+            assertTrue(RetryConfiguration.isRetryableError(new HttpException(429, "quota")));
+            assertTrue(RetryConfiguration.isRetryableError(new HttpException(502, "upstream")));
+            assertTrue(RetryConfiguration.isRetryableError(new HttpException(503, "upstream")));
+            assertTrue(RetryConfiguration.isRetryableError(new HttpException(504, "upstream")));
+        }
+
+        @Test
+        @DisplayName("a non-transient HttpException status is not retryable")
+        void langchain4jHttpExceptionNonRetryableStatus() {
+            assertFalse(RetryConfiguration.isRetryableError(new HttpException(400, "malformed body")));
+            assertFalse(RetryConfiguration.isRetryableError(new HttpException(401, "bad key")));
+            assertFalse(RetryConfiguration.isRetryableError(new HttpException(500, "upstream")));
+        }
+
+        @Test
+        @DisplayName("a wrapped HttpException is found by walking the cause chain")
+        void langchain4jHttpExceptionWrapped() {
+            assertTrue(RetryConfiguration.isRetryableError(
+                    new RuntimeException("provider call failed", new HttpException(503, "upstream"))));
+        }
+    }
+
+    /**
+     * The total-backoff budget bounds one {@code executeWithRetry} call — and ONLY
+     * the budget. Deciding "budget spent" and "this retry sleeps for zero" with the
+     * same {@code sleepFor <= 0} test conflated the two, so an agent configuring
+     * {@code "backoffDelayMs": 0} — a legitimate "retry immediately" policy — lost
+     * retries entirely on its first retryable failure.
+     */
+    @Nested
+    @DisplayName("total backoff budget")
+    class TotalBackoffBudgetTests {
+
+        @Test
+        @DisplayName("zero backoff still makes every configured attempt")
+        void zeroBackoffStillRetriesEveryAttempt() {
+            var config = new RetryConfiguration();
+            config.setMaxAttempts(5);
+            config.setBackoffDelayMs(0L);
+            config.setBackoffMultiplier(2.0);
+            config.setMaxBackoffDelayMs(10L);
+
+            AtomicInteger attempts = new AtomicInteger(0);
+            Callable<String> action = () -> {
+                attempts.incrementAndGet();
+                throw new SocketTimeoutException("always fails");
+            };
+
+            var ex = assertThrows(LifecycleException.class,
+                    () -> RetryConfiguration.executeWithRetry(action, config, "test-action"));
+
+            assertEquals(5, attempts.get(), "backoffDelayMs=0 means retry immediately, not stop retrying");
+            assertTrue(ex.getMessage().contains("failed after 5 attempts"), "got: " + ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("a negative backoff is treated as zero rather than reaching Thread.sleep")
+        void negativeBackoffDoesNotThrow() {
+            var config = new RetryConfiguration();
+            config.setMaxAttempts(3);
+            config.setBackoffDelayMs(-5L);
+            config.setBackoffMultiplier(1.0);
+            config.setMaxBackoffDelayMs(10L);
+
+            AtomicInteger attempts = new AtomicInteger(0);
+            Callable<String> action = () -> {
+                attempts.incrementAndGet();
+                throw new SocketTimeoutException("always fails");
+            };
+
+            assertThrows(LifecycleException.class, () -> RetryConfiguration.executeWithRetry(action, config, "test-action"));
+            assertEquals(3, attempts.get());
+        }
+
+        /**
+         * The budget arithmetic itself, which cannot be reached through
+         * {@code executeWithRetry} without genuinely sleeping the full 60 seconds.
+         */
+        @Test
+        @DisplayName("zero is a sleep of zero; only a spent budget answers 'stop'")
+        void budgetedSleepDistinguishesZeroFromExhausted() {
+            assertEquals(0L, RetryConfiguration.budgetedSleep(0L, 0L), "a zero backoff is not an exhausted budget");
+            assertEquals(0L, RetryConfiguration.budgetedSleep(-7L, 0L), "a negative backoff clamps to zero, it does not stop the loop");
+            assertEquals(1_000L, RetryConfiguration.budgetedSleep(1_000L, 0L));
+        }
+
+        @Test
+        @DisplayName("the last sleep is trimmed to what is left, and the next one gives up")
+        void budgetedSleepTrimsThenGivesUp() {
+            long almostSpent = RetryConfiguration.MAX_TOTAL_BACKOFF_MS - 250L;
+
+            assertEquals(250L, RetryConfiguration.budgetedSleep(30_000L, almostSpent), "the final sleep may only use what is left");
+            assertEquals(-1L, RetryConfiguration.budgetedSleep(30_000L, RetryConfiguration.MAX_TOTAL_BACKOFF_MS));
+            assertEquals(-1L, RetryConfiguration.budgetedSleep(1L, RetryConfiguration.MAX_TOTAL_BACKOFF_MS + 5_000L));
+        }
+    }
+
+    /**
+     * AGENTS.md §4.1 rule 5: a task must not block for extended periods. Attempts
+     * and delays come from an agent's JSON {@code retry} block, which had no upper
+     * bound at all — {@code {"maxAttempts": 50, "maxBackoffDelayMs": 60000}} parked
+     * a pipeline worker for the best part of an hour per turn.
+     */
+    @Nested
+    @DisplayName("engine ceilings on config-supplied retry policy")
+    class CeilingTests {
+
+        @Test
+        @DisplayName("maxAttempts is clamped")
+        void clampsAttempts() {
+            var config = new RetryConfiguration();
+            config.setMaxAttempts(50);
+            config.setBackoffDelayMs(1L);
+            config.setBackoffMultiplier(1.0);
+            config.setMaxBackoffDelayMs(1L);
+
+            AtomicInteger attempts = new AtomicInteger(0);
+            Callable<String> action = () -> {
+                attempts.incrementAndGet();
+                throw new SocketTimeoutException("always fails");
+            };
+
+            assertThrows(LifecycleException.class, () -> RetryConfiguration.executeWithRetry(action, config, "test-action"));
+            assertEquals(RetryConfiguration.MAX_ATTEMPTS_CEILING, attempts.get());
+        }
+
+        @Test
+        @DisplayName("a single backoff is clamped, and a modest configured value is left alone")
+        void clampsSingleBackoff() {
+            var overAmbitious = new RetryConfiguration();
+            overAmbitious.setMaxBackoffDelayMs(600_000L);
+            assertEquals(RetryConfiguration.MAX_BACKOFF_CEILING_MS, RetryConfiguration.effectiveMaxBackoffMs(overAmbitious));
+
+            var reasonable = new RetryConfiguration();
+            reasonable.setMaxBackoffDelayMs(5_000L);
+            assertEquals(5_000L, RetryConfiguration.effectiveMaxBackoffMs(reasonable), "config still chooses within the ceiling");
+        }
+
+        @Test
+        @DisplayName("a modest attempt count is left alone")
+        void doesNotClampReasonableAttempts() {
+            var config = new RetryConfiguration();
+            config.setMaxAttempts(4);
+            assertEquals(4, RetryConfiguration.effectiveMaxAttempts(config));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/configs/shared/RetryConfigurationTest.java
+++ b/src/test/java/ai/labs/eddi/configs/shared/RetryConfigurationTest.java
@@ -16,12 +16,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -307,6 +315,33 @@ class RetryConfigurationTest {
             assertTrue(RetryConfiguration.isRetryableError(
                     new RuntimeException("provider call failed", new HttpException(503, "upstream"))));
         }
+
+        /**
+         * The four signals are documented as an ORDER — typed verdict first, message
+         * text last — but running them interleaved down one walk implements "outermost
+         * exception wins", and the weakest signal is the one most likely to sit on the
+         * outermost wrapper. A provider wrapping an auth failure in a message that
+         * merely mentions a timeout was therefore retried until the attempts ran out,
+         * which is the exact case the ordering was written to stop.
+         */
+        @Test
+        @DisplayName("a typed NonRetriableException underneath beats a retryable-looking message above it")
+        void typedVerdictBeatsAnOuterMessage() {
+            var wrapped = new RuntimeException("timeout while calling provider", new AuthenticationException("invalid api key"));
+            assertFalse(RetryConfiguration.isRetryableError(wrapped),
+                    "the outer message must not decide before the typed verdict underneath has been read");
+
+            var deeplyWrapped = new IllegalStateException("connection reset", new RuntimeException("503 from gateway",
+                    new InvalidRequestException("model does not exist")));
+            assertFalse(RetryConfiguration.isRetryableError(deeplyWrapped));
+        }
+
+        @Test
+        @DisplayName("a typed RetriableException underneath still wins over a non-transient wrapper")
+        void typedRetriableIsFoundUnderAQuietWrapper() {
+            assertTrue(RetryConfiguration.isRetryableError(
+                    new IllegalStateException("call failed", new RateLimitException("slow down"))));
+        }
     }
 
     /**
@@ -432,6 +467,150 @@ class RetryConfigurationTest {
             config.setMaxAttempts(4);
             assertEquals(4, RetryConfiguration.effectiveMaxAttempts(config));
         }
+
+        /**
+         * An absent {@code retry} block, and a block that omits individual fields, must
+         * both resolve to the documented defaults rather than to zero — a
+         * {@code maxAttempts} of 0 means the retry loop body never runs and the caller
+         * gets a null response indistinguishable from silence.
+         */
+        @Test
+        @DisplayName("an absent or partial retry block falls back to the documented defaults")
+        void missingConfigFallsBackToDefaults() {
+            assertEquals(3, RetryConfiguration.effectiveMaxAttempts(null));
+            assertEquals(10_000L, RetryConfiguration.effectiveMaxBackoffMs(null));
+
+            var partial = new RetryConfiguration();
+            partial.setMaxAttempts(null);
+            partial.setMaxBackoffDelayMs(null);
+            assertEquals(3, RetryConfiguration.effectiveMaxAttempts(partial));
+            assertEquals(10_000L, RetryConfiguration.effectiveMaxBackoffMs(partial));
+        }
+
+        /**
+         * The "your config is not being honoured as written" warning is deduplicated
+         * and bounded on purpose: it sits on the path of every LLM and MCP call, and a
+         * log-key set that grows with config values is a leak of its own. Neither
+         * property may change what the clamp actually returns.
+         *
+         * <p>
+         * Both properties are observed at the log, because the return value cannot see
+         * either of them: {@code clampAttempts} answers
+         * {@link RetryConfiguration#MAX_ATTEMPTS_CEILING} for every over-ceiling input
+         * whether the warning is emitted once, twice or never. So the WARN records
+         * themselves are counted — one for a value reported twice, and none at all once
+         * {@code MAX_CLAMP_WARNINGS} distinct keys have been recorded.
+         * </p>
+         */
+        @Test
+        @DisplayName("the clamp warning is deduplicated and bounded, and never changes the clamped value")
+        void clampWarningIsDeduplicatedAndBounded() throws Exception {
+            // A JVM-lifetime static shared with every other test in this JVM, so this
+            // test owns it for its duration rather than inheriting whatever ran first.
+            Set<String> clampWarnings = clampWarningKeys();
+            final int bound = maxClampWarnings();
+            clampWarnings.clear();
+            try {
+                // Same value twice: the second must be recognised as already reported.
+                List<String> deduplicated = captureRetryWarnings(() -> {
+                    assertEquals(RetryConfiguration.MAX_ATTEMPTS_CEILING, RetryConfiguration.clampAttempts(4711));
+                    assertEquals(RetryConfiguration.MAX_ATTEMPTS_CEILING, RetryConfiguration.clampAttempts(4711));
+                });
+
+                assertEquals(1, deduplicated.size(),
+                        "the same clamped value must be reported exactly once; captured: " + deduplicated);
+                assertTrue(deduplicated.get(0).contains("retry.maxAttempts is configured as 4711"),
+                        "the warning must name the setting and the value the author typed; got: " + deduplicated.get(0));
+
+                // A DIFFERENT value is a different key, so it is still reported.
+                List<String> secondKey = captureRetryWarnings(
+                        () -> assertEquals(RetryConfiguration.MAX_ATTEMPTS_CEILING, RetryConfiguration.clampAttempts(4712)));
+                assertEquals(1, secondKey.size(), "a distinct clamped value is a distinct warning; captured: " + secondKey);
+
+                // Fill the key set to its bound, then prove the next distinct value is
+                // silent — and still clamped. 2 keys are already recorded above.
+                List<String> upToTheBound = captureRetryWarnings(() -> {
+                    for (int configured = 5000; configured < 5000 + bound - 2; configured++) {
+                        assertEquals(RetryConfiguration.MAX_ATTEMPTS_CEILING, RetryConfiguration.clampAttempts(configured));
+                    }
+                });
+                assertEquals(bound - 2, upToTheBound.size(),
+                        "every distinct value below the bound is reported; captured: " + upToTheBound.size());
+                assertEquals(bound, clampWarnings.size(), "the key set must be exactly full now");
+
+                List<String> pastTheBound = captureRetryWarnings(() -> {
+                    for (int configured = 6000; configured < 6100; configured++) {
+                        assertEquals(RetryConfiguration.MAX_ATTEMPTS_CEILING, RetryConfiguration.clampAttempts(configured),
+                                "the ceiling must hold whether or not the warning was still being recorded");
+                    }
+                    assertEquals(RetryConfiguration.MAX_ATTEMPTS_CEILING, RetryConfiguration.clampAttempts(Integer.MAX_VALUE));
+                });
+
+                assertTrue(pastTheBound.isEmpty(),
+                        "101 further distinct values must add nothing once the bound is reached; got " + pastTheBound.size()
+                                + " warning(s), first: " + (pastTheBound.isEmpty() ? "-" : pastTheBound.get(0)));
+                assertEquals(bound, clampWarnings.size(),
+                        "and the key set must not have grown past its bound either");
+            } finally {
+                clampWarnings.clear();
+            }
+        }
+
+        /**
+         * The private static key set behind {@code warnClamped}, reached by reflection:
+         * it is a JVM-lifetime static with no reset hook, and a test that asserts
+         * "reported exactly once" cannot start from whatever an earlier test happened
+         * to leave in it.
+         */
+        @SuppressWarnings("unchecked")
+        private Set<String> clampWarningKeys() throws Exception {
+            Field field = RetryConfiguration.class.getDeclaredField("CLAMP_WARNINGS");
+            field.setAccessible(true);
+            return (Set<String>) field.get(null);
+        }
+
+        private int maxClampWarnings() throws Exception {
+            Field field = RetryConfiguration.class.getDeclaredField("MAX_CLAMP_WARNINGS");
+            field.setAccessible(true);
+            return (int) field.get(null);
+        }
+
+        /**
+         * Every WARN {@link RetryConfiguration} emits while {@code body} runs.
+         * {@code logging.properties} turns the whole {@code ai.labs.eddi} namespace OFF
+         * for plain unit tests, so the logger is opened explicitly and put back.
+         */
+        private List<String> captureRetryWarnings(Runnable body) {
+            List<String> captured = new ArrayList<>();
+            Handler handler = new Handler() {
+                @Override
+                public void publish(LogRecord record) {
+                    if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+                        captured.add(String.valueOf(record.getMessage()));
+                    }
+                }
+
+                @Override
+                public void flush() {
+                }
+
+                @Override
+                public void close() {
+                }
+            };
+
+            Logger julLogger = Logger.getLogger(RetryConfiguration.class.getName());
+            Level previousLevel = julLogger.getLevel();
+            julLogger.setLevel(Level.ALL);
+            julLogger.addHandler(handler);
+            try {
+                body.run();
+            } finally {
+                julLogger.removeHandler(handler);
+                julLogger.setLevel(previousLevel);
+            }
+            return captured;
+        }
     }
 
     // ==================== backoff ====================
@@ -477,6 +656,95 @@ class RetryConfigurationTest {
         void nullConfigUsesDefaults() {
             // Should not throw — defaults are applied internally
             assertDoesNotThrow(() -> RetryConfiguration.backoff(1, null));
+        }
+
+        /**
+         * A {@code retry} block that omits {@code backoffDelayMs} or
+         * {@code backoffMultiplier} must fall back to the documented defaults, not to
+         * zero: a silently-zero delay turns exponential backoff into a hot retry loop
+         * against a provider that is already rate-limiting.
+         */
+        @Test
+        @DisplayName("the budget overload applies the field defaults when the config omits them")
+        void budgetOverloadAppliesFieldDefaults() {
+            var partial = new RetryConfiguration();
+            partial.setBackoffDelayMs(null);
+            partial.setBackoffMultiplier(null);
+            partial.setMaxBackoffDelayMs(5L);
+
+            // Default 1000ms base and 2.0 multiplier, both clamped by maxBackoffDelayMs.
+            assertEquals(5L, RetryConfiguration.backoff(1, partial, 0L));
+            assertEquals(5L, RetryConfiguration.backoff(3, partial, 0L),
+                    "the default multiplier still applies, and the per-sleep ceiling still caps it");
+        }
+
+        /**
+         * The per-sleep ceiling alone does not bound a caller that runs its own retry
+         * loop: at {@link RetryConfiguration#MAX_ATTEMPTS_CEILING} attempts with a
+         * configured 30-second delay the streaming path could sleep nine times — 270
+         * seconds of blocked pipeline thread, against the 60-second budget
+         * {@code executeWithRetry} applies to every other retry loop in the engine. The
+         * overload takes the running total so both paths honour one budget.
+         */
+        @Test
+        @DisplayName("the budget overload trims the last sleep and then answers -1 without sleeping")
+        void budgetOverloadStopsAtTheTotalBackoffCeiling() {
+            var config = new RetryConfiguration();
+            config.setBackoffDelayMs(30_000L);
+            config.setBackoffMultiplier(1.0);
+            config.setMaxBackoffDelayMs(30_000L);
+
+            long start = System.nanoTime();
+            long slept = RetryConfiguration.backoff(1, config, RetryConfiguration.MAX_TOTAL_BACKOFF_MS);
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+            assertEquals(-1L, slept, "a spent budget must tell the caller to stop, not sleep another 30s");
+            assertTrue(elapsedMs < 1_000, "nothing may be slept once the budget is spent, took " + elapsedMs + "ms");
+        }
+
+        @Test
+        @DisplayName("the budget overload returns what it actually slept, so the caller can accumulate it")
+        void budgetOverloadReturnsWhatItSlept() {
+            var config = new RetryConfiguration();
+            config.setBackoffDelayMs(10L);
+            config.setBackoffMultiplier(1.0);
+            config.setMaxBackoffDelayMs(10L);
+
+            assertEquals(10L, RetryConfiguration.backoff(1, config, 0L));
+            // Only 5ms of budget is left, so the sleep is trimmed to it.
+            assertEquals(5L, RetryConfiguration.backoff(1, config, RetryConfiguration.MAX_TOTAL_BACKOFF_MS - 5L));
+        }
+
+        /**
+         * A backoff interrupted mid-sleep must re-assert the thread's interrupt flag
+         * and return normally. Swallowing the interrupt would leave a cancelled
+         * pipeline thread looking healthy to everything above it, and rethrowing would
+         * turn a shutdown into a stack trace on a path whose whole job is to wait.
+         */
+        @Test
+        @DisplayName("an interrupted sleep restores the interrupt flag instead of swallowing it")
+        void interruptedBackoffRestoresTheInterruptFlag() {
+            var config = new RetryConfiguration();
+            config.setBackoffDelayMs(60_000L);
+            config.setBackoffMultiplier(1.0);
+            config.setMaxBackoffDelayMs(30_000L);
+
+            Thread.currentThread().interrupt();
+            long start = System.nanoTime();
+            long slept;
+            boolean interruptFlagAfterwards;
+            try {
+                slept = RetryConfiguration.backoff(1, config, 0L);
+                interruptFlagAfterwards = Thread.currentThread().isInterrupted();
+            } finally {
+                // Never leak the flag into whatever test runs next on this thread.
+                Thread.interrupted();
+            }
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+            assertTrue(interruptFlagAfterwards, "the interrupt must be re-asserted, not swallowed");
+            assertEquals(30_000L, slept, "the budgeted amount is still reported, so the caller's accounting stays honest");
+            assertTrue(elapsedMs < 5_000, "an already-interrupted thread must not actually sleep 30s, took " + elapsedMs + "ms");
         }
     }
 

--- a/src/test/java/ai/labs/eddi/configs/workflows/mongo/WorkflowStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/mongo/WorkflowStoreTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.net.URI;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -145,7 +147,7 @@ class WorkflowStoreTest {
         when(resourceStorage.getCurrentVersion("111111111111111111111111")).thenReturn(1);
 
         DocumentDescriptor descriptor = new DocumentDescriptor();
-        descriptor.setResource(java.net.URI.create("eddi://ai.labs.workflow/workflowstore/workflows/111111111111111111111111?version=1"));
+        descriptor.setResource(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/111111111111111111111111?version=1"));
         when(documentDescriptorStore.readDescriptor("111111111111111111111111", 1)).thenReturn(descriptor);
 
         List<DocumentDescriptor> result = store.getWorkflowDescriptorsContainingResource(resourceURI, false);
@@ -163,6 +165,62 @@ class WorkflowStoreTest {
         List<DocumentDescriptor> result = store.getWorkflowDescriptorsContainingResource(
                 "eddi://ai.labs.behavior/behaviorId?version=1", false);
         assertTrue(result.isEmpty());
+    }
+
+    /**
+     * A soft-deleted workflow keeps a history row that still contains the resource
+     * URI, so the history search returns it — but it has no current row, and
+     * {@code getCurrentVersion} answers -1, which made {@code getCurrentResourceId}
+     * throw. The throw was unguarded, so one soft-deleted workflow made
+     * {@code deleteResourceSafely} fail closed on EVERY resource from then on:
+     * cascade cleanup became a permanent no-op with an ERROR per attempt.
+     */
+    @Test
+    @DisplayName("getWorkflowDescriptorsContainingResource — a soft-deleted workflow in the history hits is skipped, not fatal")
+    void skipsHistoryOnlyWorkflowsWithNoCurrentVersion() throws Exception {
+        String resourceURI = "eddi://ai.labs.output/outputstore/outputsets/out1?version=1";
+
+        IResourceStore.IResourceId deletedWorkflow = mock(IResourceStore.IResourceId.class);
+        when(deletedWorkflow.getId()).thenReturn("222222222222222222222222");
+        when(deletedWorkflow.getVersion()).thenReturn(1);
+        IResourceStore.IResourceId liveWorkflow = mock(IResourceStore.IResourceId.class);
+        when(liveWorkflow.getId()).thenReturn("111111111111111111111111");
+        when(liveWorkflow.getVersion()).thenReturn(1);
+
+        when(resourceStorage.findResourceIdsContaining(anyString(), anyString())).thenReturn(List.of(liveWorkflow));
+        when(resourceStorage.findHistoryResourceIdsContaining(anyString(), anyString())).thenReturn(List.of(deletedWorkflow));
+        when(resourceStorage.getCurrentVersion("222222222222222222222222")).thenReturn(-1);
+        when(resourceStorage.getCurrentVersion("111111111111111111111111")).thenReturn(1);
+
+        DocumentDescriptor descriptor = new DocumentDescriptor();
+        descriptor.setResource(URI.create("eddi://ai.labs.workflow/workflowstore/workflows/111111111111111111111111?version=1"));
+        when(documentDescriptorStore.readDescriptor("111111111111111111111111", 1)).thenReturn(descriptor);
+
+        List<DocumentDescriptor> result = store.getWorkflowDescriptorsContainingResource(resourceURI, false);
+
+        assertEquals(1, result.size());
+        verify(documentDescriptorStore, never()).readDescriptor(eq("222222222222222222222222"), anyInt());
+    }
+
+    /**
+     * The version used to be scraped as "everything after the last '='", which
+     * threw an undeclared {@link NumberFormatException} for a URI with no version
+     * query or with a second query parameter. Callers feed stored
+     * {@code config.uri} values in verbatim, and the caller treats any throw as
+     * "reference check failed — NOT cascade-deleting", so one unversioned reference
+     * disabled cascade cleanup entirely.
+     */
+    @Test
+    @DisplayName("getWorkflowDescriptorsContainingResource — a URI without a usable version is a declared ResourceStoreException")
+    void rejectsUnversionedResourceUri() {
+        for (String uri : List.of("eddi://ai.labs.output/outputstore/outputsets/out1",
+                "eddi://ai.labs.output/outputstore/outputsets/out1?other=2",
+                "eddi://ai.labs.output/outputstore/outputsets/out1?version=abc",
+                "eddi://ai.labs.output/outputstore/outputsets/out1?version=0")) {
+            assertThrows(IResourceStore.ResourceStoreException.class,
+                    () -> store.getWorkflowDescriptorsContainingResource(uri, false), "must refuse: " + uri);
+        }
+        verifyNoInteractions(resourceStorage);
     }
 
     // ==================== deleteAllPermanently ====================

--- a/src/test/java/ai/labs/eddi/configs/workflows/mongo/WorkflowStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/mongo/WorkflowStoreTest.java
@@ -223,6 +223,29 @@ class WorkflowStoreTest {
         verifyNoInteractions(resourceStorage);
     }
 
+    /**
+     * The inputs that make {@code URI.create} itself blow up, rather than merely
+     * parsing to something unusable. This method is fed step {@code config.uri}
+     * values verbatim by the cascade, and an unchecked
+     * {@code IllegalArgumentException} is not in its {@code throws} clause: it
+     * escapes the caller's {@code catch (ResourceStoreException)} and takes the
+     * whole delete with it. Null, blank and syntactically illegal all have to come
+     * back as the same declared refusal.
+     */
+    @Test
+    @DisplayName("getWorkflowDescriptorsContainingResource — null, blank and unparsable URIs are the same declared refusal")
+    void rejectsUnparsableResourceUri() {
+        assertThrows(IResourceStore.ResourceStoreException.class,
+                () -> store.getWorkflowDescriptorsContainingResource(null, false), "null must be refused, not NPE");
+        assertThrows(IResourceStore.ResourceStoreException.class,
+                () -> store.getWorkflowDescriptorsContainingResource("   ", false), "blank must be refused");
+        // A space in the authority is a syntax error for java.net.URI.
+        assertThrows(IResourceStore.ResourceStoreException.class,
+                () -> store.getWorkflowDescriptorsContainingResource("eddi://ai labs/store/x?version=1", false),
+                "an unparsable URI must be refused, not raise IllegalArgumentException");
+        verifyNoInteractions(resourceStorage);
+    }
+
     // ==================== deleteAllPermanently ====================
 
     @Test

--- a/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreCrudTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreCrudTest.java
@@ -51,6 +51,13 @@ class RestWorkflowStoreCrudTest {
         jsonSchemaCreator = mock(IJsonSchemaCreator.class);
         sut = new RestWorkflowStore(workflowStore, resourceClientLibrary, documentDescriptorStore, jsonSchemaCreator,
                 permissiveGuard());
+        try {
+            // The workflow is live at v1: a cascade only runs against the CURRENT
+            // version, since it deletes referenced configs before the version check.
+            when(workflowStore.getCurrentResourceId(WORKFLOW_ID)).thenReturn(dummyResourceId(WORKFLOW_ID, 1));
+        } catch (IResourceStore.ResourceNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     private IResourceStore.IResourceId dummyResourceId(String id, int version) {
@@ -125,9 +132,51 @@ class RestWorkflowStoreCrudTest {
         @Test
         @DisplayName("should reject malformed resource URI")
         void malformedUri() {
-            // Malformed URI — createMalFormattedResourceUriException throws
+            // Malformed URI — malformedResourceUri is thrown
             // BadRequestException
             assertThrows(jakarta.ws.rs.BadRequestException.class, () -> sut.readWorkflowDescriptors("", 0, 20, "not-a-valid-uri", false));
+        }
+
+        /**
+         * The reverse-reference overload declares {@code filter}, {@code index} and
+         * {@code limit} — with {@code @DefaultValue("20")} on limit, advertising paging
+         * — and used to drop all three: a paging client got the whole list back on
+         * every page. The agent-store twin got tests for this; the workflow side is the
+         * one where a wrong argument order at the call site would go unseen, because
+         * the only other test here returns a single-element list.
+         */
+        @Test
+        @DisplayName("index and limit actually page the result")
+        void pagesTheResult() throws Exception {
+            String containingUri = "eddi://ai.labs.rules/rulestore/rulesets/abc123456789012345?version=1";
+            when(workflowStore.getWorkflowDescriptorsContainingResource(containingUri, false))
+                    .thenReturn(List.of(named("a"), named("b"), named("c"), named("d"), named("e")));
+
+            assertEquals(List.of("a", "b"), names(sut.readWorkflowDescriptors(null, 0, 2, containingUri, false)));
+            assertEquals(List.of("c", "d"), names(sut.readWorkflowDescriptors(null, 1, 2, containingUri, false)));
+            assertEquals(List.of("e"), names(sut.readWorkflowDescriptors(null, 2, 2, containingUri, false)));
+            assertTrue(sut.readWorkflowDescriptors(null, 9, 2, containingUri, false).isEmpty(),
+                    "past the end must be empty, not the full list");
+        }
+
+        @Test
+        @DisplayName("filter narrows the result")
+        void filtersTheResult() throws Exception {
+            String containingUri = "eddi://ai.labs.rules/rulestore/rulesets/abc123456789012345?version=1";
+            when(workflowStore.getWorkflowDescriptorsContainingResource(containingUri, false))
+                    .thenReturn(List.of(named("support workflow"), named("Sales Workflow"), named("triage")));
+
+            assertEquals(List.of("Sales Workflow"), names(sut.readWorkflowDescriptors("sales", 0, 20, containingUri, false)));
+        }
+
+        private DocumentDescriptor named(String name) {
+            DocumentDescriptor descriptor = new DocumentDescriptor();
+            descriptor.setName(name);
+            return descriptor;
+        }
+
+        private List<String> names(List<DocumentDescriptor> descriptors) {
+            return descriptors.stream().map(DocumentDescriptor::getName).toList();
         }
     }
 
@@ -288,6 +337,51 @@ class RestWorkflowStoreCrudTest {
 
             assertEquals(400, response.getStatus());
         }
+
+        /**
+         * Stored shapes the endpoint used to blind-cast: {@code "extensions": null}, an
+         * extension value that is an object rather than an array, and a
+         * present-but-null {@code "uri"}. Each turned this endpoint into a 500 — and it
+         * is the endpoint the re-point cascade walks for every config edit, so one
+         * malformed step blocked re-pointing the whole workflow.
+         */
+        @Test
+        @DisplayName("malformed stored steps are skipped, not a 500")
+        void malformedStepsDoNotCrash() throws Exception {
+            var config = new WorkflowConfiguration();
+
+            var nullExtensions = new WorkflowStep();
+            nullExtensions.setType(URI.create("eddi://ai.labs.parser"));
+            nullExtensions.setExtensions(null);
+            config.getWorkflowSteps().add(nullExtensions);
+
+            var objectValuedExtension = new WorkflowStep();
+            objectValuedExtension.setType(URI.create("eddi://ai.labs.parser"));
+            objectValuedExtension.getExtensions().put("dictionaries", new HashMap<String, Object>());
+            config.getWorkflowSteps().add(objectValuedExtension);
+
+            var nullUri = new WorkflowStep();
+            nullUri.setType(URI.create("eddi://ai.labs.rules"));
+            var configMap = new HashMap<String, Object>();
+            configMap.put("uri", null);
+            nullUri.setConfig(configMap);
+            config.getWorkflowSteps().add(nullUri);
+
+            // The one well-formed step, so the update still has something to re-point.
+            var good = new WorkflowStep();
+            good.setType(URI.create("eddi://ai.labs.rules"));
+            good.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/111111111111111111111111?version=1")));
+            config.getWorkflowSteps().add(good);
+
+            when(workflowStore.read(WORKFLOW_ID, 1)).thenReturn(config);
+            when(workflowStore.update(eq(WORKFLOW_ID), eq(1), any())).thenReturn(2);
+
+            URI newResourceUri = URI.create("eddi://ai.labs.rules/rulestore/rulesets/111111111111111111111111?version=2");
+            Response response = sut.updateResourceInWorkflow(WORKFLOW_ID, 1, newResourceUri);
+
+            assertEquals(200, response.getStatus());
+            assertEquals(newResourceUri, good.getConfig().get("uri"));
+        }
     }
 
     // ─── getResourceURI / getCurrentResourceId ─────────────────────────────────
@@ -326,6 +420,8 @@ class RestWorkflowStoreCrudTest {
         @Test
         @DisplayName("should log warning and still delete when ResourceStoreException occurs during cascade")
         void cascadeWithResourceStoreException() throws Exception {
+            when(workflowStore.getCurrentResourceId("aabbccddeeff112233445566"))
+                    .thenReturn(dummyResourceId("aabbccddeeff112233445566", 1));
             when(workflowStore.read("aabbccddeeff112233445566", 1))
                     .thenThrow(new IResourceStore.ResourceStoreException("DB failure"));
 
@@ -336,6 +432,8 @@ class RestWorkflowStoreCrudTest {
         @Test
         @DisplayName("should log warning and still delete when ResourceNotFoundException occurs during cascade")
         void cascadeWithResourceNotFoundException() throws Exception {
+            when(workflowStore.getCurrentResourceId("aabbccddeeff112233445566"))
+                    .thenReturn(dummyResourceId("aabbccddeeff112233445566", 1));
             when(workflowStore.read("aabbccddeeff112233445566", 1))
                     .thenThrow(new IResourceStore.ResourceNotFoundException("not found"));
 
@@ -451,6 +549,88 @@ class RestWorkflowStoreCrudTest {
             // duplicateResource should throw ServiceException wrapped by sneakyThrow
             assertThrows(Exception.class, () -> sut.duplicateWorkflow(WORKFLOW_ID, 1, true));
         }
+
+        /**
+         * {@code WorkflowStore.create} only rejects null <em>elements</em>, so a stored
+         * step without a {@code type}, or a dictionary entry without one, is legal.
+         * deleteWorkflow guarded both; the deep-copy path dereferenced them and
+         * answered 500 — after the sub-resources earlier in the loop had already been
+         * created and persisted.
+         */
+        @Test
+        @DisplayName("a step or dictionary without a type is skipped, not an NPE")
+        void deepCopyToleratesMissingTypes() throws Exception {
+            var config = new WorkflowConfiguration();
+
+            var typelessStep = new WorkflowStep();
+            typelessStep.setType(null);
+            config.getWorkflowSteps().add(typelessStep);
+
+            var parserStep = new WorkflowStep();
+            parserStep.setType(URI.create("eddi://ai.labs.parser"));
+            Map<String, Object> typelessDictionary = new HashMap<>();
+            typelessDictionary.put("config",
+                    new HashMap<>(Map.of("uri", "eddi://ai.labs.dictionary/dictionarystore/dictionaries/222222222222222222222222?version=1")));
+            List<Map<String, Object>> dictionaries = new ArrayList<>();
+            dictionaries.add(typelessDictionary);
+            parserStep.getExtensions().put("dictionaries", dictionaries);
+            config.getWorkflowSteps().add(parserStep);
+
+            when(workflowStore.read(WORKFLOW_ID, 1)).thenReturn(config);
+            when(workflowStore.create(any())).thenReturn(dummyResourceId("newwf112233445566aabb", 1));
+            when(documentDescriptorStore.readDescriptor(anyString(), any())).thenReturn(new DocumentDescriptor());
+
+            Response response = sut.duplicateWorkflow(WORKFLOW_ID, 1, true);
+
+            assertEquals(201, response.getStatus());
+            verify(resourceClientLibrary, never()).duplicateResource(any());
+        }
+
+        /**
+         * {@code ?version=0} is the documented "current version" shorthand that PUT and
+         * DELETE honour. {@code validateParameters}' normalised return value was
+         * discarded here, so {@code workflowStore.read(id, 0)} matched nothing and the
+         * endpoint answered 404.
+         */
+        @Test
+        @DisplayName("version=0 duplicates the current version instead of 404")
+        void versionZeroDuplicatesCurrent() throws Exception {
+            var config = new WorkflowConfiguration();
+            when(workflowStore.read(WORKFLOW_ID, 1)).thenReturn(config);
+            when(workflowStore.create(any())).thenReturn(dummyResourceId("newwf112233445566aabb", 1));
+            when(documentDescriptorStore.readDescriptor(anyString(), any())).thenReturn(new DocumentDescriptor());
+
+            Response response = sut.duplicateWorkflow(WORKFLOW_ID, 0, false);
+
+            assertEquals(201, response.getStatus());
+            verify(workflowStore).read(WORKFLOW_ID, 1);
+        }
+
+        /**
+         * {@code "extensions": null} is what Jackson leaves for an explicit JSON null.
+         * The deep-copy walk dereferenced it, so one such stored step turned
+         * {@code ?deepCopy=true} into a 500 — after the sub-resources earlier in the
+         * loop had already been created and persisted.
+         */
+        @Test
+        @DisplayName("a parser step with null extensions is skipped, not an NPE")
+        void deepCopyToleratesNullExtensions() throws Exception {
+            var config = new WorkflowConfiguration();
+
+            var parserStep = new WorkflowStep();
+            parserStep.setType(URI.create("eddi://ai.labs.parser"));
+            parserStep.setExtensions(null);
+            config.getWorkflowSteps().add(parserStep);
+
+            when(workflowStore.read(WORKFLOW_ID, 1)).thenReturn(config);
+            when(workflowStore.create(any())).thenReturn(dummyResourceId("newwf112233445566aabb", 1));
+            when(documentDescriptorStore.readDescriptor(anyString(), any())).thenReturn(new DocumentDescriptor());
+
+            Response response = sut.duplicateWorkflow(WORKFLOW_ID, 1, true);
+
+            assertEquals(201, response.getStatus());
+            verify(resourceClientLibrary, never()).duplicateResource(any());
+        }
     }
 
     // ─── deleteResourceSafely edge cases ───────────────────────────────────────
@@ -468,6 +648,8 @@ class RestWorkflowStoreCrudTest {
             ext.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.rules/rulestore/rulesets/111111111111111111111111?version=1")));
             config.getWorkflowSteps().add(ext);
 
+            when(workflowStore.getCurrentResourceId("aabbccddeeff112233445566"))
+                    .thenReturn(dummyResourceId("aabbccddeeff112233445566", 1));
             when(workflowStore.read("aabbccddeeff112233445566", 1)).thenReturn(config);
 
             // Resource referenced by 3 workflows — should skip
@@ -489,6 +671,8 @@ class RestWorkflowStoreCrudTest {
             ext.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.output/outputstore/outputsets/222222222222222222222222?version=1")));
             config.getWorkflowSteps().add(ext);
 
+            when(workflowStore.getCurrentResourceId("aabbccddeeff112233445566"))
+                    .thenReturn(dummyResourceId("aabbccddeeff112233445566", 1));
             when(workflowStore.read("aabbccddeeff112233445566", 1)).thenReturn(config);
             when(workflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(false)))
                     .thenReturn(List.of(new DocumentDescriptor())); // single reference
@@ -511,6 +695,9 @@ class RestWorkflowStoreCrudTest {
         ResourceAccessGuard guard = mock(ResourceAccessGuard.class);
         lenient().when(guard.seesEverything()).thenReturn(true);
         lenient().when(guard.canAccess(any(), any())).thenReturn(true);
+        // Without this the bare mock returns null from redactForCaller and visibleOnly
+        // hands back a list of nulls — which every size-only assertion passes anyway.
+        lenient().when(guard.redactForCaller(any())).thenAnswer(invocation -> invocation.getArgument(0));
         return guard;
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
@@ -14,6 +14,7 @@ import ai.labs.eddi.configs.schema.IJsonSchemaCreator;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.client.configuration.ResourceClientLibrary;
 import ai.labs.eddi.engine.runtime.service.ServiceException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -43,10 +44,29 @@ class RestWorkflowStoreTest {
     private RestWorkflowStore restWorkflowStore;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         openMocks(this);
         restWorkflowStore = new RestWorkflowStore(WorkflowStore, resourceClientLibrary, documentDescriptorStore, jsonSchemaCreator,
                 mock(ResourceAccessGuard.class));
+        // Both fixtures are live at v1. A cascade only runs against the CURRENT
+        // version: it tears the referenced configs down before the delete — the only
+        // place the version used to be checked — has run.
+        when(WorkflowStore.getCurrentResourceId("pkg1")).thenReturn(resourceId("pkg1", 1));
+        when(WorkflowStore.getCurrentResourceId("wf1")).thenReturn(resourceId("wf1", 1));
+    }
+
+    private static IResourceStore.IResourceId resourceId(String id, int version) {
+        return new IResourceStore.IResourceId() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public Integer getVersion() {
+                return version;
+            }
+        };
     }
 
     /**
@@ -96,9 +116,14 @@ class RestWorkflowStoreTest {
 
             restWorkflowStore.deleteWorkflow("pkg1", 1, true, true);
 
-            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.rules/rulestore/rulesets/beh1?version=1"), true);
-            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.apicalls/apicallstore/apicalls/http1?version=3"), true);
-            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=1"), true);
+            // permanent=false on every cascaded resource, even though the request asked
+            // for permanent=true. These three assertions used to read `true` and so
+            // pinned the defect: the "is anyone else using this?" guard is version-scoped
+            // while deleteAllPermanently is id-scoped and erases every version plus all
+            // history, so a workflow pinning a different version lost the config outright.
+            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.rules/rulestore/rulesets/beh1?version=1"), false);
+            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.apicalls/apicallstore/apicalls/http1?version=3"), false);
+            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=1"), false);
         }
 
         @Test
@@ -126,7 +151,7 @@ class RestWorkflowStoreTest {
 
             restWorkflowStore.deleteWorkflow("pkg1", 1, true, true);
 
-            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.dictionary/dictionarystore/dictionaries/dict1?version=1"), true);
+            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.dictionary/dictionarystore/dictionaries/dict1?version=1"), false);
         }
 
         @Test
@@ -163,7 +188,7 @@ class RestWorkflowStoreTest {
 
             // Only the unique resource should be deleted
             verify(resourceClientLibrary, never()).deleteResource(eq(URI.create(sharedUri)), anyBoolean());
-            verify(resourceClientLibrary).deleteResource(URI.create(uniqueUri), true);
+            verify(resourceClientLibrary).deleteResource(URI.create(uniqueUri), false);
         }
 
         @Test
@@ -223,9 +248,9 @@ class RestWorkflowStoreTest {
             config.getWorkflowSteps().add(ext2);
 
             when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
-            when(resourceClientLibrary.deleteResource(URI.create("eddi://ai.labs.rules/rulestore/rulesets/beh1?version=1"), true))
+            when(resourceClientLibrary.deleteResource(URI.create("eddi://ai.labs.rules/rulestore/rulesets/beh1?version=1"), false))
                     .thenThrow(new ServiceException("DB error"));
-            when(resourceClientLibrary.deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=1"), true))
+            when(resourceClientLibrary.deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=1"), false))
                     .thenReturn(Response.ok().build());
 
             assertDoesNotThrow(() -> restWorkflowStore.deleteWorkflow("pkg1", 1, true, true));
@@ -257,6 +282,111 @@ class RestWorkflowStoreTest {
             assertDoesNotThrow(() -> restWorkflowStore.deleteWorkflow("pkg1", 1, true, true));
 
             verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteWorkflow — cascade version guard")
+    class CascadeVersionGuard {
+
+        /**
+         * {@code workflowStore.read} falls back to history for a superseded version,
+         * and the version was only checked at the very end, inside
+         * {@code restVersionInfo.delete()}. So a cascade addressed at a stale version
+         * tore down that version's rule sets, output sets and dictionaries and only
+         * then answered 409 — leaving the live workflow pointing at configs that no
+         * longer existed.
+         */
+        @Test
+        @DisplayName("refuses a stale version with 409 before deleting any referenced resource")
+        void staleVersionRefusedBeforeAnyDeletion() throws Exception {
+            when(WorkflowStore.getCurrentResourceId("pkg1")).thenReturn(resourceId("pkg1", 2));
+
+            var thrown = assertThrows(WebApplicationException.class,
+                    () -> restWorkflowStore.deleteWorkflow("pkg1", 1, false, true));
+
+            assertEquals(Response.Status.CONFLICT.getStatusCode(), thrown.getResponse().getStatus());
+            verify(WorkflowStore, never()).read(anyString(), anyInt());
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+            verify(WorkflowStore, never()).delete(anyString(), anyInt());
+        }
+
+        @Test
+        @DisplayName("version=0 resolves to the current version and does cascade")
+        void versionZeroCascades() throws Exception {
+            mockSingleReference();
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            WorkflowStep outputStep = new WorkflowStep();
+            outputStep.setType(URI.create("eddi://ai.labs.output"));
+            outputStep.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.output/outputstore/outputsets/out1?version=1")));
+            config.getWorkflowSteps().add(outputStep);
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
+
+            restWorkflowStore.deleteWorkflow("pkg1", 0, false, true);
+
+            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=1"), false);
+            verify(WorkflowStore).delete("pkg1", 1);
+        }
+
+        /**
+         * The ordinary "purge what I already soft-deleted" flow: a workflow with no
+         * current row makes {@code getCurrentResourceId} throw. The contract is to skip
+         * the cascade and still purge the remaining history — so the guard has to
+         * answer false rather than propagate or dereference the missing current id,
+         * which on this path would abort a destructive operation partway through.
+         */
+        @Test
+        @DisplayName("an already soft-deleted workflow skips the cascade and still purges")
+        void softDeletedWorkflowSkipsCascadeButStillPurges() throws Exception {
+            when(WorkflowStore.getCurrentResourceId("pkg1"))
+                    .thenThrow(new IResourceStore.ResourceNotFoundException("no current version"));
+
+            assertDoesNotThrow(() -> restWorkflowStore.deleteWorkflow("pkg1", 1, true, true));
+
+            verify(WorkflowStore, never()).read(anyString(), anyInt());
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+            verify(WorkflowStore).deleteAllPermanently("pkg1");
+        }
+    }
+
+    /**
+     * Stored shapes the cascade walks. {@code "extensions": null} is what Jackson
+     * leaves for an explicit JSON null, and this runs on the DESTRUCTIVE path: an
+     * NPE here aborts the cascade mid-way, after some referenced resources have
+     * already been deleted.
+     */
+    @Nested
+    @DisplayName("deleteWorkflow — malformed stored steps")
+    class MalformedStepsOnTheCascade {
+
+        @Test
+        @DisplayName("a parser step with null extensions does not abort the cascade")
+        void nullExtensionsOnAParserStepDoesNotAbortTheCascade() throws Exception {
+            mockSingleReference();
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+
+            WorkflowStep parserStep = new WorkflowStep();
+            parserStep.setType(URI.create("eddi://ai.labs.parser"));
+            parserStep.setExtensions(null);
+            config.getWorkflowSteps().add(parserStep);
+
+            // Ordered after the malformed step, so it is only reached if the cascade
+            // survived it.
+            WorkflowStep outputStep = new WorkflowStep();
+            outputStep.setType(URI.create("eddi://ai.labs.output"));
+            outputStep.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.output/outputstore/outputsets/out1?version=1")));
+            config.getWorkflowSteps().add(outputStep);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
+
+            restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=1"), false);
+            verify(WorkflowStore).delete("pkg1", 1);
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
@@ -26,6 +26,9 @@ import java.net.URI;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static ai.labs.eddi.utils.LogCaptureSupport.FORGED_RECORD;
+import static ai.labs.eddi.utils.LogCaptureSupport.assertNoForgedRecordBoundary;
+import static ai.labs.eddi.utils.LogCaptureSupport.captureLogsOf;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -949,6 +952,62 @@ class RestWorkflowStoreTest {
             verify(resourceClientLibrary, times(1)).deleteResource(URI.create(pinned), false);
             assertNull(response.getHeaderString("X-Cascade-Skipped"),
                     "a cascade that deleted everything it walked must not report a skip");
+        }
+    }
+    /**
+     * CWE-117 (log injection). {@code id} is the DELETE path parameter and the
+     * store's message quotes caller input back, so a CR/LF in either closes the
+     * real record and lets the remainder read as a second line the server wrote.
+     *
+     * <p>
+     * These assert the CONTRACT, not the call: drive a forged record through the
+     * real cascade path and require that nothing carrying a record boundary reached
+     * the log. Removing either {@code sanitize(...)} fails them.
+     * </p>
+     */
+    @Nested
+    @DisplayName("deleteWorkflow — log injection (CWE-117)")
+    class LogInjection {
+
+        /** The workflow id as an attacker supplies it on the DELETE path. */
+        private static final String POISONED_WORKFLOW_ID = "pkg1" + FORGED_RECORD;
+
+        /**
+         * Live at v1 under the poisoned id, so the cascade runs far enough to reach the
+         * lines under test.
+         */
+        @BeforeEach
+        void workflowIsLiveUnderThePoisonedId() throws Exception {
+            when(WorkflowStore.getCurrentResourceId(POISONED_WORKFLOW_ID)).thenReturn(resourceId(POISONED_WORKFLOW_ID, 1));
+        }
+
+        @Test
+        @DisplayName("a CR/LF workflow id cannot forge a record through the not-found-for-cascade WARN")
+        void workflowNotFoundForCascade() throws Exception {
+            when(WorkflowStore.read(POISONED_WORKFLOW_ID, 1)).thenThrow(new IResourceStore.ResourceNotFoundException("not found"));
+
+            List<String> captured = captureLogsOf(RestWorkflowStore.class,
+                    () -> assertDoesNotThrow(() -> restWorkflowStore.deleteWorkflow(POISONED_WORKFLOW_ID, 1, false, true)));
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing — the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("not found for cascade")),
+                    "the line under test did not fire; captured: " + captured);
+            assertNoForgedRecordBoundary(captured, "RestWorkflowStore.planCascade's workflow-not-found WARN");
+        }
+
+        @Test
+        @DisplayName("a CR/LF store error message cannot forge a record through the read-failed WARN")
+        void workflowReadFailsForCascade() throws Exception {
+            when(WorkflowStore.read(POISONED_WORKFLOW_ID, 1))
+                    .thenThrow(new IResourceStore.ResourceStoreException("index unavailable" + FORGED_RECORD));
+
+            List<String> captured = captureLogsOf(RestWorkflowStore.class,
+                    () -> assertDoesNotThrow(() -> restWorkflowStore.deleteWorkflow(POISONED_WORKFLOW_ID, 1, false, true)));
+
+            assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing — the logger was not open");
+            assertTrue(captured.stream().anyMatch(value -> value.contains("Error reading workflow")),
+                    "the line under test did not fire; captured: " + captured);
+            assertNoForgedRecordBoundary(captured, "RestWorkflowStore.planCascade's read-failed WARN");
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
@@ -53,6 +53,16 @@ class RestWorkflowStoreTest {
         // place the version used to be checked — has run.
         when(WorkflowStore.getCurrentResourceId("pkg1")).thenReturn(resourceId("pkg1", 1));
         when(WorkflowStore.getCurrentResourceId("wf1")).thenReturn(resourceId("wf1", 1));
+        // Default: every referenced resource is live at exactly the version the
+        // step pins, i.e. nothing has been edited since. The cascade resolves each
+        // reference through this before it decides anything; the case where the two
+        // disagree is CascadeVersionGuard.staleReferenceResolvesToTheCurrentVersion.
+        when(resourceClientLibrary.getCurrentResourceId(any(URI.class))).thenAnswer(invocation -> {
+            URI uri = invocation.getArgument(0);
+            String query = uri.getQuery();
+            int version = query != null && query.startsWith("version=") ? Integer.parseInt(query.substring("version=".length())) : 1;
+            return resourceId(uri.getPath(), version);
+        });
     }
 
     private static IResourceStore.IResourceId resourceId(String id, int version) {
@@ -74,7 +84,7 @@ class RestWorkflowStoreTest {
      * delete)
      */
     private void mockSingleReference() throws Exception {
-        when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(false))).thenReturn(List.of(new DocumentDescriptor()));
+        when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(true))).thenReturn(List.of(new DocumentDescriptor()));
     }
 
     @Nested
@@ -175,12 +185,12 @@ class RestWorkflowStoreTest {
 
             // Shared resource referenced by 2 packages
             String sharedUri = "eddi://ai.labs.rules/rulestore/rulesets/shared1?version=1";
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(sharedUri), eq(false)))
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(sharedUri), eq(true)))
                     .thenReturn(List.of(new DocumentDescriptor(), new DocumentDescriptor()));
 
             // Unique resource referenced by only 1 package
             String uniqueUri = "eddi://ai.labs.output/outputstore/outputsets/unique1?version=1";
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(uniqueUri), eq(false))).thenReturn(List.of(new DocumentDescriptor()));
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(uniqueUri), eq(true))).thenReturn(List.of(new DocumentDescriptor()));
 
             when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
 
@@ -204,7 +214,7 @@ class RestWorkflowStoreTest {
 
             when(WorkflowStore.read("wf1", 1)).thenReturn(workflowBeingDeleted);
             // Both wf1 (the one being deleted) and wf2 reference the same output set.
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(sharedOutputUri), eq(false)))
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(sharedOutputUri), eq(true)))
                     .thenReturn(List.of(new DocumentDescriptor(), new DocumentDescriptor()));
 
             restWorkflowStore.deleteWorkflow("wf1", 1, true, true);
@@ -222,7 +232,7 @@ class RestWorkflowStoreTest {
             config.getWorkflowSteps().add(outputStep);
 
             when(WorkflowStore.read("wf1", 1)).thenReturn(config);
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(false)))
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(true)))
                     .thenThrow(new IResourceStore.ResourceStoreException("index unavailable"));
 
             restWorkflowStore.deleteWorkflow("wf1", 1, true, true);
@@ -352,6 +362,79 @@ class RestWorkflowStoreTest {
     }
 
     /**
+     * The deep copy walks the same stored shape as the cascade and had the same
+     * blind cast. It matters for the same reason: a throw here leaves behind the
+     * sub-resources it had already created and persisted.
+     */
+    @Nested
+    @DisplayName("duplicateWorkflow \u2014 malformed stored steps")
+    class MalformedStepsOnTheDeepCopy {
+
+        @Test
+        @DisplayName("a dictionaries block that is an object, not a list, does not abort the deep copy")
+        void nonListDictionariesDoesNotAbortTheDeepCopy() throws Exception {
+            WorkflowConfiguration config = new WorkflowConfiguration();
+
+            WorkflowStep parserStep = new WorkflowStep();
+            parserStep.setType(URI.create("eddi://ai.labs.parser"));
+            parserStep.getExtensions().put("dictionaries", new HashMap<String, Object>());
+            config.getWorkflowSteps().add(parserStep);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(WorkflowStore.create(any())).thenReturn(resourceId("copy1", 1));
+            when(documentDescriptorStore.readDescriptor("pkg1", 1)).thenReturn(new DocumentDescriptor());
+
+            assertDoesNotThrow(() -> restWorkflowStore.duplicateWorkflow("pkg1", 1, true));
+        }
+
+        /**
+         * Only {@code ai.labs.parser.dictionaries.regular} entries are separately
+         * stored resources with their own id; the other dictionary kinds are inline
+         * configuration, and a stored entry may carry no {@code type} at all. Copying
+         * either would ask {@code duplicateResource} for a resource that does not exist
+         * — and that throws, on a path that has already persisted the sub-resources it
+         * created before it.
+         */
+        @Test
+        @DisplayName("a deep copy only duplicates regular dictionaries, and skips entries it cannot classify")
+        void deepCopyOnlyDuplicatesRegularDictionaries() throws Exception {
+            WorkflowConfiguration config = new WorkflowConfiguration();
+
+            WorkflowStep parserStep = new WorkflowStep();
+            parserStep.setType(URI.create("eddi://ai.labs.parser"));
+
+            Map<String, Object> notAnObject = new HashMap<>();
+            notAnObject.put("type", "eddi://ai.labs.parser.dictionaries.regular");
+            // Present but not a Map, so there is nothing to read a uri out of.
+            notAnObject.put("config", "just-a-string");
+
+            Map<String, Object> typeless = new HashMap<>();
+            typeless.put("config", new HashMap<>(Map.of("uri", "eddi://ai.labs.dictionary/dictionarystore/dictionaries/typeless?version=1")));
+
+            Map<String, Object> otherKind = new HashMap<>();
+            otherKind.put("type", "eddi://ai.labs.parser.dictionaries.integer");
+            otherKind.put("config", new HashMap<>(Map.of("uri", "eddi://ai.labs.dictionary/dictionarystore/dictionaries/ints?version=1")));
+
+            Map<String, Object> noUri = new HashMap<>();
+            noUri.put("type", "eddi://ai.labs.parser.dictionaries.regular");
+            noUri.put("config", new HashMap<String, Object>());
+
+            parserStep.getExtensions().put("dictionaries",
+                    new ArrayList<>(List.of("not-a-map", notAnObject, typeless, otherKind, noUri)));
+            config.getWorkflowSteps().add(parserStep);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(WorkflowStore.create(any())).thenReturn(resourceId("copy1", 1));
+            when(documentDescriptorStore.readDescriptor("pkg1", 1)).thenReturn(new DocumentDescriptor());
+
+            Response response = restWorkflowStore.duplicateWorkflow("pkg1", 1, true);
+
+            assertEquals(201, response.getStatus());
+            verify(resourceClientLibrary, never()).duplicateResource(any());
+        }
+    }
+
+    /**
      * Stored shapes the cascade walks. {@code "extensions": null} is what Jackson
      * leaves for an explicit JSON null, and this runs on the DESTRUCTIVE path: an
      * NPE here aborts the cascade mid-way, after some referenced resources have
@@ -387,6 +470,377 @@ class RestWorkflowStoreTest {
 
             verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=1"), false);
             verify(WorkflowStore).delete("pkg1", 1);
+        }
+
+        /**
+         * {@code "dictionaries": {}} — an object where the cascade expects an array —
+         * is stored data the API accepts, and a blind
+         * {@code (List<Map<String, Object>>)} cast on it throws
+         * {@code ClassCastException} out of the destructive walk. Same shape
+         * {@code updateResourceInWorkflow} already handles defensively.
+         */
+        @Test
+        @DisplayName("a dictionaries block that is an object, not a list, does not abort the cascade")
+        void nonListDictionariesDoesNotAbortTheCascade() throws Exception {
+            mockSingleReference();
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+
+            WorkflowStep parserStep = new WorkflowStep();
+            parserStep.setType(URI.create("eddi://ai.labs.parser"));
+            parserStep.getExtensions().put("dictionaries", new HashMap<String, Object>());
+            config.getWorkflowSteps().add(parserStep);
+
+            WorkflowStep listWithJunk = new WorkflowStep();
+            listWithJunk.setType(URI.create("eddi://ai.labs.parser"));
+            listWithJunk.getExtensions().put("dictionaries", new ArrayList<>(List.of("not-an-object")));
+            config.getWorkflowSteps().add(listWithJunk);
+
+            // Ordered after both malformed steps, so it is only reached if the cascade
+            // survived them.
+            WorkflowStep outputStep = new WorkflowStep();
+            outputStep.setType(URI.create("eddi://ai.labs.output"));
+            outputStep.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.output/outputstore/outputsets/out1?version=1")));
+            config.getWorkflowSteps().add(outputStep);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
+
+            assertDoesNotThrow(() -> restWorkflowStore.deleteWorkflow("pkg1", 1, false, true));
+
+            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=1"), false);
+        }
+
+        /**
+         * A parser step's {@code dictionaries} array holds every dictionary kind the
+         * parser understands, but only {@code ai.labs.parser.dictionaries.regular} is a
+         * separately stored resource with its own id. The others are inline
+         * configuration, so cascading a delete at them would address a resource that
+         * does not exist — and an entry with no {@code type} at all is stored data the
+         * API accepts. Both are skipped, and skipping them must not stop the rest of
+         * the step being walked.
+         */
+        @Test
+        @DisplayName("only regular dictionaries are cascaded; other kinds and typeless entries are skipped")
+        void nonRegularDictionaryEntriesAreSkipped() throws Exception {
+            mockSingleReference();
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+
+            WorkflowStep parserStep = new WorkflowStep();
+            parserStep.setType(URI.create("eddi://ai.labs.parser"));
+
+            Map<String, Object> typeless = new HashMap<>();
+            typeless.put("config", new HashMap<>(Map.of("uri", "eddi://ai.labs.dictionary/dictionarystore/dictionaries/typeless?version=1")));
+
+            Map<String, Object> otherKind = new HashMap<>();
+            otherKind.put("type", "eddi://ai.labs.parser.dictionaries.integer");
+            otherKind.put("config", new HashMap<>(Map.of("uri", "eddi://ai.labs.dictionary/dictionarystore/dictionaries/ints?version=1")));
+
+            Map<String, Object> regular = new HashMap<>();
+            regular.put("type", "eddi://ai.labs.parser.dictionaries.regular");
+            regular.put("config", new HashMap<>(Map.of("uri", "eddi://ai.labs.dictionary/dictionarystore/dictionaries/dict1?version=1")));
+
+            List<Map<String, Object>> dictionaries = new ArrayList<>(List.of(typeless, otherKind, regular));
+            parserStep.getExtensions().put("dictionaries", dictionaries);
+            config.getWorkflowSteps().add(parserStep);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
+
+            Response response = restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            verify(resourceClientLibrary)
+                    .deleteResource(URI.create("eddi://ai.labs.dictionary/dictionarystore/dictionaries/dict1?version=1"), false);
+            verify(resourceClientLibrary, never())
+                    .deleteResource(eq(URI.create("eddi://ai.labs.dictionary/dictionarystore/dictionaries/typeless?version=1")), anyBoolean());
+            verify(resourceClientLibrary, never())
+                    .deleteResource(eq(URI.create("eddi://ai.labs.dictionary/dictionarystore/dictionaries/ints?version=1")), anyBoolean());
+            assertNull(response.getHeaderString("X-Cascade-Skipped"),
+                    "entries that are not separately stored resources are not 'skipped' cascade candidates");
+        }
+
+        /**
+         * {@code X-Cascade-Skipped} counts RESOURCES the cascade decided not to delete,
+         * never STEPS it walked past. Both kinds of step that name nothing to cascade —
+         * one with no {@code type} (accepted by {@code WorkflowStore.create}) and one
+         * whose {@code config} block carries no {@code uri} — are put in the same
+         * workflow as one genuinely skipped resource, so the header has to answer
+         * exactly "1".
+         *
+         * <p>
+         * The exact number is the whole point. Asserting only that the header is absent
+         * when nothing was skipped cannot distinguish this bookkeeping from no
+         * bookkeeping at all: {@code getHeaderString} answers {@code null} for a header
+         * that was never invented. Making a walked-past step increment
+         * {@code skipped[0]} turns this into "3", which is the header lying about work
+         * that was never there to do — the failure mode the counter exists to prevent.
+         * </p>
+         */
+        @Test
+        @DisplayName("steps with no type and configs with no uri are walked past, not counted as skipped")
+        void stepsWithNothingToCascadeAreNotCounted() throws Exception {
+            String cascaded = "eddi://ai.labs.output/outputstore/outputsets/out1?version=1";
+            String shared = "eddi://ai.labs.output/outputstore/outputsets/shared1?version=1";
+            mockSingleReference();
+            // One resource that IS still referenced elsewhere: the only legitimate skip
+            // in this workflow.
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(shared), eq(true)))
+                    .thenReturn(List.of(new DocumentDescriptor(), new DocumentDescriptor()));
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+
+            WorkflowStep typeless = new WorkflowStep();
+            typeless.setConfig(new HashMap<>(Map.of("uri", cascaded)));
+            config.getWorkflowSteps().add(typeless);
+
+            WorkflowStep noUri = new WorkflowStep();
+            noUri.setType(URI.create("eddi://ai.labs.rules"));
+            noUri.setConfig(new HashMap<>(Map.of("someOtherKey", "value")));
+            config.getWorkflowSteps().add(noUri);
+
+            WorkflowStep stillReferenced = new WorkflowStep();
+            stillReferenced.setType(URI.create("eddi://ai.labs.output"));
+            stillReferenced.setConfig(new HashMap<>(Map.of("uri", shared)));
+            config.getWorkflowSteps().add(stillReferenced);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
+
+            Response response = restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            // The typeless step still has a config.uri, so its resource IS cascaded —
+            // "no type" only means "no parser dictionaries to walk".
+            verify(resourceClientLibrary).deleteResource(URI.create(cascaded), false);
+            verify(resourceClientLibrary, never()).deleteResource(eq(URI.create(shared)), anyBoolean());
+            assertEquals("1", response.getHeaderString("X-Cascade-Skipped"),
+                    "only the still-referenced resource was skipped; walking past a step is not a skip");
+        }
+
+        /**
+         * A stored reference that carries no version query at all — hand-written, or
+         * imported from an older export. Re-addressing it at the live version must
+         * produce a usable URI rather than appending a second query to a string that
+         * has none.
+         */
+        @Test
+        @DisplayName("a reference with no version query is re-addressed at the live version")
+        void unversionedReferenceIsReAddressedAtTheLiveVersion() throws Exception {
+            mockSingleReference();
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            WorkflowStep step = new WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.output"));
+            step.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.output/outputstore/outputsets/out1")));
+            config.getWorkflowSteps().add(step);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.getCurrentResourceId(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1")))
+                    .thenReturn(resourceId("out1", 6));
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
+
+            restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=6"), false);
+        }
+
+        /**
+         * A reverse lookup that answers {@code null} rather than throwing has told us
+         * nothing, and this guard is the only thing standing between an irreversible
+         * cascade and a config another workflow still uses. It has to fail CLOSED, and
+         * the response has to admit that it skipped something — a cascade that deleted
+         * nothing must not answer identically to one that deleted everything.
+         */
+        @Test
+        @DisplayName("a reference check that answers null is skipped, not treated as unreferenced")
+        void nullReferenceAnswerFailsClosed() throws Exception {
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(true))).thenReturn(null);
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            WorkflowStep step = new WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.output"));
+            step.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.output/outputstore/outputsets/out1?version=1")));
+            config.getWorkflowSteps().add(step);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+
+            Response response = restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+            verify(WorkflowStore).delete("pkg1", 1);
+            assertEquals("1", response.getHeaderString("X-Cascade-Skipped"),
+                    "a reference check that could not answer must be reported, not silently treated as 'nobody uses it'");
+        }
+    }
+
+    /**
+     * What the cascade does when a step's pinned version and the version that
+     * actually exists disagree — which is the NORMAL state, since a reference is
+     * not re-pointed when the resource it names is edited.
+     */
+    @Nested
+    @DisplayName("deleteWorkflow \u2014 references resolve to the current version")
+    class StaleReferences {
+
+        /**
+         * The workflow pins {@code out1?version=1}; the output set has since been
+         * edited twice and is at v3. Against the pinned version BOTH halves of the
+         * cascade were wrong at once: the reference check asked who else pins a version
+         * nobody may still pin, and {@code deleteResource} was then rejected by the
+         * store as a stale version and swallowed as a WARN — so {@code cascade=true}
+         * deleted nothing at all for any resource that had ever been edited, while the
+         * API description said it had soft-deleted them.
+         */
+        @Test
+        @DisplayName("a stale pinned reference is deleted at the resource's current version, not the pinned one")
+        void staleReferenceResolvesToTheCurrentVersion() throws Exception {
+            String pinned = "eddi://ai.labs.output/outputstore/outputsets/out1?version=1";
+            String current = "eddi://ai.labs.output/outputstore/outputsets/out1?version=3";
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            WorkflowStep outputStep = new WorkflowStep();
+            outputStep.setType(URI.create("eddi://ai.labs.output"));
+            outputStep.setConfig(new HashMap<>(Map.of("uri", pinned)));
+            config.getWorkflowSteps().add(outputStep);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.getCurrentResourceId(URI.create(pinned)))
+                    .thenReturn(resourceId("/outputstore/outputsets/out1", 3));
+            // Only this workflow references it, asked at the version that exists.
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(current), eq(true)))
+                    .thenReturn(List.of(new DocumentDescriptor()));
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
+
+            restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            verify(resourceClientLibrary).deleteResource(URI.create(current), false);
+            verify(resourceClientLibrary, never()).deleteResource(eq(URI.create(pinned)), anyBoolean());
+        }
+
+        /**
+         * A reference whose current version cannot be resolved — an unregistered type,
+         * or a resource with no live version left — is skipped rather than guessed at,
+         * and the response says so.
+         */
+        @Test
+        @DisplayName("an unresolvable reference is skipped and counted in X-Cascade-Skipped")
+        void unresolvableReferenceIsSkippedAndCounted() throws Exception {
+            String pinned = "eddi://ai.labs.unknown/unknownstore/unknowns/u1?version=1";
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            WorkflowStep step = new WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.unknown"));
+            step.setConfig(new HashMap<>(Map.of("uri", pinned)));
+            config.getWorkflowSteps().add(step);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.getCurrentResourceId(URI.create(pinned))).thenReturn(null);
+
+            Response response = restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+            assertEquals("1", response.getHeaderString("X-Cascade-Skipped"),
+                    "a cascade that skipped everything must not answer exactly like one that deleted everything");
+        }
+
+        /**
+         * The pre-cascade version check is a check-then-act. A concurrent update
+         * committing between it and the delete used to leave the referenced resources
+         * torn down while the delete itself answered 409 for a stale version — the
+         * exact destructive outcome the version check exists to prevent. Deleting the
+         * workflow FIRST makes the store's own version check the gate.
+         */
+        @Test
+        @DisplayName("a workflow that moved on between the guard and the delete loses nothing it referenced")
+        void concurrentUpdateBetweenGuardAndDeleteCascadesNothing() throws Exception {
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            WorkflowStep outputStep = new WorkflowStep();
+            outputStep.setType(URI.create("eddi://ai.labs.output"));
+            outputStep.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.output/outputstore/outputsets/out1?version=1")));
+            config.getWorkflowSteps().add(outputStep);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(true)))
+                    .thenReturn(List.of(new DocumentDescriptor()));
+            // The guard saw v1; by the time the delete runs the workflow is at v2.
+            doThrow(new IResourceStore.ResourceModifiedException("not the latest version")).when(WorkflowStore).delete("pkg1", 1);
+
+            assertThrows(IResourceStore.ResourceModifiedException.class, () -> restWorkflowStore.deleteWorkflow("pkg1", 1, false, true));
+
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+        }
+
+        /**
+         * Version resolution has to fail closed PER RESOURCE, exactly like the
+         * reference check that follows it. {@code getCurrentResourceId} only absorbs
+         * {@code ResourceNotFoundException}: the Mongo store's
+         * {@code getCurrentVersion} does {@code new ObjectId(id)}, which raises
+         * {@code IllegalArgumentException} for the 18-23 char hex and UUID-shaped ids
+         * {@code RestUtilities.isValidId} accepts, and a transport failure surfaces as
+         * {@code MongoException}. Uncaught, ONE hand-written or imported step reference
+         * aborted the whole {@code cascade=true} delete with a 500 — before the
+         * workflow itself was deleted, so the workflow stayed undeletable-with-cascade
+         * until someone edited the stray reference out.
+         */
+        @Test
+        @DisplayName("a reference that cannot be resolved at all is skipped — the workflow is still deleted")
+        void unresolvableReferenceDoesNotAbortTheWholeDelete() throws Exception {
+            String pinned = "eddi://ai.labs.output/outputstore/outputsets/not-an-objectid?version=1";
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            WorkflowStep outputStep = new WorkflowStep();
+            outputStep.setType(URI.create("eddi://ai.labs.output"));
+            outputStep.setConfig(new HashMap<>(Map.of("uri", pinned)));
+            config.getWorkflowSteps().add(outputStep);
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.getCurrentResourceId(URI.create(pinned)))
+                    .thenThrow(new IllegalArgumentException("invalid hexadecimal representation of an ObjectId"));
+
+            Response response = assertDoesNotThrow(() -> restWorkflowStore.deleteWorkflow("pkg1", 1, false, true),
+                    "one unresolvable step reference must not turn the whole cascade delete into a 500");
+
+            // The workflow itself is gone, and the operator is told one resource was left.
+            verify(WorkflowStore).delete("pkg1", 1);
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+            assertEquals("1", response.getHeaderString("X-Cascade-Skipped"),
+                    "the unresolvable reference must be reported as skipped, not swallowed");
+        }
+
+        /**
+         * Two steps naming the same resource is ordinary (two httpcalls steps on one
+         * apicalls config). Without de-duplication the second delete found the resource
+         * already soft-deleted, {@code HistorizedResourceStore.delete} raised
+         * {@code ResourceNotFoundException}, and the delete loop counted that as a
+         * skip: a cascade that removed everything it walked answered
+         * {@code X-Cascade-Skipped: 1}. The header exists to stop the response lying
+         * about the cascade, so it must not lie the other way either.
+         */
+        @Test
+        @DisplayName("two steps naming the same resource delete it once and report nothing skipped")
+        void duplicateReferenceIsDeletedOnceAndNotReportedAsSkipped() throws Exception {
+            String pinned = "eddi://ai.labs.apicalls/apicallstore/apicalls/api1?version=1";
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            for (int i = 0; i < 2; i++) {
+                WorkflowStep step = new WorkflowStep();
+                step.setType(URI.create("eddi://ai.labs.httpcalls"));
+                step.setConfig(new HashMap<>(Map.of("uri", pinned)));
+                config.getWorkflowSteps().add(step);
+            }
+
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            mockSingleReference();
+            // Deleting the same resource a second time is what used to be counted as a
+            // skip: by then it is already soft-deleted and the store refuses.
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build())
+                    .thenThrow(new ServiceException("resource not found"));
+
+            Response response = restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            verify(resourceClientLibrary, times(1)).deleteResource(URI.create(pinned), false);
+            assertNull(response.getHeaderString("X-Cascade-Skipped"),
+                    "a cascade that deleted everything it walked must not report a skip");
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
+++ b/src/test/java/ai/labs/eddi/configs/workflows/rest/RestWorkflowStoreTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mock;
 
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -59,10 +60,63 @@ class RestWorkflowStoreTest {
         // disagree is CascadeVersionGuard.staleReferenceResolvesToTheCurrentVersion.
         when(resourceClientLibrary.getCurrentResourceId(any(URI.class))).thenAnswer(invocation -> {
             URI uri = invocation.getArgument(0);
-            String query = uri.getQuery();
-            int version = query != null && query.startsWith("version=") ? Integer.parseInt(query.substring("version=".length())) : 1;
-            return resourceId(uri.getPath(), version);
+            return resourceId(uri.getPath(), pinnedVersion(uri));
         });
+        // The workflow the cascade is deleting stops being a referrer the moment it
+        // is deleted — AbstractResourceStore.isStaleReference drops a referrer with
+        // no current row. Modelling that is what lets the post-delete re-check in
+        // deleteWorkflow mean anything: with a stub frozen at its pre-delete answer,
+        // "nobody else references this" and "one other workflow does" look alike.
+        doAnswer(invocation -> {
+            parentDeleted.set(true);
+            return null;
+        }).when(WorkflowStore).delete(anyString(), anyInt());
+        doAnswer(invocation -> {
+            parentDeleted.set(true);
+            return null;
+        }).when(WorkflowStore).deleteAllPermanently(anyString());
+    }
+
+    /**
+     * The version a stored reference pins, defaulting to 1.
+     *
+     * <p>
+     * A stored {@code config.uri} is arbitrary text — hand-written, imported, or
+     * carrying a second query parameter — so a bare
+     * {@code Integer.parseInt(query.substring(...))} threw
+     * {@code NumberFormatException} out of the mock for input the production code
+     * handles. The default is the same one the missing-query case already used.
+     * </p>
+     */
+    private static int pinnedVersion(URI uri) {
+        String query = uri.getQuery();
+        if (query == null || !query.startsWith("version=")) {
+            return 1;
+        }
+        try {
+            return Integer.parseInt(query.substring("version=".length()));
+        } catch (NumberFormatException e) {
+            return 1;
+        }
+    }
+
+    /**
+     * Whether the workflow under test has been deleted yet; see {@link #referrers}.
+     */
+    private final AtomicBoolean parentDeleted = new AtomicBoolean();
+
+    /**
+     * The reverse lookup's answer, as the real store gives it: {@code total} counts
+     * the workflow being deleted among the referrers, and that one disappears once
+     * it has been deleted.
+     */
+    private List<DocumentDescriptor> referrers(int total) {
+        int remaining = parentDeleted.get() ? total - 1 : total;
+        List<DocumentDescriptor> descriptors = new ArrayList<>();
+        for (int i = 0; i < remaining; i++) {
+            descriptors.add(new DocumentDescriptor());
+        }
+        return descriptors;
     }
 
     private static IResourceStore.IResourceId resourceId(String id, int version) {
@@ -84,7 +138,7 @@ class RestWorkflowStoreTest {
      * delete)
      */
     private void mockSingleReference() throws Exception {
-        when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(true))).thenReturn(List.of(new DocumentDescriptor()));
+        when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(true))).thenAnswer(invocation -> referrers(1));
     }
 
     @Nested
@@ -185,12 +239,11 @@ class RestWorkflowStoreTest {
 
             // Shared resource referenced by 2 packages
             String sharedUri = "eddi://ai.labs.rules/rulestore/rulesets/shared1?version=1";
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(sharedUri), eq(true)))
-                    .thenReturn(List.of(new DocumentDescriptor(), new DocumentDescriptor()));
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(sharedUri), eq(true))).thenAnswer(invocation -> referrers(2));
 
             // Unique resource referenced by only 1 package
             String uniqueUri = "eddi://ai.labs.output/outputstore/outputsets/unique1?version=1";
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(uniqueUri), eq(true))).thenReturn(List.of(new DocumentDescriptor()));
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(uniqueUri), eq(true))).thenAnswer(invocation -> referrers(1));
 
             when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
 
@@ -214,8 +267,7 @@ class RestWorkflowStoreTest {
 
             when(WorkflowStore.read("wf1", 1)).thenReturn(workflowBeingDeleted);
             // Both wf1 (the one being deleted) and wf2 reference the same output set.
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(sharedOutputUri), eq(true)))
-                    .thenReturn(List.of(new DocumentDescriptor(), new DocumentDescriptor()));
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(sharedOutputUri), eq(true))).thenAnswer(invocation -> referrers(2));
 
             restWorkflowStore.deleteWorkflow("wf1", 1, true, true);
 
@@ -585,8 +637,7 @@ class RestWorkflowStoreTest {
             mockSingleReference();
             // One resource that IS still referenced elsewhere: the only legitimate skip
             // in this workflow.
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(shared), eq(true)))
-                    .thenReturn(List.of(new DocumentDescriptor(), new DocumentDescriptor()));
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(shared), eq(true))).thenAnswer(invocation -> referrers(2));
 
             WorkflowConfiguration config = new WorkflowConfiguration();
 
@@ -671,6 +722,65 @@ class RestWorkflowStoreTest {
             assertEquals("1", response.getHeaderString("X-Cascade-Skipped"),
                     "a reference check that could not answer must be reported, not silently treated as 'nobody uses it'");
         }
+
+        /**
+         * The shared-resource decision is made BEFORE the workflow is deleted — it has
+         * to be, so the workflow still counts among the referrers. A workflow created,
+         * or re-pointed at one of these configs, in the window between the plan and the
+         * child delete would otherwise have its newly shared configuration soft-deleted
+         * underneath it. The re-check runs after the parent is gone, so the only safe
+         * answer is zero referrers.
+         */
+        @Test
+        @DisplayName("a resource that becomes referenced between the plan and the child delete is not deleted")
+        void resourceThatBecomesSharedDuringTheCascadeIsSkipped() throws Exception {
+            String outputUri = "eddi://ai.labs.output/outputstore/outputsets/out1?version=1";
+            // One referrer at both moments, but not the SAME one: when the cascade is
+            // planned it is this workflow (so the resource is a candidate), and by the
+            // time the child delete runs this workflow is gone and the one referrer is
+            // a workflow that has just been pointed at the config.
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(outputUri), eq(true)))
+                    .thenReturn(List.of(new DocumentDescriptor()));
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            WorkflowStep step = new WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.output"));
+            step.setConfig(new HashMap<>(Map.of("uri", outputUri)));
+            config.getWorkflowSteps().add(step);
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
+
+            Response response = restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            verify(WorkflowStore).delete("pkg1", 1);
+            verify(resourceClientLibrary, never()).deleteResource(any(), anyBoolean());
+            assertEquals("1", response.getHeaderString("X-Cascade-Skipped"),
+                    "the resource became shared during the cascade, so it was left alone — and the response has to say so");
+        }
+
+        /**
+         * The counterpart: nothing appeared in the window, so the re-check finds no
+         * referrer left and the delete goes through. Without this the test above would
+         * also pass against a cascade that had simply stopped deleting.
+         */
+        @Test
+        @DisplayName("a resource nobody picked up during the cascade is still deleted")
+        void resourceThatStaysUnreferencedIsStillDeleted() throws Exception {
+            mockSingleReference();
+
+            WorkflowConfiguration config = new WorkflowConfiguration();
+            WorkflowStep step = new WorkflowStep();
+            step.setType(URI.create("eddi://ai.labs.output"));
+            step.setConfig(new HashMap<>(Map.of("uri", "eddi://ai.labs.output/outputstore/outputsets/out1?version=1")));
+            config.getWorkflowSteps().add(step);
+            when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
+            when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
+
+            Response response = restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
+
+            verify(resourceClientLibrary).deleteResource(URI.create("eddi://ai.labs.output/outputstore/outputsets/out1?version=1"), false);
+            assertNull(response.getHeaderString("X-Cascade-Skipped"));
+        }
     }
 
     /**
@@ -707,8 +817,7 @@ class RestWorkflowStoreTest {
             when(resourceClientLibrary.getCurrentResourceId(URI.create(pinned)))
                     .thenReturn(resourceId("/outputstore/outputsets/out1", 3));
             // Only this workflow references it, asked at the version that exists.
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(current), eq(true)))
-                    .thenReturn(List.of(new DocumentDescriptor()));
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(eq(current), eq(true))).thenAnswer(invocation -> referrers(1));
             when(resourceClientLibrary.deleteResource(any(), anyBoolean())).thenReturn(Response.ok().build());
 
             restWorkflowStore.deleteWorkflow("pkg1", 1, false, true);
@@ -760,8 +869,7 @@ class RestWorkflowStoreTest {
             config.getWorkflowSteps().add(outputStep);
 
             when(WorkflowStore.read("pkg1", 1)).thenReturn(config);
-            when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(true)))
-                    .thenReturn(List.of(new DocumentDescriptor()));
+            when(WorkflowStore.getWorkflowDescriptorsContainingResource(anyString(), eq(true))).thenAnswer(invocation -> referrers(1));
             // The guard saw v1; by the time the delete runs the workflow is at v2.
             doThrow(new IResourceStore.ResourceModifiedException("not the latest version")).when(WorkflowStore).delete("pkg1", 1);
 

--- a/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageBranchTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageBranchTest.java
@@ -77,12 +77,14 @@ class MongoResourceStorageBranchTest {
 
         new MongoResourceStorage<>(database, "indexed", documentBuilder, String.class, "field1", "field2");
 
-        // The ID_FIELD+VERSION_FIELD unique index on currentCollection +
-        // two indexes on each collection for field1, field2
-        // = 1 (unique on current) + 2 (on current) + 2 (on history) = 5 createIndex
-        // calls
+        // current: 1 unique (_id, _version) + field1 + field2 = 3
+        // history: 1 on the nested (_id._id, _id._version) + field1 + field2 = 3.
+        // The history one was added with the nested-id filter that fixed the version-0
+        // escape: the built-in _id index covers the whole embedded subdocument and
+        // cannot serve a dotted path into it, so without it removeAllPermanently and
+        // readHistoryLatest COLLSCAN. This assertion read 2 and so pinned its absence.
         verify(curCol, times(3)).createIndex(any(Bson.class), any());
-        verify(histCol, times(2)).createIndex(any(Bson.class), any());
+        verify(histCol, times(3)).createIndex(any(Bson.class), any());
     }
 
     // ==================== findHistoryResourceIdsContaining ====================

--- a/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/mongo/MongoResourceStorageTest.java
@@ -8,10 +8,12 @@ import ai.labs.eddi.datastore.IResourceFilter;
 import ai.labs.eddi.datastore.IResourceStorage;
 import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IDocumentBuilder;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.ReplaceOptions;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -19,6 +21,7 @@ import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import java.io.IOException;
@@ -168,6 +171,76 @@ class MongoResourceStorageTest {
         storage.removeAllPermanently(VALID_ID);
         verify(currentCollection).deleteOne(any(Document.class));
         verify(historyCollection).deleteMany(any(Document.class));
+    }
+
+    /**
+     * A history row's {@code _id} is the embedded document {@code {_id: ObjectId,
+     * _version: int}}, and BSON compares embedded documents field by field. The old
+     * filter was a range — {@code $gt {_id, _version: 0}} — so a row archived at
+     * version 0 compared EQUAL to the lower bound and was excluded. Conversation
+     * descriptors are created at version 0, so permanent delete and GDPR erasure
+     * left an undeletable tombstone carrying {@code userId} behind, on MongoDB
+     * only; Postgres deletes by id and did not have the bug.
+     */
+    @Test
+    @DisplayName("removeAllPermanently — matches history rows by nested id, so version 0 is not skipped")
+    void removeAllPermanentlyCoversVersionZero() {
+        ArgumentCaptor<Document> filter = ArgumentCaptor.forClass(Document.class);
+
+        storage.removeAllPermanently(VALID_ID);
+
+        verify(historyCollection).deleteMany(filter.capture());
+        assertEquals(new ObjectId(VALID_ID), filter.getValue().get("_id._id"), "history rows must be matched by the nested id");
+        assertFalse(filter.getValue().toJson().contains("$gt"), "no range bound may exclude version 0: " + filter.getValue().toJson());
+        assertFalse(filter.getValue().toJson().contains("$lt"), "no range bound may exclude version 0: " + filter.getValue().toJson());
+    }
+
+    /** @see #removeAllPermanentlyCoversVersionZero() — same bound, same defect. */
+    @Test
+    @DisplayName("readHistoryLatest — matches by nested id and sorts on the nested version")
+    void readHistoryLatestCoversVersionZero() {
+        when(historyCollection.countDocuments(any(Document.class))).thenReturn(1L);
+
+        Document idDoc = new Document("_id", new ObjectId(VALID_ID)).append("_version", 0);
+        Document doc = new Document("_id", idDoc).append("data", "archived at v0");
+        FindIterable<Document> iterable = mock(FindIterable.class);
+        when(historyCollection.find(any(Document.class))).thenReturn(iterable);
+        when(iterable.sort(any(Document.class))).thenReturn(iterable);
+        when(iterable.limit(1)).thenReturn(iterable);
+        when(iterable.first()).thenReturn(doc);
+
+        IResourceStorage.IHistoryResource<String> result = storage.readHistoryLatest(VALID_ID);
+
+        assertNotNull(result);
+        assertEquals(0, result.getVersion());
+
+        ArgumentCaptor<Document> filter = ArgumentCaptor.forClass(Document.class);
+        verify(historyCollection).find(filter.capture());
+        assertEquals(new ObjectId(VALID_ID), filter.getValue().get("_id._id"));
+
+        ArgumentCaptor<Document> sort = ArgumentCaptor.forClass(Document.class);
+        verify(iterable).sort(sort.capture());
+        assertEquals(-1, sort.getValue().get("_id._version"), "sorting on the composite _id would order by ObjectId, not by version");
+    }
+
+    /**
+     * The nested-id filter that fixed the version-0 escape is only servable by an
+     * index on that dotted path: MongoDB's built-in {@code _id} index covers the
+     * whole embedded subdocument, so without this one every
+     * {@code removeAllPermanently} and {@code readHistoryLatest} is a COLLSCAN of
+     * the history collection — once per conversation in
+     * {@code GdprComplianceService}'s erasure loop.
+     */
+    @Test
+    @DisplayName("the history collection is indexed on the nested id the history filter matches")
+    void historyCollectionIsIndexedOnTheNestedId() {
+        ArgumentCaptor<Bson> keys = ArgumentCaptor.forClass(Bson.class);
+        verify(historyCollection, atLeastOnce()).createIndex(keys.capture(), any(IndexOptions.class));
+
+        boolean indexed = keys.getAllValues().stream()
+                .map(key -> key.toBsonDocument(Document.class, MongoClientSettings.getDefaultCodecRegistry()).toString())
+                .anyMatch(key -> key.contains("_id._id"));
+        assertTrue(indexed, "no index on '_id._id' — the history filter would COLLSCAN: " + keys.getAllValues());
     }
 
     // ==================== readHistory ====================

--- a/src/test/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibraryTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibraryTest.java
@@ -252,13 +252,22 @@ class ResourceClientLibraryTest {
             assertEquals(200, result.getStatus());
         }
 
+        /**
+         * This assertion used to read {@code assertEquals(200, …)} and so pinned the
+         * defect. Answering 200 for a type with no registered proxy made
+         * {@code RestOrphanAdmin.purgeOrphans} count every such orphan as purged and
+         * log it as purged while nothing was deleted — the whole
+         * {@code ai.labs.workflow} category, which is the biggest one. A caller must
+         * either delete or be told it did not; {@code duplicateResource} already throws
+         * for an unknown type.
+         */
         @Test
-        @DisplayName("should return OK for unknown type (graceful skip)")
-        void gracefulSkipForUnknown() throws Exception {
-            Response result = library.deleteResource(
-                    URI.create("eddi://ai.labs.unknown/store/items/" + VALID_ID + "?version=1"), false);
+        @DisplayName("an unregistered type is an error, not a silent skip")
+        void unknownTypeThrows() {
+            ServiceException thrown = assertThrows(ServiceException.class, () -> library.deleteResource(
+                    URI.create("eddi://ai.labs.unknown/store/items/" + VALID_ID + "?version=1"), false));
 
-            assertEquals(200, result.getStatus());
+            assertTrue(thrown.getMessage().contains("ai.labs.unknown"), "the message must name the type: " + thrown.getMessage());
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibraryTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/client/configuration/ResourceClientLibraryTest.java
@@ -22,6 +22,7 @@ import ai.labs.eddi.configs.parser.IRestParserStore;
 import ai.labs.eddi.configs.propertysetter.IRestPropertySetterStore;
 import ai.labs.eddi.configs.rag.IRestRagStore;
 import ai.labs.eddi.configs.dictionary.IRestDictionaryStore;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.engine.runtime.service.ServiceException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -279,6 +280,86 @@ class ResourceClientLibraryTest {
                     URI.create("eddi://ai.labs.rag/ragstore/rags/" + VALID_ID + "?version=1"), true);
 
             verify(restRagStore).deleteRag(eq(VALID_ID), eq(1), eq(true));
+        }
+    }
+
+    /**
+     * Version resolution is what the agent and workflow cascades ask before they
+     * decide anything: a step reference keeps pinning {@code ?version=1} long after
+     * the resource it names has moved to v2, and asking the reference guard about
+     * one version while deleting another is how a cascade destroys something still
+     * in use. It resolves against the STORE, not the REST facade — a cascade must
+     * not need to own a configuration in order to ask which version of it exists —
+     * and reports "cannot resolve" as null rather than by throwing.
+     */
+    @Nested
+    @DisplayName("getCurrentResourceId")
+    class GetCurrentResourceId {
+
+        private IResourceStore.IResourceId resourceId(String id, Integer version) {
+            return new IResourceStore.IResourceId() {
+                @Override
+                public String getId() {
+                    return id;
+                }
+
+                @Override
+                public Integer getVersion() {
+                    return version;
+                }
+            };
+        }
+
+        @Test
+        @DisplayName("answers the live version, not the one the reference pins")
+        void resolvesAgainstTheStoreNotThePinnedVersion() throws Exception {
+            when(ruleSetStore.getCurrentResourceId(VALID_ID)).thenReturn(resourceId(VALID_ID, 7));
+
+            var current = library.getCurrentResourceId(
+                    URI.create("eddi://ai.labs.rules/rulestore/rulesets/" + VALID_ID + "?version=1"));
+
+            assertNotNull(current);
+            assertEquals(VALID_ID, current.getId());
+            assertEquals(7, current.getVersion(), "the pinned ?version=1 must not be echoed back");
+            verify(ruleSetStore).getCurrentResourceId(VALID_ID);
+        }
+
+        @Test
+        @DisplayName("resolves the legacy authority through the same store as the canonical one")
+        void resolvesLegacyHostAlias() throws Exception {
+            when(apiCallsStore.getCurrentResourceId(VALID_ID)).thenReturn(resourceId(VALID_ID, 3));
+
+            var legacy = library.getCurrentResourceId(
+                    URI.create("eddi://ai.labs.httpcalls/httpcallsstore/httpcalls/" + VALID_ID + "?version=1"));
+            var canonical = library.getCurrentResourceId(
+                    URI.create("eddi://ai.labs.apicalls/apicallstore/apicalls/" + VALID_ID + "?version=1"));
+
+            assertEquals(3, legacy.getVersion(), "a reference written with the legacy authority must still resolve");
+            assertEquals(3, canonical.getVersion());
+        }
+
+        @Test
+        @DisplayName("a resource with no live version answers null rather than throwing")
+        void softDeletedResourceAnswersNull() throws Exception {
+            when(outputStore.getCurrentResourceId(VALID_ID))
+                    .thenThrow(new IResourceStore.ResourceNotFoundException("gone"));
+
+            assertNull(library.getCurrentResourceId(
+                    URI.create("eddi://ai.labs.output/outputstore/outputsets/" + VALID_ID + "?version=1")));
+        }
+
+        @Test
+        @DisplayName("an unregistered type answers null, and never reaches a store")
+        void unregisteredTypeAnswersNull() {
+            assertNull(library.getCurrentResourceId(
+                    URI.create("eddi://ai.labs.unknown/store/items/" + VALID_ID + "?version=1")));
+        }
+
+        @Test
+        @DisplayName("a null uri, or one carrying no resource id, answers null")
+        void unusableUriAnswersNull() {
+            assertNull(library.getCurrentResourceId(null));
+            assertNull(library.getCurrentResourceId(URI.create("eddi://ai.labs.llm/llmstore/llms/not-hex?version=1")));
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/runtime/internal/DreamServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/runtime/internal/DreamServiceTest.java
@@ -1144,18 +1144,27 @@ class DreamServiceTest {
         verify(store, times(1)).deleteEntry(anyString());
     }
 
+    /**
+     * These two used to assert that the SETTER throws, and so pinned a defect:
+     * Jackson calls it on every MongoDB read, ZIP import and instance sync, so an
+     * agent already stored with {@code summarizeTargetEntries: 0} — legal when it
+     * was written — could no longer be read, deployed, exported, or even repaired
+     * by PUT, because the read comes first.
+     * {@code AbstractResourceStore.validate}'s Javadoc states the rule outright: "a
+     * document already in the database must keep loading even if the rules
+     * tightened". The bound is a WRITE-path rule and now lives in
+     * {@code AgentStore.create}/{@code update} next to {@code HitlConfigValidation}
+     * — see {@code AgentStoreTest.UserMemoryConfigValidation}.
+     */
     @Test
-    void setSummarizeTargetEntries_rejectsZero() {
+    void setSummarizeTargetEntries_acceptsStoredOutOfRangeValuesSoTheAgentStillLoads() {
         var config = new AgentConfiguration.DreamConfig();
-        assertThrows(IllegalArgumentException.class,
-                () -> config.setSummarizeTargetEntries(0));
-    }
 
-    @Test
-    void setSummarizeTargetEntries_rejectsNegative() {
-        var config = new AgentConfiguration.DreamConfig();
-        assertThrows(IllegalArgumentException.class,
-                () -> config.setSummarizeTargetEntries(-1));
+        assertDoesNotThrow(() -> config.setSummarizeTargetEntries(0));
+        assertEquals(0, config.getSummarizeTargetEntries());
+
+        assertDoesNotThrow(() -> config.setSummarizeTargetEntries(-1));
+        assertEquals(-1, config.getSummarizeTargetEntries());
     }
 
     // === Agent ownership: a cycle configured by one agent must not act on another

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/StreamingLegacyChatExecutorRetryTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/StreamingLegacyChatExecutorRetryTest.java
@@ -471,6 +471,39 @@ class StreamingLegacyChatExecutorRetryTest {
             assertEquals(1, callCount.get());
             assertEquals("Hi there", result.response());
         }
+
+        /**
+         * The engine ceiling on {@code maxAttempts} bounds how long one config can hold
+         * a pipeline thread (AGENTS.md §4.1 rule 5). This path read
+         * {@code getMaxAttempts()} raw, so the identical {@code retry} block was capped
+         * on the tool-loop path and unbounded here — a streaming task really did run
+         * all 50 attempts.
+         */
+        @Test
+        @DisplayName("should stop at the engine ceiling, not at a configured maxAttempts above it")
+        void maxAttemptsIsCappedByTheEngineCeiling() {
+            var callCount = new AtomicInteger(0);
+
+            StreamingChatModel model = new StreamingChatModel() {
+                @Override
+                public void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                    callCount.incrementAndGet();
+                    handler.onError(new RuntimeException("persistent failure"));
+                }
+            };
+
+            var retryConfig = createRetryConfig(50, 1L);
+            // keeps the whole run in single-digit milliseconds
+            retryConfig.setMaxBackoffDelayMs(1L);
+            var task = createTask();
+            task.setRetry(retryConfig);
+
+            assertThrows(RuntimeException.class,
+                    () -> executor.execute(model, createMessages("Hi"), eventSink, task));
+
+            assertEquals(RetryConfiguration.MAX_ATTEMPTS_CEILING, callCount.get(),
+                    "a configured maxAttempts of 50 must stop at the engine ceiling");
+        }
     }
 
     // ==================== Configurable Timeout ====================

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/StreamingLegacyChatExecutorRetryTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/StreamingLegacyChatExecutorRetryTest.java
@@ -21,9 +21,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -665,6 +671,248 @@ class StreamingLegacyChatExecutorRetryTest {
             // Should not throw even though task is null internally
             assertDoesNotThrow(() -> executor.execute(model, createMessages("Hi"), eventSink));
         }
+    }
+
+    /**
+     * The total-backoff budget, not the attempt count, is what stops this loop.
+     *
+     * <p>
+     * {@code executeWithRetry} has always applied
+     * {@code RetryConfiguration.MAX_TOTAL_BACKOFF_MS}; the streaming path ran its
+     * own retry loop and applied only the per-sleep ceiling, so ten attempts at a
+     * configured 30-second delay parked a pipeline thread for 270 seconds.
+     * Threading {@code totalBackoffMs} back into {@code backoff} is what makes the
+     * two agree, and the two "budget is spent" branches are the only places that
+     * say so.
+     * </p>
+     *
+     * <h3>Why this runs in milliseconds rather than a minute</h3>
+     * <p>
+     * Spending a 60-second budget does NOT require sleeping for 60 seconds. An
+     * interrupted {@code Thread.sleep} still reports the amount it was budgeted —
+     * that is exactly what {@code RetryConfigurationTest
+     * .interruptedBackoffRestoresTheInterruptFlag} pins — so a watcher that
+     * interrupts the pipeline thread while, and only while, it is parked inside
+     * {@code RetryConfiguration.backoff} spends the whole budget in two instant
+     * attempts. The watcher is armed by the fake model itself and matches on the
+     * pipeline thread's own stack, so it can never fire during {@code latch.await}:
+     * an interrupt there is a cancellation, which this executor deliberately
+     * refuses to retry ("Streaming chat interrupted"). The fake clears the pending
+     * flag at the start of each attempt for the same reason — a provider client
+     * that consumed the cancellation — leaving the retry decision itself untouched.
+     * </p>
+     */
+    @Nested
+    @DisplayName("total backoff budget")
+    class TotalBackoffBudgetTests {
+
+        /**
+         * A backoff configured AT the per-sleep ceiling: two of them exhaust the
+         * 60-second total budget, so the third attempt is refused by the budget rather
+         * than by {@code maxAttempts} (which is 6 here and never reached).
+         */
+        private LlmConfiguration.Task ceilingBackoffTask(int maxAttempts) {
+            var task = createTask();
+            var retry = new RetryConfiguration();
+            retry.setMaxAttempts(maxAttempts);
+            retry.setBackoffDelayMs(30_000L);
+            retry.setBackoffMultiplier(1.0);
+            retry.setMaxBackoffDelayMs(30_000L);
+            task.setRetry(retry);
+            return task;
+        }
+
+        @Test
+        @DisplayName("a retried error stops on the spent backoff budget, not on maxAttempts")
+        void errorRetryStopsWhenTheBackoffBudgetIsSpent() {
+            var callCount = new AtomicInteger(0);
+            try (var interrupter = new BackoffInterrupter(Thread.currentThread())) {
+                StreamingChatModel model = new StreamingChatModel() {
+                    @Override
+                    public void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                        // A provider client that consumed the cancellation; see the class
+                        // comment. Without this the flag left by the previous interrupted
+                        // backoff would make latch.await throw and the executor would
+                        // (correctly) refuse to retry a cancellation.
+                        Thread.interrupted();
+                        callCount.incrementAndGet();
+                        handler.onError(new RuntimeException("provider 503"));
+                        interrupter.arm();
+                    }
+                };
+
+                List<String> warnings = captureExecutorWarnings(
+                        () -> assertThrows(RuntimeException.class,
+                                () -> executor.execute(model, createMessages("Hi"), eventSink, ceilingBackoffTask(6))));
+
+                assertEquals(3, callCount.get(),
+                        "two full-ceiling backoffs spend the 60s budget, so the third attempt is the last");
+                assertTrue(warnings.stream().anyMatch(w -> w.contains("Streaming error with empty response and the retry backoff budget is spent")),
+                        "the operator has to be told the budget stopped this, not the attempt count; captured: " + warnings);
+                assertTrue(warnings.stream().noneMatch(w -> w.contains("retrying (attempt 3/")),
+                        "attempt 3 must not report itself as retrying — nothing was slept and nothing follows; captured: " + warnings);
+            } finally {
+                // Never leak an interrupt into whatever test runs next on this thread.
+                Thread.interrupted();
+            }
+        }
+
+        /**
+         * The same budget bound on the timeout branch. The first two attempts fail fast
+         * with an error so the budget is spent without any real waiting; only the third
+         * attempt takes the timeout path, at the shortest backstop the config allows.
+         */
+        @Test
+        @DisplayName("a retried timeout stops on the spent backoff budget and answers an empty result")
+        void timeoutRetryStopsWhenTheBackoffBudgetIsSpent() {
+            var callCount = new AtomicInteger(0);
+            try (var interrupter = new BackoffInterrupter(Thread.currentThread())) {
+                StreamingChatModel model = new StreamingChatModel() {
+                    @Override
+                    public void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                        Thread.interrupted();
+                        if (callCount.incrementAndGet() < 3) {
+                            handler.onError(new RuntimeException("provider 503"));
+                        }
+                        // Third attempt onwards: the provider never answers at all, so
+                        // the backstop expires and the timeout branch runs with the
+                        // budget already spent. Arming here is safe — and keeps a
+                        // regression fast rather than 90 seconds slow — because the
+                        // watcher requires a RetryConfiguration.backoff frame, which
+                        // latch.await does not have.
+                        interrupter.arm();
+                    }
+                };
+
+                var task = ceilingBackoffTask(6);
+                task.setStreamingTimeoutSeconds(1);
+
+                List<String> warnings = captureExecutorWarnings(
+                        () -> {
+                            var result = executor.execute(model, createMessages("Hi"), eventSink, task);
+                            assertEquals("", result.response(), "a spent budget on the timeout branch answers empty, it does not throw");
+                            assertEquals(true, result.metadata().get("streamingTimeout"));
+                        });
+
+                assertEquals(3, callCount.get(), "the budget, not maxAttempts=6, ended the loop");
+                assertTrue(
+                        warnings.stream().anyMatch(w -> w.contains("Streaming timed out with empty response and the retry backoff budget is spent")),
+                        "captured: " + warnings);
+                assertTrue(warnings.stream().noneMatch(w -> w.contains("Streaming timed out with empty response, retrying (attempt 3/")),
+                        "attempt 3 must not report itself as retrying; captured: " + warnings);
+            } finally {
+                Thread.interrupted();
+            }
+        }
+    }
+
+    /**
+     * Interrupts {@code target} while it is parked inside
+     * {@link RetryConfiguration#backoff}, and nowhere else.
+     *
+     * <p>
+     * The stack-frame match is what makes this safe rather than merely fast: the
+     * executor also parks in {@code CountDownLatch.await}, where an interrupt means
+     * "cancelled" and takes a completely different branch. One arm, one interrupt.
+     * </p>
+     */
+    private static final class BackoffInterrupter implements AutoCloseable {
+        private final Thread target;
+        private final Thread watcher;
+        private volatile boolean armed;
+        private volatile boolean stopped;
+
+        BackoffInterrupter(Thread target) {
+            this.target = target;
+            this.watcher = new Thread(this::run, "backoff-interrupter");
+            this.watcher.setDaemon(true);
+            this.watcher.start();
+        }
+
+        void arm() {
+            armed = true;
+        }
+
+        private void run() {
+            // Reading another thread's stack needs a safepoint, so it is probed on
+            // every Nth spin rather than continuously — cheap enough not to perturb
+            // the thread being watched, frequent enough that no sleep is needed.
+            int spins = 0;
+            while (!stopped) {
+                if (armed && (++spins & 0x3FF) == 0 && target.getState() == Thread.State.TIMED_WAITING && parkedInBackoff()) {
+                    armed = false;
+                    target.interrupt();
+                }
+                Thread.onSpinWait();
+            }
+        }
+
+        private boolean parkedInBackoff() {
+            for (StackTraceElement frame : target.getStackTrace()) {
+                if (RetryConfiguration.class.getName().equals(frame.getClassName()) && "backoff".equals(frame.getMethodName())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void close() {
+            stopped = true;
+            try {
+                watcher.join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * Every WARN {@link StreamingLegacyChatExecutor} emits while {@code body} runs,
+     * with its parameters substituted into the format string.
+     * {@code logging.properties} turns the whole {@code ai.labs.eddi} namespace OFF
+     * for plain unit tests, so the logger is opened explicitly and put back.
+     */
+    private static List<String> captureExecutorWarnings(Runnable body) {
+        List<String> captured = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                if (record.getLevel().intValue() < Level.WARNING.intValue()) {
+                    return;
+                }
+                String message = String.valueOf(record.getMessage());
+                Object[] parameters = record.getParameters();
+                if (parameters != null && parameters.length > 0) {
+                    try {
+                        message = String.format(message, parameters);
+                    } catch (RuntimeException ignored) {
+                        message = message + " " + Arrays.toString(parameters);
+                    }
+                }
+                captured.add(message);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        Logger julLogger = Logger.getLogger(StreamingLegacyChatExecutor.class.getName());
+        Level previousLevel = julLogger.getLevel();
+        julLogger.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+        try {
+            body.run();
+        } finally {
+            julLogger.removeHandler(handler);
+            julLogger.setLevel(previousLevel);
+        }
+        return captured;
     }
 
     // ==================== Helpers ====================

--- a/src/test/java/ai/labs/eddi/modules/rules/impl/RuleConfigValidationTest.java
+++ b/src/test/java/ai/labs/eddi/modules/rules/impl/RuleConfigValidationTest.java
@@ -6,6 +6,7 @@ package ai.labs.eddi.modules.rules.impl;
 
 import ai.labs.eddi.configs.agents.CapabilityRegistryService;
 import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
+import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.lifecycle.exceptions.WorkflowConfigurationException;
 import ai.labs.eddi.engine.memory.IMemoryItemConverter;
@@ -314,6 +315,11 @@ class RuleConfigValidationTest {
 
         @Override
         public Response deleteResource(URI uri, boolean permanent) {
+            return null;
+        }
+
+        @Override
+        public IResourceStore.IResourceId getCurrentResourceId(URI uri) {
             return null;
         }
     }

--- a/src/test/java/ai/labs/eddi/utils/LogCaptureSupport.java
+++ b/src/test/java/ai/labs/eddi/utils/LogCaptureSupport.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Captures what a class actually wrote to its logger, for tests that assert on
+ * a log line rather than on a return value.
+ *
+ * <p>
+ * Extracted from {@code CapabilityRegistryServiceTest}, which grew the idiom
+ * first and now calls it here; the log-injection regression tests in
+ * {@code AgentSigningServiceTest}, {@code RestAgentStoreTest} and
+ * {@code RestWorkflowStoreTest} need the same thing.
+ * </p>
+ */
+public final class LogCaptureSupport {
+
+    /**
+     * A forged log record, as a caller would supply it: the CRLF closes the real
+     * record and the remainder reads as a second, server-authored line. Shared so
+     * the CWE-117 regression tests all drive the same payload.
+     */
+    public static final String FORGED_RECORD = "\r\n2026-01-01 00:00:00,000 INFO  [io.quarkus] Forged admin login succeeded";
+
+    private LogCaptureSupport() {
+    }
+
+    /**
+     * Runs {@code body} with a JUL handler attached to {@code loggerClass}'s logger
+     * and returns every message and message parameter it emitted.
+     *
+     * <p>
+     * Both halves matter: JBoss Logging's {@code warnf}/{@code infof} keep the
+     * format string as the record's message and hand the interpolated values over
+     * as record PARAMETERS, so a test that only read {@code getMessage()} would
+     * never see the argument it is asserting about.
+     * </p>
+     *
+     * <p>
+     * {@code logging.properties} turns the whole {@code ai.labs.eddi} namespace OFF
+     * for plain unit tests, so the logger has to be opened explicitly to see
+     * anything; the previous level is always put back.
+     * </p>
+     */
+    public static List<String> captureLogsOf(Class<?> loggerClass, Runnable body) {
+        List<String> captured = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                captured.add(String.valueOf(record.getMessage()));
+                if (record.getParameters() != null) {
+                    for (Object parameter : record.getParameters()) {
+                        captured.add(String.valueOf(parameter));
+                    }
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        Logger julLogger = Logger.getLogger(loggerClass.getName());
+        Level previousLevel = julLogger.getLevel();
+        julLogger.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+        try {
+            body.run();
+        } finally {
+            julLogger.removeHandler(handler);
+            julLogger.setLevel(previousLevel);
+        }
+        return captured;
+    }
+
+    /**
+     * Asserts that nothing in {@code captured} carries a record boundary — the
+     * whole point of {@link LogSanitizer#sanitize}. Kept here so the three
+     * regression tests phrase the failure identically.
+     *
+     * @param captured
+     *            everything {@link #captureLogsOf} collected
+     * @param what
+     *            names the log call under test, so a failure says which one leaked
+     */
+    public static void assertNoForgedRecordBoundary(List<String> captured, String what) {
+        for (String value : captured) {
+            if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+                throw new AssertionError("a CR/LF reached the log unsanitized from " + what
+                        + ", so a caller can forge log records (CWE-117); offending value: " + quoted(value)
+                        + "; everything captured: " + captured);
+            }
+        }
+    }
+
+    private static String quoted(String value) {
+        return "\"" + value.replace("\r", "<CR>").replace("\n", "<LF>") + "\"";
+    }
+}


### PR DESCRIPTION
The destructive configuration paths destroyed data that was still in use, and reported success while doing it.

## What was broken

**Orphan purge permanently deleted live configuration.** References are version-pinned by design, and `DocumentDescriptorFilter` rewrites a descriptor's `resource` to the new version on every PUT. So one edit of a rule set leaves the descriptor saying `?version=2` while every workflow that was not re-pointed still says `?version=1`. The scan compared those full versioned URI strings, found no match, listed the config as an orphan, and `DELETE /administration/orphans` removed **every** version of it — destroying a config a live workflow was still resolving.

**Cascade delete tore down workflows before the guard that could still reject it.** A version-mismatched cascade deleted the workflows and schedules of the version it read, then answered 409. Separately, the reference check asked whether *one pinned version* was still referenced before deleting *every* version, so a workflow another agent still used was destroyed.

**Reverse lookups crashed on soft-deleted rows.** `AgentStore` and `WorkflowStore` threw `ResourceNotFoundException` as soon as one referencing document had been soft-deleted. The caller catches and logs that, so cascade delete quietly stopped protecting shared resources at all.

**Version-0 history rows escaped permanent deletion** on MongoDB, so `deletePermanently` and GDPR erasure both reported success while leaving an undeletable descriptor tombstone behind forever.

## What changed

Identity comparison replaces versioned-string comparison in the orphan scan, with the one remaining deliberate gap documented rather than left implicit. The version guard runs before anything is deleted. Reference checks tolerate soft-deleted rows. History rows at version 0 are included in permanent removal.

## Two defects caught in review, corrected rather than shipped

The first attempt at this branch introduced two problems that an independent reviewer caught, and both are fixed here:

- The signing keypair was destroyed from the vault on a **soft** delete — a new irreversible action on the path that exists specifically to be recoverable.
- A unique compound index was created unconditionally at startup, which fails with a duplicate-key error on exactly the deployments the finding says already contain duplicates.

## How it is proven

Every behavioural change is pinned by a regression test **verified to fail with its fix reverted**. Six pre-existing cascade assertions were flipped from `permanent=true` to `permanent=false`; that inversion is deliberate and is the point of the change — permanently removing a shared resource stays an explicit, non-cascading request. A functional regression in `RetryConfiguration`'s new backoff budget was found by the auditor while that class's own suite stayed green, and is fixed with a test that fails without it.
