### PR TITLE
fix(audit,gdpr,tenancy): repair ledger persistence, erasure reporting and quota windows

### DIFF
--- a/docs/audit-ledger.md
+++ b/docs/audit-ledger.md
@@ -144,6 +144,12 @@ Redaction is applied recursively to nested maps and lists.
 
 If a database write fails, entries are **re-queued** for the next flush cycle. After 3 consecutive failures, the batch is dropped from the queue and written to a **dead-letter sink** — NATS JetStream (subject `eddi.deadletter.audit`) when a connection is available, otherwise the JSONL file at `eddi.audit.dead-letter-path`. The re-queue path respects the bound set by `eddi.audit.max-queue-size`: entries that no longer fit go to the same sink instead of growing the heap. This prevents unbounded memory growth while keeping the missing entries recoverable rather than lost.
 
+> **The dead-letter record is the whole entry, and that makes the sink a personal-data location.** It carries the `userId`, the verbatim input and output, the LLM detail and tool calls, plus the entry's own timestamp, sequence, HMAC and agent signature — anything less is not replayable, and without the `sequence` an operator cannot prove which chain positions the ledger itself abandoned, so every self-inflicted gap reads as `BROKEN` rather than `INCOMPLETE`. Secret redaction has already been applied, but user content has not.
+>
+> The GDPR erasure cascade pseudonymizes the ledger and the database logs; it does **not** touch `eddi.audit.dead-letter-path` or the `eddi.deadletter.audit` subject. Give the sink the same access controls, encryption at rest and retention handling as the ledger, and include it in your Art. 17 procedure — see [The audit dead-letter sink holds personal data](gdpr-compliance.md#the-audit-dead-letter-sink-holds-personal-data-and-erasure-does-not-reach-it).
+>
+> The image creates the default directory (`/opt/eddi/data`) and hands it to the runtime user, and the ledger reports at startup if the configured location is not writable — the sink's unavailability should be discovered before the incident that needs it, not from an error line nested inside the error line reporting the drop.
+
 ## Storage
 
 ### MongoDB (default)

--- a/docs/audit-ledger.md
+++ b/docs/audit-ledger.md
@@ -185,7 +185,18 @@ Redaction is applied recursively to nested maps and lists.
 
 ## Failure Handling
 
-If a database write fails, entries are **re-queued** for the next flush cycle. After 3 consecutive failures, the batch is dropped from the queue and written to a **dead-letter sink** — NATS JetStream (subject `eddi.deadletter.audit`) when a connection is available, otherwise the JSONL file at `eddi.audit.dead-letter-path`. The re-queue path respects the bound set by `eddi.audit.max-queue-size`: entries that no longer fit go to the same sink instead of growing the heap. This prevents unbounded memory growth while keeping the missing entries recoverable rather than lost.
+If a database write fails, entries are **re-queued** for the next flush cycle. After 3 consecutive failures, the batch is dropped from the queue and written to a **dead-letter sink** — NATS JetStream (subject `eddi.deadletter.audit`) when a connection is available, otherwise the JSONL file at `eddi.audit.dead-letter-path`.
+
+**Queue overflow has two outcomes, and only one of them is recoverable.** Both increment `eddi_audit_entries_dropped_total`, so the counter on its own does not say which happened:
+
+| Overflow path | What happens at `eddi.audit.max-queue-size` | Recoverable? |
+| ------------- | ------------------------------------------- | ------------ |
+| **Re-queue** — a failed batch coming back from the flush retry, or entries the retry budget never reached | Written to the dead-letter sink instead of growing the heap | **Yes** — replay from the sink |
+| **Submit** — a fresh entry arriving from the pipeline while the queue is already full | Refused outright: counted and logged at WARN, **not** dead-lettered | **No** — the entry is gone |
+
+The asymmetry is deliberate. A re-queued entry has already consumed its chain position, so discarding it without a record would leave a gap `/auditstore/verify` grades `BROKEN` with nothing to attribute it to — the sink is what makes that gap explicable. A refused submission has not been sequenced yet (`submit()` reserves the queue slot *before* taking a chain position, exactly so a refusal burns no number), so it leaves the chain intact and verify reports nothing at all.
+
+> **A dropped submission is unrecoverable and invisible to chain verification.** `eddi_audit_entries_dropped_total` rising while `/auditstore/verify` still says `INTACT` is the only signal that audit evidence was lost. Alert on the counter; do not treat a clean verify as proof of completeness.
 
 > **The dead-letter record is the whole entry, and that makes the sink a personal-data location.** It carries the `userId`, the verbatim input and output, the LLM detail and tool calls, plus the entry's own timestamp, sequence, HMAC and agent signature — anything less is not replayable, and without the `sequence` an operator cannot prove which chain positions the ledger itself abandoned, so every self-inflicted gap reads as `BROKEN` rather than `INCOMPLETE`. Secret redaction has already been applied, but user content has not.
 >

--- a/docs/audit-ledger.md
+++ b/docs/audit-ledger.md
@@ -209,8 +209,24 @@ The asymmetry is deliberate. A re-queued entry has already consumed its chain po
 ### MongoDB (default)
 
 - Collection: `audit_ledger`
-- Indexes: `conversationId`, `(agentId, agentVersion)`, `timestamp` (descending)
-- Operations: `insertOne`, `insertMany` only — no update or delete
+- Indexes: `conversationId`, `(agentId, agentVersion)`, `timestamp` (descending), `userId`, `(conversationId asc, timestamp desc)`, `(conversationId asc, sequence desc)`
+- Operations: `insertOne` and `insertMany`, plus one exception — `pseudonymizeByUserId` issues an `updateMany` that overwrites `userId` under GDPR Art. 17(3)(e). Nothing else mutates a stored entry, and nothing ever deletes one. The mutation is HMAC-preserving for v3 rows (the signature covers the identity *token*, which is the same for an identifier and its pseudonym)
+
+#### Building the MongoDB indexes ahead of a deploy
+
+The last three of those indexes are new in this release: `userId` backs the GDPR export and erasure scans, and the two compound ones serve the per-conversation read's filter and sort together (which is what stops large conversations hitting MongoDB's in-memory sort limit) and back `maxSequence`.
+
+`AuditStore`'s constructor issues all six `createIndex` calls synchronously, so on an existing multi-million-document `audit_ledger` the thread that first builds the bean blocks until the new ones are built. The collection stays readable and writable while they build — MongoDB 4.2+ takes the exclusive lock only briefly at the start and end — but the first request that touches the ledger after a deploy waits it out.
+
+To take that wait out of the deploy, build them first:
+
+```javascript
+db.audit_ledger.createIndex({ userId: 1 });
+db.audit_ledger.createIndex({ conversationId: 1, timestamp: -1 });
+db.audit_ledger.createIndex({ conversationId: 1, sequence: -1 });
+```
+
+`createIndex` is idempotent for an identical key pattern, so the startup calls then find the indexes already present and return immediately.
 
 ### PostgreSQL
 

--- a/docs/audit-ledger.md
+++ b/docs/audit-ledger.md
@@ -127,6 +127,49 @@ The stored value carries the version of the canonical form it was computed over,
 
 Verification never falls back from v2 to v1 — that would hand the collision straight back — and pre-existing untagged rows keep verifying under v1, so an upgrade does not turn the historical ledger into a wall of "tampered".
 
+### Chain sequences and multi-replica deployments
+
+The `sequence` signed into v3/v4 is a per-conversation chain position, allocated from a
+counter each node seeds by reading `MAX(sequence)` for that conversation from the store.
+
+**That read is not an atomic reservation.** Entries sit in a node-local queue for up to
+`eddi.audit.flush-interval-seconds` before the store can see them, so two nodes serving
+consecutive turns of the *same conversation* inside that window both read the same maximum
+and both hand out the positions after it. Neither backend indexes
+`(conversationId, sequence)` uniquely, so the duplicate is stored, and
+`/auditstore/verify` grades a duplicate exactly like a deletion — `BROKEN`.
+
+> **Known limitation — operational requirement:** a multi-replica deployment needs
+> **conversation affinity** (route every turn of one conversation to the same node) for chain
+> integrity. Without it, duplicate sequences are produced and `/auditstore/verify` grades the
+> affected conversations `BROKEN`. HMAC verification of individual entries still holds — only
+> the chain-continuity check is affected.
+
+**Deferred fix, and why it is deferred.** Removing that requirement needs storage-level
+atomic allocation — PostgreSQL `UPDATE … RETURNING` on a per-conversation counter row,
+MongoDB `findOneAndUpdate` with `$inc` — plus a unique `(conversationId, sequence)`
+constraint and a retry on collision. It is tracked as follow-up work rather than shipped here
+because it moves a store round trip from once per conversation to once per *entry*, on the
+pipeline thread, and it is a schema change on both backends.
+
+The unique constraint on its own would make things worse, not better: without the allocator
+that makes collisions impossible, a rejected insert **silently drops an audit record**,
+whereas the duplicate it prevents at least surfaces as a detectable `BROKEN` verdict.
+
+**Detection in the meantime — `eddi_audit_sequence_collisions_total`.** After each flush the
+ledger re-reads `MAX(sequence)` for the conversations it just wrote. If the store already
+holds a position this node has not handed out yet, another replica is allocating for the same
+conversation: the ledger logs a WARN naming the conversation, increments
+`eddi_audit_sequence_collisions_total`, and continues its own chain past the foreign rows. An
+operator running without affinity therefore sees the problem in metrics instead of
+discovering it at verify time.
+
+- Any non-zero value means "multi-replica without conversation affinity" — fix the routing.
+- It is a **partial** detector: two nodes that hand out exactly the same range leave a stored
+  maximum consistent with both counters, and only `/auditstore/verify` sees that duplicate.
+- Cost is one indexed `MAX(sequence)` read per conversation per flush, on the ledger's writer
+  thread — never on the pipeline thread.
+
 ## Secret Redaction
 
 All string values in audit entries pass through the `SecretRedactionFilter` before storage. The following patterns are redacted:
@@ -164,6 +207,25 @@ If a database write fails, entries are **re-queued** for the next flush cycle. A
 - Hybrid storage: indexed columns (conversation_id, agent_id, agent_version, timestamp) + JSONB for variable data
 - Selected at runtime with `eddi.datastore.type=postgres` (default `mongodb`), resolved by `DataStoreProducers.auditStore(...)` — both backends ship in the same image
 - Same insert-only contract as MongoDB
+
+#### Upgrading an existing PostgreSQL ledger
+
+This release adds `idx_audit_user` on `audit_ledger (user_id)` — without it the GDPR export and erasure scans are sequential scans over the largest never-pruned table in the system.
+
+The index is created by `ensureSchema()`, which runs lazily on the **first audit write after the deploy**, on the audit-ledger writer thread. A plain `CREATE INDEX` takes a `SHARE` lock, so while it builds:
+
+- audit inserts block and the ledger's queue fills toward `eddi.audit.max-queue-size` (entries refused past the bound are counted on `eddi_audit_entries_dropped_total`, not dead-lettered),
+- REST audit reads wait on the same monitor.
+
+On a multi-million-row ledger that pause is measured in minutes. If you cannot take it, build the index out of band **before** deploying:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_user ON audit_ledger (user_id);
+-- CONCURRENTLY leaves an INVALID index behind if it fails; verify:
+SELECT indisvalid FROM pg_index WHERE indexrelid = 'idx_audit_user'::regclass;
+```
+
+`IF NOT EXISTS` then makes the startup statement a no-op. EDDI does not issue `CONCURRENTLY` itself: it would be legal (`ensureSchema` runs on an autocommit statement, not inside a transaction block), but a failed run leaves an INVALID index that nothing in the adapter would notice or repair.
 
 ## Architecture
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,52 @@ bottom of this file and are never archived.
 
 ---
 
+## 📒 fix(audit,gdpr,tenancy): repair ledger persistence, erasure reporting and quota windows (2026-09-04)
+
+**Repo:** EDDI (`fix/review-audit-gdpr`)
+
+From the whole-repository code review. The subsystem a regulated buyer is actually paying
+for did not work on a supported backend.
+
+**The PostgreSQL audit backend could not store entries EDDI legitimately produces.**
+`conversation_id`, `AGENT_ID` and `AGENT_VERSION` were `NOT NULL`, and the insert unboxed a
+nullable `agentVersion` with `setInt`, throwing an NPE that escaped `appendBatch`'s catch
+entirely. Six shipped call sites pass a literal null — ordinary HITL approvals and group
+turns among them — so a single compliance or oversight entry **discarded roughly three
+flush windows of unrelated conversations' audit data**, while the compliance event itself
+was never recorded. On the read side `getInt` mapped a stored SQL NULL to `0`, which the
+HMAC canonical form renders differently, so any such row would have verified as tampered.
+
+The ledger is append-only evidence, not logs. Losing other conversations' entries because
+one entry is malformed is the worst possible failure mode for it.
+
+**GDPR erasure returned 200 and "complete" even when steps failed**, and reported memories
+as deleted before deleting them. It now reports per-step outcomes and answers 207 when the
+cascade is partial. The MCP admin surface for the same operation hardcoded
+`"status": "completed"` and is now driven by the real result, so an operator — or an agent
+calling the tool — is no longer told a lossy erasure succeeded.
+
+**Quota windows** were compared against a stale in-memory view, and the bootstrap silently
+ignored later configuration changes; both now warn when stored and configured values
+diverge instead of quietly preferring one.
+
+### Regression coverage
+
+Every behavioural change is pinned by a test proven to fail with its fix reverted.
+
+Three pre-existing tests were **failing on the first attempt at this branch** while the
+work reported itself green — caught by an independent reviewer running them. They are now
+genuinely closed, and closed the right way: the fixtures were corrected to stub what
+production actually calls. Five more tests in the same classes had begun passing
+*vacuously*, because the change bypassed the dead-letter branch they were written to cover;
+their stubs are restored so they exercise it again.
+
+`maxMonthlyCostUsd` is stored and displayed but never enforced, because
+`TenantQuotaService.recordCost` has no production caller. That is left as a product gap and
+now surfaces as an explicit warning rather than a silent no-op.
+
+---
+
 ## 📋 docs(config): document the four workspace properties that were breaking `main` (2026-08-30)
 
 **Repo:** EDDI (`fix/connection-extra-auth-params-code-verifier`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,59 @@ bottom of this file and are never archived.
 
 ---
 
+## 📤 fix(gdpr): stop calling an export complete while four data categories are missing (2026-09-07)
+
+**Repo:** EDDI (`fix/review-audit-gdpr`)
+
+Six review comments, plus the log-injection round.
+
+**The portability export overstated itself.** `conversationsTruncated` was the only completeness
+signal, but the endpoint's own interface documents that every export omits group transcripts,
+shared artifacts, schedules and HITL journal entries. A user whose data lived only in those
+categories received a 200 the API described as complete — a GDPR Art. 20 answer that is not true.
+`UserDataExport` now derives `complete` and `omittedCategories`, both mirrored into the MCP payload
+so the two surfaces agree, and the response carries the distinction in the status line as well as
+the body.
+
+**206 was the wrong status and is now 207.** 206 Partial Content is a *range* status and means
+something specific about byte ranges. 207 Multi-Status says "composite operation, read the body",
+which is what this is, and it is already what the sibling erasure endpoint uses. Because the four
+categories are always omitted today, the export always answers 207; the 200 branch returns when
+those exporters land. The four missing exporters are deliberately not implemented here.
+
+**A warning claimed a write that had not happened.** `warnIfCostBudgetIsUnenforceable` ran before
+`setQuota`, so a failing store still logged that the limit was stored and would apply. Moved after
+the write returns.
+
+**The SSE and synchronous quota surfaces disagreed.** A `QuotaAccountingUnavailableException` with
+no message produced `"message":""` on the streaming path while the synchronous mapper produced
+`Quota accounting unavailable`. Both now use one shared fallback.
+
+**Two stores gave a different refusal reason than the gates around them.** The Mongo and PostgreSQL
+tenant-quota stores said "Cost accounting failed" where every sibling gate says "Quota accounting
+unavailable — denying request for safety". Aligned.
+
+**A documentation contradiction, half real.** `AuditLedgerService` has two overflow paths, and only
+one dead-letters. `submit()` reserves its slot before a sequence is assigned, so a rejected
+submission is simply counted and dropped; `offerBounded()` on the retry paths dead-letters, because
+those entries already hold a chain position. The Failure Handling prose described the second and
+generalised it to both. It is now a table naming each path and its recoverability, with the
+consequence stated: a dropped submission is unrecoverable *and* leaves the chain `INTACT`, so
+`eddi_audit_entries_dropped_total` is the only signal and a clean `/auditstore/verify` is not proof
+of completeness.
+
+**One comment was wrong and is recorded as such.** A reviewer said a fixture stubbed the wrong
+descriptor read. The call graph is the other way round — `describe()` reaches `readDescriptor`, not
+`readCurrentDescriptor`, and the latter appears nowhere in the service. What misled the reviewer was
+the fixture's own comment, which claimed the opposite; the comment was corrected and the stub left
+alone. Following the suggestion would have stopped the test reaching the production guard at all.
+
+**Log injection.** The GDPR delete-all logs on both user-memory stores wrote the caller-supplied
+`userId` raw. Both now sanitize it — on the erasure path, which is exactly where a log has to be
+trustworthy.
+
+---
+
 ## 🔐 fix(gdpr): stop caching "not restricted" by default; make foreign audit sequences visible (2026-09-06)
 
 **Repo:** EDDI (`fix/review-audit-gdpr`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,42 @@ bottom of this file and are never archived.
 
 ---
 
+## 🔐 fix(gdpr): stop caching "not restricted" by default; make foreign audit sequences visible (2026-09-06)
+
+**Repo:** EDDI (`fix/review-audit-gdpr`)
+
+Two reviewer comments had been reported closed but were not. Both are now closed properly, and the
+second one is closed by admitting what is not fixed rather than by claiming it is.
+
+**The Art. 18 restriction cache failed open by default.** A previous pass added
+`eddi.gdpr.restriction-cache-ttl-seconds` and made `0` disable the cache, but left the default at
+30 seconds — so on a stock multi-replica deployment a node that had cached "not restricted" kept
+processing for up to 30 seconds after another node applied the restriction. That is exactly the
+window the comment described, and an opt-in switch does not close it. The default is now `0`:
+every turn reads the store, and caching becomes an explicit single-node or conversation-affinity
+optimisation, documented as such. The alternative considered was a positive-only cache, which was
+rejected because it would only ever help restricted users — the rare case — while still delaying
+an *un*restriction across the cluster.
+
+**Audit sequence allocation is still not cluster-safe, and now says so.** The reviewer asked for a
+storage-level atomic reservation plus a unique `(conversationId, sequence)` constraint and retry.
+That is deferred: it moves a store round trip from once per conversation to once per entry on the
+pipeline thread, and it is a schema change on two backends. The constraint must not land on its
+own either — for an audit ledger a rejected insert silently drops a record, which is worse than a
+duplicate the verifier can detect. What was genuinely missing and is cheap is *detection*:
+`flush()` now re-reads the store's maximum for each conversation it wrote and, if the store already
+holds a position at or beyond this node's next free one, increments
+`eddi_audit_sequence_collisions_total`, logs a WARN naming the conversation, and advances its
+counter past the foreign rows. An operator running multi-replica without affinity sees it in
+metrics instead of discovering it as a `BROKEN` verdict at verify time. The detector has no false
+positives and is documented as partial: two nodes handing out an identical range leave a maximum
+consistent with both counters and are still only caught at verify time.
+
+`IAuditStore` and `docs/audit-ledger.md` now lead with the limitation, the deferred fix, and why it
+is deferred, so the row can no longer be read as "already correct".
+
+---
+
 ## 📒 fix(audit,gdpr,tenancy): repair ledger persistence, erasure reporting and quota windows (2026-09-04)
 
 **Repo:** EDDI (`fix/review-audit-gdpr`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,30 @@ bottom of this file and are never archived.
 
 ---
 
+## 🕵️ fix(gdpr): log the pseudonym, not the identifier the erasure just removed (2026-09-07)
+
+**Repo:** EDDI (`fix/review-audit-gdpr`)
+
+A reviewer pushed further than the previous round did, and was right to. Sanitising the `userId` in
+the GDPR delete-all log stopped a caller forging log records, but it left the identifier itself
+sitting in the log — on the one code path whose entire purpose is to remove that identifier. Logs
+outlive the database and travel further than it does, so an erasure that writes the user's id into
+them has not finished the job (CWE-532).
+
+Both user-memory stores now log `AuditHmac.pseudonymFor(userId)`: the same deterministic SHA-256 the
+erasure cascade already substitutes into the audit ledger. An operator can still correlate the log
+line with the ledger entry, and neither holds the identifier. The pseudonym is hex, so it also
+cannot carry a record boundary — the injection fix is subsumed rather than discarded.
+
+`PostgresUserMemoryStore.deleteAllForUser` gained the null guard `MongoUserMemoryStore` has always
+had. Erasing "all entries for user null" is not a request anyone means, and the pseudonym refuses a
+null identifier rather than hashing one.
+
+The regression test asserts the stronger contract: the raw id must not appear in the captured log at
+all, and the pseudonym prefix must. Reverting the change fails it with the offending line quoted.
+
+---
+
 ## 📤 fix(gdpr): stop calling an export complete while four data categories are missing (2026-09-07)
 
 **Repo:** EDDI (`fix/review-audit-gdpr`)

--- a/docs/gdpr-compliance.md
+++ b/docs/gdpr-compliance.md
@@ -139,6 +139,40 @@ EDDI provides no application-level audit purge.
 > removed; if your deployment sets `eddi.audit.retentionDays` (or
 > `EDDI_AUDIT_RETENTIONDAYS`), drop it and use database-level archival instead.
 
+### The audit dead-letter sink holds personal data, and erasure does not reach it
+
+When the ledger cannot persist an entry it writes that entry to the dead-letter
+sink — NATS JetStream when a connection is available, otherwise the JSONL file
+at `eddi.audit.dead-letter-path` (default
+`/opt/eddi/data/eddi-audit-deadletter.jsonl`). **The record is the whole audit
+entry**: the `userId`, the verbatim prompt and response, the LLM detail and the
+tool calls, plus the HMAC and agent signature. It has to be, or a dropped entry
+is neither replayable nor usable as evidence of what the ledger itself lost.
+
+The consequence for Art. 17 is that the sink is a **second location holding
+personal data that the erasure cascade does not touch**. `DELETE
+/admin/gdpr/{userId}` pseudonymizes the ledger and the database logs; nothing
+rewrites the JSONL file or the JetStream subject. Secret *redaction* has already
+been applied to the entry (see
+[Secret Redaction](audit-ledger.md#secret-redaction)), but user content has not,
+because preserving the entry is the whole point of the sink.
+
+As the controller you must therefore:
+
+- [ ] Treat `eddi.audit.dead-letter-path` (and the `eddi.deadletter.audit`
+      JetStream subject) as an audit-data location in your record of processing
+      activities, with the same access controls and encryption at rest as the
+      ledger itself.
+- [ ] Include it in the erasure procedure: either replay and truncate it once
+      the store is healthy again, or pseudonymize the affected records by hand.
+      `eddi_audit_entries_dropped_total` tells you whether the sink has ever
+      been written to; a zero counter and an absent file mean there is nothing
+      to do.
+- [ ] Give it a retention period. As with the ledger, EDDI never expires it.
+
+A non-empty dead-letter sink is an incident, not a steady state — see
+[Incident Response](incident-response.md).
+
 **Data minimization (Art. 5(1)(e)):** Review the default retention periods
 and reduce them to the minimum necessary for your use case.
 

--- a/docs/gdpr-compliance.md
+++ b/docs/gdpr-compliance.md
@@ -16,7 +16,8 @@ curl -X DELETE https://your-eddi-instance/admin/gdpr/{userId} \
   -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
 ```
 
-The response includes per-store counts:
+The response carries a count for every store the cascade touches, plus whether
+the cascade actually finished:
 ```json
 {
   "userId": "user-123",
@@ -25,11 +26,42 @@ The response includes per-store counts:
   "conversationMappingsDeleted": 3,
   "logsPseudonymized": 42,
   "auditEntriesPseudonymized": 156,
+  "attachmentsDeleted": 4,
+  "journalEntriesDeleted": 2,
+  "checkpointsDeleted": 9,
+  "groupConversationsDeleted": 1,
+  "sharedArtifactsDeleted": 0,
+  "schedulesDeleted": 0,
+  "failedSteps": [],
+  "complete": true,
   "completedAt": "2026-04-02T15:30:00Z"
 }
 ```
 
-**Via MCP:** Use the `delete_user_data` tool with `confirmation="CONFIRM"`.
+> **Check `complete` before filing the request as fulfilled.** The cascade
+> deliberately continues past a failing store, so the categories after it are
+> still erased — which is exactly why `conversationsDeleted: 0` on its own cannot
+> be read as "this user had no conversations". When any step throws, the endpoint
+> answers **207 Multi-Status**, `complete` is `false`, and `failedSteps` names the
+> steps that did not run. Some of the user's data is still there: re-run the
+> erasure and do not report it to the data subject as done. A cascade in which
+> every step succeeded answers **200** with an empty `failedSteps`.
+>
+> The step names are `userMemories`, `restrictionCache`, `conversationIdLookup`,
+> `attachments`, `hitlToolJournal`, `conversationDescriptors`,
+> `conversationCheckpoints`, `conversations`, `conversationMappingIntents`,
+> `conversationMappings`, `conversationMappingCache`, `groupConversations`,
+> `sharedArtifacts`, `schedules`, `databaseLogs` and `auditLedger`, and they name
+> the stores in the list below plus the two cache evictions and the two lookups
+> the cascade needs to reach them. `conversationIdLookup` is the worst one to
+> see: the id resolution the per-conversation sweeps depend on failed, so those
+> sweeps ran over nothing and their zero counts mean "not attempted", not
+> "nothing to do".
+
+**Via MCP:** Use the `delete_user_data` tool with `confirmation="CONFIRM"`. It
+reports the same outcome: `status` is `"completed"` only when every step
+succeeded and `"partially_completed"` otherwise, alongside the same `complete`
+and `failedSteps`.
 
 **What happens:**
 1. User memories — **permanently deleted**
@@ -62,18 +94,37 @@ The export includes all user data in a structured, machine-readable JSON format:
   the binaries themselves are not inlined and must be fetched via the attachment
   download API
 
-> **Check `conversationsTruncated` before handing the bundle to the data subject.**
-> Conversation snapshots are capped per request (1,000), because each one is a full
-> document load assembled in memory on the request thread. When the cap bites, the
-> endpoint answers **206 Partial Content** and the payload carries
-> `conversationsTruncated: true` alongside `totalConversations` — the number the
-> user actually has. A bundle in that state is **not** a complete Art. 15 / Art. 20
-> response; the omitted conversations are still retrievable individually through the
-> conversation API. A 200 with `conversationsTruncated: false` is the complete
-> bundle. (The audit-record cap of 10,000 is still reported in the server log only.)
+> **Check `complete` before handing the bundle to the data subject.** The endpoint
+> answers **200** only when the bundle covers everything EDDI holds on the user,
+> and **207 Multi-Status** otherwise. Three things can make it incomplete, and each
+> is named in the payload:
+>
+> - `omittedCategories` — personal-data categories this exporter does not reach.
+>   **Today this list is never empty**: group conversation transcripts, shared
+>   artifacts, schedules and HITL journal entries are erased by the Art. 17
+>   cascade as this user's personal data but are not yet exportable. So the export
+>   endpoint currently answers **207 on every request** and `complete` is always
+>   `false`. It becomes 200 when those four exporters land.
+> - `conversationsTruncated` — the per-request conversation cap (1,000) bit,
+>   because each snapshot is a full document load assembled in memory on the
+>   request thread. `totalConversations` says how many the user actually has, and
+>   the omitted ones remain retrievable individually through the conversation API.
+> - `failedConversationIds` — conversations the exporter could not load at all,
+>   listed by id, and therefore absent from `conversations`. Retry the export or
+>   fetch those ids individually.
+>
+> A bundle with `complete: false` is **not** a complete Art. 15 / Art. 20
+> response — do not file the request as fulfilled on it. (The audit-record cap of
+> 10,000 is still reported in the server log only.)
+>
+> 207 rather than 206 Partial Content, which earlier releases sent: 206 is a range
+> status and RFC 9110 requires a `Content-Range` alongside it, which this endpoint
+> neither reads nor produces. Any client still branching on 206 needs updating.
 
-**Via MCP:** Use the `export_user_data` tool. It reports the same two fields; an
-agent acting on its answer must not report a truncated bundle as fulfilled.
+**Via MCP:** Use the `export_user_data` tool. It reports the same fields in the
+payload — `complete`, `omittedCategories`, `conversationsTruncated`,
+`totalConversations` and `failedConversationIds` — and an agent acting on its
+answer must not report an incomplete bundle as fulfilled.
 
 ### 3. Right to Restriction of Processing (GDPR Art. 18 / LGPD Art. 18)
 

--- a/docs/gdpr-compliance.md
+++ b/docs/gdpr-compliance.md
@@ -62,7 +62,18 @@ The export includes all user data in a structured, machine-readable JSON format:
   the binaries themselves are not inlined and must be fetched via the attachment
   download API
 
-**Via MCP:** Use the `export_user_data` tool.
+> **Check `conversationsTruncated` before handing the bundle to the data subject.**
+> Conversation snapshots are capped per request (1,000), because each one is a full
+> document load assembled in memory on the request thread. When the cap bites, the
+> endpoint answers **206 Partial Content** and the payload carries
+> `conversationsTruncated: true` alongside `totalConversations` — the number the
+> user actually has. A bundle in that state is **not** a complete Art. 15 / Art. 20
+> response; the omitted conversations are still retrievable individually through the
+> conversation API. A 200 with `conversationsTruncated: false` is the complete
+> bundle. (The audit-record cap of 10,000 is still reported in the server log only.)
+
+**Via MCP:** Use the `export_user_data` tool. It reports the same two fields; an
+agent acting on its answer must not report a truncated bundle as fulfilled.
 
 ### 3. Right to Restriction of Processing (GDPR Art. 18 / LGPD Art. 18)
 
@@ -90,6 +101,30 @@ curl -X DELETE https://your-eddi-instance/admin/gdpr/{userId}/restrict \
 - Existing data is preserved (not deleted)
 - Restriction status is stored as a user memory entry
 - All restriction/unrestriction events are logged in the audit ledger
+
+**Caching the restriction flag — `eddi.gdpr.restriction-cache-ttl-seconds` (default `0`, i.e. no caching)**
+
+The flag is read at conversation start and again on every `say`/`sayStreaming`, so it sits on
+the hottest path in the system. **By default it is nonetheless read from the store every
+time**: no verdict is cached, a restriction applied on any replica takes effect on every
+replica at once, and a store outage always answers **503**
+(`ProcessingRestrictionUnavailableException`) rather than being absorbed by a cached verdict.
+The cost of that default is one indexed lookup per turn.
+
+Setting the property above `0` switches on a **node-local** cache with that TTL.
+`restrict`/`unrestrict` publish through it, so the node serving the admin call applies the
+change on the very next turn — but there is no cross-node invalidation, so **any other node
+keeps answering "not restricted" from its own cache until the TTL expires**, and for the same
+reason keeps answering from cache during a store outage instead of failing closed. A cached
+negative verdict is a suspended Art. 18 legal control, which is why it is not the default.
+
+- **Multi-replica without conversation affinity** — keep the default (`0`). This is the only
+  safe setting there until cluster-wide invalidation exists.
+- **Single node, or a cluster with conversation affinity** — every turn of a conversation and
+  every admin call reach the same node, which is what makes the explicit invalidation
+  sufficient. Setting e.g. `eddi.gdpr.restriction-cache-ttl-seconds=30` there buys back the
+  per-turn lookup. Treat it as an explicit topology assertion, not a tuning knob: it is wrong
+  the moment a second replica is added.
 
 **Use cases:**
 - User disputes accuracy of stored data (Art. 18(1)(a))

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -273,6 +273,7 @@ eddi_schedule_fire_duration_seconds         # Fire latency (timer)
 ```text
 eddi_tenant_quota_allowed_total             # Slot acquisitions granted (untagged)
 eddi_tenant_quota_denied_total{tenant,type} # Quota denials, always tagged
+eddi_tenant_quota_unavailable_total{tenant,type} # Refusals caused by the quota store failing, not by a limit
 eddi_tenant_usage_conversations_total       # Conversation usage (per tenant)
 eddi_tenant_usage_api_calls_total           # API call usage (per tenant)
 eddi_tenant_usage_cost_total                # Cost usage (per tenant)
@@ -300,6 +301,27 @@ sum(rate(eddi_tenant_quota_denied_total[5m]))
 `eddi_tenant_quota_allowed_total` counts **slot acquisitions only**. The read-only
 gates (`checkAgentQuota`, `checkCostBudget`) deliberately do not touch it, so
 `allowed / (allowed + denied)` is not a true accept rate.
+
+`eddi_tenant_quota_unavailable_total` is the *other* reason a request is refused:
+the quota store could not answer at all — a driver failure in whichever store is
+configured (a `MongoException` in `MongoTenantQuotaStore`, which is the default
+backend, or a `SQLException` in `PostgresTenantQuotaStore`) — so the turn is
+denied for safety without any limit having been reached. It covers **both** store
+calls a gate makes: reading the tenant's configuration and incrementing the
+counter. The read runs first, so on a full outage it is the one that fails —
+which is why a failing read used to exit as an opaque `500` on MongoDB and to
+bypass enforcement silently on PostgreSQL, while only a partial outage (reads up,
+writes down) ever reached the counter. It used to be counted on `eddi_tenant_quota_denied_total`
+and answered `429` with `Retry-After: 60`, so a database outage looked exactly
+like a tenant burning through its allowance on the very graph you would use to
+decide whether to raise a limit. It now answers `503`
+(`quota_accounting_unavailable`) and carries the same `tenant` / `type` tags, so
+the two can sit side by side:
+
+```promql
+# Infrastructure, not allowance
+sum(rate(eddi_tenant_quota_unavailable_total[5m])) by (tenant)
+```
 
 ### Coordinator Metrics
 
@@ -478,7 +500,13 @@ eddi_conversations_listing_owner_scan_exhausted_total  # Conversation listing ga
 
 ```text
 eddi_audit_entries_dropped_total            # Audit entries dropped (compliance-critical)
+eddi_audit_sequence_collisions_total        # Chain positions allocated by another replica
 ```
+
+`eddi_audit_sequence_collisions_total` is non-zero only on a multi-replica deployment
+without conversation affinity, where two nodes allocate the same per-conversation chain
+positions and `/auditstore/verify` then grades those conversations `BROKEN`. See
+[Chain sequences and multi-replica deployments](audit-ledger.md#chain-sequences-and-multi-replica-deployments).
 
 ### Deployed Agents
 
@@ -565,6 +593,13 @@ groups:
           severity: critical
         annotations:
           summary: "Audit entries are being dropped — compliance risk"
+
+      - alert: AuditSequenceCollisions
+        expr: eddi_audit_sequence_collisions_total > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "Audit chain positions are being allocated by more than one replica — enable conversation affinity"
 
       # Warning
       - alert: HighToolFailureRate

--- a/docs/monitoring/eddi-full-metrics-dashboard.json
+++ b/docs/monitoring/eddi-full-metrics-dashboard.json
@@ -10211,6 +10211,157 @@
               "sort": "desc"
             }
           }
+        },
+        {
+          "id": 159,
+          "type": "timeseries",
+          "title": "Audit chain positions allocated by another replica",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "`eddi_audit_sequence_collisions_total` — the audit ledger found a chain position already stored that this node had not handed out, which means a second replica is allocating positions for the same conversation. Sequence allocation is a `MAX(sequence)` read rather than an atomic reservation, so this produces duplicate positions and `/auditstore/verify` grades those conversations BROKEN. Any non-zero value means the deployment is running multiple replicas without conversation affinity — fix the routing. It is a partial detector: two nodes handing out an identical range are only caught at verify time.",
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(eddi_audit_sequence_collisions_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": false,
+                "axisSoftMin": 0,
+                "stacking": {
+                  "mode": "none",
+                  "group": "A"
+                },
+                "gradientMode": "none",
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "hidden",
+              "placement": "bottom",
+              "showLegend": false,
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 158,
+          "type": "timeseries",
+          "title": "Quota refusals caused by the store, not by a limit",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "`eddi_tenant_quota_unavailable_total` by `type` — the quota store could not answer, so the turn was refused for safety without any limit being reached — a driver failure in whichever store is configured (`MongoException` in `MongoTenantQuotaStore`, the default backend, or `SQLException` in `PostgresTenantQuotaStore`). These used to be counted on `eddi_tenant_quota_denied_total` and answered 429 with `Retry-After: 60`, so a database outage looked exactly like a tenant burning through its allowance on the panels above. They now answer 503 `quota_accounting_unavailable`. Any sustained non-zero value here is an infrastructure problem, not a capacity decision — alert on it separately from the denial panels.",
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum by (type) (rate(eddi_tenant_quota_unavailable_total{job=~\"$job\"}[$__rate_interval]))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "range": true,
+              "legendFormat": "{{type}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": false,
+                "axisSoftMin": 0,
+                "stacking": {
+                  "mode": "none",
+                  "group": "A"
+                },
+                "gradientMode": "none",
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true,
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
         }
       ]
     },

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -109,6 +109,17 @@ RUN mkdir -p /deployments/tmp/import && \
       chown -R 185:0 /deployments/tmp && \
       chmod -R 775 /deployments/tmp
 
+# Default location of eddi.audit.dead-letter-path — the audit ledger's last-resort
+# sink for entries it has to abandon. Nothing in this image created it, and UID 185
+# cannot create a directory under /opt at runtime, so on the documented
+# `docker run` / docker-compose quick start every dead-letter write threw
+# NoSuchFileException into a swallowed catch and the abandoned audit entries were
+# gone outright rather than recoverable. Only the Kubernetes manifests mount a
+# volume here; the image has to provide the directory for everyone else.
+RUN mkdir -p /opt/eddi/data && \
+      chown -R 185:0 /opt/eddi && \
+      chmod -R 775 /opt/eddi
+
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
 COPY --chown=185 target/quarkus-app/*.jar /deployments/
 COPY --chown=185 target/quarkus-app/app/ /deployments/app/

--- a/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
@@ -371,7 +371,8 @@ public class MongoUserMemoryStore implements IUserMemoryStore {
     public void deleteAllForUser(String userId) throws IResourceStore.ResourceStoreException {
         RuntimeUtilities.checkNotNull(userId, FIELD_USER_ID);
         DeleteResult result = memoriesCollection.deleteMany(eq(FIELD_USER_ID, userId));
-        LOGGER.infof("[MEMORY] GDPR delete-all for user '%s': %d entries removed", userId, result.getDeletedCount());
+        LOGGER.infof("[MEMORY] GDPR delete-all for user '%s': %d entries removed", LogSanitizer.sanitize(userId),
+                result.getDeletedCount());
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/mongo/MongoUserMemoryStore.java
@@ -28,6 +28,7 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.*;
 import java.util.regex.Pattern;
+import ai.labs.eddi.engine.audit.AuditHmac;
 
 import static com.mongodb.client.model.Filters.*;
 import static com.mongodb.client.model.Sorts.descending;
@@ -371,8 +372,11 @@ public class MongoUserMemoryStore implements IUserMemoryStore {
     public void deleteAllForUser(String userId) throws IResourceStore.ResourceStoreException {
         RuntimeUtilities.checkNotNull(userId, FIELD_USER_ID);
         DeleteResult result = memoriesCollection.deleteMany(eq(FIELD_USER_ID, userId));
-        LOGGER.infof("[MEMORY] GDPR delete-all for user '%s': %d entries removed", LogSanitizer.sanitize(userId),
-                result.getDeletedCount());
+        // The pseudonym, not the identifier - see PostgresUserMemoryStore for the
+        // reasoning. Both stores must agree, or an operator reading one log and not
+        // the other draws a different conclusion about what was erased.
+        LOGGER.infof("[MEMORY] GDPR delete-all for user '%s': %d entries removed",
+                AuditHmac.pseudonymFor(userId), result.getDeletedCount());
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresAuditStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresAuditStore.java
@@ -34,12 +34,27 @@ import java.util.*;
 @DefaultBean
 public class PostgresAuditStore implements IAuditStore {
 
+    /**
+     * {@code conversation_id}, {@code AGENT_ID} and {@code AGENT_VERSION} are
+     * deliberately nullable.
+     * <p>
+     * They used to be {@code NOT NULL}, which made this backend unable to store
+     * entries the rest of the system legitimately produces: GDPR compliance events
+     * have no conversation and no agent, and the HITL/group oversight entries know
+     * the conversation but not the agent version. {@link AuditEntry#agentVersion()}
+     * is an {@code Integer} precisely because "unknown" is a value, and MongoDB
+     * stores and returns it as null. On PostgreSQL those entries failed on write —
+     * and because {@code AuditLedgerService.flush} re-queued the whole batch, a
+     * single one of them discarded three flush windows of unrelated conversations'
+     * audit data every time a pending approval was cancelled or a facilitator
+     * emitted a checkpoint.
+     */
     private static final String CREATE_TABLE = """
             CREATE TABLE IF NOT EXISTS audit_ledger (
                 id UUID PRIMARY KEY,
-                conversation_id TEXT NOT NULL,
-                AGENT_ID TEXT NOT NULL,
-                AGENT_VERSION INTEGER NOT NULL,
+                conversation_id TEXT,
+                AGENT_ID TEXT,
+                AGENT_VERSION INTEGER,
                 user_id TEXT,
                 environment TEXT,
                 step_index INTEGER NOT NULL,
@@ -79,6 +94,16 @@ public class PostgresAuditStore implements IAuditStore {
      */
     private static final String ADD_AGENT_SIGNATURE_COLUMN = "ALTER TABLE audit_ledger ADD COLUMN IF NOT EXISTS agent_signature TEXT";
 
+    /**
+     * Relaxes the three {@code NOT NULL} constraints on ledgers created before this
+     * fix. Dropping a constraint a column does not have is a no-op in PostgreSQL,
+     * so these are idempotent and safe to run on every start.
+     */
+    private static final String[] DROP_NOT_NULL_CONSTRAINTS = {
+            "ALTER TABLE audit_ledger ALTER COLUMN conversation_id DROP NOT NULL",
+            "ALTER TABLE audit_ledger ALTER COLUMN AGENT_ID DROP NOT NULL",
+            "ALTER TABLE audit_ledger ALTER COLUMN AGENT_VERSION DROP NOT NULL"};
+
     private static final String CREATE_INDEX_CONV = "CREATE INDEX IF NOT EXISTS idx_audit_conv ON audit_ledger (conversation_id)";
     /** Chain verification reads a conversation's entries in sequence order. */
     private static final String CREATE_INDEX_CONV_SEQ = "CREATE INDEX IF NOT EXISTS idx_audit_conv_seq ON audit_ledger (conversation_id, sequence)";
@@ -86,12 +111,41 @@ public class PostgresAuditStore implements IAuditStore {
     private static final String CREATE_INDEX_AGENT = "CREATE INDEX IF NOT EXISTS idx_audit_agent ON audit_ledger (AGENT_ID, AGENT_VERSION)";
     private static final String CREATE_INDEX_TS = "CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_ledger (created_at DESC)";
 
+    /**
+     * GDPR export and erasure both scan the ledger by {@code user_id} — it is the
+     * largest, append-only, never-pruned table in the system, and both operations
+     * are legally deadline-bound. Without this index they are sequential scans.
+     * <p>
+     * <strong>Upgrade note.</strong> On the first start after this change the index
+     * is built on an existing ledger, and a plain (non-{@code CONCURRENTLY})
+     * {@code CREATE INDEX} takes a {@code SHARE} lock: audit inserts block for the
+     * duration of the build, which on a multi-million-row table is minutes.
+     * {@code CREATE INDEX CONCURRENTLY} is not an option here because it cannot run
+     * inside {@code ensureSchema}'s statement batch (PostgreSQL forbids it in a
+     * transaction block) and it can leave an INVALID index behind on failure, which
+     * nothing in this class would notice or repair. Operators of large existing
+     * ledgers who cannot take that pause should build {@code idx_audit_user} with
+     * {@code CREATE INDEX CONCURRENTLY} out of band before deploying;
+     * {@code IF NOT EXISTS} then makes this statement a no-op.
+     */
+    private static final String CREATE_INDEX_USER = "CREATE INDEX IF NOT EXISTS idx_audit_user ON audit_ledger (user_id)";
+
+    /**
+     * {@code ON CONFLICT (id) DO NOTHING} makes the insert idempotent, which is
+     * what lets {@code AuditLedgerService} retry a failed batch entry by entry: a
+     * JDBC batch in autocommit stops at the first failing statement and commits the
+     * ones before it, so a plain retry of the whole batch would collide with rows
+     * that already landed. Re-inserting an entry with a different body under the
+     * same id is not a scenario the ledger has — entry ids are per-submission
+     * UUIDs.
+     */
     private static final String INSERT_SQL = """
             INSERT INTO audit_ledger
                 (id, conversation_id, AGENT_ID, AGENT_VERSION, user_id, environment,
                  step_index, task_id, task_type, task_index, duration_ms, cost, hmac, created_at, data, sequence,
                  agent_signature)
             VALUES (?::uuid, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?)
+            ON CONFLICT (id) DO NOTHING
             """;
 
     private static final String SELECT_ALL = """
@@ -117,10 +171,14 @@ public class PostgresAuditStore implements IAuditStore {
             stmt.execute(CREATE_TABLE);
             stmt.execute(ADD_SEQUENCE_COLUMN); // idempotent upgrades for pre-existing ledgers
             stmt.execute(ADD_AGENT_SIGNATURE_COLUMN);
+            for (String alter : DROP_NOT_NULL_CONSTRAINTS) {
+                stmt.execute(alter);
+            }
             stmt.execute(CREATE_INDEX_CONV);
             stmt.execute(CREATE_INDEX_CONV_SEQ);
             stmt.execute(CREATE_INDEX_AGENT);
             stmt.execute(CREATE_INDEX_TS);
+            stmt.execute(CREATE_INDEX_USER);
             schemaInitialized = true;
         } catch (SQLException e) {
             throw new RuntimeException("Failed to initialize audit_ledger table", e);
@@ -198,6 +256,26 @@ public class PostgresAuditStore implements IAuditStore {
     }
 
     @Override
+    public long maxSequence(String conversationId) {
+        ensureSchema();
+        String sql = "SELECT MAX(sequence) FROM audit_ledger WHERE conversation_id = ?";
+        try (Connection conn = dataSourceInstance.get().getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, conversationId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    long max = rs.getLong(1);
+                    // MAX over an empty set is SQL NULL, which getLong reports as 0 —
+                    // indistinguishable from a real position 0 without wasNull().
+                    return rs.wasNull() ? AuditEntry.UNSEQUENCED : max;
+                }
+            }
+            return AuditEntry.UNSEQUENCED;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to read max audit sequence", e);
+        }
+    }
+
+    @Override
     public List<AuditEntry> getEntriesByUserId(String userId, int skip, int limit) {
         ensureSchema();
         String sql = "SELECT " + SELECT_ALL + " FROM audit_ledger"
@@ -224,7 +302,10 @@ public class PostgresAuditStore implements IAuditStore {
         ps.setString(1, entry.id() != null ? entry.id() : UUID.randomUUID().toString());
         ps.setString(2, entry.conversationId());
         ps.setString(3, entry.agentId());
-        ps.setInt(4, entry.agentVersion());
+        // setObject, not setInt: agentVersion is a nullable Integer and unboxing a
+        // null here threw an NPE that escaped appendBatch's SQLException|IOException
+        // catch entirely, taking the whole flush batch down with it.
+        ps.setObject(4, entry.agentVersion(), Types.INTEGER);
         ps.setString(5, entry.userId());
         ps.setString(6, entry.environment());
         ps.setInt(7, entry.stepIndex());
@@ -266,7 +347,11 @@ public class PostgresAuditStore implements IAuditStore {
     @SuppressWarnings("unchecked")
     private AuditEntry fromRow(ResultSet rs, Map<String, Object> data) throws SQLException {
         Timestamp ts = rs.getTimestamp("created_at");
-        return new AuditEntry(rs.getString("id"), rs.getString("conversation_id"), rs.getString("AGENT_ID"), rs.getInt("AGENT_VERSION"),
+        // getObject, not getInt: getInt maps SQL NULL to 0, and the HMAC canonical
+        // form renders null and 0 differently — so a null-versioned entry would read
+        // back as version 0 and report as tampered forever.
+        Integer agentVersion = rs.getObject("AGENT_VERSION", Integer.class);
+        return new AuditEntry(rs.getString("id"), rs.getString("conversation_id"), rs.getString("AGENT_ID"), agentVersion,
                 rs.getString("user_id"), rs.getString("environment"), rs.getInt("step_index"), rs.getString("task_id"), rs.getString("task_type"),
                 rs.getInt("task_index"), rs.getLong("duration_ms"), (Map<String, Object>) data.get("input"), (Map<String, Object>) data.get("output"),
                 (Map<String, Object>) data.get("llmDetail"), (Map<String, Object>) data.get("toolCalls"),

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresAuditStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresAuditStore.java
@@ -116,17 +116,26 @@ public class PostgresAuditStore implements IAuditStore {
      * largest, append-only, never-pruned table in the system, and both operations
      * are legally deadline-bound. Without this index they are sequential scans.
      * <p>
-     * <strong>Upgrade note.</strong> On the first start after this change the index
-     * is built on an existing ledger, and a plain (non-{@code CONCURRENTLY})
-     * {@code CREATE INDEX} takes a {@code SHARE} lock: audit inserts block for the
-     * duration of the build, which on a multi-million-row table is minutes.
-     * {@code CREATE INDEX CONCURRENTLY} is not an option here because it cannot run
-     * inside {@code ensureSchema}'s statement batch (PostgreSQL forbids it in a
-     * transaction block) and it can leave an INVALID index behind on failure, which
-     * nothing in this class would notice or repair. Operators of large existing
-     * ledgers who cannot take that pause should build {@code idx_audit_user} with
-     * {@code CREATE INDEX CONCURRENTLY} out of band before deploying;
-     * {@code IF NOT EXISTS} then makes this statement a no-op.
+     * <strong>Upgrade note — read before deploying onto a large ledger.</strong> On
+     * the first start after this change the index is built on the existing table
+     * from {@link #ensureSchema()}, which runs lazily on the first
+     * {@code appendBatch}/{@code appendEntry}/{@code getEntries} — that is, on the
+     * audit-ledger-writer thread, holding this class's monitor. A plain
+     * (non-{@code CONCURRENTLY}) {@code CREATE INDEX} takes a {@code SHARE} lock,
+     * so for the duration of the build audit inserts block, the ledger's queue
+     * fills toward its bound, and REST audit reads wait on the same monitor. On a
+     * multi-million-row table that is minutes.
+     * <p>
+     * {@code CREATE INDEX CONCURRENTLY} is <em>not</em> illegal here —
+     * {@code ensureSchema} issues its statements on a plain autocommit
+     * {@link Statement}, not inside a transaction block, which is the only thing
+     * PostgreSQL forbids it in. It is avoided for the other reason: on failure it
+     * leaves an INVALID index behind, and nothing in this class would notice or
+     * repair one. Operators of large existing ledgers who cannot take the pause
+     * should build {@code idx_audit_user} with {@code CREATE INDEX CONCURRENTLY}
+     * out of band <em>before</em> deploying and check {@code pg_index.indisvalid};
+     * {@code IF NOT EXISTS} then makes this statement a no-op. Written up for
+     * operators in {@code docs/audit-ledger.md}.
      */
     private static final String CREATE_INDEX_USER = "CREATE INDEX IF NOT EXISTS idx_audit_user ON audit_ledger (user_id)";
 
@@ -138,6 +147,14 @@ public class PostgresAuditStore implements IAuditStore {
      * that already landed. Re-inserting an entry with a different body under the
      * same id is not a scenario the ledger has — entry ids are per-submission
      * UUIDs.
+     * <p>
+     * The idempotency holds only for an entry that <em>has</em> an id, which is why
+     * {@code AuditLedgerService.scrubSecrets} stamps one before signing rather than
+     * leaving it to {@link #setEntryParams}: a fresh UUID minted per attempt here
+     * would give the batch write and the per-entry retry different primary keys and
+     * store the same entry twice, which the chain verifier grades as a DUPLICATE
+     * ({@code BROKEN}). The fallback below remains for direct callers that bypass
+     * the ledger.
      */
     private static final String INSERT_SQL = """
             INSERT INTO audit_ledger

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
@@ -537,7 +537,8 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
             try (PreparedStatement ps = conn.prepareStatement("DELETE FROM usermemories WHERE user_id = ?")) {
                 ps.setString(1, userId);
                 int count = ps.executeUpdate();
-                LOGGER.infof("[MEMORY] GDPR delete-all for user '%s': %d entries removed", userId, count);
+                LOGGER.infof("[MEMORY] GDPR delete-all for user '%s': %d entries removed", LogSanitizer.sanitize(userId),
+                        count);
             }
         } catch (SQLException e) {
             throw new IResourceStore.ResourceStoreException("Failed to delete all data for userId=" + userId, e);

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
@@ -553,7 +553,18 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
                         AuditHmac.pseudonymFor(userId), count);
             }
         } catch (SQLException e) {
-            throw new IResourceStore.ResourceStoreException("Failed to delete all data for userId=" + userId, e);
+            // Pseudonymised for the same reason as the success log above: a caller that
+            // logs or serialises this exception would otherwise persist the identifier
+            // the erasure exists to remove (CWE-532).
+            //
+            // The sibling methods above deliberately keep the raw userId in their
+            // messages. On a read, merge or property delete the user's data legitimately
+            // exists and their identifier appears throughout the system, so the
+            // identifier is diagnostics rather than a leak. Erasure is the one path where
+            // the whole point is that the identifier stops existing - do not "even these
+            // up" without that distinction in mind.
+            throw new IResourceStore.ResourceStoreException(
+                    "Failed to delete all data for user=" + AuditHmac.pseudonymFor(userId), e);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStore.java
@@ -20,6 +20,8 @@ import jakarta.enterprise.inject.Instance;
 import javax.sql.DataSource;
 import java.sql.*;
 import java.util.*;
+import ai.labs.eddi.engine.audit.AuditHmac;
+import ai.labs.eddi.utils.RuntimeUtilities;
 
 /**
  * PostgreSQL implementation of {@link IUserMemoryStore}. All data lives in a
@@ -532,13 +534,23 @@ public class PostgresUserMemoryStore implements IUserMemoryStore {
 
     @Override
     public void deleteAllForUser(String userId) throws IResourceStore.ResourceStoreException {
+        // Parity with MongoUserMemoryStore, which has always guarded this. Erasing
+        // "all entries for user null" is not a request anyone means, and the pseudonym
+        // derived below refuses a null identifier rather than hashing one.
+        RuntimeUtilities.checkNotNull(userId, "userId");
         ensureSchema();
         try (Connection conn = dataSourceInstance.get().getConnection()) {
             try (PreparedStatement ps = conn.prepareStatement("DELETE FROM usermemories WHERE user_id = ?")) {
                 ps.setString(1, userId);
                 int count = ps.executeUpdate();
-                LOGGER.infof("[MEMORY] GDPR delete-all for user '%s': %d entries removed", LogSanitizer.sanitize(userId),
-                        count);
+                // The pseudonym, not the identifier. This line records an ERASURE, so
+                // writing the raw userId would leave in the log exactly the identifier
+                // the erasure exists to remove (CWE-532) - and logs outlive the database
+                // and travel further. AuditHmac.pseudonymFor is the same deterministic
+                // SHA-256 the erasure cascade substitutes into the audit ledger, so an
+                // operator can still correlate the two without either holding the id.
+                LOGGER.infof("[MEMORY] GDPR delete-all for user '%s': %d entries removed",
+                        AuditHmac.pseudonymFor(userId), count);
             }
         } catch (SQLException e) {
             throw new IResourceStore.ResourceStoreException("Failed to delete all data for userId=" + userId, e);

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditHmac.java
@@ -7,6 +7,8 @@ package ai.labs.eddi.engine.audit;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
 
 import javax.crypto.Mac;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -171,8 +173,8 @@ public final class AuditHmac {
      */
     public static byte[] deriveHmacKey(String masterKey) {
         try {
-            javax.crypto.SecretKeyFactory factory = javax.crypto.SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-            javax.crypto.spec.PBEKeySpec spec = new javax.crypto.spec.PBEKeySpec(masterKey.toCharArray(),
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            PBEKeySpec spec = new PBEKeySpec(masterKey.toCharArray(),
                     PBKDF2_SALT.getBytes(StandardCharsets.UTF_8), PBKDF2_ITERATIONS, 256);
             return factory.generateSecret(spec).getEncoded();
         } catch (Exception e) {
@@ -225,34 +227,6 @@ public final class AuditHmac {
     }
 
     /**
-     * Verify that an audit entry's HMAC matches the expected value.
-     * <p>
-     * The canonical form is selected from the stored value's version tag: a
-     * {@link #V3_PREFIX} row is held to v3 only, a {@link #V2_PREFIX} row to v2
-     * only, and an untagged row (written before either existed) to v1. A form is
-     * never retried against another — falling back would hand the weaker form's
-     * collisions back to an attacker.
-     * <p>
-     * The digests are compared as raw bytes through
-     * {@link MessageDigest#isEqual(byte[], byte[])} rather than with
-     * {@link String#equals(Object)}, which returns on the first differing character
-     * and so leaks, through timing, how much of a forged HMAC is correct — enough
-     * to reconstruct one digit at a time against a compliance ledger. The version
-     * prefix is <em>not</em> secret (it only selects the canonicalizer), so
-     * inspecting it with {@code startsWith} is fine; it is the digest comparison
-     * that has to be data-independent.
-     * <p>
-     * A stored value that is not valid hex — truncated, mangled, or never a digest
-     * at all — cannot match anything and is rejected rather than throwing. Hex
-     * parsing accepts either case; every digest this class writes is lowercase.
-     *
-     * @param entry
-     *            the audit entry with its hmac field populated
-     * @param hmacKey
-     *            the 32-byte HMAC key
-     * @return true if the HMAC is valid, false if tampered
-     */
-    /**
      * The canonical-form version a stored HMAC names: {@code "v4"}, {@code "v3"},
      * {@code "v2"}, {@code "v1"} for a bare pre-tag digest, or {@code null} for an
      * unsigned value.
@@ -282,6 +256,23 @@ public final class AuditHmac {
         return "v1";
     }
 
+    /**
+     * Boolean convenience wrapper over {@link #verify(AuditEntry, byte[], boolean)}
+     * — true when the entry verifies as written, false when it was altered.
+     * <p>
+     * Legacy-recovery is off, so a pre-v4 row whose stored timestamp lost precision
+     * on the way into the database reports false here even though it is intact.
+     * Production uses {@code AuditLedgerService.verifyEntry}, which distinguishes
+     * MATCH from MATCH_RECOVERED and reports UNSIGNED and SIGNING_DISABLED
+     * separately; this method is kept for tests and callers that only need a yes/no
+     * on a v4 row.
+     *
+     * @param entry
+     *            the audit entry with its hmac field populated
+     * @param hmacKey
+     *            the 32-byte HMAC key
+     * @return true if the HMAC verifies, false if it does not
+     */
     public static boolean verifyHmac(AuditEntry entry, byte[] hmacKey) {
         return verify(entry, hmacKey, false) != VerificationOutcome.MISMATCH;
     }

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.audit;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import ai.labs.eddi.configs.agents.AgentSigningService;
 import ai.labs.eddi.engine.audit.model.AuditEntry;
@@ -32,15 +33,27 @@ import java.time.Instant;
 import java.nio.charset.StandardCharsets;
 import com.fasterxml.jackson.core.type.TypeReference;
 import ai.labs.eddi.utils.LogSanitizer;
-import java.util.Map;
 
 /**
  * Async batch writer for the immutable audit ledger.
  * <p>
  * Follows the same pattern as
- * {@link ai.labs.eddi.engine.runtime.BoundedLogStore}: non-blocking capture via
- * a {@link ConcurrentLinkedQueue}, with a {@link ScheduledExecutorService}
+ * {@link ai.labs.eddi.engine.runtime.BoundedLogStore}: capture into a bounded
+ * {@link ConcurrentLinkedQueue}, with a {@link ScheduledExecutorService}
  * flushing entries to {@link IAuditStore} at a configurable interval.
+ * <p>
+ * <strong>{@link #submit} does not touch the store, but it is not
+ * free.</strong> Before an entry is queued the caller's thread scrubs it,
+ * assigns its chain position, hashes it and signs it — CPU-bound work
+ * proportional to the size of the prompts and responses being recorded. What it
+ * no longer does is I/O: seeding a conversation's sequence counter reads the
+ * store, and that read used to happen inside
+ * {@code ConcurrentHashMap.computeIfAbsent} while holding the sequence read
+ * lock, so one slow query stalled every other submitter that hashed to the same
+ * bin as well as any eviction waiting for the write lock (a
+ * {@code ReentrantReadWriteLock} refuses new readers once a writer has queued).
+ * The seed is now resolved by {@link #prewarmSequenceCounter} before either is
+ * taken.
  * <p>
  * Before persisting, each entry passes through:
  * <ol>
@@ -59,8 +72,25 @@ public class AuditLedgerService {
     private static final Logger LOGGER = Logger.getLogger(AuditLedgerService.class);
     private static final int MAX_FLUSH_RETRIES = 3;
 
+    /**
+     * How many consecutive refusals the per-entry fallback tolerates before it
+     * declares the store unavailable and stops calling it for the rest of the
+     * batch. See {@link #appendIndividually}.
+     */
+    static final int MAX_CONSECUTIVE_ENTRY_FAILURES = 10;
+
     /** Default bound for {@code eddi.audit.max-queue-size}. */
     static final int DEFAULT_MAX_QUEUE_SIZE = 100_000;
+
+    /**
+     * Fallback for {@code eddi.audit.flush-interval-seconds} when the configured
+     * value is not a usable period. Mirrors the {@code defaultValue} on the config
+     * property. An operator setting 0 in the hope of "flush immediately" used to
+     * take the whole application down at {@code @PostConstruct} with an
+     * {@code IllegalArgumentException("period <= 0")} thrown from inside the
+     * executor API — a stack trace that never names the property responsible.
+     */
+    static final int DEFAULT_FLUSH_INTERVAL_SECONDS = 3;
 
     /**
      * Threshold at which sequence-counter eviction kicks in. On overflow, counters
@@ -109,7 +139,7 @@ public class AuditLedgerService {
     private final boolean enabled;
     private final int flushIntervalSeconds;
     private final Optional<String> masterKeyConfig;
-    private final io.micrometer.core.instrument.Counter droppedCounter;
+    private final Counter droppedCounter;
     private final Instance<Connection> natsConnectionInstance;
     private final String deadLetterPath;
     private final boolean agentSigningEnabled;
@@ -168,6 +198,11 @@ public class AuditLedgerService {
      * Counts scans that evicted nothing — see {@link #getFutileEvictionScans()}.
      */
     private final AtomicLong futileEvictionScans = new AtomicLong();
+    /**
+     * Set by {@link #shutdown()} before the final flush. A failure after this point
+     * has no later attempt, so {@link #flush()} dead-letters instead of re-queuing.
+     */
+    private volatile boolean shuttingDown = false;
     private ScheduledExecutorService flushExecutor;
 
     @Inject
@@ -186,7 +221,13 @@ public class AuditLedgerService {
         this.recoverLegacyMaxRows = recoverLegacyMaxRows;
         this.auditStore = auditStore;
         this.enabled = enabled;
-        this.flushIntervalSeconds = flushIntervalSeconds;
+        if (flushIntervalSeconds > 0) {
+            this.flushIntervalSeconds = flushIntervalSeconds;
+        } else {
+            this.flushIntervalSeconds = DEFAULT_FLUSH_INTERVAL_SECONDS;
+            LOGGER.warnv("eddi.audit.flush-interval-seconds must be a positive number of seconds; {0} is not a period. "
+                    + "Falling back to the default of {1}s.", flushIntervalSeconds, DEFAULT_FLUSH_INTERVAL_SECONDS);
+        }
         this.masterKeyConfig = masterKeyConfig;
         this.deadLetterPath = deadLetterPath;
         this.agentSigningEnabled = agentSigningEnabled;
@@ -230,6 +271,8 @@ public class AuditLedgerService {
             LOGGER.info("Audit Ledger: HMAC signing disabled (no vault master key).");
         }
 
+        checkDeadLetterSinkReachable();
+
         flushExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
             Thread t = new Thread(r, "audit-ledger-writer");
             t.setDaemon(true);
@@ -240,9 +283,41 @@ public class AuditLedgerService {
         LOGGER.infov("Audit Ledger initialized (flush every {0}s)", flushIntervalSeconds);
     }
 
+    /**
+     * Report at startup whether the last-resort sink can actually be written.
+     * <p>
+     * The default path lives under {@code /opt/eddi/data}, which only the
+     * Kubernetes manifests mount — the shipped container image never creates it and
+     * the runtime user cannot create it under {@code /opt}. So on the documented
+     * docker/docker-compose quick start every dead-letter write threw
+     * {@code NoSuchFileException} into a swallowed catch, and the entries the
+     * ledger abandoned were gone outright rather than recoverable. Discovering that
+     * during the incident, from an error line nested inside the error line that
+     * reported the drop, is the wrong time; {@link #writeToDeadLetter} now also
+     * creates the directory, and this says so up front if it cannot.
+     */
+    private void checkDeadLetterSinkReachable() {
+        try {
+            Path parent = Path.of(deadLetterPath).toAbsolutePath().getParent();
+            if (parent == null || Files.isDirectory(parent)) {
+                return;
+            }
+            Files.createDirectories(parent);
+            LOGGER.infov("Created audit dead-letter directory {0}", parent);
+        } catch (Exception e) {
+            LOGGER.warnv("Audit dead-letter sink {0} is not writable ({1}). Entries the ledger has to abandon "
+                    + "will be lost rather than recoverable — point eddi.audit.dead-letter-path at a writable "
+                    + "location or mount a volume there.", deadLetterPath, e.getMessage());
+        }
+    }
+
     @PreDestroy
     void shutdown() {
         if (flushExecutor != null) {
+            // Tells flush() that a failure has no next attempt: re-queuing would put
+            // entries into a queue nothing will ever drain again, losing them with
+            // neither a dead-letter record nor a dropped-counter increment.
+            shuttingDown = true;
             flush(); // Final flush
             flushExecutor.shutdown();
             try {
@@ -253,6 +328,37 @@ public class AuditLedgerService {
                 flushExecutor.shutdownNow();
                 Thread.currentThread().interrupt();
             }
+            // Anything submitted while the final flush was running is still storable
+            // — the drain below records it as dropped, so try the store once more
+            // first. On a healthy store this persists it; on a failing one
+            // shuttingDown makes flush() dead-letter it directly, and the drain then
+            // finds nothing.
+            flush();
+            // Anything submitted during THAT flush has no flush left — the executor
+            // is down and the scheduled task will never run again — so the sink is
+            // the only thing between it and silent loss.
+            drainQueueToDeadLetter();
+        }
+    }
+
+    /**
+     * Move anything still queued after the final flush to the dead-letter sink.
+     * Covers entries submitted while the last flush was running, which no scheduled
+     * flush will ever pick up — and which a healthy store would have accepted, so
+     * {@link #shutdown()} attempts one more flush before calling this rather than
+     * recording them as dropped without ever offering them.
+     */
+    private void drainQueueToDeadLetter() {
+        List<AuditEntry> remaining = new ArrayList<>();
+        AuditEntry entry;
+        while ((entry = queue.poll()) != null) {
+            queueSize.decrementAndGet();
+            remaining.add(entry);
+        }
+        if (!remaining.isEmpty()) {
+            LOGGER.errorv("Audit ledger shut down with {0} unflushed entries — writing them to the dead-letter sink", remaining.size());
+            droppedCounter.increment(remaining.size());
+            writeToDeadLetter(remaining);
         }
     }
 
@@ -283,6 +389,12 @@ public class AuditLedgerService {
         // eviction needs the write lock and this thread is about to hold the read
         // lock, which a ReentrantReadWriteLock cannot upgrade.
         evictSequenceCountersIfFull(entry.conversationId());
+
+        // Seed this conversation's counter BEFORE taking the lock. Seeding reads the
+        // store, and doing that under the read lock stalled every other submitter
+        // (a ReentrantReadWriteLock refuses new readers once eviction has queued for
+        // the write lock) as well as eviction itself.
+        prewarmSequenceCounter(entry.conversationId());
 
         boolean queued = false;
         // Read lock (shared — submitters never contend with each other) spans
@@ -395,14 +507,14 @@ public class AuditLedgerService {
      * without risk, once the table reaches {@link #MAX_TRACKED_CONVERSATIONS}.
      * <p>
      * The table used to be {@code clear()}ed wholesale, on the reasoning that
-     * "re-seeding is correct, only slower". It is not: the counter is seeded from
-     * {@code countByConversation}, which sees only what the store already holds.
-     * Entries sit in {@link #queue} for up to one flush interval — longer while a
-     * failing store is being retried — so clearing mid-flight re-issued positions
-     * those entries had already consumed. Duplicates are graded exactly like gaps
-     * ({@code ChainStatus.BROKEN}), and unlike a gap there is no exculpatory record
-     * for them: the ledger would report the deployment as tampered because its own
-     * bookkeeping wrapped around.
+     * "re-seeding is correct, only slower". It is not: the counter is re-seeded
+     * from the store (see {@link #seedSequence}), which sees only what it already
+     * holds. Entries sit in {@link #queue} for up to one flush interval — longer
+     * while a failing store is being retried — so clearing mid-flight re-issued
+     * positions those entries had already consumed. Duplicates are graded exactly
+     * like gaps ({@code ChainStatus.BROKEN}), and unlike a gap there is no
+     * exculpatory record for them: the ledger would report the deployment as
+     * tampered because its own bookkeeping wrapped around.
      * <p>
      * A counter is safe to drop only when every position it handed out is already
      * accounted for somewhere the re-seed can see: persisted in the store, or
@@ -418,23 +530,24 @@ public class AuditLedgerService {
      * rule, so the verdict is unchanged — only its reason is.
      * <p>
      * <b>Conversations with dead-lettered positions stay pinned for the process
-     * lifetime, and that cannot starve the table.</b> Re-seeding them is not merely
-     * inconvenient, it is unsound: the seed comes from {@code countByConversation},
-     * which counts persisted rows, and a dead-lettered gap makes that count smaller
-     * than the next free position. With sequences 0-9 where 3 and 5 never landed,
-     * the count is 8 while the next position is 10 — so a re-seed would hand out 8
-     * and 9 a second time. Accounting for the highest known undelivered position
-     * does not rescue it either ({@code max(8, 6)} is still 8); a sound re-seed
-     * would need a {@code maxSequence(conversationId)} that {@link IAuditStore}
-     * does not expose. Retention is therefore correct, and it is bounded:
-     * {@link #undeliveredTracked} counts <em>sequences</em>, so at most
-     * {@link #MAX_TRACKED_UNDELIVERED} conversations can be pinned (one sequence
-     * each, the worst case) out of a {@link #MAX_TRACKED_CONVERSATIONS} table —
-     * leaving 80% of it evictable. {@code undeliveredPinCannotExhaustTheTable}
-     * exercises that end to end: a dead-lettered conversation stays pinned while
-     * the persisted ones around it are reclaimed, a later conversation still
-     * receives a real position rather than {@code UNSEQUENCED}, and the pinned
-     * chain resumes past its dead-lettered position instead of reusing it.
+     * lifetime, and that cannot starve the table.</b> The pin is now
+     * belt-and-braces rather than the only thing holding the chain together:
+     * {@link #seedSequence} re-seeds from {@link IAuditStore#maxSequence} + 1, so
+     * even an evicted counter resumes past its dead-lettered positions instead of
+     * reusing them. (It used to seed from {@code countByConversation}, which counts
+     * persisted rows: with sequences 0-9 where 3 and 5 never landed the count is 8
+     * while the next position is 10, so a re-seed handed out 8 and 9 a second time
+     * — and duplicates are graded {@code BROKEN}.) Retaining them keeps the
+     * attribution table and the counter consistent for the process's lifetime, and
+     * it is bounded: {@link #undeliveredTracked} counts <em>sequences</em>, so at
+     * most {@link #MAX_TRACKED_UNDELIVERED} conversations can be pinned (one
+     * sequence each, the worst case) out of a {@link #MAX_TRACKED_CONVERSATIONS}
+     * table — leaving 80% of it evictable.
+     * {@code undeliveredPinCannotExhaustTheTable} exercises that end to end: a
+     * dead-lettered conversation stays pinned while the persisted ones around it
+     * are reclaimed, a later conversation still receives a real position rather
+     * than {@code UNSEQUENCED}, and the pinned chain resumes past its dead-lettered
+     * position instead of reusing it.
      */
     private void evictSequenceCountersIfFull(String conversationId) {
         // Fast path: nothing to do until the table is full, and a conversation
@@ -532,7 +645,17 @@ public class AuditLedgerService {
         }
 
         try {
-            AtomicLong counter = conversationSequences.computeIfAbsent(conversationId, id -> new AtomicLong(auditStore.countByConversation(id)));
+            // Normally already present — prewarmSequenceCounter resolved the seed
+            // outside this lock. The inline path only runs when an eviction landed in
+            // between, and it still resolves the seed OUTSIDE the mapping function:
+            // ConcurrentHashMap holds a bin lock for the duration of computeIfAbsent,
+            // and its contract forbids long-running work there. A store round trip
+            // inside it blocked every other submitter that hashed to the same bin.
+            AtomicLong counter = conversationSequences.get(conversationId);
+            if (counter == null) {
+                long seed = seedSequence(conversationId);
+                counter = conversationSequences.computeIfAbsent(conversationId, id -> new AtomicLong(seed));
+            }
             return counter.getAndIncrement();
         } catch (Exception e) {
             // A failed seed must not fabricate a duplicate sequence — an unsequenced
@@ -540,6 +663,55 @@ public class AuditLedgerService {
             LOGGER.warnv("Could not seed audit sequence for conversation {0}: {1}", sanitize(conversationId), e.getMessage());
             return AuditEntry.UNSEQUENCED;
         }
+    }
+
+    /**
+     * Resolve a conversation's sequence counter ahead of the assignment lock, so
+     * the store round trip the seed needs happens on no lock and inside no
+     * {@code ConcurrentHashMap} mapping function.
+     * <p>
+     * Two submitters racing here both compute the same seed and one insert wins, so
+     * the duplicate work is harmless. An eviction that drops the counter
+     * immediately afterwards is harmless too: nothing has been handed out yet, so
+     * the re-seed produces the same number.
+     */
+    private void prewarmSequenceCounter(String conversationId) {
+        if (conversationId == null || conversationId.isBlank() || !auditStore.supportsSequence()) {
+            return;
+        }
+        if (conversationSequences.containsKey(conversationId) || conversationSequences.size() >= MAX_TRACKED_CONVERSATIONS) {
+            return;
+        }
+        try {
+            long seed = seedSequence(conversationId);
+            conversationSequences.computeIfAbsent(conversationId, id -> new AtomicLong(seed));
+        } catch (Exception e) {
+            // Left unseeded on purpose: nextSequence retries and, if that fails too,
+            // records the entry as UNSEQUENCED rather than guessing a position.
+            LOGGER.warnv("Could not pre-seed audit sequence for conversation {0}: {1}", sanitize(conversationId), e.getMessage());
+        }
+    }
+
+    /**
+     * The next free chain position for a conversation, as the store sees it.
+     * <p>
+     * {@code max(sequence) + 1}, not {@code countByConversation()}. The count is
+     * the number of rows that landed, which stops matching the next free position
+     * the moment one was handed out and never persisted — a dead-lettered entry, a
+     * dropped batch. Seeding from the count then re-issues positions that are
+     * already spoken for, and {@code /auditstore/verify} grades duplicates as
+     * {@code BROKEN}: the ledger reporting the deployment as tampered because of
+     * its own bookkeeping. The in-memory {@code undelivered} pin only held that off
+     * within one process lifetime and on one node.
+     * <p>
+     * Falls back to the count for a store that does not implement
+     * {@link IAuditStore#maxSequence} (legacy rows that predate the sequence column
+     * report {@link AuditEntry#UNSEQUENCED}, and counting them is what the chain
+     * verifier already expects — see {@code RestAuditStore.checkChain}).
+     */
+    private long seedSequence(String conversationId) {
+        long max = auditStore.maxSequence(conversationId);
+        return max >= 0 ? max + 1 : auditStore.countByConversation(conversationId);
     }
 
     /**
@@ -577,30 +749,20 @@ public class AuditLedgerService {
                 auditStore.appendBatch(batch);
                 consecutiveFailures.set(0);
             } catch (Exception e) {
-                int failures = consecutiveFailures.incrementAndGet();
-                LOGGER.errorv("Failed to flush {0} audit entries (attempt {1}/{2}): {3}", batch.size(), failures, MAX_FLUSH_RETRIES, e.getMessage());
-
-                if (failures < MAX_FLUSH_RETRIES) {
-                    // Re-queue entries at the front so the next flush retries them.
-                    // The re-offer respects the bound: whatever no longer fits goes
-                    // straight to the dead-letter sink instead of growing the heap.
-                    List<AuditEntry> rejected = new ArrayList<>();
-                    for (int i = batch.size() - 1; i >= 0; i--) {
-                        if (!offerBounded(batch.get(i))) {
-                            rejected.add(batch.get(i));
-                        }
-                    }
-                    LOGGER.warnv("Re-queued {0} audit entries for retry", batch.size() - rejected.size());
-                    if (!rejected.isEmpty()) {
-                        LOGGER.errorv("Audit queue full — dead-lettering {0} entries that did not fit on retry", rejected.size());
-                        writeToDeadLetter(rejected);
-                    }
-                } else {
-                    LOGGER.errorv("Dropping {0} audit entries after {1} consecutive failures — writing to dead-letter log", batch.size(),
-                            MAX_FLUSH_RETRIES);
-                    droppedCounter.increment(batch.size());
-                    writeToDeadLetter(batch);
+                LOGGER.errorv("Failed to flush {0} audit entries as a batch ({1}) — retrying them individually", batch.size(), e.getMessage());
+                // A bulk write is not atomic in either backend, so re-offering the
+                // whole batch punished every entry for one bad row: the retry carried
+                // the rows that HAD landed back into the store (duplicate keys), so
+                // nothing new was written, and after MAX_FLUSH_RETRIES three flush
+                // windows of unrelated conversations' records were dead-lettered
+                // together. Retry per entry instead — both stores' single-entry
+                // inserts are idempotent — so only the entry that genuinely cannot
+                // be stored is abandoned.
+                List<AuditEntry> unstorable = appendIndividually(batch);
+                if (unstorable.isEmpty()) {
                     consecutiveFailures.set(0);
+                } else {
+                    handlePersistentFailures(unstorable);
                 }
             } finally {
                 // Every outcome has put these positions somewhere eviction can see
@@ -610,6 +772,97 @@ public class AuditLedgerService {
                 // find something. Bump last, once the move is visible.
                 flushGeneration.incrementAndGet();
             }
+        }
+    }
+
+    /**
+     * Persist a failed batch one entry at a time.
+     * <p>
+     * Both stores make a single-entry insert idempotent (MongoDB ignores
+     * {@code E11000}, PostgreSQL uses {@code ON CONFLICT (id) DO NOTHING}), so the
+     * rows an aborted bulk write already committed are simply re-accepted here and
+     * only the genuinely unstorable ones come back.
+     *
+     * <b>The pass gives up after {@link #MAX_CONSECUTIVE_ENTRY_FAILURES}
+     * consecutive refusals.</b> The fallback exists to isolate a poison entry from
+     * the batch around it, which needs only enough attempts to tell one bad row
+     * from a bad store. An outage refuses every one of them, and this method runs
+     * on the writer thread inside {@code synchronized flush()} — the same monitor
+     * the {@code @PreDestroy} final flush waits on. Without a cap, a queue grown
+     * toward {@link #DEFAULT_MAX_QUEUE_SIZE} against an unreachable PostgreSQL
+     * (connect timeouts measured in tens of seconds) would block both for hours,
+     * where the old whole-batch retry failed once per flush window. The remaining
+     * entries are returned unstorable without a store call, which puts them back on
+     * the queue for the next flush exactly as if they had been attempted.
+     *
+     * @return the entries that still could not be stored
+     */
+    private List<AuditEntry> appendIndividually(List<AuditEntry> batch) {
+        List<AuditEntry> unstorable = new ArrayList<>();
+        int consecutiveEntryFailures = 0;
+        for (int i = 0; i < batch.size(); i++) {
+            AuditEntry entry = batch.get(i);
+            if (consecutiveEntryFailures >= MAX_CONSECUTIVE_ENTRY_FAILURES) {
+                int abandoned = batch.size() - i;
+                LOGGER.errorv("Audit store refused {0} entries in a row — treating it as unavailable and abandoning the "
+                        + "per-entry retry for the remaining {1} of this batch", MAX_CONSECUTIVE_ENTRY_FAILURES, abandoned);
+                unstorable.addAll(batch.subList(i, batch.size()));
+                break;
+            }
+            try {
+                auditStore.appendEntry(entry);
+                consecutiveEntryFailures = 0;
+            } catch (Exception e) {
+                consecutiveEntryFailures++;
+                LOGGER.errorv("Audit entry {0} (conversation {1}, sequence {2}) could not be stored: {3}", sanitize(entry.id()),
+                        sanitize(entry.conversationId()), entry.sequence(), e.getMessage());
+                unstorable.add(entry);
+            }
+        }
+        return unstorable;
+    }
+
+    /**
+     * Decide what happens to entries the per-entry retry could not store either:
+     * one more pass through the queue while attempts remain, the dead-letter sink
+     * once they are exhausted — and always the sink during shutdown, because there
+     * is no later flush to retry them.
+     */
+    private void handlePersistentFailures(List<AuditEntry> unstorable) {
+        if (shuttingDown) {
+            LOGGER.errorv("Audit ledger is shutting down — dead-lettering {0} entries that could not be stored", unstorable.size());
+            droppedCounter.increment(unstorable.size());
+            writeToDeadLetter(unstorable);
+            return;
+        }
+
+        int failures = consecutiveFailures.incrementAndGet();
+        if (failures >= MAX_FLUSH_RETRIES) {
+            LOGGER.errorv("Dropping {0} audit entries after {1} consecutive failures — writing to dead-letter log", unstorable.size(),
+                    MAX_FLUSH_RETRIES);
+            droppedCounter.increment(unstorable.size());
+            writeToDeadLetter(unstorable);
+            consecutiveFailures.set(0);
+            return;
+        }
+
+        // Appended for retry — a ConcurrentLinkedQueue has no front insertion, so
+        // these go behind whatever was submitted meanwhile. (The loop used to run
+        // backwards under a comment claiming front insertion, which only reversed
+        // the batch.) The re-offer respects the queue bound: whatever no longer
+        // fits goes straight to the dead-letter sink instead of growing the heap.
+        List<AuditEntry> rejected = new ArrayList<>();
+        for (AuditEntry entry : unstorable) {
+            if (!offerBounded(entry)) {
+                rejected.add(entry);
+            }
+        }
+        LOGGER.warnv("Re-queued {0} audit entries for retry (attempt {1}/{2})", unstorable.size() - rejected.size(), failures, MAX_FLUSH_RETRIES);
+        if (!rejected.isEmpty()) {
+            // Not counted here: reserveQueueSlot already increments droppedCounter
+            // once per refusal.
+            LOGGER.errorv("Audit queue full — dead-lettering {0} entries that did not fit on retry", rejected.size());
+            writeToDeadLetter(rejected);
         }
     }
 
@@ -811,6 +1064,15 @@ public class AuditLedgerService {
         return queueSize.get();
     }
 
+    /**
+     * The period the flush task actually runs at, after the constructor has
+     * replaced an unusable configured value with
+     * {@link #DEFAULT_FLUSH_INTERVAL_SECONDS}.
+     */
+    int getFlushIntervalSeconds() {
+        return flushIntervalSeconds;
+    }
+
     /** Conversations currently holding a sequence counter. */
     int getTrackedConversationCount() {
         return conversationSequences.size();
@@ -902,6 +1164,12 @@ public class AuditLedgerService {
             for (AuditEntry entry : entries) {
                 lines.add(serializeDeadLetterEntry(entry, null));
             }
+            // StandardOpenOption.CREATE creates the file, never its parent — and the
+            // default path's parent does not exist in the shipped container image.
+            Path parent = dlPath.toAbsolutePath().getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
             Files.write(dlPath, lines, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
             LOGGER.infov("Wrote {0} entries to dead-letter log: {1}", entries.size(), dlPath.toAbsolutePath());
         } catch (Exception e) {
@@ -910,8 +1178,23 @@ public class AuditLedgerService {
     }
 
     /**
-     * Serializes a dead-letter entry as a JSON string using Jackson for correct
+     * Serializes a dead-letter record as a JSON string using Jackson for correct
      * escaping of all field values.
+     * <p>
+     * The record carries the <em>whole</em> entry, not a five-field summary. The
+     * summary was neither replayable nor the "durable evidence"
+     * {@link #undeliveredSequences} rests its INCOMPLETE-not-BROKEN verdict on:
+     * with no {@code sequence} in it, an operator who restarted after a dead-letter
+     * event had no way to prove which positions the ledger itself dropped, so every
+     * self-inflicted gap read as {@code BROKEN} forever — and the audit content,
+     * the HMAC and the agent signature were gone outright.
+     * <p>
+     * Fields are written individually rather than by serializing the record, so the
+     * output does not depend on the injected mapper having a JSR-310 module
+     * registered. {@code timestamp} keeps its original meaning — the moment the
+     * record was abandoned — and the entry's own timestamp is
+     * {@code entryTimestamp} so existing sink consumers keep reading what they read
+     * before.
      *
      * @param entry
      *            the audit entry to serialize
@@ -930,6 +1213,27 @@ public class AuditLedgerService {
         dlMap.put("agentId", entry.agentId());
         dlMap.put("taskId", entry.taskId());
         dlMap.put("taskType", entry.taskType());
+        dlMap.put("id", entry.id());
+        dlMap.put("sequence", entry.sequence());
+        dlMap.put("agentVersion", entry.agentVersion());
+        // userId, input and output make the sink a personal-data location that the
+        // GDPR erasure cascade does not reach — deliberately, because without them
+        // the record is neither replayable nor evidence of what was lost. See
+        // docs/gdpr-compliance.md, "The audit dead-letter sink holds personal data".
+        dlMap.put("userId", entry.userId());
+        dlMap.put("environment", entry.environment());
+        dlMap.put("stepIndex", entry.stepIndex());
+        dlMap.put("taskIndex", entry.taskIndex());
+        dlMap.put("durationMs", entry.durationMs());
+        dlMap.put("cost", entry.cost());
+        dlMap.put("entryTimestamp", entry.timestamp() != null ? entry.timestamp().toString() : null);
+        dlMap.put("hmac", entry.hmac());
+        dlMap.put("agentSignature", entry.agentSignature());
+        dlMap.put("actions", entry.actions());
+        dlMap.put("input", entry.input());
+        dlMap.put("output", entry.output());
+        dlMap.put("llmDetail", entry.llmDetail());
+        dlMap.put("toolCalls", entry.toolCalls());
 
         try {
             return objectMapper.writeValueAsString(dlMap);

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditLedgerService.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.nio.file.*;
+import java.time.Duration;
 import java.time.Instant;
 import java.nio.charset.StandardCharsets;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -42,18 +43,21 @@ import ai.labs.eddi.utils.LogSanitizer;
  * {@link ConcurrentLinkedQueue}, with a {@link ScheduledExecutorService}
  * flushing entries to {@link IAuditStore} at a configurable interval.
  * <p>
- * <strong>{@link #submit} does not touch the store, but it is not
- * free.</strong> Before an entry is queued the caller's thread scrubs it,
- * assigns its chain position, hashes it and signs it — CPU-bound work
- * proportional to the size of the prompts and responses being recorded. What it
- * no longer does is I/O: seeding a conversation's sequence counter reads the
- * store, and that read used to happen inside
- * {@code ConcurrentHashMap.computeIfAbsent} while holding the sequence read
- * lock, so one slow query stalled every other submitter that hashed to the same
- * bin as well as any eviction waiting for the write lock (a
+ * <strong>{@link #submit} is not free, and it is not I/O-free either.</strong>
+ * Before an entry is queued the caller's thread scrubs it, assigns its chain
+ * position, hashes it and signs it — CPU-bound work proportional to the size of
+ * the prompts and responses being recorded. On top of that, the <em>first</em>
+ * entry of a conversation (and the first after its counter is evicted) still
+ * pays one synchronous store read to seed the chain counter — see
+ * {@link #seedSequence}. What changed is only <em>where</em> that read happens:
+ * it used to run inside {@code ConcurrentHashMap.computeIfAbsent} while holding
+ * the sequence read lock, so one slow query stalled every other submitter that
+ * hashed to the same bin as well as any eviction waiting for the write lock (a
  * {@code ReentrantReadWriteLock} refuses new readers once a writer has queued).
- * The seed is now resolved by {@link #prewarmSequenceCounter} before either is
- * taken.
+ * {@link #prewarmSequenceCounter} now resolves the seed before either is taken,
+ * so a slow seed costs the calling turn and nothing else. Moving it off the
+ * caller thread entirely (assign {@link AuditEntry#UNSEQUENCED} on submit and
+ * back-fill on the flush thread before signing) is still open.
  * <p>
  * Before persisting, each entry passes through:
  * <ol>
@@ -76,8 +80,25 @@ public class AuditLedgerService {
      * How many consecutive refusals the per-entry fallback tolerates before it
      * declares the store unavailable and stops calling it for the rest of the
      * batch. See {@link #appendIndividually}.
+     * <p>
+     * Three, not ten: telling a poison row from a dead store needs <em>one</em>
+     * success, not ten failures, and every attempt against an unreachable store
+     * costs a full connection-acquisition timeout on the writer thread.
      */
-    static final int MAX_CONSECUTIVE_ENTRY_FAILURES = 10;
+    static final int MAX_CONSECUTIVE_ENTRY_FAILURES = 3;
+
+    /**
+     * Wall-clock budget for one per-entry retry pass, on top of
+     * {@link #MAX_CONSECUTIVE_ENTRY_FAILURES}.
+     * <p>
+     * The failure cap alone bounds the number of <em>calls</em>, not the time they
+     * take: against a store that is unreachable rather than refusing, each call
+     * blocks for the pool's acquisition timeout (Agroal's default is 5s), so even a
+     * small cap turns one flush into tens of seconds on the monitor the
+     * {@code @PreDestroy} final flush waits on. The budget is checked before every
+     * call, so a pass costs at most one in-flight call beyond it.
+     */
+    static final Duration ENTRY_RETRY_BUDGET = Duration.ofSeconds(2);
 
     /** Default bound for {@code eddi.audit.max-queue-size}. */
     static final int DEFAULT_MAX_QUEUE_SIZE = 100_000;
@@ -140,6 +161,14 @@ public class AuditLedgerService {
     private final int flushIntervalSeconds;
     private final Optional<String> masterKeyConfig;
     private final Counter droppedCounter;
+    /**
+     * Conversations observed with chain positions this node did not allocate — see
+     * {@link #detectForeignSequenceAllocation}. Non-zero means the deployment is
+     * running multiple replicas without conversation affinity, and
+     * {@code /auditstore/verify} will grade the affected conversations
+     * {@code BROKEN}.
+     */
+    private final Counter sequenceCollisionCounter;
     private final Instance<Connection> natsConnectionInstance;
     private final String deadLetterPath;
     private final boolean agentSigningEnabled;
@@ -234,6 +263,7 @@ public class AuditLedgerService {
         this.defaultTenantId = defaultTenantId;
         this.maxQueueSize = maxQueueSize > 0 ? maxQueueSize : DEFAULT_MAX_QUEUE_SIZE;
         this.droppedCounter = meterRegistry.counter("eddi_audit_entries_dropped_total");
+        this.sequenceCollisionCounter = meterRegistry.counter("eddi_audit_sequence_collisions_total");
         this.natsConnectionInstance = natsConnectionInstance;
         this.agentSigningService = agentSigningService;
         this.objectMapper = objectMapper;
@@ -253,7 +283,18 @@ public class AuditLedgerService {
      */
     static AuditLedgerService createForTesting(IAuditStore auditStore, boolean enabled, int flushIntervalSeconds, String masterKeyConfig,
                                                MeterRegistry meterRegistry, int maxQueueSize) {
-        return new AuditLedgerService(auditStore, enabled, flushIntervalSeconds, Optional.ofNullable(masterKeyConfig), "eddi-audit-deadletter.jsonl",
+        return createForTesting(auditStore, enabled, flushIntervalSeconds, masterKeyConfig, meterRegistry, maxQueueSize,
+                "eddi-audit-deadletter.jsonl");
+    }
+
+    /**
+     * Factory method for unit testing with an explicit dead-letter path — so a test
+     * can point the sink at a temporary location instead of the working directory,
+     * and assert what {@link #checkDeadLetterSinkReachable()} makes of it.
+     */
+    static AuditLedgerService createForTesting(IAuditStore auditStore, boolean enabled, int flushIntervalSeconds, String masterKeyConfig,
+                                               MeterRegistry meterRegistry, int maxQueueSize, String deadLetterPath) {
+        return new AuditLedgerService(auditStore, enabled, flushIntervalSeconds, Optional.ofNullable(masterKeyConfig), deadLetterPath,
                 false, "default", maxQueueSize, true, 500, meterRegistry, null, null, new ObjectMapper());
     }
 
@@ -295,19 +336,49 @@ public class AuditLedgerService {
      * during the incident, from an error line nested inside the error line that
      * reported the drop, is the wrong time; {@link #writeToDeadLetter} now also
      * creates the directory, and this says so up front if it cannot.
+     * <p>
+     * <strong>Existence is not writability.</strong> Checking only that the
+     * directory is there passed every case where it exists but cannot be written —
+     * a root-owned mount, {@code readOnlyRootFilesystem: true} without a volume at
+     * the path (a common CIS hardening setting), an {@code emptyDir} with the wrong
+     * {@code fsGroup}, or a {@code dead-letter-path} that names a directory rather
+     * than a file. So the check performs the exact operation
+     * {@link #writeToDeadLetter} performs: open the sink for append. A file the
+     * probe itself had to create is removed again, so a healthy deployment does not
+     * grow an empty dead-letter file that monitoring would read as an incident.
+     *
+     * @return true when the sink was proven writable — package-visible so a test
+     *         can assert the verdict instead of scraping the log
      */
-    private void checkDeadLetterSinkReachable() {
+    boolean checkDeadLetterSinkReachable() {
+        Path dlPath = Path.of(deadLetterPath).toAbsolutePath();
         try {
-            Path parent = Path.of(deadLetterPath).toAbsolutePath().getParent();
-            if (parent == null || Files.isDirectory(parent)) {
-                return;
+            Path parent = dlPath.getParent();
+            if (parent != null && !Files.isDirectory(parent)) {
+                Files.createDirectories(parent);
+                LOGGER.infov("Created audit dead-letter directory {0}", parent);
             }
-            Files.createDirectories(parent);
-            LOGGER.infov("Created audit dead-letter directory {0}", parent);
+            // notExists, not !exists: both are false when the answer cannot be
+            // determined (an I/O error while reading attributes — a network mount
+            // hiccup, or a Windows ACL granting FILE_APPEND_DATA without
+            // FILE_READ_ATTRIBUTES), and this guard has to fail in one direction
+            // only. Read as "exists, or we cannot prove otherwise", an undeterminable
+            // answer leaves the file alone; read as "does not exist" it would delete a
+            // real dead-letter file — the one place abandoned evidence is recoverable
+            // from — after an append-open that happened to succeed.
+            boolean existedBefore = !Files.notExists(dlPath);
+            try (var probe = Files.newOutputStream(dlPath, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+                probe.flush(); // opening is the check; nothing is written
+            }
+            if (!existedBefore) {
+                Files.deleteIfExists(dlPath);
+            }
+            return true;
         } catch (Exception e) {
             LOGGER.warnv("Audit dead-letter sink {0} is not writable ({1}). Entries the ledger has to abandon "
                     + "will be lost rather than recoverable — point eddi.audit.dead-letter-path at a writable "
                     + "location or mount a volume there.", deadLetterPath, e.getMessage());
+            return false;
         }
     }
 
@@ -758,11 +829,15 @@ public class AuditLedgerService {
                 // together. Retry per entry instead — both stores' single-entry
                 // inserts are idempotent — so only the entry that genuinely cannot
                 // be stored is abandoned.
-                List<AuditEntry> unstorable = appendIndividually(batch);
-                if (unstorable.isEmpty()) {
+                IndividualRetryOutcome outcome = appendIndividually(batch);
+                // Deferred entries were never offered to the store, so they are not
+                // evidence of anything: re-queue them and let the next pass continue
+                // where the budget cut this one off.
+                requeueDeferred(outcome.deferred());
+                if (outcome.unstorable().isEmpty()) {
                     consecutiveFailures.set(0);
                 } else {
-                    handlePersistentFailures(unstorable);
+                    handlePersistentFailures(outcome.unstorable());
                 }
             } finally {
                 // Every outcome has put these positions somewhere eviction can see
@@ -772,6 +847,78 @@ public class AuditLedgerService {
                 // find something. Bump last, once the move is visible.
                 flushGeneration.incrementAndGet();
             }
+            // Last, and outside the try: the rows this node wrote are now visible, so
+            // anything the store holds ABOVE them was written by somebody else.
+            detectForeignSequenceAllocation(batch);
+        }
+    }
+
+    /**
+     * Report a second writer allocating chain positions for a conversation this
+     * node is also allocating for — the multi-replica-without-affinity failure
+     * described on {@link IAuditStore#maxSequence}, made visible in metrics instead
+     * of at {@code /auditstore/verify} time.
+     * <p>
+     * The predicate is exact and has no false positives: if the store already holds
+     * a position greater than or equal to this node's <em>next free</em> one, then
+     * every position this node still has to hand out for that conversation is
+     * already taken, and handing it out produces the duplicate that
+     * {@code /auditstore/verify} grades {@code BROKEN}. In the healthy
+     * single-writer case the stored maximum is always below the next free position,
+     * because this node is the only source of those numbers. Reading the counter
+     * after the store can only make the check <em>less</em> sensitive (a concurrent
+     * submitter may have advanced it), never falsely positive.
+     * <p>
+     * It is not a complete detector, and must not be sold as one: two nodes that
+     * hand out exactly the same range leave a stored maximum that matches both of
+     * their counters, and only {@code /auditstore/verify} sees that duplicate.
+     * Complete detection at allocation time needs the atomic reservation this
+     * deliberately does not implement.
+     * <p>
+     * On a hit the counter is also advanced past the foreign rows. That is the
+     * correct chain position to continue from — the intervening positions exist, so
+     * nothing is skipped — and it keeps a permanently misconfigured deployment from
+     * re-reporting the same conversation on every flush.
+     * <p>
+     * Cost: one indexed {@code MAX(sequence)} read per conversation in the batch,
+     * on the writer thread, never on the pipeline thread. Skipped entirely for
+     * stores that do not sequence, during shutdown, and for conversations whose
+     * counter has been evicted (the next entry re-seeds from the store anyway).
+     */
+    private void detectForeignSequenceAllocation(List<AuditEntry> batch) {
+        if (shuttingDown || conversationSequences.isEmpty() || !auditStore.supportsSequence()) {
+            return;
+        }
+        var conversationIds = new LinkedHashSet<String>();
+        collectConversationIds(batch, conversationIds);
+        for (String conversationId : conversationIds) {
+            AtomicLong counter = conversationSequences.get(conversationId);
+            if (counter == null) {
+                continue;
+            }
+            long nextFree = counter.get();
+            long storedMax;
+            try {
+                storedMax = auditStore.maxSequence(conversationId);
+            } catch (Exception e) {
+                // A store that cannot answer is the flush's problem, not this
+                // check's: it has already been reported by the append above.
+                LOGGER.debugv("Could not read the stored audit sequence for conversation {0}: {1}",
+                        sanitize(conversationId), e.getMessage());
+                continue;
+            }
+            if (storedMax < nextFree) {
+                continue;
+            }
+            sequenceCollisionCounter.increment();
+            LOGGER.warnv("Audit chain position {0} for conversation {1} is already stored, but this node's next "
+                    + "free position is {2} — another replica is allocating positions for the same conversation. "
+                    + "Sequence allocation is not cluster-safe: route every turn of a conversation to the same "
+                    + "node (conversation affinity), or /auditstore/verify will grade this conversation BROKEN. "
+                    + "Continuing from {3}.", storedMax, sanitize(conversationId), nextFree, storedMax + 1);
+            // accumulateAndGet, not set: submitters increment this concurrently, and
+            // the counter must only ever move forward.
+            counter.accumulateAndGet(storedMax + 1, Math::max);
         }
     }
 
@@ -784,34 +931,85 @@ public class AuditLedgerService {
      * only the genuinely unstorable ones come back.
      *
      * <b>The pass gives up after {@link #MAX_CONSECUTIVE_ENTRY_FAILURES}
-     * consecutive refusals.</b> The fallback exists to isolate a poison entry from
-     * the batch around it, which needs only enough attempts to tell one bad row
-     * from a bad store. An outage refuses every one of them, and this method runs
-     * on the writer thread inside {@code synchronized flush()} — the same monitor
-     * the {@code @PreDestroy} final flush waits on. Without a cap, a queue grown
-     * toward {@link #DEFAULT_MAX_QUEUE_SIZE} against an unreachable PostgreSQL
-     * (connect timeouts measured in tens of seconds) would block both for hours,
-     * where the old whole-batch retry failed once per flush window. The remaining
-     * entries are returned unstorable without a store call, which puts them back on
-     * the queue for the next flush exactly as if they had been attempted.
+     * consecutive refusals or {@link #ENTRY_RETRY_BUDGET} of wall clock, and it
+     * does not run at all during shutdown.</b> The fallback exists to isolate a
+     * poison entry from the batch around it, which needs only enough attempts to
+     * tell one bad row from a bad store. An outage refuses every one of them, and
+     * this method runs on the writer thread inside {@code synchronized flush()} —
+     * the same monitor the {@code @PreDestroy} final flush waits on. A cap on the
+     * <em>number</em> of calls is not enough on its own: against a store that is
+     * unreachable rather than refusing, every call blocks for the connection pool's
+     * acquisition timeout, so the cap alone multiplied one flush's cost by itself.
+     * On the shutdown path that was fatal in a way the old whole-batch retry was
+     * not — {@link #shutdown()} runs two flushes around a 5s
+     * {@code awaitTermination} before {@link #drainQueueToDeadLetter}, and
+     * {@code terminationGracePeriodSeconds} is 30 in the shipped Kubernetes
+     * manifests, so a rolling deploy during a store failover was SIGKILLed inside
+     * this loop and the drain never ran. There is no later attempt to protect once
+     * {@link #shuttingDown} is set, so the whole batch goes straight back for
+     * dead-lettering instead; the sink carries the full entry, so nothing is lost
+     * that the store would have taken.
      *
-     * @return the entries that still could not be stored
+     * <b>Running out of budget is not a store failure — unless the store took
+     * nothing.</b> A pass that stops on the clock having stored at least one entry
+     * has met a store that is merely slow, so the tail it never offered is
+     * {@code deferred} — never offered, therefore not failed. Both groups used to
+     * come back as one list, and one poison row inside a large backlog on a
+     * healthy-but-slow store then dead-lettered thousands of storable entries after
+     * three flushes and counted them on {@code eddi_audit_entries_dropped_total},
+     * while the store had been accepting everything it was handed. But a pass that
+     * stops on the clock having stored <em>nothing</em> and refused at least one
+     * entry has met a store that is unavailable, and that it learned this from the
+     * clock rather than from {@link #MAX_CONSECUTIVE_ENTRY_FAILURES} is an accident
+     * of how long that store takes to say no: against a store whose per-call
+     * timeout exceeds {@link #ENTRY_RETRY_BUDGET} (Agroal's acquisition default is
+     * 5s, the budget is 2s) the failure cap is unreachable, because the pass never
+     * reaches a second call. Deferring that tail made the backlog circulate forever
+     * — one entry reached the sink per three flushes while the rest went round
+     * again — and once the queue reached its bound every newly submitted entry was
+     * discarded at {@code submit()} with no dead-letter record at all. The tail is
+     * therefore classified by what the pass <em>observed</em>, not by which stop
+     * condition fired; see {@link #abandonedTailReason}.
+     *
+     * @return what the store refused, and what this pass ran out of time to offer
      */
-    private List<AuditEntry> appendIndividually(List<AuditEntry> batch) {
+    private IndividualRetryOutcome appendIndividually(List<AuditEntry> batch) {
+        if (shuttingDown) {
+            LOGGER.errorv("Audit ledger is shutting down — not retrying {0} entries one by one; they go to the "
+                    + "dead-letter sink so the shutdown stays inside its grace period", batch.size());
+            // Not deferred: deferral means "the next flush takes these", and during
+            // shutdown there is no next flush.
+            return new IndividualRetryOutcome(new ArrayList<>(batch), List.of());
+        }
+
         List<AuditEntry> unstorable = new ArrayList<>();
         int consecutiveEntryFailures = 0;
+        int stored = 0;
+        long deadline = System.nanoTime() + ENTRY_RETRY_BUDGET.toNanos();
         for (int i = 0; i < batch.size(); i++) {
             AuditEntry entry = batch.get(i);
-            if (consecutiveEntryFailures >= MAX_CONSECUTIVE_ENTRY_FAILURES) {
-                int abandoned = batch.size() - i;
-                LOGGER.errorv("Audit store refused {0} entries in a row — treating it as unavailable and abandoning the "
-                        + "per-entry retry for the remaining {1} of this batch", MAX_CONSECUTIVE_ENTRY_FAILURES, abandoned);
-                unstorable.addAll(batch.subList(i, batch.size()));
-                break;
+            // Re-read shuttingDown every iteration: a SIGTERM can land while a
+            // scheduled flush is already inside this loop, and that flush holds the
+            // monitor the final flush is waiting on.
+            boolean shutdownStarted = shuttingDown;
+            boolean outOfBudget = System.nanoTime() - deadline >= 0;
+            boolean storeRefusing = consecutiveEntryFailures >= MAX_CONSECUTIVE_ENTRY_FAILURES;
+            if (storeRefusing || outOfBudget || shutdownStarted) {
+                List<AuditEntry> remaining = List.copyOf(batch.subList(i, batch.size()));
+                String abandonReason = abandonedTailReason(storeRefusing, shutdownStarted, stored, unstorable.size(),
+                        remaining.size());
+                if (abandonReason != null) {
+                    LOGGER.error(abandonReason);
+                    unstorable.addAll(remaining);
+                    return new IndividualRetryOutcome(unstorable, List.of());
+                }
+                LOGGER.warn(budgetExhaustedMessage(unstorable.size(), remaining.size()));
+                return new IndividualRetryOutcome(unstorable, remaining);
             }
             try {
                 auditStore.appendEntry(entry);
                 consecutiveEntryFailures = 0;
+                stored++;
             } catch (Exception e) {
                 consecutiveEntryFailures++;
                 LOGGER.errorv("Audit entry {0} (conversation {1}, sequence {2}) could not be stored: {3}", sanitize(entry.id()),
@@ -819,7 +1017,137 @@ public class AuditLedgerService {
                 unstorable.add(entry);
             }
         }
-        return unstorable;
+        return new IndividualRetryOutcome(unstorable, List.of());
+    }
+
+    /**
+     * Why a stopped per-entry pass hands its unoffered tail to
+     * {@link #handlePersistentFailures} rather than to the next flush — or
+     * {@code null} when deferral is the honest answer.
+     * <p>
+     * Deferral is only safe when a next flush exists and can be expected to do
+     * better than this one. Three cases say it cannot:
+     * <ul>
+     * <li><b>The failure cap fired.</b> The store is refusing, so the tail it never
+     * reached is at the same risk as the entries that were refused.</li>
+     * <li><b>A SIGTERM landed mid-pass.</b> There is no next flush to defer to —
+     * the same reason the pre-loop check dead-letters the whole batch. Re-queuing
+     * here was rescued only by {@link #shutdown()}'s own drain, while the log told
+     * the operator the entries had been deferred "to the next flush" that would
+     * never run.</li>
+     * <li><b>The budget expired and the store had accepted nothing.</b> Against a
+     * store whose per-call timeout exceeds {@link #ENTRY_RETRY_BUDGET} the failure
+     * cap cannot be reached — one call spends the whole budget — so this is the
+     * only signal that separates "unavailable" from "slow", and without it the
+     * backlog never escalates to the sink.</li>
+     * </ul>
+     *
+     * @param storeRefusing
+     *            whether {@link #MAX_CONSECUTIVE_ENTRY_FAILURES} was reached
+     * @param shutdownStarted
+     *            whether {@link #shuttingDown} was set while the loop was running
+     * @param stored
+     *            entries this pass offered and the store accepted
+     * @param refused
+     *            entries this pass offered and the store rejected
+     * @param remaining
+     *            entries the pass stopped before offering
+     * @return the sentence to log at ERROR, or {@code null} to defer the tail
+     */
+    static String abandonedTailReason(boolean storeRefusing, boolean shutdownStarted, int stored, int refused, int remaining) {
+        if (storeRefusing) {
+            return "Audit store refused " + MAX_CONSECUTIVE_ENTRY_FAILURES + " entries in a row — treating it as unavailable "
+                    + "and abandoning the per-entry retry for the remaining " + remaining + " of this batch";
+        }
+        if (shutdownStarted) {
+            return "Audit ledger started shutting down mid-pass — abandoning the per-entry retry for the remaining " + remaining
+                    + " entries of this batch. There is no next flush, so they are dead-lettered rather than deferred";
+        }
+        if (stored == 0 && refused > 0) {
+            return "Audit store refused every one of the " + refused + " entries this pass offered and the "
+                    + ENTRY_RETRY_BUDGET.toSeconds() + "s per-entry retry budget ran out before the remaining " + remaining
+                    + " could be offered — a store that has accepted nothing is unavailable rather than slow, so the tail is "
+                    + "escalated with the refusals instead of being deferred back onto the queue";
+        }
+        return null;
+    }
+
+    /**
+     * The sentence a budget-exhausted pass logs.
+     * <p>
+     * Refusing and running out of wall clock are not alternatives — a pass can
+     * refuse an entry, keep going, and only then hit the deadline. The message used
+     * to open with "accepted what it was offered" in every such case, so an
+     * operator reading it had no reason to look for the rows that the very same
+     * flush was re-queueing or dead-lettering two lines later in
+     * {@code handlePersistentFailures}. The verb is therefore chosen from
+     * {@code refused}, and both counts are named, because the two groups leave this
+     * flush by different doors.
+     * <p>
+     * This message covers deferral only. The stop conditions that abandon the tail
+     * instead — a refusing store, a SIGTERM mid-pass, or a budget that expired
+     * against a store which had accepted nothing — are worded by
+     * {@link #abandonedTailReason}, so no case reaches here that a "deferring to
+     * the next flush" sentence would misdescribe.
+     *
+     * @param refused
+     *            entries this pass offered and the store rejected
+     * @param deferred
+     *            entries the deadline stopped it from offering at all
+     */
+    static String budgetExhaustedMessage(int refused, int deferred) {
+        if (refused == 0) {
+            return "Audit store accepted what it was offered but the " + ENTRY_RETRY_BUDGET.toSeconds()
+                    + "s per-entry retry budget ran out — deferring the remaining " + deferred
+                    + " entries of this batch to the next flush";
+        }
+        return "Audit store refused " + refused + " of the entries it was offered and the "
+                + ENTRY_RETRY_BUDGET.toSeconds() + "s per-entry retry budget ran out"
+                + " before the remaining " + deferred + " could be offered — the " + refused
+                + " refused are re-queued or dead-lettered by this same flush, the " + deferred
+                + " unoffered are deferred to the next one";
+    }
+
+    /**
+     * What one per-entry retry pass produced.
+     *
+     * @param unstorable
+     *            entries the store refused, plus — when the pass stopped because
+     *            the store was refusing everything — the tail it did not get to
+     * @param deferred
+     *            entries the pass ran out of wall clock before offering. They have
+     *            failed at nothing, so they are re-queued without touching
+     *            {@code consecutiveFailures} and cannot be dead-lettered on the
+     *            strength of someone else's poison row.
+     */
+    private record IndividualRetryOutcome(List<AuditEntry> unstorable, List<AuditEntry> deferred) {
+    }
+
+    /**
+     * Put entries the retry budget never reached back on the queue.
+     * <p>
+     * Deliberately silent about {@code consecutiveFailures}: the store accepted
+     * everything it was offered in this pass, so there is nothing to escalate. The
+     * queue bound still applies — an overflow goes to the sink rather than the
+     * heap, exactly as on the failure path.
+     */
+    private void requeueDeferred(List<AuditEntry> deferred) {
+        if (deferred.isEmpty()) {
+            return;
+        }
+        List<AuditEntry> rejected = new ArrayList<>();
+        for (AuditEntry entry : deferred) {
+            if (!offerBounded(entry)) {
+                rejected.add(entry);
+            }
+        }
+        LOGGER.warnv("Re-queued {0} audit entries the retry budget did not reach", deferred.size() - rejected.size());
+        if (!rejected.isEmpty()) {
+            // Not counted here: reserveQueueSlot already increments droppedCounter
+            // once per refusal.
+            LOGGER.errorv("Audit queue full — dead-lettering {0} entries that did not fit when deferred", rejected.size());
+            writeToDeadLetter(rejected);
+        }
     }
 
     /**
@@ -842,6 +1170,12 @@ public class AuditLedgerService {
                     MAX_FLUSH_RETRIES);
             droppedCounter.increment(unstorable.size());
             writeToDeadLetter(unstorable);
+            // The budget restarts deliberately: it counts attempts spent on THESE
+            // entries, and they are now durably in the sink. Leaving it exhausted
+            // would dead-letter every subsequent flush on its first failure, so a
+            // store that recovers between two flushes would never get the two
+            // retries the policy promises. The cost of restarting it is bounded by
+            // ENTRY_RETRY_BUDGET per flush, not by the queue length.
             consecutiveFailures.set(0);
             return;
         }
@@ -1094,10 +1428,21 @@ public class AuditLedgerService {
     // ==================== Private Helpers ====================
 
     /**
-     * Scrub potential secrets from string values in the entry's maps.
+     * Scrub potential secrets from string values in the entry's maps, and stamp an
+     * id if the caller did not supply one.
+     * <p>
+     * The id has to be minted exactly once, here, because it is the conflict key
+     * both stores' idempotent single-entry inserts rest on ({@code ON CONFLICT (id)
+     * DO NOTHING}, {@code E11000} tolerated). {@code PostgresAuditStore} used to
+     * mint one per <em>attempt</em> instead, so a null-id entry that landed in an
+     * aborted batch was inserted a second time under a different primary key by the
+     * per-entry retry — and a duplicate sequence is graded {@code BROKEN}, exactly
+     * like a deletion. Stamping before the HMAC is computed also keeps the id
+     * inside what the signature covers.
      */
     private static AuditEntry scrubSecrets(AuditEntry entry) {
-        return new AuditEntry(entry.id(), entry.conversationId(), entry.agentId(), entry.agentVersion(), entry.userId(), entry.environment(),
+        String id = entry.id() != null ? entry.id() : UUID.randomUUID().toString();
+        return new AuditEntry(id, entry.conversationId(), entry.agentId(), entry.agentVersion(), entry.userId(), entry.environment(),
                 entry.stepIndex(), entry.taskId(), entry.taskType(), entry.taskIndex(), entry.durationMs(), scrubMap(entry.input()),
                 scrubMap(entry.output()), scrubMap(entry.llmDetail()), scrubMap(entry.toolCalls()), entry.actions(), entry.cost(), entry.timestamp(),
                 null, // HMAC not yet computed
@@ -1204,6 +1549,40 @@ public class AuditLedgerService {
      * @return JSON string
      */
     String serializeDeadLetterEntry(AuditEntry entry, String type) {
+        Map<String, Object> dlMap = metadataOnlyDeadLetterRecord(entry, type);
+        // userId, input and output make the sink a personal-data location that the
+        // GDPR erasure cascade does not reach — deliberately, because without them
+        // the record is neither replayable nor evidence of what was lost. See
+        // docs/gdpr-compliance.md, "The audit dead-letter sink holds personal data".
+        dlMap.put("userId", entry.userId());
+        dlMap.put("actions", entry.actions());
+        dlMap.put("input", entry.input());
+        dlMap.put("output", entry.output());
+        dlMap.put("llmDetail", entry.llmDetail());
+        dlMap.put("toolCalls", entry.toolCalls());
+
+        try {
+            return objectMapper.writeValueAsString(dlMap);
+        } catch (JsonProcessingException e) {
+            // Degrade to the metadata, do not vanish. The entry most likely to reach
+            // this branch is the one carrying a payload Jackson cannot render — which
+            // is also the one the store most likely rejected, so it is exactly the
+            // entry an operator needs to attribute a chain gap and to replay. The old
+            // {"error":"serialization_failed"} threw away its id, sequence and
+            // conversationId along with the payload that caused the failure, leaving
+            // the gap indistinguishable from a deletion.
+            LOGGER.errorv("Jackson serialization failed for dead-letter entry {0}: {1} — writing metadata only",
+                    sanitize(entry.id()), e.getMessage());
+            return serializeMetadataOnly(entry, type, e);
+        }
+    }
+
+    /**
+     * The fixed-shape half of a dead-letter record: identity, chain position and
+     * signatures. Everything here is a String, a number or null, so it cannot fail
+     * to serialize — which is what makes it a usable fallback for the payload half.
+     */
+    private Map<String, Object> metadataOnlyDeadLetterRecord(AuditEntry entry, String type) {
         Map<String, Object> dlMap = new LinkedHashMap<>();
         if (type != null) {
             dlMap.put("type", type);
@@ -1216,11 +1595,6 @@ public class AuditLedgerService {
         dlMap.put("id", entry.id());
         dlMap.put("sequence", entry.sequence());
         dlMap.put("agentVersion", entry.agentVersion());
-        // userId, input and output make the sink a personal-data location that the
-        // GDPR erasure cascade does not reach — deliberately, because without them
-        // the record is neither replayable nor evidence of what was lost. See
-        // docs/gdpr-compliance.md, "The audit dead-letter sink holds personal data".
-        dlMap.put("userId", entry.userId());
         dlMap.put("environment", entry.environment());
         dlMap.put("stepIndex", entry.stepIndex());
         dlMap.put("taskIndex", entry.taskIndex());
@@ -1229,18 +1603,28 @@ public class AuditLedgerService {
         dlMap.put("entryTimestamp", entry.timestamp() != null ? entry.timestamp().toString() : null);
         dlMap.put("hmac", entry.hmac());
         dlMap.put("agentSignature", entry.agentSignature());
-        dlMap.put("actions", entry.actions());
-        dlMap.put("input", entry.input());
-        dlMap.put("output", entry.output());
-        dlMap.put("llmDetail", entry.llmDetail());
-        dlMap.put("toolCalls", entry.toolCalls());
+        return dlMap;
+    }
 
+    /**
+     * The last-resort record: everything except the payload maps, plus a marker
+     * naming why the payload is missing. Still carries the id, the sequence and the
+     * conversation, which is what {@link #undeliveredSequences} needs to grade the
+     * gap {@code INCOMPLETE} rather than {@code BROKEN}, and what a replay needs to
+     * find the turn again.
+     */
+    private String serializeMetadataOnly(AuditEntry entry, String type, JsonProcessingException cause) {
+        Map<String, Object> dlMap = metadataOnlyDeadLetterRecord(entry, type);
+        dlMap.put("userId", entry.userId());
+        dlMap.put("actions", entry.actions());
+        dlMap.put("payloadError", "serialization_failed: " + cause.getOriginalMessage());
         try {
             return objectMapper.writeValueAsString(dlMap);
         } catch (JsonProcessingException e) {
-            // Absolute fallback — should never happen with simple string maps.
-            // Do NOT embed entry fields here: we'd reintroduce the escaping bug.
-            LOGGER.errorv("Jackson serialization failed for dead-letter entry: {0}", e.getMessage());
+            // Absolute fallback — should never happen, every value above is a String,
+            // a number or null. Do NOT embed entry fields here by hand: we'd
+            // reintroduce the escaping bug Jackson is used to avoid.
+            LOGGER.errorv("Jackson serialization failed even for the dead-letter metadata: {0}", e.getMessage());
             return "{\"error\":\"serialization_failed\"}";
         }
     }

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditStore.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditStore.java
@@ -5,9 +5,13 @@
 package ai.labs.eddi.engine.audit;
 
 import ai.labs.eddi.engine.audit.model.AuditEntry;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.MongoWriteException;
+import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.InsertManyOptions;
 import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -65,6 +69,9 @@ public class AuditStore implements IAuditStore {
     private static final String F_AGENT_SIGNATURE = "agentSignature";
     private static final String F_SEQUENCE = "sequence";
 
+    /** MongoDB's {@code E11000 duplicate key} error code. */
+    private static final int DUPLICATE_KEY_ERROR = 11000;
+
     private final MongoCollection<Document> collection;
 
     @Inject
@@ -75,13 +82,46 @@ public class AuditStore implements IAuditStore {
         collection.createIndex(Indexes.ascending(F_CONVERSATION_ID));
         collection.createIndex(Indexes.ascending(F_AGENT_ID, F_AGENT_VERSION));
         collection.createIndex(Indexes.descending(F_TIMESTAMP));
+        // GDPR export (getEntriesByUserId) and erasure (pseudonymizeByUserId) both
+        // select on userId. audit_ledger is the largest, append-only, never-pruned
+        // collection in the system and both operations are legally deadline-bound,
+        // so without this they are full collection scans — and updateMany holds a
+        // write lock for the duration.
+        collection.createIndex(Indexes.ascending(F_USER_ID));
+        // Per-conversation reads sort by timestamp descending; the compound index
+        // serves the filter and the sort together, so large conversations stop
+        // hitting MongoDB's in-memory sort limit. It also backs maxSequence.
+        collection.createIndex(Indexes.compoundIndex(Indexes.ascending(F_CONVERSATION_ID), Indexes.descending(F_TIMESTAMP)));
+        collection.createIndex(Indexes.compoundIndex(Indexes.ascending(F_CONVERSATION_ID), Indexes.descending(F_SEQUENCE)));
     }
 
+    /**
+     * Insert one entry, treating "already stored" as success — see
+     * {@link #appendBatch} for why the retry path needs that.
+     */
     @Override
     public void appendEntry(AuditEntry entry) {
-        collection.insertOne(toDocument(entry));
+        try {
+            collection.insertOne(toDocument(entry));
+        } catch (MongoWriteException e) {
+            if (e.getError().getCode() != DUPLICATE_KEY_ERROR) {
+                throw e;
+            }
+        }
     }
 
+    /**
+     * Insert a batch, unordered and duplicate-tolerant.
+     * <p>
+     * Unordered so one rejected document does not stop the ones behind it — an
+     * ordered {@code insertMany} persists the prefix and abandons the rest, which
+     * combined with the ledger's whole-batch retry meant a single bad entry
+     * discarded three flush windows of unrelated conversations' records.
+     * Duplicate-key errors are ignored for the same reason the PostgreSQL insert
+     * carries {@code ON CONFLICT (id) DO NOTHING}: a retry of a partially-applied
+     * batch must be able to re-offer the documents that already landed. Every other
+     * write error is still raised, so a genuinely broken store is not hidden.
+     */
     @Override
     public void appendBatch(List<AuditEntry> entries) {
         if (entries == null || entries.isEmpty())
@@ -92,7 +132,16 @@ public class AuditStore implements IAuditStore {
             documents.add(toDocument(entry));
         }
 
-        collection.insertMany(documents);
+        try {
+            collection.insertMany(documents, new InsertManyOptions().ordered(false));
+        } catch (MongoBulkWriteException e) {
+            List<BulkWriteError> fatal = e.getWriteErrors().stream()
+                    .filter(error -> error.getCode() != DUPLICATE_KEY_ERROR)
+                    .toList();
+            if (!fatal.isEmpty()) {
+                throw e;
+            }
+        }
     }
 
     @Override
@@ -119,6 +168,16 @@ public class AuditStore implements IAuditStore {
     public List<AuditEntry> getEntriesByUserId(String userId, int skip, int limit) {
         Document filter = new Document(F_USER_ID, userId);
         return query(filter, skip, limit);
+    }
+
+    @Override
+    public long maxSequence(String conversationId) {
+        Document highest = collection.find(new Document(F_CONVERSATION_ID, conversationId))
+                .sort(new Document(F_SEQUENCE, -1))
+                .projection(new Document(F_SEQUENCE, 1))
+                .limit(1)
+                .first();
+        return highest == null ? AuditEntry.UNSEQUENCED : readSequence(highest);
     }
     // ==================== Private Helpers ====================
 

--- a/src/main/java/ai/labs/eddi/engine/audit/AuditStore.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/AuditStore.java
@@ -121,6 +121,21 @@ public class AuditStore implements IAuditStore {
      * carries {@code ON CONFLICT (id) DO NOTHING}: a retry of a partially-applied
      * batch must be able to re-offer the documents that already landed. Every other
      * write error is still raised, so a genuinely broken store is not hidden.
+     * <p>
+     * <strong>A write-concern error is not a duplicate.</strong>
+     * {@code MongoBulkWriteException} is also how the driver reports a failure of
+     * the write concern itself — a {@code w=majority} acknowledgement timing out
+     * during a replica-set election, say — and in that shape
+     * {@link MongoBulkWriteException#getWriteErrors()} is <em>empty</em> while
+     * {@link MongoBulkWriteException#getWriteConcernError()} is set. Filtering only
+     * the per-document errors therefore returned normally for a batch whose
+     * durability was never confirmed: {@code AuditLedgerService} cleared its
+     * in-flight batch, reset its failure counter and left the chain counters past
+     * positions a rollback could still erase — no retry, no dead-letter record, no
+     * dropped-counter increment, and {@code /auditstore/verify} reporting the
+     * conversation {@code BROKEN} later on. The production connection string sets
+     * {@code w=majority}, so this is the ordinary failover shape rather than an
+     * exotic one.
      */
     @Override
     public void appendBatch(List<AuditEntry> entries) {
@@ -135,6 +150,9 @@ public class AuditStore implements IAuditStore {
         try {
             collection.insertMany(documents, new InsertManyOptions().ordered(false));
         } catch (MongoBulkWriteException e) {
+            if (e.getWriteConcernError() != null) {
+                throw e;
+            }
             List<BulkWriteError> fatal = e.getWriteErrors().stream()
                     .filter(error -> error.getCode() != DUPLICATE_KEY_ERROR)
                     .toList();

--- a/src/main/java/ai/labs/eddi/engine/audit/IAuditStore.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/IAuditStore.java
@@ -130,4 +130,31 @@ public interface IAuditStore {
     default boolean supportsSequence() {
         return false;
     }
+
+    /**
+     * The highest chain position this store holds for a conversation, or
+     * {@link AuditEntry#UNSEQUENCED} when it holds none (or cannot answer).
+     * <p>
+     * This is what a sequence counter must be seeded from.
+     * {@link #countByConversation} counts <em>persisted rows</em>, which is a
+     * different number the moment any position was handed out but never stored:
+     * with positions 0-9 issued and 3 and 5 dead-lettered, the count is 8 while the
+     * next free position is 10 — so a re-seed from the count hands 8 and 9 out a
+     * second time, and {@code /auditstore/verify} grades duplicates exactly like
+     * deletions ({@code BROKEN}). The ledger would then accuse the deployment of
+     * tampering because of its own bookkeeping. Seeding from {@code max + 1} cannot
+     * do that, and it survives a restart and a second cluster node, which the
+     * in-memory "undelivered" pin does not.
+     * <p>
+     * The default returns {@link AuditEntry#UNSEQUENCED} so a store that does not
+     * implement it falls back to the count — the previous behaviour, and harmless
+     * for stores that do not persist a sequence at all.
+     *
+     * @param conversationId
+     *            the conversation to ask about
+     * @return the highest stored sequence, or {@link AuditEntry#UNSEQUENCED}
+     */
+    default long maxSequence(String conversationId) {
+        return AuditEntry.UNSEQUENCED;
+    }
 }

--- a/src/main/java/ai/labs/eddi/engine/audit/IAuditStore.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/IAuditStore.java
@@ -143,8 +143,39 @@ public interface IAuditStore {
      * second time, and {@code /auditstore/verify} grades duplicates exactly like
      * deletions ({@code BROKEN}). The ledger would then accuse the deployment of
      * tampering because of its own bookkeeping. Seeding from {@code max + 1} cannot
-     * do that, and it survives a restart and a second cluster node, which the
-     * in-memory "undelivered" pin does not.
+     * do that, and unlike the in-memory "undelivered" pin it survives a restart.
+     * <p>
+     * <strong>KNOWN LIMITATION — sequence allocation is not cluster-safe.</strong>
+     * This is a read, not an atomic reservation: entries sit in a node-local queue
+     * for up to {@code eddi.audit.flush-interval-seconds} before the store can see
+     * them, so two nodes serving consecutive turns of one conversation inside that
+     * window both read the same maximum and both hand out the positions after it.
+     * Neither backend indexes {@code (conversationId, sequence)} uniquely, so the
+     * duplicate is accepted and {@code /auditstore/verify} grades the conversation
+     * {@code BROKEN}. <strong>A multi-replica deployment therefore needs
+     * conversation affinity for chain integrity today</strong> — individual HMACs
+     * still verify; it is the chain-continuity check that is affected.
+     * <p>
+     * <strong>Deferred fix, and why.</strong> Removing that requirement needs a
+     * storage-level atomic counter — PostgreSQL {@code UPDATE ... RETURNING} on a
+     * per-conversation counter row, MongoDB {@code findOneAndUpdate} with
+     * {@code $inc} — plus a unique {@code (conversationId, sequence)} constraint
+     * and a retry on collision. It is a separate change because it moves a store
+     * round trip from once per conversation to once per <em>entry</em>, on the
+     * pipeline thread, and it is a schema change on both backends. The unique
+     * constraint must not be added on its own either: without the allocator that
+     * makes collisions impossible, a rejected insert silently drops an audit
+     * record, which is worse than the duplicate it prevents — a duplicate at least
+     * surfaces as a detectable {@code BROKEN} verdict.
+     * <p>
+     * <strong>Until then the condition is detected, not silent.</strong>
+     * {@code AuditLedgerService.detectForeignSequenceAllocation} re-reads this
+     * value after each flush and, when the store already holds a position this node
+     * has not handed out yet, logs a WARN naming the conversation and increments
+     * {@code eddi_audit_sequence_collisions_total}. A non-zero counter means
+     * "multi-replica without conversation affinity". It is a partial detector — two
+     * nodes that hand out an identical range are still only caught at verify time —
+     * and no substitute for the fix above.
      * <p>
      * The default returns {@link AuditEntry#UNSEQUENCED} so a store that does not
      * implement it falls back to the count — the previous behaviour, and harmless

--- a/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/model/AuditVerificationReport.java
@@ -170,7 +170,7 @@ public record AuditVerificationReport(String scope, String scopeId, boolean sign
     }
 
     /**
-     * One entry that did not verify cleanly.
+     * One entry the sweep could not mark VALID.
      *
      * @param entryId
      *            the audit entry id
@@ -182,10 +182,6 @@ public record AuditVerificationReport(String scope, String scopeId, boolean sign
      *            when the entry was written
      * @param status
      *            why it is listed here
-     */
-    /**
-     * One entry the sweep could not mark VALID.
-     *
      * @param hmacVersion
      *            which canonical form the stored HMAC names ({@code v1}–{@code v4},
      *            or {@code null} for UNSIGNED). This is the triage field: an

--- a/src/main/java/ai/labs/eddi/engine/audit/rest/RestAuditStore.java
+++ b/src/main/java/ai/labs/eddi/engine/audit/rest/RestAuditStore.java
@@ -53,14 +53,38 @@ public class RestAuditStore implements IRestAuditStore {
         this.auditLedgerService = auditLedgerService;
     }
 
+    /**
+     * Page size used when a read endpoint is given no usable {@code limit}. Small
+     * on purpose: an audit entry carries full prompts and responses.
+     */
+    static final int DEFAULT_READ_LIMIT = 100;
+
+    /** Hard ceiling on one page of audit entries, whatever the caller asks for. */
+    static final int MAX_READ_LIMIT = 1_000;
+
     @Override
     public List<AuditEntry> getAuditTrail(String conversationId, int skip, int limit) {
-        return auditStore.getEntries(conversationId, skip, limit);
+        return auditStore.getEntries(conversationId, clampSkip(skip), clampReadLimit(limit));
     }
 
     @Override
     public List<AuditEntry> getAuditTrailByAgent(String agentId, Integer agentVersion, int skip, int limit) {
-        return auditStore.getEntriesByAgent(agentId, agentVersion, skip, limit);
+        return auditStore.getEntriesByAgent(agentId, agentVersion, clampSkip(skip), clampReadLimit(limit));
+    }
+
+    /**
+     * Bound a read page the way {@link #clampLimit} bounds a verification sweep.
+     * <p>
+     * The read endpoints used to pass the query parameter through untouched, and
+     * the two backends disagree about what an out-of-range value means: MongoDB
+     * treats {@code limit <= 0} as "no limit" and materialises every audit entry
+     * ever written for the scope — millions of rows with full prompts — into one
+     * response on the request thread, while PostgreSQL rejects a negative
+     * {@code LIMIT} or {@code OFFSET} with a 500. Same request, different failure,
+     * neither of them what the caller meant.
+     */
+    private static int clampReadLimit(int limit) {
+        return limit < 1 ? DEFAULT_READ_LIMIT : Math.min(limit, MAX_READ_LIMIT);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/engine/caching/CacheFactory.java
+++ b/src/main/java/ai/labs/eddi/engine/caching/CacheFactory.java
@@ -16,7 +16,15 @@ import java.util.concurrent.ConcurrentHashMap;
 public class CacheFactory implements ICacheFactory {
     private final ConcurrentHashMap<String, Cache<?, ?>> caches = new ConcurrentHashMap<>();
 
-    // Cache size configs (previously in infinispan-embedded.xml)
+    // Cache size configs (previously in infinispan-embedded.xml).
+    //
+    // Keyed by string on purpose — this is a registry, and importing the service
+    // classes that request each cache would point the dependency the wrong way.
+    // CacheFactoryTest binds the entries that have a named constant
+    // (GdprComplianceService.RESTRICTION_CACHE_NAME,
+    // TenantQuotaService.QUOTA_CACHE_NAME) back to it, so renaming one without
+    // updating this map fails there rather than silently reverting that cache to
+    // DEFAULT_MAX_SIZE.
     private static final Map<String, Long> CACHE_SIZES = Map.ofEntries(
             Map.entry("userConversations", 10_000L),
             Map.entry("agentTriggers", 1_000L),
@@ -34,6 +42,20 @@ public class CacheFactory implements ICacheFactory {
             // this cap only exists to bound memory if pages are produced faster than
             // they age out.
             Map.entry("paginated-tool-responses", 1_000L),
+
+            // Keyed by userId like "userConversations", so the keyspace is the number
+            // of ACTIVE users rather than a fixed set: at the 1_000 default a
+            // deployment with a few thousand concurrent users thrashes precisely under
+            // load, and Caffeine's W-TinyLFU then rejects the newly inserted key
+            // rather than an old one (see RATE_SIZED_EVICTION_HEADROOM). A miss is not
+            // an error, so nothing would log it — the per-turn store round trip on the
+            // hottest path in the system would simply come back. One Boolean per user.
+            Map.entry("gdprProcessingRestrictions", 10_000L),
+
+            // Keyed by tenantId, and tenants are few even in multi-tenant deployments.
+            // Listed rather than left to the default so the sizing sits on record next
+            // to the per-user caches above.
+            Map.entry("tenantQuotas", 1_000L),
 
             // Floor only — the real capacity is derived from the TTL the cache is
             // asked for, see RATE_SIZED_CACHES. This entry applies solely if something
@@ -93,6 +115,20 @@ public class CacheFactory implements ICacheFactory {
         double ttlSeconds = ttl.toMillis() / 1000.0;
         long required = (long) Math.ceil(peakRps * ttlSeconds * RATE_SIZED_EVICTION_HEADROOM);
         return Math.max(configured, required);
+    }
+
+    /**
+     * Whether {@code cacheName} has its own entry in {@link #CACHE_SIZES}, as
+     * opposed to inheriting {@link #DEFAULT_MAX_SIZE}.
+     * <p>
+     * Exists because {@link #maximumSizeFor} cannot tell the two apart: a cache
+     * deliberately listed at 1,000 and a cache nobody sized both answer 1,000, so a
+     * test asserting the number alone stays green when the entry is deleted — which
+     * is precisely the regression the entries were added to prevent, and a cache
+     * that silently reverts to the default logs nothing.
+     */
+    static boolean hasExplicitSize(String cacheName) {
+        return CACHE_SIZES.containsKey(cacheName);
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
@@ -29,6 +29,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 
@@ -66,6 +67,15 @@ public class GdprComplianceService {
     private final Instance<ISharedArtifactStore> sharedArtifactStoreInstance;
     private final IScheduleStore scheduleStore;
     private final ICache<String, UserConversation> userConversationCache;
+    /**
+     * Art. 18 restriction flags, short-TTL. {@code isProcessingRestricted} is
+     * called at conversation start and on every {@code say}/{@code sayStreaming},
+     * so an uncached lookup is a store round trip per turn on the hottest path in
+     * the system — to read a flag only an admin endpoint ever changes. Both of
+     * those endpoints invalidate the entry explicitly, so the TTL is only a
+     * backstop for another cluster node's write.
+     */
+    private final ICache<String, Boolean> restrictionCache;
 
     @Inject
     public GdprComplianceService(IUserMemoryStore userMemoryStore,
@@ -96,7 +106,20 @@ public class GdprComplianceService {
         this.sharedArtifactStoreInstance = sharedArtifactStoreInstance;
         this.scheduleStore = scheduleStore;
         this.userConversationCache = cacheFactory.getCache(USER_CONVERSATION_CACHE_NAME);
+        this.restrictionCache = cacheFactory.getCache(RESTRICTION_CACHE_NAME, RESTRICTION_CACHE_TTL);
     }
+
+    /** Name of the short-TTL cache behind {@link #isProcessingRestricted}. */
+    static final String RESTRICTION_CACHE_NAME = "gdprProcessingRestrictions";
+
+    /**
+     * Backstop TTL for {@link #RESTRICTION_CACHE_NAME}. Short, because a
+     * restriction applied on another cluster node has to take effect quickly;
+     * explicit invalidation in
+     * {@code restrictProcessing}/{@code unrestrictProcessing} covers the
+     * single-node case immediately.
+     */
+    static final Duration RESTRICTION_CACHE_TTL = Duration.ofSeconds(30);
 
     /**
      * Name of the Caffeine cache {@code RestUserConversationStore} reads managed
@@ -153,16 +176,27 @@ public class GdprComplianceService {
         String pseudonym = AuditHmac.pseudonymFor(userId);
         LOGGER.infof("[GDPR] Starting erasure cascade for pseudonym '%s'", pseudonym);
 
+        // Every step below is allowed to fail without aborting the cascade — but a
+        // failure must be visible in the response, or an admin files an Art. 17
+        // request as fulfilled while the data is still there.
+        var failedSteps = new ArrayList<String>();
+
         // 1. Delete user memories
         long memoriesDeleted = 0;
         try {
-            memoriesDeleted = userMemoryStore.countEntries(userId);
+            long countedMemories = userMemoryStore.countEntries(userId);
             userMemoryStore.deleteAllForUser(userId);
+            // The restriction flag lives in the same store and has just been deleted
+            // with everything else, so a cached "restricted" verdict is now wrong.
+            forgetRestriction(userId);
+            // Assigned only once the delete returned: assigning before it made the
+            // response claim N memories deleted when the delete had thrown and zero
+            // were.
+            memoriesDeleted = countedMemories;
             LOGGER.infof("[GDPR] Deleted %d user memory entries [%s]",
                     memoriesDeleted, pseudonym);
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete user memories [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "userMemories", e, pseudonym);
         }
 
         // 2. Delete attachments for all user conversations
@@ -175,15 +209,24 @@ public class GdprComplianceService {
         try {
             conversationIds = conversationMemoryStore.getConversationIdsByUserId(userId);
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to resolve conversation ids for user [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "conversationIdLookup", e, pseudonym);
         }
 
+        // The per-conversation loops below wrap EACH conversation in its own try.
+        // With the try outside the loop, the first conversation whose attachment
+        // (or journal, or descriptor, or checkpoint) delete threw ended the sweep:
+        // every remaining conversation kept the PII the cascade exists to remove,
+        // and the response still looked plausible. The export path in this class
+        // already isolates per conversation for exactly this reason.
         try {
             if (attachmentStorageInstance.isResolvable()) {
                 var attachmentStorage = attachmentStorageInstance.get();
                 for (String convId : conversationIds) {
-                    attachmentsDeleted += attachmentStorage.deleteByConversation(convId);
+                    try {
+                        attachmentsDeleted += attachmentStorage.deleteByConversation(convId);
+                    } catch (Exception e) {
+                        recordFailure(failedSteps, "attachments", e, pseudonym);
+                    }
                 }
                 if (attachmentsDeleted > 0) {
                     LOGGER.infof("[GDPR] Deleted %d attachments across %d conversations [%s]",
@@ -191,41 +234,39 @@ public class GdprComplianceService {
                 }
             }
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete attachments [%s]", pseudonym);
+            recordFailure(failedSteps, "attachments", e, pseudonym);
         }
 
         // 3. Delete HITL tool execution journal entries for user conversations.
         // Must run BEFORE the conversations themselves are deleted (step 4b), since
         // the journal entries reference conversation ids.
         long journalEntriesDeleted = 0;
-        try {
-            for (String convId : conversationIds) {
+        for (String convId : conversationIds) {
+            try {
                 journalEntriesDeleted += hitlToolJournalStore.deleteByConversationId(convId);
+            } catch (Exception e) {
+                recordFailure(failedSteps, "hitlToolJournal", e, pseudonym);
             }
-            if (journalEntriesDeleted > 0) {
-                LOGGER.infof("[GDPR] Deleted %d HITL tool journal entries [%s]",
-                        journalEntriesDeleted, pseudonym);
-            }
-        } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete HITL tool journal entries [%s]",
-                    pseudonym);
+        }
+        if (journalEntriesDeleted > 0) {
+            LOGGER.infof("[GDPR] Deleted %d HITL tool journal entries [%s]",
+                    journalEntriesDeleted, pseudonym);
         }
 
         // 4a. Delete conversation descriptors (must run BEFORE or alongside
         // the snapshot delete so the ids are still available)
         long descriptorsDeleted = 0;
-        try {
-            for (String convId : conversationIds) {
+        for (String convId : conversationIds) {
+            try {
                 conversationDescriptorStore.deleteAllDescriptor(convId);
                 descriptorsDeleted++;
+            } catch (Exception e) {
+                recordFailure(failedSteps, "conversationDescriptors", e, pseudonym);
             }
-            if (descriptorsDeleted > 0) {
-                LOGGER.infof("[GDPR] Deleted %d conversation descriptors [%s]",
-                        descriptorsDeleted, pseudonym);
-            }
-        } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete conversation descriptors [%s]",
-                    pseudonym);
+        }
+        if (descriptorsDeleted > 0) {
+            LOGGER.infof("[GDPR] Deleted %d conversation descriptors [%s]",
+                    descriptorsDeleted, pseudonym);
         }
 
         // 4b. Delete conversation memory checkpoints.
@@ -233,17 +274,16 @@ public class GdprComplianceService {
         // same PII the conversation holds — so an erasure that stopped at the
         // snapshots left a full copy of it behind.
         long checkpointsDeleted = 0;
-        try {
-            for (String convId : conversationIds) {
+        for (String convId : conversationIds) {
+            try {
                 checkpointsDeleted += checkpointStore.deleteByConversationId(convId);
+            } catch (Exception e) {
+                recordFailure(failedSteps, "conversationCheckpoints", e, pseudonym);
             }
-            if (checkpointsDeleted > 0) {
-                LOGGER.infof("[GDPR] Deleted %d conversation checkpoints [%s]",
-                        checkpointsDeleted, pseudonym);
-            }
-        } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete conversation checkpoints [%s]",
-                    pseudonym);
+        }
+        if (checkpointsDeleted > 0) {
+            LOGGER.infof("[GDPR] Deleted %d conversation checkpoints [%s]",
+                    checkpointsDeleted, pseudonym);
         }
 
         // 4c. Delete conversation memory snapshots
@@ -254,8 +294,7 @@ public class GdprComplianceService {
             LOGGER.infof("[GDPR] Deleted %d conversations [%s]",
                     conversationsDeleted, pseudonym);
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete conversations [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "conversations", e, pseudonym);
         }
 
         // 5. Delete managed conversation mappings.
@@ -269,8 +308,7 @@ public class GdprComplianceService {
                     .filter(Objects::nonNull)
                     .toList();
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to resolve conversation mapping intents [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "conversationMappingIntents", e, pseudonym);
         }
 
         try {
@@ -278,8 +316,7 @@ public class GdprComplianceService {
             LOGGER.infof("[GDPR] Deleted %d conversation mappings [%s]",
                     mappingsDeleted, pseudonym);
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete conversation mappings [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "conversationMappings", e, pseudonym);
         }
 
         // 5b. Evict the mappings from the read-through cache.
@@ -291,8 +328,7 @@ public class GdprComplianceService {
                 userConversationCache.remove(userConversationCacheKey(intent, userId));
             }
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to invalidate conversation mapping cache [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "conversationMappingCache", e, pseudonym);
         }
 
         // 5c. Delete group conversation transcripts. A GroupConversation stores the
@@ -307,8 +343,7 @@ public class GdprComplianceService {
                 }
             }
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete group conversations [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "groupConversations", e, pseudonym);
         }
 
         // 5c2. Delete shared artifacts (I17). Artifacts carry ownerUserId (the
@@ -324,8 +359,7 @@ public class GdprComplianceService {
                 }
             }
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete shared artifacts [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "sharedArtifacts", e, pseudonym);
         }
 
         // 5d. Delete schedules owned by the user. Left behind, they keep firing new
@@ -337,7 +371,7 @@ public class GdprComplianceService {
                 LOGGER.infof("[GDPR] Deleted %d schedules [%s]", schedulesDeleted, pseudonym);
             }
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to delete schedules [%s]", pseudonym);
+            recordFailure(failedSteps, "schedules", e, pseudonym);
         }
 
         // 6. Pseudonymize database logs (not deleted — operational data)
@@ -347,8 +381,7 @@ public class GdprComplianceService {
             LOGGER.infof("[GDPR] Pseudonymized %d log entries [%s]",
                     logsPseudonymized, pseudonym);
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to pseudonymize logs [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "databaseLogs", e, pseudonym);
         }
 
         // 7. Pseudonymize audit ledger (retained under Art. 17(3)(e))
@@ -358,20 +391,30 @@ public class GdprComplianceService {
             LOGGER.infof("[GDPR] Pseudonymized %d audit entries [%s]",
                     auditPseudonymized, pseudonym);
         } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to pseudonymize audit entries [%s]",
-                    pseudonym);
+            recordFailure(failedSteps, "auditLedger", e, pseudonym);
         }
 
         var result = new GdprDeletionResult(userId, memoriesDeleted,
                 conversationsDeleted, mappingsDeleted, logsPseudonymized,
-                auditPseudonymized, Instant.now());
+                auditPseudonymized, attachmentsDeleted, journalEntriesDeleted,
+                checkpointsDeleted, groupConversationsDeleted, sharedArtifactsDeleted,
+                schedulesDeleted, failedSteps, Instant.now());
 
-        LOGGER.infof("[GDPR] Erasure cascade complete [%s]: "
-                + "memories=%d, conversations=%d, checkpoints=%d, mappings=%d, "
-                + "groupConversations=%d, sharedArtifacts=%d, schedules=%d, logs=%d, audit=%d",
-                pseudonym, memoriesDeleted, conversationsDeleted, checkpointsDeleted,
-                mappingsDeleted, groupConversationsDeleted, sharedArtifactsDeleted, schedulesDeleted,
-                logsPseudonymized, auditPseudonymized);
+        if (result.complete()) {
+            LOGGER.infof("[GDPR] Erasure cascade complete [%s]: "
+                    + "memories=%d, conversations=%d, checkpoints=%d, mappings=%d, "
+                    + "groupConversations=%d, sharedArtifacts=%d, schedules=%d, logs=%d, audit=%d",
+                    pseudonym, memoriesDeleted, conversationsDeleted, checkpointsDeleted,
+                    mappingsDeleted, groupConversationsDeleted, sharedArtifactsDeleted, schedulesDeleted,
+                    logsPseudonymized, auditPseudonymized);
+        } else {
+            LOGGER.errorf("[GDPR] Erasure cascade INCOMPLETE [%s] — failed steps: %s. "
+                    + "memories=%d, conversations=%d, checkpoints=%d, mappings=%d, "
+                    + "groupConversations=%d, sharedArtifacts=%d, schedules=%d, logs=%d, audit=%d",
+                    pseudonym, result.failedSteps(), memoriesDeleted, conversationsDeleted, checkpointsDeleted,
+                    mappingsDeleted, groupConversationsDeleted, sharedArtifactsDeleted, schedulesDeleted,
+                    logsPseudonymized, auditPseudonymized);
+        }
 
         // Write compliance event to immutable audit ledger
         var auditDetails = new LinkedHashMap<String, Object>();
@@ -386,9 +429,25 @@ public class GdprComplianceService {
         auditDetails.put("schedulesDeleted", schedulesDeleted);
         auditDetails.put("logsPseudonymized", logsPseudonymized);
         auditDetails.put("auditPseudonymized", auditPseudonymized);
+        auditDetails.put("complete", result.complete());
+        auditDetails.put("failedSteps", result.failedSteps());
         submitComplianceAuditEntry("GDPR_ERASURE", pseudonym, auditDetails);
 
         return result;
+    }
+
+    /**
+     * Log a failed cascade step and record its name for the result.
+     * <p>
+     * Recorded once per step even when a per-conversation loop fails repeatedly —
+     * the caller needs to know <em>which</em> category is incomplete, not how many
+     * conversations were affected; the log carries that.
+     */
+    private static void recordFailure(List<String> failedSteps, String step, Exception e, String pseudonym) {
+        LOGGER.errorf(e, "[GDPR] Failed step '%s' [%s]", step, pseudonym);
+        if (!failedSteps.contains(step)) {
+            failedSteps.add(step);
+        }
     }
 
     /**
@@ -410,31 +469,44 @@ public class GdprComplianceService {
             LOGGER.errorf(e, "[GDPR] Failed to export memories [%s]", pseudonym);
         }
 
+        // Resolved ONCE and reused by the conversation and attachment blocks below.
+        // Both used to call getConversationIdsByUserId separately, which is a second
+        // full lookup for the same list.
+        List<String> conversationIds = List.of();
+        try {
+            conversationIds = conversationMemoryStore.getConversationIdsByUserId(userId);
+        } catch (Exception e) {
+            LOGGER.errorf(e, "[GDPR] Failed to resolve conversation ids for export [%s]", pseudonym);
+        }
+
         // 2. Conversation snapshots (lightweight export)
         var conversations = new ArrayList<UserDataExport.ConversationExportEntry>();
-        try {
-            var conversationIds = conversationMemoryStore
-                    .getConversationIdsByUserId(userId);
-            for (var convId : conversationIds) {
-                try {
-                    var snapshot = conversationMemoryStore
-                            .loadConversationMemorySnapshot(convId);
-                    if (snapshot != null) {
-                        conversations.add(new UserDataExport.ConversationExportEntry(
-                                convId,
-                                snapshot.getAgentId(),
-                                snapshot.getAgentVersion(),
-                                snapshot.getConversationState(),
-                                snapshot.getConversationOutputs()));
-                    }
-                } catch (Exception e) {
-                    LOGGER.warnf("[GDPR] Skipping conversation %s during export: %s",
-                            convId, e.getMessage());
+        // Each snapshot is a full document load and the whole bundle is assembled in
+        // memory on the request thread, so the same cap that already bounds the audit
+        // entries bounds these. A user with thousands of conversations otherwise held
+        // a JAX-RS worker for minutes and produced a response measured in hundreds of
+        // megabytes.
+        int exportable = Math.min(conversationIds.size(), CONVERSATION_EXPORT_LIMIT);
+        if (conversationIds.size() > CONVERSATION_EXPORT_LIMIT) {
+            LOGGER.warnf("[GDPR] User has %d conversations; exporting the first %d [%s]",
+                    conversationIds.size(), CONVERSATION_EXPORT_LIMIT, pseudonym);
+        }
+        for (var convId : conversationIds.subList(0, exportable)) {
+            try {
+                var snapshot = conversationMemoryStore
+                        .loadConversationMemorySnapshot(convId);
+                if (snapshot != null) {
+                    conversations.add(new UserDataExport.ConversationExportEntry(
+                            convId,
+                            snapshot.getAgentId(),
+                            snapshot.getAgentVersion(),
+                            snapshot.getConversationState(),
+                            snapshot.getConversationOutputs()));
                 }
+            } catch (Exception e) {
+                LOGGER.warnf("[GDPR] Skipping conversation %s during export: %s",
+                        convId, e.getMessage());
             }
-        } catch (Exception e) {
-            LOGGER.errorf(e, "[GDPR] Failed to export conversations [%s]",
-                    pseudonym);
         }
 
         // 3. Managed conversation mappings
@@ -465,7 +537,7 @@ public class GdprComplianceService {
         try {
             if (attachmentStorageInstance.isResolvable()) {
                 var store = attachmentStorageInstance.get();
-                for (var convId : conversationMemoryStore.getConversationIdsByUserId(userId)) {
+                for (var convId : conversationIds) {
                     try {
                         for (var a : store.listByConversation(convId)) {
                             attachmentEntries.add(new UserDataExport.AttachmentExportEntry(
@@ -506,6 +578,13 @@ public class GdprComplianceService {
     private static final int AUDIT_EXPORT_LIMIT = 10_000;
 
     /**
+     * Cap on conversation snapshots in one export bundle — the counterpart of
+     * {@link #AUDIT_EXPORT_LIMIT}, which already bounded the audit half of the same
+     * response while the conversation half was unbounded.
+     */
+    static final int CONVERSATION_EXPORT_LIMIT = 1_000;
+
+    /**
      * Restrict processing for a user (GDPR Art. 18). Data is preserved but new
      * conversations and message processing are blocked.
      *
@@ -523,7 +602,11 @@ public class GdprComplianceService {
                     List.of(), null, false, 0,
                     Instant.now(), Instant.now());
             userMemoryStore.upsert(entry);
+            restrictionCache.put(userId, true);
         } catch (Exception e) {
+            // Drop any cached verdict rather than leaving a stale "not restricted"
+            // in place after a half-applied write.
+            forgetRestriction(userId);
             LOGGER.errorf(e, "[GDPR] Failed to restrict processing [%s]",
                     pseudonym);
             throw new RuntimeException("Failed to restrict processing", e);
@@ -548,7 +631,15 @@ public class GdprComplianceService {
             if (existing.isPresent()) {
                 userMemoryStore.deleteEntry(existing.get().id());
             }
+            // Publish the lift, do not merely forget it. A cached "true" that
+            // outlives the removal keeps answering "restricted" for up to
+            // RESTRICTION_CACHE_TTL on this node, so a user an admin has just
+            // cleared keeps receiving 403 "Processing is restricted for this user
+            // (GDPR Art. 18)" on every turn — a false legal statement about someone
+            // who is no longer restricted.
+            restrictionCache.put(userId, false);
         } catch (Exception e) {
+            forgetRestriction(userId);
             LOGGER.errorf(e, "[GDPR] Failed to unrestrict processing [%s]",
                     pseudonym);
             throw new RuntimeException("Failed to unrestrict processing", e);
@@ -558,22 +649,58 @@ public class GdprComplianceService {
     }
 
     /**
+     * Drop a cached restriction verdict. Null-safe because it is called from catch
+     * blocks, where throwing would replace the failure being reported (Caffeine
+     * rejects a null key outright).
+     */
+    private void forgetRestriction(String userId) {
+        if (userId != null) {
+            restrictionCache.remove(userId);
+        }
+    }
+
+    /**
      * Check if processing is restricted for a user.
+     * <p>
+     * Read through a short-TTL cache: this runs at conversation start and again on
+     * every {@code say}/{@code sayStreaming}, so an uncached lookup is a store
+     * round trip per turn on the hottest path in the system — to read a flag only
+     * {@link #restrictProcessing} and {@link #unrestrictProcessing} ever change,
+     * and both publish through the cache.
      *
      * @param userId
      *            the user to check
      * @return true if a processing restriction is in effect
+     * @throws ProcessingRestrictionUnavailableException
+     *             if the flag cannot be read at all. Still fail-closed — the caller
+     *             must not process the turn — but reported as the availability
+     *             failure it is rather than as a restriction nobody applied.
      */
     public boolean isProcessingRestricted(String userId) {
+        if (userId == null) {
+            // Nothing to look up and nothing to cache — Caffeine rejects a null key
+            // outright, so this must not reach the cache.
+            return false;
+        }
+        Boolean cached = restrictionCache.get(userId);
+        if (cached != null) {
+            return cached;
+        }
         try {
             var entry = userMemoryStore.getByKey(userId, RESTRICTION_KEY);
-            return entry.isPresent() && "true".equals(String.valueOf(entry.get().value()));
+            boolean restricted = entry.isPresent() && "true".equals(String.valueOf(entry.get().value()));
+            restrictionCache.put(userId, restricted);
+            return restricted;
         } catch (Exception e) {
-            // Fail-closed: if we can't verify restriction status, block processing
-            // to prevent accidental processing of a restricted user during outages
+            // Still fail-closed — the turn does not proceed — but no longer
+            // fail-dishonest. Returning true here told the user "Processing is
+            // restricted for this user (GDPR Art. 18)" with a 403 whenever the store
+            // hiccuped, which is a false statement about them and hides the outage
+            // from 5xx-based monitoring.
             LOGGER.errorf("[GDPR] Failed to check processing restriction for user " +
-                    "(fail-closed — blocking processing): %s", e.getMessage());
-            return true;
+                    "(blocking processing): %s", e.getMessage());
+            throw new ProcessingRestrictionUnavailableException(
+                    "Cannot determine processing-restriction status right now; the request was not processed", e);
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
@@ -27,6 +27,7 @@ import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.time.Duration;
@@ -44,6 +45,14 @@ import java.util.*;
  * <strong>Export:</strong> Aggregates all user data into a single
  * JSON-serializable bundle (GDPR Art. 15/20 — Right of Access / Data
  * Portability).
+ * <p>
+ * <strong>Restriction (Art. 18):</strong> {@link #isProcessingRestricted} reads
+ * the store on every call by default — the verdict is <em>not</em> cached
+ * unless a deployment opts in with {@link #RESTRICTION_CACHE_TTL_PROPERTY}. The
+ * cache is node-local and has no cross-node invalidation, so a cached "not
+ * restricted" is exactly what would let a second replica keep processing a user
+ * who has just been restricted elsewhere. Caching is a single-node /
+ * conversation-affinity optimisation, not a default.
  *
  * @author ginccc
  * @since 6.0.0
@@ -68,12 +77,21 @@ public class GdprComplianceService {
     private final IScheduleStore scheduleStore;
     private final ICache<String, UserConversation> userConversationCache;
     /**
-     * Art. 18 restriction flags, short-TTL. {@code isProcessingRestricted} is
-     * called at conversation start and on every {@code say}/{@code sayStreaming},
-     * so an uncached lookup is a store round trip per turn on the hottest path in
-     * the system — to read a flag only an admin endpoint ever changes. Both of
-     * those endpoints invalidate the entry explicitly, so the TTL is only a
-     * backstop for another cluster node's write.
+     * Art. 18 restriction flags, short-TTL — <strong>off unless a deployment
+     * switches it on</strong>. {@code isProcessingRestricted} is called at
+     * conversation start and on every {@code say}/{@code sayStreaming}, so an
+     * uncached lookup is a store round trip per turn on the hottest path in the
+     * system — to read a flag only an admin endpoint ever changes. That is the
+     * whole case for caching, and it is only sound on one node (or with
+     * conversation affinity), which is why it is opt-in. Both admin endpoints
+     * invalidate the entry explicitly, so the TTL is only a backstop for another
+     * cluster node's write.
+     * <p>
+     * <strong>Null unless caching is switched on, which is not the default</strong>
+     * — see {@link #RESTRICTION_CACHE_TTL_PROPERTY}. Every access goes through
+     * {@link #cachedRestriction}, {@link #publishRestriction},
+     * {@link #offerUnrestricted} or {@link #forgetRestriction}, so the disabled
+     * case is handled in one place rather than at each call site.
      */
     private final ICache<String, Boolean> restrictionCache;
 
@@ -91,7 +109,9 @@ public class GdprComplianceService {
             Instance<GroupConversationStore> groupConversationStoreInstance,
             Instance<ISharedArtifactStore> sharedArtifactStoreInstance,
             IScheduleStore scheduleStore,
-            ICacheFactory cacheFactory) {
+            ICacheFactory cacheFactory,
+            @ConfigProperty(name = RESTRICTION_CACHE_TTL_PROPERTY,
+                            defaultValue = RESTRICTION_CACHE_TTL_DEFAULT) long restrictionCacheTtlSeconds) {
         this.userMemoryStore = userMemoryStore;
         this.conversationMemoryStore = conversationMemoryStore;
         this.userConversationStore = userConversationStore;
@@ -106,20 +126,81 @@ public class GdprComplianceService {
         this.sharedArtifactStoreInstance = sharedArtifactStoreInstance;
         this.scheduleStore = scheduleStore;
         this.userConversationCache = cacheFactory.getCache(USER_CONVERSATION_CACHE_NAME);
-        this.restrictionCache = cacheFactory.getCache(RESTRICTION_CACHE_NAME, RESTRICTION_CACHE_TTL);
+        this.restrictionCache = restrictionCacheTtlSeconds <= 0
+                ? null
+                : cacheFactory.getCache(RESTRICTION_CACHE_NAME, Duration.ofSeconds(restrictionCacheTtlSeconds));
+        if (this.restrictionCache == null) {
+            LOGGER.infof("[GDPR] Art. 18 restriction caching is off (%s=%d); every check reads the store.",
+                    RESTRICTION_CACHE_TTL_PROPERTY, restrictionCacheTtlSeconds);
+        }
     }
 
-    /** Name of the short-TTL cache behind {@link #isProcessingRestricted}. */
-    static final String RESTRICTION_CACHE_NAME = "gdprProcessingRestrictions";
+    /**
+     * Test seam: the shipped default (caching off), without a running
+     * configuration.
+     */
+    GdprComplianceService(IUserMemoryStore userMemoryStore,
+            IConversationMemoryStore conversationMemoryStore,
+            IUserConversationStore userConversationStore,
+            IDatabaseLogs databaseLogs,
+            IAuditStore auditStore,
+            AuditLedgerService auditLedgerService,
+            Instance<IAttachmentStore> attachmentStorageInstance,
+            IHitlToolJournalStore hitlToolJournalStore,
+            IConversationDescriptorStore conversationDescriptorStore,
+            IConversationCheckpointStore checkpointStore,
+            Instance<GroupConversationStore> groupConversationStoreInstance,
+            Instance<ISharedArtifactStore> sharedArtifactStoreInstance,
+            IScheduleStore scheduleStore,
+            ICacheFactory cacheFactory) {
+        this(userMemoryStore, conversationMemoryStore, userConversationStore, databaseLogs, auditStore,
+                auditLedgerService, attachmentStorageInstance, hitlToolJournalStore, conversationDescriptorStore,
+                checkpointStore, groupConversationStoreInstance, sharedArtifactStoreInstance, scheduleStore,
+                cacheFactory, Long.parseLong(RESTRICTION_CACHE_TTL_DEFAULT));
+    }
 
     /**
-     * Backstop TTL for {@link #RESTRICTION_CACHE_NAME}. Short, because a
-     * restriction applied on another cluster node has to take effect quickly;
-     * explicit invalidation in
-     * {@code restrictProcessing}/{@code unrestrictProcessing} covers the
-     * single-node case immediately.
+     * Name of the short-TTL cache behind {@link #isProcessingRestricted}.
+     * <p>
+     * Public because its sizing lives in {@code CacheFactory.CACHE_SIZES} under
+     * this exact string and {@code CacheFactoryTest} asserts the two still meet: a
+     * rename here with the map left alone silently drops the cache back to the
+     * 1,000 default, which nothing else would report.
      */
-    static final Duration RESTRICTION_CACHE_TTL = Duration.ofSeconds(30);
+    public static final String RESTRICTION_CACHE_NAME = "gdprProcessingRestrictions";
+
+    /**
+     * How long a restriction verdict may be reused without re-reading the store, in
+     * seconds. <strong>0 — the default — switches the cache off entirely</strong>,
+     * so every check reads the store.
+     * <p>
+     * The cache is node-local and there is no cross-node invalidation, so a
+     * <em>negative</em> verdict cached here is the one thing that can let a
+     * restricted user keep being processed: node A applies the Art. 18 restriction
+     * and evicts its own entry, while node B goes on answering "not restricted"
+     * from cache until the TTL expires — and, for the same reason, keeps answering
+     * from cache through a store outage instead of failing closed. Explicit
+     * invalidation in {@code restrictProcessing}/{@code unrestrictProcessing}
+     * closes that window on the node that served the admin call only.
+     * <p>
+     * That fail-open window is why the shipped default is 0 rather than a short
+     * TTL: a default has to be safe on every topology, and on a multi-replica
+     * deployment a cached {@code false} suspends a legal control for the length of
+     * the TTL. The cost of the default is one indexed lookup per turn.
+     * <p>
+     * Setting it above 0 is an <em>explicit single-node or conversation-affinity
+     * optimisation</em>: it says "every turn of a conversation, and every admin
+     * call, reaches the same node", which is what makes the explicit invalidation
+     * sufficient. Do not set it on a cluster without affinity until cluster-wide
+     * invalidation exists.
+     */
+    static final String RESTRICTION_CACHE_TTL_PROPERTY = "eddi.gdpr.restriction-cache-ttl-seconds";
+
+    /**
+     * Default for {@link #RESTRICTION_CACHE_TTL_PROPERTY}, as MicroProfile needs a
+     * String. Zero: no verdict is cached unless a deployment asks for it.
+     */
+    static final String RESTRICTION_CACHE_TTL_DEFAULT = "0";
 
     /**
      * Name of the Caffeine cache {@code RestUserConversationStore} reads managed
@@ -441,13 +522,27 @@ public class GdprComplianceService {
      * <p>
      * Recorded once per step even when a per-conversation loop fails repeatedly —
      * the caller needs to know <em>which</em> category is incomplete, not how many
-     * conversations were affected; the log carries that.
+     * conversations were affected.
+     * <p>
+     * The <em>stack trace</em> is logged once per step too, for the same reason.
+     * These calls sit inside per-conversation loops, so a user with 5,000
+     * conversations during a store outage produced 20,000 ERROR stack traces for
+     * one erasure request and buried the single line that matters. Repeats are
+     * still reported — at WARN, with the cause's message — so nothing goes
+     * unrecorded; only the identical trace is not repeated.
+     *
+     * @return whether this call logged the full stack trace (true on the first
+     *         failure of a step) — so a test can assert the dedup without scraping
+     *         the log
      */
-    private static void recordFailure(List<String> failedSteps, String step, Exception e, String pseudonym) {
-        LOGGER.errorf(e, "[GDPR] Failed step '%s' [%s]", step, pseudonym);
-        if (!failedSteps.contains(step)) {
-            failedSteps.add(step);
+    static boolean recordFailure(List<String> failedSteps, String step, Exception e, String pseudonym) {
+        if (failedSteps.contains(step)) {
+            LOGGER.warnf("[GDPR] Failed step '%s' again [%s]: %s", step, pseudonym, e.getMessage());
+            return false;
         }
+        LOGGER.errorf(e, "[GDPR] Failed step '%s' [%s]", step, pseudonym);
+        failedSteps.add(step);
+        return true;
     }
 
     /**
@@ -486,10 +581,21 @@ public class GdprComplianceService {
         // entries bounds these. A user with thousands of conversations otherwise held
         // a JAX-RS worker for minutes and produced a response measured in hundreds of
         // megabytes.
-        int exportable = Math.min(conversationIds.size(), CONVERSATION_EXPORT_LIMIT);
-        if (conversationIds.size() > CONVERSATION_EXPORT_LIMIT) {
-            LOGGER.warnf("[GDPR] User has %d conversations; exporting the first %d [%s]",
-                    conversationIds.size(), CONVERSATION_EXPORT_LIMIT, pseudonym);
+        // Residue, deliberately not fixed here: *which* conversations survive the cap
+        // is whatever order the store returned. MongoDB's natural order is not
+        // insertion order, so a truncated bundle is an arbitrary 200 of 1,200 rather
+        // than the oldest or the newest. The bundle says it is truncated and gives the
+        // total, which is what makes the response honest; making the subset itself
+        // predictable needs an ordered projection in both conversation stores.
+        int totalConversations = conversationIds.size();
+        int exportable = Math.min(totalConversations, CONVERSATION_EXPORT_LIMIT);
+        // Reported in the bundle, not only in the log: a subject access request that
+        // silently omits 200 of 1,200 conversations while answering 200 OK is the
+        // same misreporting the erasure half of this class answers 207 for.
+        boolean conversationsTruncated = totalConversations > CONVERSATION_EXPORT_LIMIT;
+        if (conversationsTruncated) {
+            LOGGER.warnf("[GDPR] User has %d conversations; exporting the first %d and marking the bundle truncated [%s]",
+                    totalConversations, CONVERSATION_EXPORT_LIMIT, pseudonym);
         }
         for (var convId : conversationIds.subList(0, exportable)) {
             try {
@@ -556,20 +662,23 @@ public class GdprComplianceService {
         }
 
         LOGGER.infof("[GDPR] Export complete [%s]: memories=%d, "
-                + "conversations=%d, managedConversations=%d, auditEntries=%d, attachments=%d",
-                pseudonym, memories.size(), conversations.size(),
+                + "conversations=%d of %d, truncated=%s, managedConversations=%d, auditEntries=%d, attachments=%d",
+                pseudonym, memories.size(), conversations.size(), totalConversations, conversationsTruncated,
                 managedConversations.size(), auditExportEntries.size(), attachmentEntries.size());
 
         // Write compliance event to immutable audit ledger
         submitComplianceAuditEntry("GDPR_EXPORT", pseudonym, Map.of(
                 "memoriesExported", memories.size(),
                 "conversationsExported", conversations.size(),
+                "totalConversations", totalConversations,
+                "conversationsTruncated", conversationsTruncated,
                 "managedConversationsExported", managedConversations.size(),
                 "auditEntriesExported", auditExportEntries.size(),
                 "attachmentsExported", attachmentEntries.size()));
 
         return new UserDataExport(userId, Instant.now(), memories,
-                conversations, managedConversations, auditExportEntries, attachmentEntries);
+                conversations, managedConversations, auditExportEntries, attachmentEntries,
+                totalConversations, conversationsTruncated);
     }
 
     // === Right to Restriction of Processing (GDPR Art. 18) ===
@@ -602,7 +711,7 @@ public class GdprComplianceService {
                     List.of(), null, false, 0,
                     Instant.now(), Instant.now());
             userMemoryStore.upsert(entry);
-            restrictionCache.put(userId, true);
+            publishRestriction(userId, true);
         } catch (Exception e) {
             // Drop any cached verdict rather than leaving a stale "not restricted"
             // in place after a half-applied write.
@@ -631,13 +740,13 @@ public class GdprComplianceService {
             if (existing.isPresent()) {
                 userMemoryStore.deleteEntry(existing.get().id());
             }
-            // Publish the lift, do not merely forget it. A cached "true" that
-            // outlives the removal keeps answering "restricted" for up to
-            // RESTRICTION_CACHE_TTL on this node, so a user an admin has just
+            // Publish the lift, do not merely forget it. Where caching is switched
+            // on, a cached "true" that outlives the removal keeps answering
+            // "restricted" for the whole TTL on this node, so a user an admin has just
             // cleared keeps receiving 403 "Processing is restricted for this user
             // (GDPR Art. 18)" on every turn — a false legal statement about someone
             // who is no longer restricted.
-            restrictionCache.put(userId, false);
+            publishRestriction(userId, false);
         } catch (Exception e) {
             forgetRestriction(userId);
             LOGGER.errorf(e, "[GDPR] Failed to unrestrict processing [%s]",
@@ -654,19 +763,62 @@ public class GdprComplianceService {
      * rejects a null key outright).
      */
     private void forgetRestriction(String userId) {
-        if (userId != null) {
+        if (userId != null && restrictionCache != null) {
             restrictionCache.remove(userId);
         }
     }
 
     /**
+     * The published verdict for a user, or null when nothing is published — which
+     * is always the case while caching is switched off, so the caller reads the
+     * store every time.
+     */
+    private Boolean cachedRestriction(String userId) {
+        return restrictionCache == null ? null : restrictionCache.get(userId);
+    }
+
+    /** Force a verdict into the cache, if there is one. */
+    private void publishRestriction(String userId, boolean restricted) {
+        if (restrictionCache != null) {
+            restrictionCache.put(userId, restricted);
+        }
+    }
+
+    /**
+     * Offer "not restricted" without displacing a restriction another writer
+     * already published; returns the value that ends up published, or null when
+     * caching is off and the caller should simply use its own store read.
+     */
+    private Boolean offerUnrestricted(String userId) {
+        return restrictionCache == null ? null : restrictionCache.putIfAbsent(userId, false);
+    }
+
+    /**
      * Check if processing is restricted for a user.
      * <p>
-     * Read through a short-TTL cache: this runs at conversation start and again on
-     * every {@code say}/{@code sayStreaming}, so an uncached lookup is a store
-     * round trip per turn on the hottest path in the system — to read a flag only
-     * {@link #restrictProcessing} and {@link #unrestrictProcessing} ever change,
-     * and both publish through the cache.
+     * <strong>By default this reads the store on every call.</strong>
+     * {@link #RESTRICTION_CACHE_TTL_PROPERTY} defaults to 0, so no verdict is
+     * cached: a restriction applied on any node takes effect on every node at once,
+     * and a store outage always raises
+     * {@link ProcessingRestrictionUnavailableException} rather than being absorbed
+     * by a cached verdict. The cost is one indexed lookup per turn — this runs at
+     * conversation start and again on every {@code say}/{@code sayStreaming}, which
+     * is the hottest path in the system, to read a flag only an admin endpoint ever
+     * changes.
+     * <p>
+     * A deployment that is a single node, or a cluster with conversation affinity,
+     * may buy that lookup back by setting the property above 0. The cache is then
+     * node-local, and {@link #restrictProcessing} and {@link #unrestrictProcessing}
+     * publish through it so the node serving the admin call applies the change on
+     * the very next turn.
+     * <p>
+     * With caching on, a miss publishes the value read from the store
+     * <em>monotonically toward restriction</em>: a {@code true} overwrites whatever
+     * is cached, a {@code false} is only offered and yields to any value already
+     * there. This method is not the only writer — concurrent misses publish too —
+     * so neither a plain {@code put} nor a plain {@code putIfAbsent} is safe on its
+     * own; see the comment at the publish site. The caller always gets a value that
+     * is at least as restrictive as its own store read.
      *
      * @param userId
      *            the user to check
@@ -682,15 +834,39 @@ public class GdprComplianceService {
             // outright, so this must not reach the cache.
             return false;
         }
-        Boolean cached = restrictionCache.get(userId);
+        Boolean cached = cachedRestriction(userId);
         if (cached != null) {
             return cached;
         }
         try {
             var entry = userMemoryStore.getByKey(userId, RESTRICTION_KEY);
             boolean restricted = entry.isPresent() && "true".equals(String.valueOf(entry.get().value()));
-            restrictionCache.put(userId, restricted);
-            return restricted;
+            // Publish monotonically toward restriction: within one TTL window a
+            // "restricted" observation always wins, whoever else is writing.
+            //
+            // This read is not atomic with restrictProcessing, and it is not the only
+            // writer either — two concurrent misses of this very method also publish.
+            // A plain put loses an administrative restriction applied mid-read (T1
+            // reads false, an admin writes the row and publishes true, T1 overwrites
+            // it with the stale false and the node processes a restricted user for
+            // the whole TTL). A plain putIfAbsent loses the opposite way,
+            // which is worse: T2 misses and publishes false, T1 misses, reads true
+            // from the store, and its putIfAbsent is refused — so T1 would return the
+            // sibling's false and process a turn its OWN read said must be blocked.
+            //
+            // So: a true is forced into the cache and returned; a false is only
+            // offered, and yields to whatever is already published (which may be a
+            // restriction from restrictProcessing or from a concurrent reader).
+            // Erring toward "restricted" for at most one TTL is the safe direction
+            // for an Art. 18 legal control — an unrestrictProcessing that loses this
+            // race delays a release by 30s, while the other direction processes data
+            // that must not be processed.
+            if (restricted) {
+                publishRestriction(userId, true);
+                return true;
+            }
+            Boolean published = offerUnrestricted(userId);
+            return published != null ? published : false;
         } catch (Exception e) {
             // Still fail-closed — the turn does not proceed — but no longer
             // fail-dishonest. Returning true here told the user "Processing is

--- a/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
@@ -278,9 +278,6 @@ public class GdprComplianceService {
         try {
             long countedMemories = userMemoryStore.countEntries(userId);
             userMemoryStore.deleteAllForUser(userId);
-            // The restriction flag lives in the same store and has just been deleted
-            // with everything else, so a cached "restricted" verdict is now wrong.
-            forgetRestriction(userId);
             // Assigned only once the delete returned: assigning before it made the
             // response claim N memories deleted when the delete had thrown and zero
             // were.
@@ -289,6 +286,21 @@ public class GdprComplianceService {
                     memoriesDeleted, pseudonym);
         } catch (Exception e) {
             recordFailure(failedSteps, "userMemories", e, pseudonym);
+        }
+
+        // 1b. Drop any cached Art. 18 restriction verdict. The flag lives in the
+        // store the step above has just emptied, so a cached "restricted" verdict is
+        // now wrong.
+        //
+        // Its own try, and its own step name, for the reason step 5b below has one:
+        // folded into the try above, an eviction that threw after the delete had
+        // succeeded left memoriesDeleted at 0 and named "userMemories" as the failed
+        // step — the response reporting an erasure that did happen as one that did
+        // not, and sending a DPO to re-run a cascade whose memory half was done.
+        try {
+            forgetRestriction(userId);
+        } catch (Exception e) {
+            recordFailure(failedSteps, "restrictionCache", e, pseudonym);
         }
 
         // 2. Delete attachments for all user conversations
@@ -608,6 +620,14 @@ public class GdprComplianceService {
             LOGGER.warnf("[GDPR] User has %d conversations; exporting the first %d and marking the bundle truncated [%s]",
                     totalConversations, CONVERSATION_EXPORT_LIMIT, pseudonym);
         }
+        // A snapshot this loop cannot load is a conversation missing from the bundle,
+        // and it used to be missing silently: logged at WARN and dropped, while
+        // conversationsTruncated — the only completeness signal — stayed false. A DPO
+        // handed the data subject an Art. 15 bundle the code knew was short. The ids
+        // are collected so the bundle can name what it lost, and they count against
+        // UserDataExport.complete() the same way the cap does; conversationsTruncated
+        // stays the cap's own signal and is not overloaded with this.
+        var failedConversationIds = new ArrayList<String>();
         for (var convId : conversationIds.subList(0, exportable)) {
             try {
                 var snapshot = conversationMemoryStore
@@ -619,8 +639,17 @@ public class GdprComplianceService {
                             snapshot.getAgentVersion(),
                             snapshot.getConversationState(),
                             snapshot.getConversationOutputs()));
+                } else {
+                    // The id came from this same store moments ago, so an absent
+                    // document is a conversation lost between the two reads, not an
+                    // empty one — indistinguishable from a load failure to the reader
+                    // of the bundle, and reported as such.
+                    failedConversationIds.add(convId);
+                    LOGGER.warnf("[GDPR] Conversation %s vanished between id lookup and export [%s]",
+                            convId, pseudonym);
                 }
             } catch (Exception e) {
+                failedConversationIds.add(convId);
                 LOGGER.warnf("[GDPR] Skipping conversation %s during export: %s",
                         convId, e.getMessage());
             }
@@ -673,23 +702,30 @@ public class GdprComplianceService {
         }
 
         LOGGER.infof("[GDPR] Export complete [%s]: memories=%d, "
-                + "conversations=%d of %d, truncated=%s, managedConversations=%d, auditEntries=%d, attachments=%d",
+                + "conversations=%d of %d, truncated=%s, failedConversations=%d, managedConversations=%d, "
+                + "auditEntries=%d, attachments=%d",
                 pseudonym, memories.size(), conversations.size(), totalConversations, conversationsTruncated,
-                managedConversations.size(), auditExportEntries.size(), attachmentEntries.size());
+                failedConversationIds.size(), managedConversations.size(), auditExportEntries.size(),
+                attachmentEntries.size());
 
-        // Write compliance event to immutable audit ledger
+        // Write compliance event to immutable audit ledger.
+        // conversationsFailed is part of the record because the ledger entry is the
+        // evidence that this export happened: an entry saying 998 of 1,000 were
+        // exported with nothing to explain the two is a discrepancy nobody can
+        // account for after the fact.
         submitComplianceAuditEntry("GDPR_EXPORT", pseudonym, Map.of(
                 "memoriesExported", memories.size(),
                 "conversationsExported", conversations.size(),
                 "totalConversations", totalConversations,
                 "conversationsTruncated", conversationsTruncated,
+                "conversationsFailed", failedConversationIds.size(),
                 "managedConversationsExported", managedConversations.size(),
                 "auditEntriesExported", auditExportEntries.size(),
                 "attachmentsExported", attachmentEntries.size()));
 
         return new UserDataExport(userId, Instant.now(), memories,
                 conversations, managedConversations, auditExportEntries, attachmentEntries,
-                totalConversations, conversationsTruncated);
+                totalConversations, conversationsTruncated, failedConversationIds);
     }
 
     // === Right to Restriction of Processing (GDPR Art. 18) ===

--- a/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/GdprComplianceService.java
@@ -156,7 +156,7 @@ public class GdprComplianceService {
         this(userMemoryStore, conversationMemoryStore, userConversationStore, databaseLogs, auditStore,
                 auditLedgerService, attachmentStorageInstance, hitlToolJournalStore, conversationDescriptorStore,
                 checkpointStore, groupConversationStoreInstance, sharedArtifactStoreInstance, scheduleStore,
-                cacheFactory, Long.parseLong(RESTRICTION_CACHE_TTL_DEFAULT));
+                cacheFactory, RESTRICTION_CACHE_TTL_DEFAULT_SECONDS);
     }
 
     /**
@@ -199,8 +199,19 @@ public class GdprComplianceService {
     /**
      * Default for {@link #RESTRICTION_CACHE_TTL_PROPERTY}, as MicroProfile needs a
      * String. Zero: no verdict is cached unless a deployment asks for it.
+     * <p>
+     * Kept as a pair with {@link #RESTRICTION_CACHE_TTL_DEFAULT_SECONDS} rather
+     * than parsed at runtime. A {@code @ConfigProperty} default has to be a
+     * compile-time String constant, but the CDI-free constructor below needs the
+     * number, and {@code Long.parseLong} on a literal is a parse that can only ever
+     * succeed - noise that a reader and a static analyser both have to reason
+     * about. {@code GdprComplianceServiceTest#theTwoDefaultConstantsAgree} fails if
+     * the two ever drift.
      */
     static final String RESTRICTION_CACHE_TTL_DEFAULT = "0";
+
+    /** The numeric half of {@link #RESTRICTION_CACHE_TTL_DEFAULT}. */
+    static final long RESTRICTION_CACHE_TTL_DEFAULT_SECONDS = 0L;
 
     /**
      * Name of the Caffeine cache {@code RestUserConversationStore} reads managed

--- a/src/main/java/ai/labs/eddi/engine/gdpr/GdprDeletionResult.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/GdprDeletionResult.java
@@ -5,9 +5,22 @@
 package ai.labs.eddi.engine.gdpr;
 
 import java.time.Instant;
+import java.util.List;
 
 /**
  * Result of a GDPR cascading user data deletion.
+ * <p>
+ * The counters describe every store the cascade touches, not just the five it
+ * used to report. Attachments, HITL journal entries, checkpoints, group
+ * transcripts, shared artifacts and schedules were computed and written to the
+ * audit ledger but never returned, so the DPO producing an Art. 17 confirmation
+ * could not see whether they had been touched without reading the server log.
+ * <p>
+ * {@link #complete()} and {@link #failedSteps()} exist because the cascade
+ * deliberately continues past a failing step: without them a run in which
+ * {@code deleteConversationsByUserId} threw was indistinguishable from a user
+ * who simply had no conversations, and the request was filed as fulfilled while
+ * the data was still there.
  *
  * @param userId
  *            the user whose data was deleted
@@ -21,6 +34,20 @@ import java.time.Instant;
  *            number of database log entries pseudonymized
  * @param auditEntriesPseudonymized
  *            number of audit ledger entries pseudonymized
+ * @param attachmentsDeleted
+ *            number of binary attachments removed
+ * @param journalEntriesDeleted
+ *            number of HITL tool journal entries removed
+ * @param checkpointsDeleted
+ *            number of conversation memory checkpoints removed
+ * @param groupConversationsDeleted
+ *            number of group discussion transcripts removed
+ * @param sharedArtifactsDeleted
+ *            number of shared artifacts removed
+ * @param schedulesDeleted
+ *            number of schedules removed
+ * @param failedSteps
+ *            names of the cascade steps that threw; empty on a clean run
  * @param completedAt
  *            timestamp of completion
  *
@@ -34,5 +61,35 @@ public record GdprDeletionResult(
         long conversationMappingsDeleted,
         long logsPseudonymized,
         long auditEntriesPseudonymized,
+        long attachmentsDeleted,
+        long journalEntriesDeleted,
+        long checkpointsDeleted,
+        long groupConversationsDeleted,
+        long sharedArtifactsDeleted,
+        long schedulesDeleted,
+        List<String> failedSteps,
         Instant completedAt) {
+
+    /**
+     * Compatibility constructor for the original seven-component shape, so existing
+     * callers and tests keep compiling. Reports the six added counters as 0 and the
+     * run as clean.
+     */
+    public GdprDeletionResult(String userId, long memoriesDeleted, long conversationsDeleted, long conversationMappingsDeleted,
+            long logsPseudonymized, long auditEntriesPseudonymized, Instant completedAt) {
+        this(userId, memoriesDeleted, conversationsDeleted, conversationMappingsDeleted, logsPseudonymized, auditEntriesPseudonymized,
+                0, 0, 0, 0, 0, 0, List.of(), completedAt);
+    }
+
+    public GdprDeletionResult {
+        failedSteps = failedSteps == null ? List.of() : List.copyOf(failedSteps);
+    }
+
+    /**
+     * Whether every step of the cascade succeeded. False means some of the user's
+     * data may still exist — the caller must not report the erasure as fulfilled.
+     */
+    public boolean complete() {
+        return failedSteps.isEmpty();
+    }
 }

--- a/src/main/java/ai/labs/eddi/engine/gdpr/GdprDeletionResult.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/GdprDeletionResult.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.engine.gdpr;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -88,7 +90,16 @@ public record GdprDeletionResult(
     /**
      * Whether every step of the cascade succeeded. False means some of the user's
      * data may still exist — the caller must not report the erasure as fulfilled.
+     * <p>
+     * Annotated because this is a derived method, not a record component and not a
+     * bean getter, so Jackson left it out of the REST entity while
+     * {@code McpGdprTools} puts it into the MCP payload explicitly — the same
+     * result reported in two different shapes, and a client written against the MCP
+     * JSON silently reading null from the REST one. {@code READ_ONLY} keeps it out
+     * of deserialization, where the canonical record constructor has no matching
+     * component.
      */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public boolean complete() {
         return failedSteps.isEmpty();
     }

--- a/src/main/java/ai/labs/eddi/engine/gdpr/IRestGdprAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/IRestGdprAdmin.java
@@ -7,8 +7,12 @@ package ai.labs.eddi.engine.gdpr;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /**
@@ -34,19 +38,43 @@ public interface IRestGdprAdmin {
                summary = "Cascade-delete all user data (GDPR Art. 17)",
                description = "Deletes user memories and conversations. "
                        + "Pseudonymizes audit ledger and database log entries. "
-                       + "Returns a summary of affected records.")
-    GdprDeletionResult deleteUserData(
-                                      @PathParam("userId")
-                                      @Parameter(description = "User ID to erase", required = true) String userId);
+                       + "Returns a summary of affected records. "
+                       + "Responds 200 when every step of the cascade succeeded and 207 Multi-Status when "
+                       + "one or more failed — 'failedSteps' in the body names them, and the erasure must "
+                       + "NOT be reported to the data subject as fulfilled until they succeed.")
+    @APIResponse(responseCode = "200", description = "Erasure cascade completed in full",
+                 content = @Content(schema = @Schema(implementation = GdprDeletionResult.class)))
+    @APIResponse(responseCode = "207", description = "Erasure cascade partially failed — see 'failedSteps'",
+                 content = @Content(schema = @Schema(implementation = GdprDeletionResult.class)))
+    Response deleteUserData(
+                            @PathParam("userId")
+                            @Parameter(description = "User ID to erase", required = true) String userId);
 
+    /**
+     * <strong>Known gap.</strong> The bundle covers five categories: memories,
+     * conversation snapshots, managed conversation mappings, audit processing
+     * records and attachment metadata. It does <em>not</em> yet include the group
+     * discussion transcripts, shared artifacts, schedules and HITL tool journal
+     * entries that {@link #deleteUserData} erases as this user's personal data —
+     * the two halves of the feature disagree about what the user's data is, and
+     * only the deleting half is right. Closing it needs read-by-user methods those
+     * four stores do not have (their erasure counterparts page with an escaped
+     * regex and an exact re-check), plus a decision on how a bundle that could run
+     * to hundreds of megabytes is delivered.
+     * <p>
+     * Conversation snapshots are capped per bundle; audit entries were already
+     * capped. Both caps are reported in the server log when they bite.
+     */
     @GET
     @Path("/{userId}/export")
     @Operation(
                operationId = "exportUserDataGdpr",
                summary = "Export all user data (GDPR Art. 15/20)",
-               description = "Returns all data associated with a user, including "
-                       + "memories, conversations, managed conversation mappings, "
-                       + "and audit processing records.")
+               description = "Returns all data associated with a user: memories, conversations, "
+                       + "managed conversation mappings, audit processing records and attachment "
+                       + "metadata. Group discussion transcripts, shared artifacts, schedules and "
+                       + "HITL journal entries are NOT yet included, although the erasure endpoint "
+                       + "does delete them — see the interface javadoc.")
     UserDataExport exportUserData(
                                   @PathParam("userId")
                                   @Parameter(description = "User ID to export", required = true) String userId);

--- a/src/main/java/ai/labs/eddi/engine/gdpr/IRestGdprAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/IRestGdprAdmin.java
@@ -62,13 +62,27 @@ public interface IRestGdprAdmin {
      * regex and an exact re-check), plus a decision on how a bundle that could run
      * to hundreds of megabytes is delivered.
      * <p>
+     * <strong>Which is why this endpoint does not answer 200 today.</strong> The
+     * gap is part of the response rather than a footnote here: every bundle carries
+     * {@code complete: false} and an {@code omittedCategories} list naming those
+     * four stores, and the status is 207 Multi-Status. Without it, a user whose
+     * data lives only in the four omitted categories received an empty bundle with
+     * a 200 documented as "complete export bundle" — an Art. 20 answer that
+     * overstates itself to the one reader who cannot check it. It becomes 200 once
+     * the four exporters land and the list goes empty.
+     * <p>
      * Conversation snapshots are capped per bundle; audit entries were already
      * capped. When the conversation cap bites, the response says so in the payload
-     * ({@code totalConversations}, {@code conversationsTruncated}) and the status
-     * is 206 Partial Content — a bundle that silently omits conversations while
-     * answering 200 lets a DPO hand a data subject an incomplete Art. 15 bundle
-     * believing it complete, which is the same misreporting {@link #deleteUserData}
-     * answers 207 for. The audit cap is still reported in the server log only.
+     * ({@code totalConversations}, {@code conversationsTruncated}) and counts
+     * against {@code complete} the same way — a bundle that silently omits
+     * conversations while answering 200 lets a DPO hand a data subject an
+     * incomplete Art. 15 bundle believing it complete, which is the same
+     * misreporting {@link #deleteUserData} answers 207 for. The audit cap is still
+     * reported in the server log only.
+     * <p>
+     * 207 rather than the 206 Partial Content this used to send: 206 is a range
+     * status, RFC 9110 requires a {@code Content-Range} with it, and this endpoint
+     * neither reads a {@code Range} nor produces one.
      */
     @GET
     @Path("/{userId}/export")
@@ -80,12 +94,17 @@ public interface IRestGdprAdmin {
                        + "metadata. Group discussion transcripts, shared artifacts, schedules and "
                        + "HITL journal entries are NOT yet included, although the erasure endpoint "
                        + "does delete them — see the interface javadoc. "
-                       + "Responds 200 when the bundle is complete and 206 Partial Content when the "
-                       + "per-request conversation cap bit — 'conversationsTruncated' is then true and "
-                       + "'totalConversations' says how many the user has.")
-    @APIResponse(responseCode = "200", description = "Complete export bundle",
+                       + "Responds 200 only when the bundle covers everything, and 207 Multi-Status "
+                       + "otherwise: 'complete' says which, 'omittedCategories' names the categories "
+                       + "this exporter does not reach, and 'conversationsTruncated' with "
+                       + "'totalConversations' report the per-request conversation cap. Because those "
+                       + "four categories are always omitted today, the answer is currently always 207 "
+                       + "— the export must NOT be handed to the data subject as a complete Art. 15/20 "
+                       + "bundle while 'complete' is false.")
+    @APIResponse(responseCode = "200", description = "Complete export bundle — every category covered, nothing truncated",
                  content = @Content(schema = @Schema(implementation = UserDataExport.class)))
-    @APIResponse(responseCode = "206", description = "Bundle truncated at the conversation cap — see 'conversationsTruncated'",
+    @APIResponse(responseCode = "207",
+                 description = "Incomplete bundle — see 'complete', 'omittedCategories' and 'conversationsTruncated'",
                  content = @Content(schema = @Schema(implementation = UserDataExport.class)))
     Response exportUserData(
                             @PathParam("userId")

--- a/src/main/java/ai/labs/eddi/engine/gdpr/IRestGdprAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/IRestGdprAdmin.java
@@ -63,7 +63,12 @@ public interface IRestGdprAdmin {
      * to hundreds of megabytes is delivered.
      * <p>
      * Conversation snapshots are capped per bundle; audit entries were already
-     * capped. Both caps are reported in the server log when they bite.
+     * capped. When the conversation cap bites, the response says so in the payload
+     * ({@code totalConversations}, {@code conversationsTruncated}) and the status
+     * is 206 Partial Content — a bundle that silently omits conversations while
+     * answering 200 lets a DPO hand a data subject an incomplete Art. 15 bundle
+     * believing it complete, which is the same misreporting {@link #deleteUserData}
+     * answers 207 for. The audit cap is still reported in the server log only.
      */
     @GET
     @Path("/{userId}/export")
@@ -74,10 +79,17 @@ public interface IRestGdprAdmin {
                        + "managed conversation mappings, audit processing records and attachment "
                        + "metadata. Group discussion transcripts, shared artifacts, schedules and "
                        + "HITL journal entries are NOT yet included, although the erasure endpoint "
-                       + "does delete them — see the interface javadoc.")
-    UserDataExport exportUserData(
-                                  @PathParam("userId")
-                                  @Parameter(description = "User ID to export", required = true) String userId);
+                       + "does delete them — see the interface javadoc. "
+                       + "Responds 200 when the bundle is complete and 206 Partial Content when the "
+                       + "per-request conversation cap bit — 'conversationsTruncated' is then true and "
+                       + "'totalConversations' says how many the user has.")
+    @APIResponse(responseCode = "200", description = "Complete export bundle",
+                 content = @Content(schema = @Schema(implementation = UserDataExport.class)))
+    @APIResponse(responseCode = "206", description = "Bundle truncated at the conversation cap — see 'conversationsTruncated'",
+                 content = @Content(schema = @Schema(implementation = UserDataExport.class)))
+    Response exportUserData(
+                            @PathParam("userId")
+                            @Parameter(description = "User ID to export", required = true) String userId);
 
     @POST
     @Path("/{userId}/restrict")

--- a/src/main/java/ai/labs/eddi/engine/gdpr/IRestGdprAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/IRestGdprAdmin.java
@@ -96,15 +96,18 @@ public interface IRestGdprAdmin {
                        + "does delete them — see the interface javadoc. "
                        + "Responds 200 only when the bundle covers everything, and 207 Multi-Status "
                        + "otherwise: 'complete' says which, 'omittedCategories' names the categories "
-                       + "this exporter does not reach, and 'conversationsTruncated' with "
-                       + "'totalConversations' report the per-request conversation cap. Because those "
+                       + "this exporter does not reach, 'conversationsTruncated' with "
+                       + "'totalConversations' report the per-request conversation cap, and "
+                       + "'failedConversationIds' names conversations that could not be loaded at all "
+                       + "and are therefore absent from the bundle. Because those "
                        + "four categories are always omitted today, the answer is currently always 207 "
                        + "— the export must NOT be handed to the data subject as a complete Art. 15/20 "
                        + "bundle while 'complete' is false.")
     @APIResponse(responseCode = "200", description = "Complete export bundle — every category covered, nothing truncated",
                  content = @Content(schema = @Schema(implementation = UserDataExport.class)))
     @APIResponse(responseCode = "207",
-                 description = "Incomplete bundle — see 'complete', 'omittedCategories' and 'conversationsTruncated'",
+                 description = "Incomplete bundle — see 'complete', 'omittedCategories', "
+                         + "'conversationsTruncated' and 'failedConversationIds'",
                  content = @Content(schema = @Schema(implementation = UserDataExport.class)))
     Response exportUserData(
                             @PathParam("userId")

--- a/src/main/java/ai/labs/eddi/engine/gdpr/ProcessingRestrictionUnavailableException.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/ProcessingRestrictionUnavailableException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.gdpr;
+
+/**
+ * Thrown when the GDPR Art. 18 restriction flag could not be read at all —
+ * store failover, pool exhaustion, timeout.
+ * <p>
+ * This is still fail-closed: the turn does not proceed, because a user whose
+ * processing <em>is</em> restricted must not be processed just because the
+ * lookup failed. What changes is what the caller is told. The check used to
+ * return {@code true} on any exception, so a transient store error turned every
+ * turn for every user into {@code 403 processing_restricted} with the body
+ * "Processing is restricted for this user (GDPR Art. 18)" — a legal statement
+ * about the user that was simply false, and a status code that hid an outage
+ * from any monitoring keyed on 5xx. A distinct exception mapped to 503 says the
+ * honest thing: the service cannot answer right now, try again.
+ *
+ * @author ginccc
+ * @since 6.0.0
+ */
+public class ProcessingRestrictionUnavailableException extends RuntimeException {
+
+    public ProcessingRestrictionUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/gdpr/ProcessingRestrictionUnavailableExceptionMapper.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/ProcessingRestrictionUnavailableExceptionMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.gdpr;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.Map;
+
+/**
+ * Maps {@link ProcessingRestrictionUnavailableException} to HTTP 503 Service
+ * Unavailable — the honest status for "we could not read the restriction flag",
+ * as opposed to the 403 the fail-closed path used to return, which told the
+ * user their processing was restricted when nobody had restricted it.
+ *
+ * @author ginccc
+ * @since 6.0.0
+ */
+@Provider
+public class ProcessingRestrictionUnavailableExceptionMapper implements ExceptionMapper<ProcessingRestrictionUnavailableException> {
+
+    @Override
+    public Response toResponse(ProcessingRestrictionUnavailableException exception) {
+        return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                .entity(Map.of(
+                        "error", "restriction_status_unavailable",
+                        "message", exception.getMessage()))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/gdpr/ProcessingRestrictionUnavailableExceptionMapper.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/ProcessingRestrictionUnavailableExceptionMapper.java
@@ -16,6 +16,13 @@ import java.util.Map;
  * Unavailable — the honest status for "we could not read the restriction flag",
  * as opposed to the 403 the fail-closed path used to return, which told the
  * user their processing was restricted when nobody had restricted it.
+ * <p>
+ * This mapper only fires on the synchronous entry points. {@code say} and
+ * {@code sayStreaming} are resumed through an {@code AsyncResponse}, which
+ * never reaches an {@code ExceptionMapper}, so {@code RestAgentEngine} and
+ * {@code RestAgentEngineStreaming} carry explicit branches that reproduce this
+ * status, body and header — the same arrangement quota and backpressure already
+ * need. Change all three together.
  *
  * @author ginccc
  * @since 6.0.0
@@ -28,8 +35,34 @@ public class ProcessingRestrictionUnavailableExceptionMapper implements Exceptio
         return Response.status(Response.Status.SERVICE_UNAVAILABLE)
                 .entity(Map.of(
                         "error", "restriction_status_unavailable",
-                        "message", exception.getMessage()))
+                        // Guarded, like the quota mapper it mirrors: Map.of throws
+                        // NullPointerException on a null value, and an exception mapper
+                        // that throws produces exactly the opaque 500 this class exists
+                        // to replace.
+                        "message", messageOf(exception)))
                 .type(MediaType.APPLICATION_JSON)
+                // Retryable: the flag could not be read, which is a transient
+                // availability failure, not a statement about the user.
+                .header("Retry-After", "5")
                 .build();
+    }
+
+    /**
+     * The body's {@code message}, never null.
+     * <p>
+     * Shared with the {@code AsyncResponse} branches in
+     * {@code RestAgentEngine.sayInternal} and
+     * {@code RestAgentEngineStreaming.buildErrorEvent}, which cannot reach this
+     * mapper and so reproduce its body themselves — the class Javadoc's "change all
+     * three together" is only enforceable if the three read the same text from one
+     * place.
+     *
+     * @param exception
+     *            the failure being reported
+     * @return the exception's own message, or a fixed fallback when it has none
+     */
+    public static String messageOf(ProcessingRestrictionUnavailableException exception) {
+        String message = exception.getMessage();
+        return message != null ? message : "Processing-restriction status unavailable";
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/gdpr/RestGdprAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/RestGdprAdmin.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.gdpr;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 /**
@@ -30,11 +31,30 @@ public class RestGdprAdmin implements IRestGdprAdmin {
         this.gdprComplianceService = gdprComplianceService;
     }
 
+    /** HTTP 207 Multi-Status, which {@link Response.Status} does not define. */
+    static final int MULTI_STATUS = 207;
+
+    /**
+     * Answers 207 when any cascade step failed.
+     * <p>
+     * The cascade deliberately continues past a failing store so the remaining
+     * categories are still erased — which used to mean the admin got a 200 and a
+     * result whose {@code conversationsDeleted=0} was indistinguishable from "this
+     * user had no conversations", and filed the Art. 17 request as fulfilled while
+     * the conversations were still there. The status now carries that distinction
+     * even for a caller that does not read the body.
+     */
     @Override
-    public GdprDeletionResult deleteUserData(String userId) {
+    public Response deleteUserData(String userId) {
         validateUserId(userId);
         LOGGER.info("GDPR erasure request received");
-        return gdprComplianceService.deleteUserData(userId);
+        GdprDeletionResult result = gdprComplianceService.deleteUserData(userId);
+        if (!result.complete()) {
+            LOGGER.warnf("GDPR erasure incomplete — failed steps: %s", result.failedSteps());
+        }
+        return Response.status(result.complete() ? Response.Status.OK.getStatusCode() : MULTI_STATUS)
+                .entity(result)
+                .build();
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/engine/gdpr/RestGdprAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/RestGdprAdmin.java
@@ -57,18 +57,28 @@ public class RestGdprAdmin implements IRestGdprAdmin {
                 .build();
     }
 
-    /** HTTP 206 Partial Content, for a bundle the conversation cap truncated. */
-    static final int PARTIAL_CONTENT = Response.Status.PARTIAL_CONTENT.getStatusCode();
-
     /**
-     * Answers 206 when the conversation cap truncated the bundle.
+     * Answers 207 whenever the bundle is not everything EDDI holds on the user.
      * <p>
-     * Same reasoning as the 207 above. The cap used to be visible only in the
-     * server log, so a data-portability request for a user with 1,200 conversations
-     * returned 200 with 200 of them silently missing — an arbitrary 200 on MongoDB,
-     * whose natural order is not insertion order. The body now carries
-     * {@code totalConversations} and {@code conversationsTruncated}; the status
-     * carries the same distinction for a caller that does not read the body.
+     * Same reasoning as the 207 above, and now the same status. Two things used to
+     * be wrong here. The cap was visible only in the server log, so a
+     * data-portability request for a user with 1,200 conversations returned 200
+     * with 200 of them silently missing — an arbitrary 200 on MongoDB, whose
+     * natural order is not insertion order. And the cap was then the <em>only</em>
+     * completeness check, while the exporter has never covered group transcripts,
+     * shared artifacts, schedules or HITL journal entries: a user whose data lives
+     * only in those four categories received an empty bundle, 200 OK, documented as
+     * complete — an Art. 20 answer that overstates itself to the one reader who
+     * cannot check it. {@link UserDataExport#complete()} answers both questions and
+     * the status follows it; {@code omittedCategories} in the body names what is
+     * missing.
+     * <p>
+     * 207, not the 206 this used to send. 206 Partial Content is defined for range
+     * requests and RFC 9110 requires a {@code Content-Range} with it, which this
+     * endpoint neither reads nor produces — a conforming client is entitled to
+     * treat the body as a malformed range response. 207 already means "composite
+     * operation, read the body for what actually happened" on the erasure half of
+     * this API, which is the same thing being said.
      */
     @Override
     public Response exportUserData(String userId) {
@@ -79,7 +89,11 @@ public class RestGdprAdmin implements IRestGdprAdmin {
             LOGGER.warnf("GDPR export truncated — %d of %d conversations returned",
                     export.conversations().size(), export.totalConversations());
         }
-        return Response.status(export.conversationsTruncated() ? PARTIAL_CONTENT : Response.Status.OK.getStatusCode())
+        if (!export.complete()) {
+            LOGGER.warnf("GDPR export incomplete — conversationsTruncated: %s, omitted categories: %s",
+                    export.conversationsTruncated(), export.omittedCategories());
+        }
+        return Response.status(export.complete() ? Response.Status.OK.getStatusCode() : MULTI_STATUS)
                 .entity(export)
                 .build();
     }

--- a/src/main/java/ai/labs/eddi/engine/gdpr/RestGdprAdmin.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/RestGdprAdmin.java
@@ -57,11 +57,31 @@ public class RestGdprAdmin implements IRestGdprAdmin {
                 .build();
     }
 
+    /** HTTP 206 Partial Content, for a bundle the conversation cap truncated. */
+    static final int PARTIAL_CONTENT = Response.Status.PARTIAL_CONTENT.getStatusCode();
+
+    /**
+     * Answers 206 when the conversation cap truncated the bundle.
+     * <p>
+     * Same reasoning as the 207 above. The cap used to be visible only in the
+     * server log, so a data-portability request for a user with 1,200 conversations
+     * returned 200 with 200 of them silently missing — an arbitrary 200 on MongoDB,
+     * whose natural order is not insertion order. The body now carries
+     * {@code totalConversations} and {@code conversationsTruncated}; the status
+     * carries the same distinction for a caller that does not read the body.
+     */
     @Override
-    public UserDataExport exportUserData(String userId) {
+    public Response exportUserData(String userId) {
         validateUserId(userId);
         LOGGER.info("GDPR export request received");
-        return gdprComplianceService.exportUserData(userId);
+        UserDataExport export = gdprComplianceService.exportUserData(userId);
+        if (export.conversationsTruncated()) {
+            LOGGER.warnf("GDPR export truncated — %d of %d conversations returned",
+                    export.conversations().size(), export.totalConversations());
+        }
+        return Response.status(export.conversationsTruncated() ? PARTIAL_CONTENT : Response.Status.OK.getStatusCode())
+                .entity(export)
+                .build();
     }
 
     @Override

--- a/src/main/java/ai/labs/eddi/engine/gdpr/UserDataExport.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/UserDataExport.java
@@ -29,6 +29,18 @@ import java.util.Map;
  *            all managed (intent-based) conversation mappings
  * @param auditEntries
  *            processing records from the audit ledger (capped at 10,000)
+ * @param attachments
+ *            attachment metadata for the exported conversations
+ * @param totalConversations
+ *            how many conversations the user has — <em>not</em> necessarily
+ *            {@code conversations.size()}, see {@code conversationsTruncated}
+ * @param conversationsTruncated
+ *            true when the per-request conversation cap bit, so this bundle is
+ *            <strong>incomplete</strong>. Handing a data subject an Art. 15/20
+ *            bundle that silently omits conversations is the same class of
+ *            misreporting the erasure half of this API answers 207 for, so the
+ *            cap is stated in the payload and not only in the server log;
+ *            {@code RestGdprAdmin} answers 206 Partial Content when it is set.
  *
  * @author ginccc
  * @since 6.0.0
@@ -40,7 +52,9 @@ public record UserDataExport(
         List<ConversationExportEntry> conversations,
         List<UserConversation> managedConversations,
         List<AuditExportEntry> auditEntries,
-        List<AttachmentExportEntry> attachments) {
+        List<AttachmentExportEntry> attachments,
+        int totalConversations,
+        boolean conversationsTruncated) {
 
     /**
      * Backward-compatible constructor without attachment metadata.
@@ -49,6 +63,18 @@ public record UserDataExport(
             List<ConversationExportEntry> conversations, List<UserConversation> managedConversations,
             List<AuditExportEntry> auditEntries) {
         this(userId, exportedAt, memories, conversations, managedConversations, auditEntries, List.of());
+    }
+
+    /**
+     * Backward-compatible constructor for the shape that predates the truncation
+     * marker — reports the bundle as complete, carrying every conversation it
+     * holds.
+     */
+    public UserDataExport(String userId, Instant exportedAt, List<UserMemoryEntry> memories,
+            List<ConversationExportEntry> conversations, List<UserConversation> managedConversations,
+            List<AuditExportEntry> auditEntries, List<AttachmentExportEntry> attachments) {
+        this(userId, exportedAt, memories, conversations, managedConversations, auditEntries, attachments,
+                conversations == null ? 0 : conversations.size(), false);
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/gdpr/UserDataExport.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/UserDataExport.java
@@ -43,6 +43,15 @@ import java.util.Map;
  *            cap is stated in the payload and not only in the server log. It is
  *            <em>one</em> of the reasons a bundle can be incomplete — see
  *            {@link #complete()} for the whole answer.
+ * @param failedConversationIds
+ *            conversations the exporter could not load, so they are
+ *            <strong>absent</strong> from {@code conversations}. Kept separate
+ *            from {@code conversationsTruncated}, which stays the per-request
+ *            cap's own signal: a snapshot that failed to load used to be logged
+ *            at WARN and dropped while every completeness marker in the payload
+ *            still said the bundle was whole, so a DPO handed the data subject
+ *            an Art. 15 answer the code knew was short. Counts against
+ *            {@link #complete()}.
  *
  * @author ginccc
  * @since 6.0.0
@@ -56,7 +65,25 @@ public record UserDataExport(
         List<AuditExportEntry> auditEntries,
         List<AttachmentExportEntry> attachments,
         int totalConversations,
-        boolean conversationsTruncated) {
+        boolean conversationsTruncated,
+        List<String> failedConversationIds) {
+
+    public UserDataExport {
+        failedConversationIds = failedConversationIds == null ? List.of() : List.copyOf(failedConversationIds);
+    }
+
+    /**
+     * Backward-compatible constructor for the shape that predates the
+     * failed-conversation list — every conversation the bundle carries is one that
+     * loaded.
+     */
+    public UserDataExport(String userId, Instant exportedAt, List<UserMemoryEntry> memories,
+            List<ConversationExportEntry> conversations, List<UserConversation> managedConversations,
+            List<AuditExportEntry> auditEntries, List<AttachmentExportEntry> attachments,
+            int totalConversations, boolean conversationsTruncated) {
+        this(userId, exportedAt, memories, conversations, managedConversations, auditEntries, attachments,
+                totalConversations, conversationsTruncated, List.of());
+    }
 
     /**
      * Backward-compatible constructor without attachment metadata.
@@ -119,10 +146,16 @@ public record UserDataExport(
      * answering an Art. 15/20 request needs the honest answer, so the omitted
      * categories count against completeness exactly as the cap does. False until
      * those four stores are exportable.
+     * <p>
+     * {@link #failedConversationIds()} counts too, and for the same reason: a
+     * conversation the exporter could not load is missing from the bundle whether
+     * the cap or a failed read is why. That third term is masked today by the
+     * omitted categories always being non-empty — it becomes the load-bearing one
+     * the moment those four exporters land.
      */
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public boolean complete() {
-        return !conversationsTruncated && omittedCategories().isEmpty();
+        return !conversationsTruncated && failedConversationIds.isEmpty() && omittedCategories().isEmpty();
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/gdpr/UserDataExport.java
+++ b/src/main/java/ai/labs/eddi/engine/gdpr/UserDataExport.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.configs.properties.model.UserMemoryEntry;
 import ai.labs.eddi.engine.memory.model.ConversationOutput;
 import ai.labs.eddi.engine.memory.model.ConversationState;
 import ai.labs.eddi.engine.triggermanagement.model.UserConversation;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
 import java.util.List;
@@ -39,8 +40,9 @@ import java.util.Map;
  *            <strong>incomplete</strong>. Handing a data subject an Art. 15/20
  *            bundle that silently omits conversations is the same class of
  *            misreporting the erasure half of this API answers 207 for, so the
- *            cap is stated in the payload and not only in the server log;
- *            {@code RestGdprAdmin} answers 206 Partial Content when it is set.
+ *            cap is stated in the payload and not only in the server log. It is
+ *            <em>one</em> of the reasons a bundle can be incomplete — see
+ *            {@link #complete()} for the whole answer.
  *
  * @author ginccc
  * @since 6.0.0
@@ -75,6 +77,52 @@ public record UserDataExport(
             List<AuditExportEntry> auditEntries, List<AttachmentExportEntry> attachments) {
         this(userId, exportedAt, memories, conversations, managedConversations, auditEntries, attachments,
                 conversations == null ? 0 : conversations.size(), false);
+    }
+
+    /**
+     * Personal-data categories this exporter does not reach yet, named as the
+     * erasure cascade names them in {@code GdprDeletionResult}.
+     * <p>
+     * The two halves of the feature disagree about what the user's data is:
+     * {@code deleteUserData} erases group discussion transcripts, shared artifacts,
+     * schedules and HITL tool journal entries as this user's personal data, and the
+     * export omits all four (closing the gap needs read-by-user methods those
+     * stores do not have — see {@code IRestGdprAdmin}). Until it is closed, the
+     * omission is part of the answer rather than a footnote in the interface
+     * Javadoc: a data subject whose data lives only in these categories would
+     * otherwise be handed an empty bundle described as complete.
+     */
+    public static final List<String> OMITTED_CATEGORIES = List.of("groupConversations", "sharedArtifacts", "schedules", "journalEntries");
+
+    /**
+     * The categories this bundle is known not to cover.
+     * <p>
+     * Annotated for the reason {@code GdprDeletionResult.complete()} is: a derived
+     * method is neither a record component nor a bean getter, so Jackson would
+     * leave it out of the REST entity while {@code McpGdprTools} puts it into the
+     * MCP payload explicitly, and a client written against one surface would read
+     * null from the other. {@code READ_ONLY} keeps it out of deserialization, where
+     * the canonical constructor has no matching component.
+     */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public List<String> omittedCategories() {
+        return OMITTED_CATEGORIES;
+    }
+
+    /**
+     * Whether this bundle covers everything EDDI holds on the user.
+     * <p>
+     * {@code conversationsTruncated} used to be the only completeness signal, so a
+     * user with fewer conversations than the cap got a bundle described as complete
+     * however many whole categories were missing from it — and a user whose data
+     * lives <em>only</em> in {@link #OMITTED_CATEGORIES} got an empty one. A DPO
+     * answering an Art. 15/20 request needs the honest answer, so the omitted
+     * categories count against completeness exactly as the cap does. False until
+     * those four stores are exportable.
+     */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public boolean complete() {
+        return !conversationsTruncated && omittedCategories().isEmpty();
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/ConversationService.java
@@ -16,6 +16,8 @@ import ai.labs.eddi.engine.audit.AuditLedgerService;
 import ai.labs.eddi.engine.events.HitlResumeCompletedEvent;
 import ai.labs.eddi.engine.gdpr.GdprComplianceService;
 import ai.labs.eddi.engine.gdpr.ProcessingRestrictedException;
+import ai.labs.eddi.engine.gdpr.ProcessingRestrictionUnavailableException;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
@@ -360,7 +362,13 @@ public class ConversationService implements IConversationService {
             // (avoids burning quota on GDPR-restricted or agent-not-ready failures)
             QuotaCheckResult quotaCheck = tenantQuotaService.acquireConversationSlot();
             if (!quotaCheck.allowed()) {
-                throw new QuotaExceededException(quotaCheck.reason());
+                throw quotaCheck.accountingUnavailable()
+                        // A store that could not answer is a 503, not a 429: the
+                        // tenant is not over anything, and a client that backs off
+                        // for a minute on the strength of a Retry-After is reacting
+                        // to the wrong signal.
+                        ? new QuotaAccountingUnavailableException(quotaCheck.reason())
+                        : new QuotaExceededException(quotaCheck.reason());
             }
 
             // Decided here, at the only moment it CAN be decided: this is still the
@@ -587,7 +595,13 @@ public class ConversationService implements IConversationService {
             // agent-not-ready failures)
             QuotaCheckResult quotaCheck = tenantQuotaService.acquireApiCallSlot();
             if (!quotaCheck.allowed()) {
-                throw new QuotaExceededException(quotaCheck.reason());
+                throw quotaCheck.accountingUnavailable()
+                        // A store that could not answer is a 503, not a 429: the
+                        // tenant is not over anything, and a client that backs off
+                        // for a minute on the strength of a Retry-After is reacting
+                        // to the wrong signal.
+                        ? new QuotaAccountingUnavailableException(quotaCheck.reason())
+                        : new QuotaExceededException(quotaCheck.reason());
             }
 
             admittedTurn = new ProcessingTurn(processingConversationCount);
@@ -654,8 +668,22 @@ public class ConversationService implements IConversationService {
                     withResolutionPrincipal(conversationMemory, executeConversation), notifySkipped, processingTurn);
 
             conversationCoordinator.submitInOrder(conversationId, processUserInput);
-        } catch (ProcessingRestrictedException | QuotaExceededException | ConversationAwaitingApprovalException e) {
-            releaseTurn(admittedTurn); // all three are thrown before the turn is admitted
+        } catch (ProcessingRestrictedException | ProcessingRestrictionUnavailableException | QuotaExceededException
+                | QuotaAccountingUnavailableException | ConversationAwaitingApprovalException e) {
+            // All five are thrown before the turn is admitted, and none is an internal
+            // fault of this class: the generic handler below logs a full ERROR stack
+            // trace, which for the restriction-unavailable case meant every turn of
+            // every user wrote two of them (here and again in RestAgentEngine) for the
+            // duration of a store failover. The REST layer reports each one with its
+            // own status.
+            //
+            // QuotaAccountingUnavailableException is listed even though it extends
+            // RejectedExecutionException: it is thrown two lines after the
+            // QuotaExceededException it replaces on the same denial, so leaving it out
+            // put exactly the log flood this multi-catch removes back on the
+            // quota-store outage path — one ERROR stack trace per turn, on top of
+            // TenantQuotaService.recordDenial's own.
+            releaseTurn(admittedTurn);
             throw e;
         } catch (AgentMismatchException | AgentNotReadyException | ConversationEndedException e) {
             releaseTurn(admittedTurn);
@@ -724,7 +752,13 @@ public class ConversationService implements IConversationService {
             // agent-not-ready failures)
             QuotaCheckResult quotaCheck = tenantQuotaService.acquireApiCallSlot();
             if (!quotaCheck.allowed()) {
-                throw new QuotaExceededException(quotaCheck.reason());
+                throw quotaCheck.accountingUnavailable()
+                        // A store that could not answer is a 503, not a 429: the
+                        // tenant is not over anything, and a client that backs off
+                        // for a minute on the strength of a Retry-After is reacting
+                        // to the wrong signal.
+                        ? new QuotaAccountingUnavailableException(quotaCheck.reason())
+                        : new QuotaExceededException(quotaCheck.reason());
             }
 
             admittedTurn = new ProcessingTurn(processingConversationCount);
@@ -830,8 +864,22 @@ public class ConversationService implements IConversationService {
                     withResolutionPrincipal(conversationMemory, executeConversation), notifySkipped, processingTurn);
 
             conversationCoordinator.submitInOrder(conversationId, processUserInput);
-        } catch (ProcessingRestrictedException | QuotaExceededException | ConversationAwaitingApprovalException e) {
-            releaseTurn(admittedTurn); // all three are thrown before the turn is admitted
+        } catch (ProcessingRestrictedException | ProcessingRestrictionUnavailableException | QuotaExceededException
+                | QuotaAccountingUnavailableException | ConversationAwaitingApprovalException e) {
+            // All five are thrown before the turn is admitted, and none is an internal
+            // fault of this class: the generic handler below logs a full ERROR stack
+            // trace, which for the restriction-unavailable case meant every turn of
+            // every user wrote two of them (here and again in RestAgentEngine) for the
+            // duration of a store failover. The REST layer reports each one with its
+            // own status.
+            //
+            // QuotaAccountingUnavailableException is listed even though it extends
+            // RejectedExecutionException: it is thrown two lines after the
+            // QuotaExceededException it replaces on the same denial, so leaving it out
+            // put exactly the log flood this multi-catch removes back on the
+            // quota-store outage path — one ERROR stack trace per turn, on top of
+            // TenantQuotaService.recordDenial's own.
+            releaseTurn(admittedTurn);
             throw e;
         } catch (AgentMismatchException | AgentNotReadyException | ConversationEndedException e) {
             releaseTurn(admittedTurn);

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentAdministration.java
@@ -25,6 +25,7 @@ import ai.labs.eddi.engine.runtime.ThreadContext;
 import ai.labs.eddi.engine.runtime.internal.IDeploymentListener;
 import ai.labs.eddi.engine.runtime.model.DeploymentEvent;
 import ai.labs.eddi.engine.runtime.service.ServiceException;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.utils.LogSanitizer;
@@ -269,7 +270,15 @@ public class RestAgentAdministration implements IRestAgentAdministration {
         var result = tenantQuotaService.checkAgentQuota(tenantQuotaService.getDefaultTenantId(), deployedAgentIds.size());
         if (!result.allowed()) {
             log.warnf("Denying deployment of Agent %s to %s: %s", agentId, environment, result.reason());
-            throw new QuotaExceededException(result.reason());
+            // A store that could not answer is a 503, not a 429 — same split as the
+            // conversation and API-call gates in ConversationService. This one is
+            // synchronous, so QuotaAccountingUnavailableExceptionMapper runs and
+            // gives it the honest code; without the branch the deploy answered 429
+            // quota_exceeded with Retry-After: 60 for an outage the dashboard was
+            // already counting on eddi.tenant.quota.unavailable{type=agent}.
+            throw result.accountingUnavailable()
+                    ? new QuotaAccountingUnavailableException(result.reason())
+                    : new QuotaExceededException(result.reason());
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
@@ -36,6 +36,7 @@ import ai.labs.eddi.engine.security.OwnershipValidator;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
 import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.rest.QuotaAccountingUnavailableExceptionMapper;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -301,11 +302,13 @@ public class RestAgentEngine implements IRestAgentEngine {
             // Before the RejectedExecutionException branch below, which it extends:
             // that branch would already answer 503 rather than 500, but with
             // "capacity_exceeded", and this is not capacity. The quota store could
-            // not answer at all, so the honest error code names that.
+            // not answer at all, so the honest error code names that. The message
+            // comes from the mapper's accessor so all three surfaces that report this
+            // condition read one fallback rather than three copies of a literal.
             LOGGER.warnf("Quota accounting unavailable for conversation %s: %s", sanitize(conversationId), e.getMessage());
             response.resume(Response.status(Response.Status.SERVICE_UNAVAILABLE)
                     .entity(Map.of("error", "quota_accounting_unavailable",
-                            "message", e.getMessage() != null ? e.getMessage() : "Quota accounting unavailable"))
+                            "message", QuotaAccountingUnavailableExceptionMapper.messageOf(e)))
                     .type(MediaType.APPLICATION_JSON).header("Retry-After", "5").build());
         } catch (RejectedExecutionException e) {
             // Same reason as the quota branch above: say() is resumed through an

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngine.java
@@ -9,6 +9,8 @@ import ai.labs.eddi.datastore.IResourceStore.ResourceStoreException;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IConversationService.*;
 import ai.labs.eddi.engine.gdpr.ProcessingRestrictedException;
+import ai.labs.eddi.engine.gdpr.ProcessingRestrictionUnavailableException;
+import ai.labs.eddi.engine.gdpr.ProcessingRestrictionUnavailableExceptionMapper;
 import ai.labs.eddi.engine.hitl.HitlAccessGuard;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.api.IRestAgentEngine;
@@ -32,6 +34,7 @@ import ai.labs.eddi.engine.model.InputData;
 import ai.labs.eddi.engine.security.ConversationAccessGuard;
 import ai.labs.eddi.engine.security.OwnershipValidator;
 import ai.labs.eddi.engine.security.spaces.ResourceAccessGuard;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -255,6 +258,23 @@ public class RestAgentEngine implements IRestAgentEngine {
         } catch (ProcessingRestrictedException e) {
             LOGGER.warnf("GDPR processing restricted: %s", e.getMessage());
             response.resume(Response.status(Response.Status.FORBIDDEN).type(TEXT_PLAIN).entity(e.getMessage()).build());
+        } catch (ProcessingRestrictionUnavailableException e) {
+            // Same reason as the quota and backpressure branches below: say() is
+            // resumed through an AsyncResponse, so
+            // ProcessingRestrictionUnavailableExceptionMapper never runs and the
+            // generic handler turned a store failover into a 500 with two ERROR stack
+            // traces per turn — hiding an outage from any monitoring keyed on 503,
+            // and on the hottest path in the system. Body and headers mirror the
+            // mapper so both surfaces look identical to clients — including the null
+            // guard, because Map.of throws NullPointerException on a null value and an
+            // exception raised inside a catch clause is not seen by the sibling
+            // catches: the AsyncResponse would never be resumed and the request would
+            // hang to its timeout.
+            LOGGER.warnf("GDPR restriction status unavailable for conversation %s: %s", sanitize(conversationId), e.getMessage());
+            response.resume(Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(Map.of("error", "restriction_status_unavailable",
+                            "message", ProcessingRestrictionUnavailableExceptionMapper.messageOf(e)))
+                    .type(MediaType.APPLICATION_JSON).header("Retry-After", "5").build());
         } catch (ResourceNotFoundException e) {
             response.resume(new NotFoundException());
         } catch (ConversationNotFoundException e) {
@@ -277,6 +297,16 @@ public class RestAgentEngine implements IRestAgentEngine {
             response.resume(Response.status(TOO_MANY_REQUESTS)
                     .entity(Map.of("error", "quota_exceeded", "message", e.getMessage()))
                     .type(MediaType.APPLICATION_JSON).header("Retry-After", "60").build());
+        } catch (QuotaAccountingUnavailableException e) {
+            // Before the RejectedExecutionException branch below, which it extends:
+            // that branch would already answer 503 rather than 500, but with
+            // "capacity_exceeded", and this is not capacity. The quota store could
+            // not answer at all, so the honest error code names that.
+            LOGGER.warnf("Quota accounting unavailable for conversation %s: %s", sanitize(conversationId), e.getMessage());
+            response.resume(Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(Map.of("error", "quota_accounting_unavailable",
+                            "message", e.getMessage() != null ? e.getMessage() : "Quota accounting unavailable"))
+                    .type(MediaType.APPLICATION_JSON).header("Retry-After", "5").build());
         } catch (RejectedExecutionException e) {
             // Same reason as the quota branch above: say() is resumed through an
             // AsyncResponse, so RejectedExecutionExceptionMapper never runs and the

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -13,7 +13,10 @@ import ai.labs.eddi.engine.api.IConversationService.ConversationNotFoundExceptio
 import ai.labs.eddi.engine.api.IConversationService.StreamingResponseHandler;
 import ai.labs.eddi.engine.api.IRestAgentEngineStreaming;
 import ai.labs.eddi.engine.gdpr.ProcessingRestrictedException;
+import ai.labs.eddi.engine.gdpr.ProcessingRestrictionUnavailableException;
+import ai.labs.eddi.engine.gdpr.ProcessingRestrictionUnavailableExceptionMapper;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 
 import ai.labs.eddi.engine.lifecycle.TaskId;
@@ -240,12 +243,12 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
      * the opaque internal-error shape.
      * <p>
      * These are not internal errors: the non-streaming twin
-     * ({@code RestAgentEngine}) gives each a proper status (409/410/404/429/403)
-     * with a client-safe body, and before this method the SAME condition on the
-     * streaming path surfaced as {@code {"message":"Internal server error"}} —
-     * observed live when a message was sent into an AWAITING_HUMAN conversation:
-     * the backend refused correctly and the client rendered an opaque 500-style
-     * blob with no way to react.
+     * ({@code RestAgentEngine}) gives each a proper status
+     * (409/410/404/429/403/503) with a client-safe body, and before this method the
+     * SAME condition on the streaming path surfaced as {@code {"message":"Internal
+     * server error"}} — observed live when a message was sent into an
+     * AWAITING_HUMAN conversation: the backend refused correctly and the client
+     * rendered an opaque 500-style blob with no way to react.
      * <p>
      * Per exception, the message mirrors exactly what the twin already discloses —
      * echoed for the conditions whose message is a fixed safe template
@@ -281,12 +284,31 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
         } else if (e instanceof AgentMismatchException) {
             code = "agent_mismatch";
             message = "Agent version mismatch";
+        } else if (e instanceof QuotaAccountingUnavailableException) {
+            // Before QuotaExceededException is irrelevant (they are unrelated types),
+            // but the distinction is the same one RestAgentEngine draws: the store
+            // could not answer, so this is not the tenant being over a limit. The
+            // message is this class's own fixed text and names nothing internal.
+            code = "quota_accounting_unavailable";
+            message = e.getMessage();
         } else if (e instanceof QuotaExceededException) {
             code = "quota_exceeded";
             message = e.getMessage();
         } else if (e instanceof ProcessingRestrictedException) {
             code = "processing_restricted";
             message = e.getMessage();
+        } else if (e instanceof ProcessingRestrictionUnavailableException restrictionUnavailable) {
+            // The twin answers 503 restriction_status_unavailable. Without this
+            // branch a store failover reached the client as
+            // {"message":"Internal server error"} on every streamed turn, with an
+            // ERROR stack trace per turn behind it — the honest-503 fix had landed on
+            // the synchronous start endpoint only. The message is a fixed template
+            // naming no deployment internals, so it is echoed rather than replaced —
+            // through the mapper's accessor, so a thrower that supplies no message
+            // produces the same sentence here as on the other two surfaces instead of
+            // an empty one.
+            code = "restriction_status_unavailable";
+            message = ProcessingRestrictionUnavailableExceptionMapper.messageOf(restrictionUnavailable);
         } else {
             return logAndBuildOpaqueErrorEvent(context, e);
         }

--- a/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/RestAgentEngineStreaming.java
@@ -18,6 +18,7 @@ import ai.labs.eddi.engine.gdpr.ProcessingRestrictionUnavailableExceptionMapper;
 import ai.labs.eddi.engine.memory.model.SimpleConversationMemorySnapshot;
 import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.rest.QuotaAccountingUnavailableExceptionMapper;
 
 import ai.labs.eddi.engine.lifecycle.TaskId;
 import ai.labs.eddi.engine.lifecycle.model.ControlSignal;
@@ -284,13 +285,16 @@ public class RestAgentEngineStreaming implements IRestAgentEngineStreaming {
         } else if (e instanceof AgentMismatchException) {
             code = "agent_mismatch";
             message = "Agent version mismatch";
-        } else if (e instanceof QuotaAccountingUnavailableException) {
+        } else if (e instanceof QuotaAccountingUnavailableException quotaUnavailable) {
             // Before QuotaExceededException is irrelevant (they are unrelated types),
             // but the distinction is the same one RestAgentEngine draws: the store
             // could not answer, so this is not the tenant being over a limit. The
-            // message is this class's own fixed text and names nothing internal.
+            // message is this class's own fixed text and names nothing internal, so
+            // it is echoed rather than replaced — through the mapper's accessor, so a
+            // thrower that supplies no message produces the same sentence here as on
+            // the other two surfaces instead of "message":"".
             code = "quota_accounting_unavailable";
-            message = e.getMessage();
+            message = QuotaAccountingUnavailableExceptionMapper.messageOf(quotaUnavailable);
         } else if (e instanceof QuotaExceededException) {
             code = "quota_exceeded";
             message = e.getMessage();

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutor.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/MemberTurnExecutor.java
@@ -30,7 +30,7 @@ import ai.labs.eddi.engine.model.Context;
 import ai.labs.eddi.engine.model.Deployment.Environment;
 import ai.labs.eddi.engine.model.InputData;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
-import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.QuotaRefusal;
 import io.micrometer.core.instrument.Counter;
 import org.jboss.logging.Logger;
 
@@ -275,9 +275,16 @@ public class MemberTurnExecutor {
                 var result = conversationService.startConversation(DEFAULT_ENV, member.agentId(), gc.getUserId(), groupContext);
                 privateConvId = result.conversationId();
                 gc.getMemberConversationIds().put(convKey, privateConvId);
-            } catch (QuotaExceededException qe) {
-                throw new GroupDiscussionException("Tenant quota exceeded: " + qe.getMessage(), qe);
             } catch (Exception e) {
+                // Any quota refusal — over a limit OR the store unable to answer —
+                // affects every member, so it aborts the discussion instead of
+                // becoming this member's SKIPPED entry. Matched on the marker rather
+                // than on QuotaExceededException: the accounting-outage type extends
+                // RejectedExecutionException, so a type-by-type guard silently stopped
+                // covering it and an outage degraded into a discussion that "completed".
+                if (e instanceof QuotaRefusal refusal) {
+                    throw new GroupDiscussionException(refusal.refusalSummary() + ": " + e.getMessage(), e);
+                }
                 return handleAgentFailure(member, phaseIdx, phase, protocol, e, "Failed to start conversation", targetAgentId);
             }
         }
@@ -514,9 +521,12 @@ public class MemberTurnExecutor {
                     throw new GroupConversationService.MemberTurnCancelledException();
                 }
                 Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
-                // Quota errors are non-retryable and affect all agents — abort immediately
-                if (cause instanceof QuotaExceededException) {
-                    throw new GroupDiscussionException("Tenant quota exceeded: " + cause.getMessage(), cause);
+                // Quota errors are non-retryable and affect all agents — abort
+                // immediately. QuotaRefusal covers the accounting outage too: retrying a
+                // member maxRetries times against a store that cannot answer pays a
+                // connection-acquisition timeout per attempt on the phase thread.
+                if (cause instanceof QuotaRefusal refusal) {
+                    throw new GroupDiscussionException(refusal.refusalSummary() + ": " + cause.getMessage(), cause);
                 }
                 if (protocol.onAgentFailure() == ProtocolConfig.MemberFailurePolicy.RETRY && retries < maxRetries) {
                     retries++;

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/PhaseExecutionEngine.java
@@ -24,7 +24,7 @@ import ai.labs.eddi.engine.internal.GroupConversationService.MemberTurnCancellat
 import ai.labs.eddi.engine.internal.GroupConversationService.MemberTurnCancelledException;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.QuotaRefusal;
 import ai.labs.eddi.utils.LogSanitizer;
 import org.jboss.logging.Logger;
 
@@ -862,7 +862,7 @@ public class PhaseExecutionEngine {
                         // convert a cancellation into an error transcript entry.
                         throw new CompletionException(e);
                     } catch (GroupDiscussionException e) {
-                        if (e.getCause() instanceof QuotaExceededException) {
+                        if (e.getCause() instanceof QuotaRefusal) {
                             throw new CompletionException(e);
                         }
                         LOGGER.errorf("Parallel phase failed for %s: %s", speaker.agentId(), e.getMessage());
@@ -920,7 +920,7 @@ public class PhaseExecutionEngine {
                         Instant.now(), "Timeout", null));
             } catch (ExecutionException e) {
                 // Unwrap: CompletionException → GroupDiscussionException →
-                // QuotaExceededException
+                // QuotaRefusal (over-limit or accounting outage)
                 Throwable cause = e.getCause();
                 if (cause instanceof CompletionException ce) {
                     cause = ce.getCause();
@@ -933,7 +933,7 @@ public class PhaseExecutionEngine {
                     continue;
                 }
                 if (cause instanceof GroupDiscussionException gde
-                        && gde.getCause() instanceof QuotaExceededException) {
+                        && gde.getCause() instanceof QuotaRefusal) {
                     // Release the remaining speakers and propagate
                     cancellation.cancel();
                     throw gde;

--- a/src/main/java/ai/labs/eddi/engine/internal/groups/TaskForceEngine.java
+++ b/src/main/java/ai/labs/eddi/engine/internal/groups/TaskForceEngine.java
@@ -29,7 +29,7 @@ import ai.labs.eddi.engine.internal.TaskListParser;
 import ai.labs.eddi.engine.lifecycle.GroupConversationEventSink;
 import ai.labs.eddi.engine.lifecycle.model.DiscussionControlToken;
 import ai.labs.eddi.engine.security.CallerIdentityContext;
-import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.QuotaRefusal;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
 import ai.labs.eddi.utils.LogSanitizer;
 import org.jboss.logging.Logger;
@@ -450,7 +450,7 @@ public class TaskForceEngine {
                             // Quota errors are non-retryable — abort all tasks immediately.
                             // Checked before the cancellation guard so a quota breach is still
                             // reported even when the wave is already unwinding.
-                            if (e.getCause() instanceof QuotaExceededException) {
+                            if (e.getCause() instanceof QuotaRefusal) {
                                 errors.add(e);
                                 return; // exit the entire agent's CompletableFuture
                             }
@@ -563,7 +563,7 @@ public class TaskForceEngine {
 
             // Quota errors always abort, regardless of onAgentFailure policy
             for (GroupDiscussionException error : errors) {
-                if (error.getCause() instanceof QuotaExceededException) {
+                if (error.getCause() instanceof QuotaRefusal) {
                     throw error;
                 }
             }

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpAdminTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpAdminTools.java
@@ -34,7 +34,7 @@ import ai.labs.eddi.engine.schedule.model.ScheduleFireLog;
 import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IRestAgentAdministration;
 import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
-import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.QuotaRefusal;
 import ai.labs.eddi.engine.runtime.internal.CronDescriber;
 import ai.labs.eddi.engine.runtime.internal.CronParser;
 import ai.labs.eddi.engine.runtime.internal.ScheduleFireExecutor;
@@ -158,13 +158,18 @@ public class McpAdminTools {
             }
 
             return resultJson("deployed", result);
-        } catch (QuotaExceededException e) {
-            // Return the quota reason rather than the generic message: an MCP client
-            // (and the model driving it) cannot self-correct from "check server logs"
-            // and will retry the deploy in a loop.
-            LOGGER.warn("MCP deploy_agent denied by quota for Agent " + agentId + ": " + e.getMessage());
-            return errorJson(e.getMessage());
         } catch (Exception e) {
+            // Match the QuotaRefusal marker rather than one concrete class: the
+            // accounting-outage refusal is a sibling of QuotaExceededException, not a
+            // subclass, so a catch naming only the latter drops a store outage into
+            // the generic branch below.
+            if (e instanceof QuotaRefusal) {
+                // Return the quota reason rather than the generic message: an MCP client
+                // (and the model driving it) cannot self-correct from "check server logs"
+                // and will retry the deploy in a loop.
+                LOGGER.warn("MCP deploy_agent refused by quota layer for Agent " + agentId + ": " + e.getMessage());
+                return errorJson(e.getMessage());
+            }
             LOGGER.error("MCP deploy_agent failed for Agent " + agentId, e);
             return errorJson("Failed to deploy agent. Check server logs for details.");
         }

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGdprTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGdprTools.java
@@ -31,6 +31,16 @@ public class McpGdprTools {
 
     private static final Logger LOGGER = Logger.getLogger(McpGdprTools.class);
 
+    /** Reported when every step of the erasure cascade succeeded. */
+    static final String STATUS_COMPLETED = "completed";
+
+    /**
+     * Reported when at least one step failed. Deliberately not "completed": the
+     * erasure must not be filed as fulfilled while {@code failedSteps} is
+     * non-empty.
+     */
+    static final String STATUS_PARTIAL = "partially_completed";
+
     private final GdprComplianceService gdprComplianceService;
     private final IJsonSerialization jsonSerialization;
     private final SecurityIdentity identity;
@@ -51,7 +61,11 @@ public class McpGdprTools {
     @Tool(name = "delete_user_data", description = "Cascade-delete all user "
             + "data across all stores (GDPR Art. 17 Right to Erasure). "
             + "Deletes memories and conversations. Pseudonymizes audit and log "
-            + "entries. IRREVERSIBLE — confirmation='CONFIRM' required.")
+            + "entries. IRREVERSIBLE — confirmation='CONFIRM' required. "
+            + "Returns status='completed' only when every step succeeded; "
+            + "status='partially_completed' with a non-empty 'failedSteps' means "
+            + "some of the user's data still exists and the erasure must NOT be "
+            + "reported to the data subject as fulfilled.")
     public String deleteUserData(
                                  @ToolArg(description = "User ID to erase (required)") String userId,
                                  @ToolArg(description = "Must be 'CONFIRM' to proceed") String confirmation) {
@@ -66,7 +80,15 @@ public class McpGdprTools {
         try {
             var result = gdprComplianceService.deleteUserData(userId);
             var map = new LinkedHashMap<String, Object>();
-            map.put("status", "completed");
+            // "completed" used to be hardcoded here. The cascade deliberately
+            // continues past a failing store, so an admin — or an LLM agent acting
+            // on this tool's answer — was told an Art. 17 request was fulfilled
+            // while the data was still there. Report what actually happened and
+            // name the steps that did not run, exactly as the REST surface does
+            // with its 207.
+            map.put("status", result.complete() ? STATUS_COMPLETED : STATUS_PARTIAL);
+            map.put("complete", result.complete());
+            map.put("failedSteps", result.failedSteps());
             map.put("userId", result.userId());
             map.put("memoriesDeleted", result.memoriesDeleted());
             map.put("conversationsDeleted", result.conversationsDeleted());
@@ -75,7 +97,19 @@ public class McpGdprTools {
             map.put("logsPseudonymized", result.logsPseudonymized());
             map.put("auditEntriesPseudonymized",
                     result.auditEntriesPseudonymized());
+            // The six counters the cascade has always computed and written to the
+            // ledger but never returned to the caller.
+            map.put("attachmentsDeleted", result.attachmentsDeleted());
+            map.put("journalEntriesDeleted", result.journalEntriesDeleted());
+            map.put("checkpointsDeleted", result.checkpointsDeleted());
+            map.put("groupConversationsDeleted", result.groupConversationsDeleted());
+            map.put("sharedArtifactsDeleted", result.sharedArtifactsDeleted());
+            map.put("schedulesDeleted", result.schedulesDeleted());
             map.put("completedAt", result.completedAt().toString());
+            if (!result.complete()) {
+                LOGGER.warnf("MCP delete_user_data: erasure cascade incomplete — failed steps: %s",
+                        result.failedSteps());
+            }
             return jsonSerialization.serialize(map);
         } catch (Exception e) {
             LOGGER.errorf(e, "MCP delete_user_data failed");

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGdprTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGdprTools.java
@@ -123,8 +123,9 @@ public class McpGdprTools {
             + "'complete'=false means the bundle is INCOMPLETE and must NOT be handed to the "
             + "data subject as a complete Art. 15 bundle: 'omittedCategories' names the "
             + "personal-data categories this exporter does not reach (always non-empty today), "
-            + "and 'conversationsTruncated'=true means the per-request conversation cap bit, "
-            + "with 'totalConversations' saying how many the user has.")
+            + "'conversationsTruncated'=true means the per-request conversation cap bit, "
+            + "with 'totalConversations' saying how many the user has, and "
+            + "'failedConversationIds' names conversations that could not be loaded at all.")
     public String exportUserData(
                                  @ToolArg(description = "User ID to export (required)") String userId) {
         requireRole(identity, authEnabled, "eddi-admin");
@@ -147,6 +148,11 @@ public class McpGdprTools {
             map.put("omittedCategories", export.omittedCategories());
             map.put("totalConversations", export.totalConversations());
             map.put("conversationsTruncated", export.conversationsTruncated());
+            // The third reason a bundle can be short, alongside the cap and the
+            // omitted categories: conversations the exporter could not load at all.
+            // Left out here, an agent reading complete=false with
+            // conversationsTruncated=false has nothing to say why.
+            map.put("failedConversationIds", export.failedConversationIds());
             map.put("managedConversationsCount",
                     export.managedConversations().size());
             map.put("memories", export.memories());

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGdprTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGdprTools.java
@@ -120,10 +120,11 @@ public class McpGdprTools {
     @Tool(name = "export_user_data", description = "Export all data for a user "
             + "(GDPR Art. 15/20 Right of Access / Data Portability). "
             + "Returns memories, conversations, and managed conversation mappings. "
-            + "'conversationsTruncated'=true means the per-request conversation cap bit "
-            + "and the bundle is INCOMPLETE — 'totalConversations' says how many the user "
-            + "has, and the export must NOT be handed to the data subject as a complete "
-            + "Art. 15 bundle.")
+            + "'complete'=false means the bundle is INCOMPLETE and must NOT be handed to the "
+            + "data subject as a complete Art. 15 bundle: 'omittedCategories' names the "
+            + "personal-data categories this exporter does not reach (always non-empty today), "
+            + "and 'conversationsTruncated'=true means the per-request conversation cap bit, "
+            + "with 'totalConversations' saying how many the user has.")
     public String exportUserData(
                                  @ToolArg(description = "User ID to export (required)") String userId) {
         requireRole(identity, authEnabled, "eddi-admin");
@@ -137,8 +138,13 @@ public class McpGdprTools {
             map.put("exportedAt", export.exportedAt().toString());
             map.put("memoriesCount", export.memories().size());
             map.put("conversationsCount", export.conversations().size());
-            // The REST surface says the same thing with a 206; an LLM agent calling
-            // this tool has only the payload to go on, so the cap has to be in it.
+            // The REST surface says the same thing with a 207; an LLM agent calling
+            // this tool has only the payload to go on, so the cap — and the four
+            // categories the exporter never reaches — have to be in it. Same shape as
+            // the REST body, for the reason delete_user_data reports 'complete': one
+            // result told two different ways is a client reading null from one of them.
+            map.put("complete", export.complete());
+            map.put("omittedCategories", export.omittedCategories());
             map.put("totalConversations", export.totalConversations());
             map.put("conversationsTruncated", export.conversationsTruncated());
             map.put("managedConversationsCount",

--- a/src/main/java/ai/labs/eddi/engine/mcp/McpGdprTools.java
+++ b/src/main/java/ai/labs/eddi/engine/mcp/McpGdprTools.java
@@ -119,7 +119,11 @@ public class McpGdprTools {
 
     @Tool(name = "export_user_data", description = "Export all data for a user "
             + "(GDPR Art. 15/20 Right of Access / Data Portability). "
-            + "Returns memories, conversations, and managed conversation mappings.")
+            + "Returns memories, conversations, and managed conversation mappings. "
+            + "'conversationsTruncated'=true means the per-request conversation cap bit "
+            + "and the bundle is INCOMPLETE — 'totalConversations' says how many the user "
+            + "has, and the export must NOT be handed to the data subject as a complete "
+            + "Art. 15 bundle.")
     public String exportUserData(
                                  @ToolArg(description = "User ID to export (required)") String userId) {
         requireRole(identity, authEnabled, "eddi-admin");
@@ -133,6 +137,10 @@ public class McpGdprTools {
             map.put("exportedAt", export.exportedAt().toString());
             map.put("memoriesCount", export.memories().size());
             map.put("conversationsCount", export.conversations().size());
+            // The REST surface says the same thing with a 206; an LLM agent calling
+            // this tool has only the payload to go on, so the cap has to be in it.
+            map.put("totalConversations", export.totalConversations());
+            map.put("conversationsTruncated", export.conversationsTruncated());
             map.put("managedConversationsCount",
                     export.managedConversations().size());
             map.put("memories", export.memories());

--- a/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceSharingService.java
+++ b/src/main/java/ai/labs/eddi/engine/security/spaces/ResourceSharingService.java
@@ -15,6 +15,7 @@ import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ServiceUnavailableException;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
@@ -353,6 +354,18 @@ public class ResourceSharingService {
         return descriptor == null ? null : new VersionedDescriptor(descriptor, current.getVersion());
     }
 
+    /**
+     * Load a descriptor for a caller that has already passed
+     * {@code accessGuard.requireAccess}.
+     * <p>
+     * A {@link ResourceStoreException} is the store's I/O failure type — a MongoDB
+     * failover, an exhausted PostgreSQL pool — not an access decision. It used to
+     * be translated into {@link ForbiddenException}, so during an outage the
+     * sharing dialog told an operator they were not allowed to view the sharing
+     * state of a resource they in fact own, and the outage never showed up in
+     * monitoring keyed on 5xx. By the time this runs the authorization question is
+     * settled; anything thrown here is infrastructure, and 503 says so.
+     */
     private DocumentDescriptor loadOrThrow(String id) {
         try {
             VersionedDescriptor loaded = loadOrNull(id);
@@ -363,7 +376,8 @@ public class ResourceSharingService {
         } catch (ResourceNotFoundException e) {
             throw new NotFoundException("No such resource: " + id);
         } catch (ResourceStoreException e) {
-            throw new ForbiddenException("Unable to read the sharing state of this resource");
+            LOGGER.errorf(e, "Could not read the sharing state of resource %s", sanitize(id));
+            throw new ServiceUnavailableException("Unable to read the sharing state of this resource right now");
         }
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
+++ b/src/main/java/ai/labs/eddi/engine/setup/AgentSetupService.java
@@ -35,7 +35,7 @@ import ai.labs.eddi.engine.mcp.McpApiToolBuilder;
 import ai.labs.eddi.engine.model.Deployment;
 import ai.labs.eddi.engine.runtime.client.factory.IRestInterfaceFactory;
 import ai.labs.eddi.engine.runtime.client.factory.RestInterfaceFactory;
-import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.QuotaRefusal;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import ai.labs.eddi.modules.llm.tools.UrlValidationUtils;
 import ai.labs.eddi.modules.output.model.types.TextOutputItem;
@@ -1696,21 +1696,25 @@ public class AgentSetupService {
                 result.put("deployed", false);
                 result.put("deployError", "Unexpected deploy response: HTTP " + httpStatus);
             }
-        } catch (QuotaExceededException quotaError) {
-            // agentAdmin is the CDI bean, not an HTTP proxy, so
-            // QuotaExceededExceptionMapper
-            // never runs here. Surface the reason verbatim — it is actionable ("undeploy an
-            // agent first") and the generic branch below would hide it behind "check the
-            // logs",
-            // leaving an agent designer or a sub-agent-creating model unable to
-            // self-correct.
-            LOGGER.warn("Deploy denied by quota for Agent " + agentId + ": " + quotaError.getMessage());
-            result.put("deployed", false);
-            result.put("deployError", quotaError.getMessage());
         } catch (Exception deployError) {
-            LOGGER.warn("Deploy failed for Agent " + agentId, deployError);
-            result.put("deployed", false);
-            result.put("deployError", "Deployment failed. Check server logs for details.");
+            // Match the QuotaRefusal marker rather than one concrete class: the
+            // accounting-outage refusal is a sibling of QuotaExceededException, not a
+            // subclass, so a catch naming only the latter drops a store outage into
+            // the generic branch below.
+            if (deployError instanceof QuotaRefusal) {
+                // agentAdmin is the CDI bean, not an HTTP proxy, so no exception mapper
+                // runs here. Surface the reason verbatim — it is actionable ("undeploy an
+                // agent first") and the generic branch would hide it behind "check the
+                // logs", leaving an agent designer or a sub-agent-creating model unable
+                // to self-correct.
+                LOGGER.warn("Deploy refused by quota layer for Agent " + agentId + ": " + deployError.getMessage());
+                result.put("deployed", false);
+                result.put("deployError", deployError.getMessage());
+            } else {
+                LOGGER.warn("Deploy failed for Agent " + agentId, deployError);
+                result.put("deployed", false);
+                result.put("deployError", "Deployment failed. Check server logs for details.");
+            }
         }
         return result;
     }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/ITenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/ITenantQuotaStore.java
@@ -56,6 +56,14 @@ public interface ITenantQuotaStore {
 
     /**
      * Delete quota configuration for a tenant.
+     * <p>
+     * <strong>No REST surface and no production caller today</strong> —
+     * {@code IRestTenantQuota} exposes list/get/update but no DELETE, so this is
+     * reached only from tests and from embedded use. Whether to publish a DELETE
+     * endpoint is an open question (a tenant with no quota row is treated as
+     * <em>unlimited</em>, so deleting the bootstrapped default tenant's row
+     * silently turns enforcement off), which is why the method is documented rather
+     * than removed or wired up on the reviewer's behalf.
      *
      * @param tenantId
      *            tenant identifier

--- a/src/main/java/ai/labs/eddi/engine/tenancy/ITenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/ITenantQuotaStore.java
@@ -28,14 +28,58 @@ import java.util.List;
  */
 public interface ITenantQuotaStore {
 
+    /**
+     * Denial reason every implementation uses when the store itself could not
+     * answer — as opposed to the tenant genuinely being over a limit.
+     * <p>
+     * Paired with {@link QuotaCheckResult#unavailable}, which is what makes the
+     * difference visible to the caller: an over-limit denial is 429 with
+     * {@code Retry-After: 60} and belongs on {@code eddi.tenant.quota.denied}, an
+     * outage is 503 {@code quota_accounting_unavailable} and belongs on
+     * {@code eddi.tenant.quota.unavailable}. Shared here rather than owned by one
+     * store because the distinction has to hold on <em>every</em> backend — it
+     * shipped PostgreSQL-only, while {@code eddi.datastore.type} defaults to
+     * mongodb, so the documented behaviour did not apply to the default deployment.
+     */
+    String ACCOUNTING_UNAVAILABLE = "Quota accounting unavailable — denying request for safety";
+
+    /**
+     * Refuse the request, flagged as an accounting outage rather than a limit
+     * breach.
+     * <p>
+     * {@link QuotaCheckResult#denied} would still route it through the ordinary
+     * over-quota path: {@code TenantQuotaService} increments
+     * {@code eddi.tenant.quota.denied} and the REST layer answers 429 with
+     * {@code Retry-After: 60}. Only the reason string differed, so a store outage
+     * looked exactly like a tenant burning through its allowance — to the dashboard
+     * and to the client.
+     *
+     * @return a denied result flagged {@code accountingUnavailable}
+     */
+    static QuotaCheckResult accountingUnavailable() {
+        return QuotaCheckResult.unavailable(ACCOUNTING_UNAVAILABLE);
+    }
+
     // ─── Quota Configuration ───
 
     /**
      * Get quota configuration for a tenant.
+     * <p>
+     * This is the first store call every gate in {@link TenantQuotaService} makes,
+     * so on a real outage it is the one that fails — the {@code tryIncrement*}
+     * methods below are never reached. It must therefore fail closed exactly as
+     * they do, and it cannot say so in its return value: {@code null} already means
+     * "this tenant has no quota row", which the service treats as unlimited. A
+     * store that could not be reached throws
+     * {@link QuotaAccountingUnavailableException} instead. Returning null for a
+     * driver failure silently disabled enforcement for every tenant, while the
+     * write half of the very same outage refused the request with a 503.
      *
      * @param tenantId
      *            tenant identifier
-     * @return the quota config, or null if not found
+     * @return the quota config, or null if the tenant has none configured
+     * @throws QuotaAccountingUnavailableException
+     *             if the store could not be reached
      */
     TenantQuota getQuota(String tenantId);
 

--- a/src/main/java/ai/labs/eddi/engine/tenancy/InMemoryTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/InMemoryTenantQuotaStore.java
@@ -17,6 +17,7 @@ import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 import java.util.List;
 import java.util.Map;
+import java.time.Clock;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -36,8 +37,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * microseconds (a few field reads, one integer increment, one timestamp
  * comparison). No I/O or allocation occurs under the lock.
  * <p>
- * This is the default bean; a DB-backed store can override it via
- * {@code @LookupIfProperty} in future phases.
+ * <strong>Not what production runs.</strong> {@code DataStoreProducers} selects
+ * {@link PostgresTenantQuotaStore} or {@link MongoTenantQuotaStore} for every
+ * deployment, so this implementation is reachable only from tests and from an
+ * embedded use where no datastore producer applies. Its Javadoc used to call it
+ * "the default bean", which invited readers to reason about production
+ * behaviour — including its rolling-window semantics — from this class.
  */
 @ApplicationScoped
 @DefaultBean
@@ -48,6 +53,9 @@ public class InMemoryTenantQuotaStore implements ITenantQuotaStore {
     private final Map<String, TenantQuota> quotas = new ConcurrentHashMap<>();
     private final Map<String, TenantUsageCounters> usageMap = new ConcurrentHashMap<>();
 
+    /** See {@code TenantUsageCounters}. Production always gets systemUTC. */
+    private final Clock clock;
+
     @Inject
     public InMemoryTenantQuotaStore(@ConfigProperty(name = "eddi.tenant.default-id", defaultValue = "default") String defaultTenantId,
             @ConfigProperty(name = "eddi.tenant.quota.enabled", defaultValue = "false") boolean enabled,
@@ -56,6 +64,7 @@ public class InMemoryTenantQuotaStore implements ITenantQuotaStore {
             @ConfigProperty(name = "eddi.tenant.quota.max-api-calls-per-minute", defaultValue = "-1") int maxApiCalls,
             @ConfigProperty(name = "eddi.tenant.quota.max-monthly-cost-usd", defaultValue = "-1") double maxCost) {
 
+        this.clock = Clock.systemUTC();
         var defaultQuota = new TenantQuota(defaultTenantId, maxConvPerDay, maxAgents, maxApiCalls, maxCost, enabled);
         quotas.put(defaultTenantId, defaultQuota);
 
@@ -67,6 +76,15 @@ public class InMemoryTenantQuotaStore implements ITenantQuotaStore {
      * Test-only constructor — no CDI injection.
      */
     public InMemoryTenantQuotaStore(TenantQuota defaultQuota) {
+        this(defaultQuota, Clock.systemUTC());
+    }
+
+    /**
+     * Test-only constructor taking the clock, so a test can pin "now" and step
+     * across a window boundary deliberately — parity with the two DB-backed stores.
+     */
+    public InMemoryTenantQuotaStore(TenantQuota defaultQuota, Clock clock) {
+        this.clock = clock;
         quotas.put(defaultQuota.tenantId(), defaultQuota);
     }
 
@@ -178,6 +196,6 @@ public class InMemoryTenantQuotaStore implements ITenantQuotaStore {
     }
 
     private TenantUsageCounters getOrCreateCounters(String tenantId) {
-        return usageMap.computeIfAbsent(tenantId, k -> new TenantUsageCounters());
+        return usageMap.computeIfAbsent(tenantId, k -> new TenantUsageCounters(clock));
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStore.java
@@ -110,7 +110,7 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
         // InMemoryTenantQuotaStore).
         // Uses $setOnInsert so an existing quota is never overwritten, even under
         // races.
-        quotas.findOneAndUpdate(
+        Document existing = quotas.findOneAndUpdate(
                 Filters.eq("tenantId", defaultTenantId),
                 Updates.combine(
                         Updates.setOnInsert("tenantId", defaultTenantId),
@@ -122,6 +122,14 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
                 new FindOneAndUpdateOptions().upsert(true));
         LOGGER.infof("Ensured default tenant quota exists: tenantId=%s, enabled=%s, maxConv=%d, maxAgents=%d, maxApi=%d, maxCost=%.2f",
                 defaultTenantId, enabled, maxConvPerDay, maxAgents, maxApiCalls, maxCost);
+        // findOneAndUpdate returns the document as it was BEFORE the upsert, so a
+        // non-null result means the row already existed and $setOnInsert did
+        // nothing. See TenantQuotaBootstrapCheck for why an operator has to be told
+        // rather than silently overridden.
+        if (existing != null) {
+            TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(toQuota(existing),
+                    new TenantQuota(defaultTenantId, maxConvPerDay, maxAgents, maxApiCalls, maxCost, enabled));
+        }
     }
 
     /**
@@ -426,21 +434,43 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
                 doc.getBoolean("enabled", false));
     }
 
+    /**
+     * Map a stored usage document to a snapshot, zeroing every counter whose window
+     * has already expired.
+     * <p>
+     * {@link ITenantQuotaStore#getUsage} documents that the snapshot "reflects
+     * current-window values only", and enforcement does roll the windows — but this
+     * read did not, so the dashboard showed yesterday's {@code conversationsToday}
+     * and the last active minute's {@code apiCallsThisMinute} until the next
+     * increment happened to roll them. An operator saw a tenant "at its daily
+     * limit" the morning after while the very next request would have been allowed.
+     * The predicate is the same one {@code rollWindowIfExpired} uses, so read and
+     * enforcement agree; the stored document is left untouched, because a read must
+     * not write.
+     */
     private UsageSnapshot toSnapshot(String tenantId, Document doc) {
+        Instant now = clock.instant();
+        Instant currentMinuteStart = now.truncatedTo(ChronoUnit.MINUTES);
+        Instant currentDayStart = now.truncatedTo(ChronoUnit.DAYS);
+        YearMonth currentMonth = YearMonth.now(clock.withZone(ZoneOffset.UTC));
+
         Instant minuteStart = doc.getLong("minuteStart") != null
                 ? Instant.ofEpochMilli(doc.getLong("minuteStart"))
-                : clock.instant();
+                : now;
         Instant dayStart = doc.getLong("dayStart") != null
                 ? Instant.ofEpochMilli(doc.getLong("dayStart"))
-                : clock.instant();
+                : now;
         YearMonth costMonth = doc.getString("costMonth") != null
                 ? YearMonth.parse(doc.getString("costMonth"))
-                : YearMonth.now(clock.withZone(ZoneOffset.UTC));
-        return new UsageSnapshot(
-                tenantId,
-                doc.getInteger("conversationsToday", 0),
-                doc.getInteger("apiCallsThisMinute", 0),
-                doc.getDouble("monthlyCostUsd") != null ? doc.getDouble("monthlyCostUsd") : 0.0,
+                : currentMonth;
+
+        int conversationsToday = dayStart.isBefore(currentDayStart) ? 0 : doc.getInteger("conversationsToday", 0);
+        int apiCallsThisMinute = minuteStart.isBefore(currentMinuteStart) ? 0 : doc.getInteger("apiCallsThisMinute", 0);
+        double monthlyCost = costMonth.equals(currentMonth) && doc.getDouble("monthlyCostUsd") != null
+                ? doc.getDouble("monthlyCostUsd")
+                : 0.0;
+
+        return new UsageSnapshot(tenantId, conversationsToday, apiCallsThisMinute, monthlyCost,
                 minuteStart, dayStart, costMonth);
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStore.java
@@ -4,10 +4,13 @@
  */
 package ai.labs.eddi.engine.tenancy;
 
+import static ai.labs.eddi.engine.tenancy.ITenantQuotaStore.accountingUnavailable;
+
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.tenancy.model.TenantQuota;
 import ai.labs.eddi.engine.tenancy.model.UsageSnapshot;
 import ai.labs.eddi.utils.LogSanitizer;
+import com.mongodb.MongoException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
@@ -182,10 +185,33 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
 
     // ─── Quota Configuration ───
 
+    /**
+     * Fails closed and <em>honestly</em> on a driver error, exactly like the three
+     * mutators below.
+     * <p>
+     * This is the first store call every gate in {@code TenantQuotaService} makes,
+     * so on a real outage it is the one that throws — the mutators are never
+     * reached. Left unwrapped, a {@code MongoTimeoutException} travelled through
+     * {@code TenantQuotaService} (which does not catch) into
+     * {@code ConversationService}'s generic handler and out as an opaque 500, with
+     * no tick on {@code eddi.tenant.quota.unavailable} and nothing on the dashboard
+     * panel that promises it. Wrapping only the write half therefore covered just
+     * the partial outage where reads succeed and writes fail.
+     * <p>
+     * A {@code null} return cannot carry the outage: it already means "no quota
+     * configured for this tenant", which the service treats as unlimited. Hence the
+     * exception — see {@link QuotaAccountingUnavailableException}.
+     */
     @Override
     public TenantQuota getQuota(String tenantId) {
-        Document doc = quotas.find(Filters.eq("tenantId", tenantId)).first();
-        return doc != null ? toQuota(doc) : null;
+        try {
+            Document doc = quotas.find(Filters.eq("tenantId", tenantId)).first();
+            return doc != null ? toQuota(doc) : null;
+        } catch (MongoException e) {
+            LOGGER.errorf("Failed to read quota for tenant '%s': %s",
+                    LogSanitizer.sanitize(tenantId), LogSanitizer.sanitize(e.getMessage()));
+            throw new QuotaAccountingUnavailableException(ACCOUNTING_UNAVAILABLE, e);
+        }
     }
 
     @Override
@@ -238,8 +264,35 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
     // the consequence is at worst a single false denial per window transition,
     // never over- or under-counting. Not a data corruption risk.
 
+    /**
+     * The three mutators below each wrap their body rather than letting a
+     * {@link MongoException} escape.
+     * <p>
+     * An escaping driver exception is not a quota answer at all: it travelled
+     * through {@code TenantQuotaService.acquireConversationSlot} (which does not
+     * catch) into {@code ConversationService}'s generic handler and out as a 500
+     * with a stack trace, while the same outage on PostgreSQL produced 503
+     * {@code quota_accounting_unavailable}, a {@code Retry-After} and a tick on
+     * {@code eddi.tenant.quota.unavailable}. Since {@code eddi.datastore.type}
+     * defaults to mongodb, the documented behaviour applied to neither the default
+     * deployment nor its dashboard panel.
+     * <p>
+     * Failing closed is unchanged — the request is still refused. Only its
+     * <em>description</em> changes, from "the server broke" to "quota accounting is
+     * down".
+     */
     @Override
     public QuotaCheckResult tryIncrementConversations(String tenantId, int limit) {
+        try {
+            return incrementConversationsWithinLimit(tenantId, limit);
+        } catch (MongoException e) {
+            LOGGER.errorf("Failed to increment conversations for tenant '%s': %s",
+                    LogSanitizer.sanitize(tenantId), LogSanitizer.sanitize(e.getMessage()));
+            return accountingUnavailable();
+        }
+    }
+
+    private QuotaCheckResult incrementConversationsWithinLimit(String tenantId, int limit) {
         if (limit < 0) {
             return QuotaCheckResult.OK;
         }
@@ -259,8 +312,19 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
         return QuotaCheckResult.denied("Daily conversation limit reached (" + limit + ")");
     }
 
+    /** See {@link #tryIncrementConversations} for why the body is wrapped. */
     @Override
     public QuotaCheckResult tryIncrementApiCalls(String tenantId, int limit) {
+        try {
+            return incrementApiCallsWithinLimit(tenantId, limit);
+        } catch (MongoException e) {
+            LOGGER.errorf("Failed to increment API calls for tenant '%s': %s",
+                    LogSanitizer.sanitize(tenantId), LogSanitizer.sanitize(e.getMessage()));
+            return accountingUnavailable();
+        }
+    }
+
+    private QuotaCheckResult incrementApiCallsWithinLimit(String tenantId, int limit) {
         if (limit < 0) {
             return QuotaCheckResult.OK;
         }
@@ -280,8 +344,23 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
         return QuotaCheckResult.denied("API rate limit reached (" + limit + "/min)");
     }
 
+    /**
+     * See {@link #tryIncrementConversations} for why the body is wrapped. Cost
+     * accounting fails closed for the same reason the PostgreSQL store does: a
+     * budget that cannot be read must not be treated as a budget with room left.
+     */
     @Override
     public QuotaCheckResult tryAddCost(String tenantId, double cost, double limit) {
+        try {
+            return addCostWithinBudget(tenantId, cost, limit);
+        } catch (MongoException e) {
+            LOGGER.errorf("Failed to add cost for tenant '%s': %s",
+                    LogSanitizer.sanitize(tenantId), LogSanitizer.sanitize(e.getMessage()));
+            return QuotaCheckResult.unavailable("Cost accounting failed — denying request for safety");
+        }
+    }
+
+    private QuotaCheckResult addCostWithinBudget(String tenantId, double cost, double limit) {
         String monthKey = YearMonth.now(clock.withZone(ZoneOffset.UTC)).toString();
 
         // Fast path: the document already carries the current month.

--- a/src/main/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStore.java
@@ -348,6 +348,14 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
      * See {@link #tryIncrementConversations} for why the body is wrapped. Cost
      * accounting fails closed for the same reason the PostgreSQL store does: a
      * budget that cannot be read must not be treated as a budget with room left.
+     * <p>
+     * The refusal carries {@link ITenantQuotaStore#ACCOUNTING_UNAVAILABLE} like
+     * every other outage path. It used to carry a wording of its own, which reached
+     * the client verbatim — {@code ConversationService} puts {@code reason()} into
+     * the {@code QuotaAccountingUnavailableException} the 503 body is built from —
+     * so one outage produced two different {@code message} strings depending on
+     * which gate happened to fail first. That is precisely the parity
+     * {@code ACCOUNTING_UNAVAILABLE} was extracted to hold.
      */
     @Override
     public QuotaCheckResult tryAddCost(String tenantId, double cost, double limit) {
@@ -356,7 +364,7 @@ public class MongoTenantQuotaStore implements ITenantQuotaStore {
         } catch (MongoException e) {
             LOGGER.errorf("Failed to add cost for tenant '%s': %s",
                     LogSanitizer.sanitize(tenantId), LogSanitizer.sanitize(e.getMessage()));
-            return QuotaCheckResult.unavailable("Cost accounting failed — denying request for safety");
+            return ITenantQuotaStore.accountingUnavailable();
         }
     }
 

--- a/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
@@ -48,6 +48,13 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
 
     private static final Logger LOGGER = Logger.getLogger(PostgresTenantQuotaStore.class);
 
+    /**
+     * Denial reason used when the store itself could not answer. Distinct from a
+     * real limit breach so an operator (and the metric) can tell an outage from a
+     * tenant that is genuinely over quota.
+     */
+    static final String ACCOUNTING_UNAVAILABLE = "Quota accounting unavailable — denying request for safety";
+
     private static final String CREATE_QUOTAS_TABLE = """
             CREATE TABLE IF NOT EXISTS tenant_quotas (
                 tenant_id VARCHAR(255) PRIMARY KEY,
@@ -84,9 +91,22 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             ON CONFLICT (tenant_id) DO NOTHING
             """;
 
+    /**
+     * {@code day_start >= ?}, not {@code =}, matching
+     * {@code MongoTenantQuotaStore}'s {@code Filters.gte}.
+     * <p>
+     * Exact equality made a stored window that is <em>ahead</em> of the caller's
+     * clock unmatchable in every direction: the fast path missed (M+1 != M), the
+     * materialise-or-roll missed (its guard is {@code stored < now}), and the retry
+     * missed — so a node whose clock stepped backwards (NTP correction, VM
+     * suspend/resume) or lagged another instance by a minute denied every single
+     * request with "limit reached" until wall-clock time caught up. A window ahead
+     * of us is still a current window; counting into it is the conservative answer
+     * and it is what the MongoDB backend already did for the same input.
+     */
     private static final String INCREMENT_CONVERSATIONS = """
             UPDATE tenant_usage SET conversations_today = conversations_today + 1
-            WHERE tenant_id = ? AND day_start = ? AND conversations_today < ?
+            WHERE tenant_id = ? AND day_start >= ? AND conversations_today < ?
             RETURNING conversations_today
             """;
 
@@ -108,9 +128,12 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             WHERE tenant_usage.day_start < ?
             """;
 
+    /**
+     * See {@link #INCREMENT_CONVERSATIONS} for why the window match is {@code >=}.
+     */
     private static final String INCREMENT_API_CALLS = """
             UPDATE tenant_usage SET api_calls_this_minute = api_calls_this_minute + 1
-            WHERE tenant_id = ? AND minute_start = ? AND api_calls_this_minute < ?
+            WHERE tenant_id = ? AND minute_start >= ? AND api_calls_this_minute < ?
             RETURNING api_calls_this_minute
             """;
 
@@ -236,12 +259,20 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
                 LOGGER.infof("Bootstrapped default tenant quota: tenantId=%s, enabled=%s, maxConv=%d, maxAgents=%d, maxApi=%d, maxCost=%.2f",
                         quota.tenantId(), quota.enabled(), quota.maxConversationsPerDay(),
                         quota.maxAgentsPerTenant(), quota.maxApiCallsPerMinute(), quota.maxMonthlyCostUsd());
+            } else {
+                // ON CONFLICT DO NOTHING fired: the row predates this start, so the
+                // properties changed nothing. Re-read it and tell the operator when it
+                // no longer describes what they configured. Costs one extra SELECT per
+                // start, and only on the branch where a row already exists.
+                TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(
+                        getQuotaInternal(conn, quota.tenantId()), quota);
             }
         }
     }
 
     /**
-     * Internal quota lookup reusing an existing connection (used during bootstrap).
+     * Internal quota lookup reusing an existing connection. Serves
+     * {@link #getQuota}; bootstrap uses {@link #bootstrapDefaultQuota}.
      */
     private TenantQuota getQuotaInternal(Connection conn, String tenantId) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(
@@ -257,7 +288,8 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
     }
 
     /**
-     * Internal quota upsert reusing an existing connection (used during bootstrap).
+     * Internal quota upsert reusing an existing connection. Serves
+     * {@link #setQuota}; bootstrap uses {@link #bootstrapDefaultQuota}.
      */
     private void setQuotaInternal(Connection conn, TenantQuota quota) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(
@@ -282,13 +314,25 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
         }
     }
 
+    /**
+     * Fails <em>open</em> on a store error, deliberately and unlike the accounting
+     * writes below.
+     * <p>
+     * A null return means "no quota configured", which {@code TenantQuotaService}
+     * treats as unlimited. Failing closed here would turn a database blip into a
+     * total outage for every tenant — quotas are a cost control, not an
+     * authorization boundary. Logged at ERROR so the silent bypass is visible; the
+     * accounting writes fail closed because a lost increment silently voids a limit
+     * that IS configured.
+     */
     @Override
     public TenantQuota getQuota(String tenantId) {
         ensureSchema();
         try (Connection conn = dataSourceInstance.get().getConnection()) {
             return getQuotaInternal(conn, tenantId);
         } catch (SQLException e) {
-            LOGGER.warnf("Failed to read quota for tenant '%s': %s", sanitize(tenantId), sanitize(e.getMessage()));
+            LOGGER.errorf("Failed to read quota for tenant '%s' — quota enforcement is bypassed for this request: %s",
+                    sanitize(tenantId), sanitize(e.getMessage()));
         }
         return null;
     }
@@ -396,6 +440,12 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             }
         } catch (SQLException e) {
             LOGGER.errorf("Failed to increment conversations for tenant '%s': %s", sanitize(tenantId), sanitize(e.getMessage()));
+            // Still fail closed (matching tryAddCost), but do not dress an
+            // infrastructure fault as a quota breach: the caller used to receive
+            // "Daily conversation limit reached (1000)" with Retry-After for a
+            // SQLException, and the denied-counter metric spiked as if the tenant
+            // were over quota.
+            return QuotaCheckResult.denied(ACCOUNTING_UNAVAILABLE);
         }
 
         return QuotaCheckResult.denied("Daily conversation limit reached (" + limit + ")");
@@ -430,6 +480,9 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             }
         } catch (SQLException e) {
             LOGGER.errorf("Failed to increment API calls for tenant '%s': %s", sanitize(tenantId), sanitize(e.getMessage()));
+            // See tryIncrementConversations: fail closed, but say what actually
+            // happened.
+            return QuotaCheckResult.denied(ACCOUNTING_UNAVAILABLE);
         }
 
         return QuotaCheckResult.denied("API rate limit reached (" + limit + "/min)");
@@ -565,16 +618,30 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
                 rs.getBoolean("enabled"));
     }
 
+    /**
+     * Map a stored usage row to a snapshot, zeroing every counter whose window has
+     * already expired — see {@code MongoTenantQuotaStore#toSnapshot} for why the
+     * read has to do this and why it must not write.
+     */
     private UsageSnapshot toSnapshot(String tenantId, ResultSet rs) throws SQLException {
+        Instant now = clock.instant();
+        long currentMinuteStartMs = now.truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
+        long currentDayStartMs = now.truncatedTo(ChronoUnit.DAYS).toEpochMilli();
+        YearMonth currentMonth = YearMonth.now(clock.withZone(ZoneOffset.UTC));
+
+        long minuteStartMs = rs.getLong("minute_start");
+        long dayStartMs = rs.getLong("day_start");
+        YearMonth costMonth = rs.getString("cost_month") != null
+                ? YearMonth.parse(rs.getString("cost_month"))
+                : currentMonth;
+
         return new UsageSnapshot(
                 tenantId,
-                rs.getInt("conversations_today"),
-                rs.getInt("api_calls_this_minute"),
-                rs.getDouble("monthly_cost_usd"),
-                Instant.ofEpochMilli(rs.getLong("minute_start")),
-                Instant.ofEpochMilli(rs.getLong("day_start")),
-                rs.getString("cost_month") != null
-                        ? YearMonth.parse(rs.getString("cost_month"))
-                        : YearMonth.now(clock.withZone(ZoneOffset.UTC)));
+                dayStartMs < currentDayStartMs ? 0 : rs.getInt("conversations_today"),
+                minuteStartMs < currentMinuteStartMs ? 0 : rs.getInt("api_calls_this_minute"),
+                costMonth.equals(currentMonth) ? rs.getDouble("monthly_cost_usd") : 0.0,
+                Instant.ofEpochMilli(minuteStartMs),
+                Instant.ofEpochMilli(dayStartMs),
+                costMonth);
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
@@ -7,6 +7,7 @@ package ai.labs.eddi.engine.tenancy;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.tenancy.model.TenantQuota;
 import ai.labs.eddi.engine.tenancy.model.UsageSnapshot;
+import static ai.labs.eddi.engine.tenancy.ITenantQuotaStore.accountingUnavailable;
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -47,13 +48,6 @@ import java.util.List;
 public class PostgresTenantQuotaStore implements ITenantQuotaStore {
 
     private static final Logger LOGGER = Logger.getLogger(PostgresTenantQuotaStore.class);
-
-    /**
-     * Denial reason used when the store itself could not answer. Distinct from a
-     * real limit breach so an operator (and the metric) can tell an outage from a
-     * tenant that is genuinely over quota.
-     */
-    static final String ACCOUNTING_UNAVAILABLE = "Quota accounting unavailable — denying request for safety";
 
     private static final String CREATE_QUOTAS_TABLE = """
             CREATE TABLE IF NOT EXISTS tenant_quotas (
@@ -211,6 +205,15 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
         this.clock = clock;
     }
 
+    /**
+     * Every public method calls this first, and until the first call succeeds it
+     * takes a connection — so on a database that has been unreachable since
+     * startup, this is where the outage surfaces rather than in the method that
+     * called it. It therefore raises the same refusal the rest of the store does; a
+     * plain {@code RuntimeException} here escaped {@code TenantQuotaService}'s
+     * gates (which match the refusal type) and left that window answering an opaque
+     * 500 while the identical outage a moment later answered 503.
+     */
     private synchronized void ensureSchema() {
         if (schemaInitialized)
             return;
@@ -230,7 +233,7 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
 
             schemaInitialized = true;
         } catch (SQLException e) {
-            throw new RuntimeException("Failed to initialize tenant quota tables", e);
+            throw new QuotaAccountingUnavailableException(ACCOUNTING_UNAVAILABLE, e);
         }
     }
 
@@ -315,15 +318,25 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
     }
 
     /**
-     * Fails <em>open</em> on a store error, deliberately and unlike the accounting
-     * writes below.
+     * Fails <em>closed</em> on a store error, like the accounting writes below.
      * <p>
-     * A null return means "no quota configured", which {@code TenantQuotaService}
-     * treats as unlimited. Failing closed here would turn a database blip into a
-     * total outage for every tenant — quotas are a cost control, not an
-     * authorization boundary. Logged at ERROR so the silent bypass is visible; the
-     * accounting writes fail closed because a lost increment silently voids a limit
-     * that IS configured.
+     * It used to return null, which {@code TenantQuotaService} reads as "no quota
+     * configured" and therefore as unlimited. That made the same outage produce
+     * opposite policies depending on which call happened to fail first: the read
+     * half silently disabled enforcement for every tenant, the write half refused
+     * the request with an honest 503. It cannot be both. The read is the one that
+     * runs first on every gate, so fail-open won in practice and the write-side
+     * refusal was mostly unreachable.
+     * <p>
+     * The "a database blip should not become a total outage" argument for fail-open
+     * does not survive contact with the deployment: {@code tenant_quotas} lives in
+     * the same database as conversation memory, so a store that cannot answer this
+     * query cannot serve the turn either. All that changed is the error the caller
+     * sees — an honest 503 with {@code Retry-After} and a tick on
+     * {@code eddi.tenant.quota.unavailable} instead of a bypassed limit.
+     * <p>
+     * A {@code null} return still means exactly one thing: this tenant has no quota
+     * row. Hence the exception rather than a sentinel.
      */
     @Override
     public TenantQuota getQuota(String tenantId) {
@@ -331,10 +344,9 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
         try (Connection conn = dataSourceInstance.get().getConnection()) {
             return getQuotaInternal(conn, tenantId);
         } catch (SQLException e) {
-            LOGGER.errorf("Failed to read quota for tenant '%s' — quota enforcement is bypassed for this request: %s",
-                    sanitize(tenantId), sanitize(e.getMessage()));
+            LOGGER.errorf("Failed to read quota for tenant '%s': %s", sanitize(tenantId), sanitize(e.getMessage()));
+            throw new QuotaAccountingUnavailableException(ACCOUNTING_UNAVAILABLE, e);
         }
-        return null;
     }
 
     @Override
@@ -445,7 +457,7 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             // "Daily conversation limit reached (1000)" with Retry-After for a
             // SQLException, and the denied-counter metric spiked as if the tenant
             // were over quota.
-            return QuotaCheckResult.denied(ACCOUNTING_UNAVAILABLE);
+            return accountingUnavailable();
         }
 
         return QuotaCheckResult.denied("Daily conversation limit reached (" + limit + ")");
@@ -482,7 +494,7 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             LOGGER.errorf("Failed to increment API calls for tenant '%s': %s", sanitize(tenantId), sanitize(e.getMessage()));
             // See tryIncrementConversations: fail closed, but say what actually
             // happened.
-            return QuotaCheckResult.denied(ACCOUNTING_UNAVAILABLE);
+            return accountingUnavailable();
         }
 
         return QuotaCheckResult.denied("API rate limit reached (" + limit + "/min)");
@@ -530,8 +542,9 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
         } catch (SQLException e) {
             LOGGER.errorf("Failed to add cost for tenant '%s': %s", sanitize(tenantId), sanitize(e.getMessage()));
             // Fail closed — if cost accounting fails, deny the request rather than
-            // silently bypassing budget enforcement
-            return QuotaCheckResult.denied("Cost accounting failed — denying request for safety");
+            // silently bypassing budget enforcement. Flagged as an outage rather
+            // than a budget breach, for the reason accountingUnavailable() gives.
+            return QuotaCheckResult.unavailable("Cost accounting failed — denying request for safety");
         }
         return QuotaCheckResult.OK;
     }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStore.java
@@ -543,8 +543,13 @@ public class PostgresTenantQuotaStore implements ITenantQuotaStore {
             LOGGER.errorf("Failed to add cost for tenant '%s': %s", sanitize(tenantId), sanitize(e.getMessage()));
             // Fail closed — if cost accounting fails, deny the request rather than
             // silently bypassing budget enforcement. Flagged as an outage rather
-            // than a budget breach, for the reason accountingUnavailable() gives.
-            return QuotaCheckResult.unavailable("Cost accounting failed — denying request for safety");
+            // than a budget breach, for the reason accountingUnavailable() gives —
+            // and with its wording, not a second one of this method's own. The
+            // reason reaches the client verbatim (ConversationService puts it into
+            // the QuotaAccountingUnavailableException the 503 body is built from),
+            // so a private phrasing here meant one outage produced two different
+            // messages depending on which gate failed first.
+            return ITenantQuotaStore.accountingUnavailable();
         }
         return QuotaCheckResult.OK;
     }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/QuotaAccountingUnavailableException.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/QuotaAccountingUnavailableException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.tenancy;
+
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Thrown when the quota store could not answer — the request is refused for
+ * safety, not because any limit was reached.
+ * <p>
+ * Both outcomes fail closed, but they are different events and used to be
+ * indistinguishable: a {@code SQLException} inside
+ * {@code PostgresTenantQuotaStore} came back as an ordinary denial, so the
+ * caller received {@code 429 quota_exceeded} with {@code Retry-After: 60} and
+ * {@code eddi.tenant.quota.denied} spiked as if the tenant had burned through
+ * its allowance. Only the reason string differed, which no client and no
+ * dashboard reads.
+ * <p>
+ * Extends {@link RejectedExecutionException} deliberately: every surface that
+ * already answers 503 for backpressure — the
+ * {@code RejectedExecutionExceptionMapper}, the explicit
+ * {@code RestAgentEngine.sayInternal} branch that exists because an
+ * {@code AsyncResponse} never reaches a mapper — therefore answers 503 for this
+ * too, rather than 500, without having to enumerate it. The surfaces that
+ * distinguish it further do so by catching this type first, and
+ * {@link ai.labs.eddi.engine.tenancy.rest.QuotaAccountingUnavailableExceptionMapper}
+ * gives the synchronous endpoints the honest error code that the
+ * {@code RejectedExecutionException} mapper cannot.
+ * <p>
+ * It implements {@link QuotaRefusal} because it is still the quota layer saying
+ * no: callers that abort on a quota refusal rather than degrade — the
+ * group-conversation engines — must treat it exactly as they treat
+ * {@link QuotaExceededException}.
+ * <p>
+ * The stores also raise it from {@code getQuota}, which cannot express the
+ * outage in its return value: {@code null} there already means "this tenant has
+ * no quota configured", which {@code TenantQuotaService} treats as unlimited.
+ * {@link TenantQuotaService} catches it at every gate and converts it back into
+ * a {@code QuotaCheckResult} flagged {@code accountingUnavailable}, so the read
+ * half and the write half of an outage are counted and answered identically.
+ *
+ * @author ginccc
+ * @since 6.0.0
+ */
+public class QuotaAccountingUnavailableException extends RejectedExecutionException implements QuotaRefusal {
+
+    public QuotaAccountingUnavailableException(String message) {
+        super(message);
+    }
+
+    /**
+     * Keeps the driver exception attached. The stores raise this in place of the
+     * {@code SQLException} or {@code MongoException} they caught, and a schema or
+     * connection failure is not diagnosable without the original stack.
+     */
+    public QuotaAccountingUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public String refusalSummary() {
+        return "Tenant quota accounting unavailable";
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/tenancy/QuotaExceededException.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/QuotaExceededException.java
@@ -9,9 +9,14 @@ package ai.labs.eddi.engine.tenancy;
  * Requests) by
  * {@link ai.labs.eddi.engine.tenancy.rest.QuotaExceededExceptionMapper}.
  */
-public class QuotaExceededException extends RuntimeException {
+public class QuotaExceededException extends RuntimeException implements QuotaRefusal {
 
     public QuotaExceededException(String message) {
         super(message);
+    }
+
+    @Override
+    public String refusalSummary() {
+        return "Tenant quota exceeded";
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/QuotaRefusal.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/QuotaRefusal.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.tenancy;
+
+/**
+ * Implemented by every exception the tenant-quota layer raises to refuse a
+ * request, whatever the reason.
+ * <p>
+ * Callers that must react to "the quota layer said no" — as opposed to "this
+ * one agent failed" — match on this type rather than on a concrete exception
+ * class. The group-conversation engines are the reason it exists: they treat a
+ * quota refusal as non-retryable and affecting every member, so they abort the
+ * whole discussion instead of recording a SKIPPED turn. When
+ * {@link QuotaAccountingUnavailableException} was added beside
+ * {@link QuotaExceededException} — which had to extend
+ * {@link java.util.concurrent.RejectedExecutionException}, so it could not
+ * simply subclass it — the six {@code instanceof QuotaExceededException} guards
+ * in {@code MemberTurnExecutor}, {@code TaskForceEngine} and
+ * {@code PhaseExecutionEngine} silently stopped matching, and a quota-store
+ * outage degraded into per-member retries against a dead store or a transcript
+ * full of SKIPPED entries with the discussion reported complete.
+ * <p>
+ * Matching on the marker means the next refusal type is handled by those guards
+ * the day it is introduced rather than the day someone notices.
+ *
+ * @since 6.0.0
+ */
+public interface QuotaRefusal {
+
+    /**
+     * Short operator-facing label naming <em>which</em> refusal this is, used to
+     * prefix the message of the wrapping exception.
+     * <p>
+     * "Tenant quota exceeded: Quota accounting unavailable — denying request for
+     * safety" is the sentence that gets written without it, and it is false in its
+     * first half.
+     *
+     * @return a label such as {@code "Tenant quota exceeded"}
+     */
+    String refusalSummary();
+}

--- a/src/main/java/ai/labs/eddi/engine/tenancy/TenantQuotaBootstrapCheck.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/TenantQuotaBootstrapCheck.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.tenancy;
+
+import ai.labs.eddi.engine.tenancy.model.TenantQuota;
+import org.jboss.logging.Logger;
+
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
+
+/**
+ * Startup check shared by the DB-backed quota stores.
+ *
+ * @since 6.0.0
+ */
+final class TenantQuotaBootstrapCheck {
+
+    private static final Logger LOGGER = Logger.getLogger(TenantQuotaBootstrapCheck.class);
+
+    private TenantQuotaBootstrapCheck() {
+    }
+
+    /**
+     * Tell the operator when {@code eddi.tenant.quota.*} no longer describes what
+     * is enforced.
+     * <p>
+     * Both DB-backed stores bootstrap the default tenant's quota insert-only
+     * ({@code $setOnInsert} / {@code ON CONFLICT DO NOTHING}), so the properties
+     * take effect exactly once — on the first start against an empty database. An
+     * operator who later enables quotas or raises a limit by environment variable
+     * and redeploys changes nothing, and nothing used to say so: the stored row
+     * silently won and the config surface was effectively write-once. (The
+     * in-memory store, by contrast, always reflects the properties, so the same
+     * configuration behaved differently per backend.)
+     * <p>
+     * Overwriting the stored row instead is not an option — it would clobber limits
+     * set through {@code PUT /administration/quotas/&#123;id&#125;} on every
+     * restart.
+     *
+     * @param stored
+     *            the quota already in the database, or null if none
+     * @param configured
+     *            what {@code eddi.tenant.quota.*} asks for
+     * @return whether a warning was emitted — so a test can assert the condition
+     *         without scraping the log
+     */
+    static boolean warnIfStoredQuotaDiffersFromConfig(TenantQuota stored, TenantQuota configured) {
+        if (stored == null || configured == null || stored.equals(configured)) {
+            return false;
+        }
+        LOGGER.warnf("Stored quota for tenant '%s' differs from the configured eddi.tenant.quota.* properties; "
+                + "the stored values win. stored=%s configured=%s — use PUT /administration/quotas/%s "
+                + "if the properties are what you meant.",
+                sanitize(configured.tenantId()), stored, configured, sanitize(configured.tenantId()));
+        return true;
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/tenancy/TenantQuotaBootstrapCheck.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/TenantQuotaBootstrapCheck.java
@@ -5,6 +5,9 @@
 package ai.labs.eddi.engine.tenancy;
 
 import ai.labs.eddi.engine.tenancy.model.TenantQuota;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.ConfigValue;
 import org.jboss.logging.Logger;
 
 import static ai.labs.eddi.utils.LogSanitizer.sanitize;
@@ -37,6 +40,28 @@ final class TenantQuotaBootstrapCheck {
      * Overwriting the stored row instead is not an option — it would clobber limits
      * set through {@code PUT /administration/quotas/&#123;id&#125;} on every
      * restart.
+     * <p>
+     * <strong>Silent when the properties carry no intent.</strong> An operator who
+     * set the quota through {@code PUT} and left {@code eddi.tenant.quota.*} at its
+     * defaults has said nothing for the stored row to contradict, and warning them
+     * on every restart forever is how the one warning that matters — an environment
+     * variable that was changed and ignored — gets tuned out.
+     * <p>
+     * "Left at its defaults" is answered by {@link #quotaPropertiesWereSet()}, not
+     * by comparing the values against {@link TenantQuota#unlimited}. The values
+     * cannot answer it: {@code application.properties} ships
+     * {@code eddi.tenant.quota.enabled=false} and every limit at -1, so an operator
+     * who deliberately sets {@code EDDI_TENANT_QUOTA_ENABLED=false} to switch
+     * enforcement off produces byte-for-byte the same {@code configured} object as
+     * one who touched nothing — and that is precisely the case where a stored
+     * {@code enabled=true} row keeps enforcing against their explicit instruction,
+     * which is the one warning this check exists to emit. Both conditions are
+     * required, so the value comparison still guards against a config source that
+     * reports provenance we cannot read.
+     * <p>
+     * This is provenance on the <em>property</em>, not on the row. Telling a
+     * config-sourced row from a REST-sourced one still needs a {@code source}
+     * column in both DB-backed stores.
      *
      * @param stored
      *            the quota already in the database, or null if none
@@ -46,7 +71,29 @@ final class TenantQuotaBootstrapCheck {
      *         without scraping the log
      */
     static boolean warnIfStoredQuotaDiffersFromConfig(TenantQuota stored, TenantQuota configured) {
+        return warnIfStoredQuotaDiffersFromConfig(stored, configured, quotaPropertiesWereSet());
+    }
+
+    /**
+     * Same check with the property provenance supplied rather than resolved, so the
+     * decision can be exercised without a running configuration.
+     *
+     * @param stored
+     *            the quota already in the database, or null if none
+     * @param configured
+     *            what {@code eddi.tenant.quota.*} asks for
+     * @param propertiesWereSet
+     *            whether the deployment supplied any {@code eddi.tenant.quota.*}
+     *            property itself, rather than inheriting the shipped defaults
+     * @return whether a warning was emitted
+     */
+    static boolean warnIfStoredQuotaDiffersFromConfig(TenantQuota stored, TenantQuota configured, boolean propertiesWereSet) {
         if (stored == null || configured == null || stored.equals(configured)) {
+            return false;
+        }
+        if (!propertiesWereSet && configured.equals(TenantQuota.unlimited(configured.tenantId()))) {
+            LOGGER.infof("Tenant '%s' has a stored quota and eddi.tenant.quota.* is at its defaults, so the stored "
+                    + "values are what is enforced. stored=%s", sanitize(configured.tenantId()), stored);
             return false;
         }
         LOGGER.warnf("Stored quota for tenant '%s' differs from the configured eddi.tenant.quota.* properties; "
@@ -54,5 +101,70 @@ final class TenantQuotaBootstrapCheck {
                 + "if the properties are what you meant.",
                 sanitize(configured.tenantId()), stored, configured, sanitize(configured.tenantId()));
         return true;
+    }
+
+    /** Every property the bootstrap insert reads. */
+    private static final String[] QUOTA_PROPERTIES = {
+            "eddi.tenant.quota.enabled",
+            "eddi.tenant.quota.max-conversations-per-day",
+            "eddi.tenant.quota.max-agents-per-tenant",
+            "eddi.tenant.quota.max-api-calls-per-minute",
+            "eddi.tenant.quota.max-monthly-cost-usd"};
+
+    /**
+     * Ordinal of the {@code application.properties} EDDI itself ships. Anything
+     * above it — an external {@code config/application.properties} (260), a
+     * {@code .env} (295), an environment variable (300), a system property (400) —
+     * came from the deployment.
+     */
+    private static final int BUNDLED_PROPERTIES_ORDINAL = 250;
+
+    /**
+     * Whether the deployment supplied any {@code eddi.tenant.quota.*} property of
+     * its own.
+     * <p>
+     * Reads the config source each value actually came from rather than its value,
+     * because the shipped defaults and a deliberate "turn enforcement off" are the
+     * same five values.
+     *
+     * @return true if at least one quota property came from a source that outranks
+     *         the bundled {@code application.properties}; false if none did, and
+     *         also if the configuration cannot be read at all — an unanswerable
+     *         question must not turn into a warning on every restart, which is the
+     *         noise this check was tuned to avoid
+     */
+    static boolean quotaPropertiesWereSet() {
+        try {
+            return quotaPropertiesWereSet(ConfigProvider.getConfig());
+        } catch (RuntimeException e) {
+            LOGGER.debugf("Could not determine where eddi.tenant.quota.* came from: %s", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * The ordinal comparison itself, against a configuration handed in rather than
+     * looked up.
+     * <p>
+     * Split out so the boundary can be pinned deterministically: asserting it
+     * through {@link ConfigProvider} means asserting about the machine the test
+     * runs on, and a developer or CI runner that exports
+     * {@code EDDI_TENANT_QUOTA_*} (plausible on a host that also runs the
+     * docker-compose stack from a {@code .env}) supplies a value at ordinal 300 and
+     * flips the answer.
+     *
+     * @param config
+     *            the configuration to interrogate
+     * @return true if at least one quota property came from a source that outranks
+     *         the bundled {@code application.properties}
+     */
+    static boolean quotaPropertiesWereSet(Config config) {
+        for (String property : QUOTA_PROPERTIES) {
+            ConfigValue value = config.getConfigValue(property);
+            if (value != null && value.getValue() != null && value.getSourceOrdinal() > BUNDLED_PROPERTIES_ORDINAL) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/TenantQuotaService.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/TenantQuotaService.java
@@ -4,6 +4,9 @@
  */
 package ai.labs.eddi.engine.tenancy;
 
+import ai.labs.eddi.engine.caching.CacheFactory;
+import ai.labs.eddi.engine.caching.ICache;
+import ai.labs.eddi.engine.caching.ICacheFactory;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.tenancy.model.TenantQuota;
 import ai.labs.eddi.engine.tenancy.model.UsageSnapshot;
@@ -14,6 +17,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
+
+import java.time.Duration;
 
 /**
  * Tenant quota enforcement engine.
@@ -39,6 +44,35 @@ public class TenantQuotaService {
     @Inject
     MeterRegistry meterRegistry;
 
+    @Inject
+    ICacheFactory cacheFactory;
+
+    /** Name of the short-TTL cache behind {@link #quotaFor}. */
+    static final String QUOTA_CACHE_NAME = "tenantQuotas";
+
+    /**
+     * How long a tenant's quota configuration is reused before it is read again.
+     * <p>
+     * Short enough that a change made on another cluster node takes effect within
+     * seconds, long enough that the configuration is not fetched twice per
+     * conversation turn. {@code RestTenantQuota} invalidates explicitly on write,
+     * so this only bounds the cross-node case.
+     */
+    static final Duration QUOTA_CACHE_TTL = Duration.ofSeconds(5);
+
+    /**
+     * Quota configuration, cached per tenant.
+     * <p>
+     * Every gate in this class opened with {@code quotaStore.getQuota(tenantId)},
+     * and {@code ConversationService} calls two of them per request — so each turn
+     * paid a store round trip (two pooled connection checkouts on PostgreSQL) on
+     * the hottest path in the system, usually only to learn that quotas are
+     * disabled. Only non-null results are cached: a tenant with no quota row is the
+     * "unlimited" case, it is rare once the default tenant is bootstrapped, and a
+     * {@code ConcurrentMap} cannot hold a null anyway.
+     */
+    private ICache<String, TenantQuota> quotaCache;
+
     @ConfigProperty(name = "eddi.tenant.default-id", defaultValue = "default")
     String defaultTenantId;
 
@@ -60,6 +94,7 @@ public class TenantQuotaService {
     @PostConstruct
     void init() {
         quotaAllowedCounter = meterRegistry.counter("eddi.tenant.quota.allowed");
+        quotaCache = cacheFactory.getCache(QUOTA_CACHE_NAME, QUOTA_CACHE_TTL);
         LOGGER.info("Tenant quota service initialized");
     }
 
@@ -77,6 +112,54 @@ public class TenantQuotaService {
         this.meterRegistry = meterRegistry;
         this.defaultTenantId = defaultTenantId;
         this.quotaAllowedCounter = meterRegistry.counter("eddi.tenant.quota.allowed");
+        this.cacheFactory = new CacheFactory();
+        this.quotaCache = this.cacheFactory.getCache(QUOTA_CACHE_NAME, QUOTA_CACHE_TTL);
+    }
+
+    /**
+     * The tenant's quota configuration, from the short-TTL cache when possible.
+     *
+     * @return the quota, or null when the tenant has none configured
+     */
+    private TenantQuota quotaFor(String tenantId) {
+        if (tenantId == null || quotaCache == null) {
+            return quotaStore.getQuota(tenantId);
+        }
+        TenantQuota cached = quotaCache.get(tenantId);
+        if (cached != null) {
+            return cached;
+        }
+        TenantQuota resolved = quotaStore.getQuota(tenantId);
+        if (resolved != null) {
+            quotaCache.put(tenantId, resolved);
+        }
+        return resolved;
+    }
+
+    /**
+     * Store a tenant's quota and make it effective on this node immediately.
+     * <p>
+     * The enforcement gates read configuration through {@link #QUOTA_CACHE_TTL}, so
+     * a write straight to the store would not apply until the entry expired.
+     * Writing through here is the supported path; a write made on another cluster
+     * node is still bounded by the TTL.
+     */
+    public void setQuota(TenantQuota quota) {
+        quotaStore.setQuota(quota);
+        if (quota != null) {
+            invalidateQuotaCache(quota.tenantId());
+        }
+    }
+
+    /**
+     * Forget a tenant's cached quota configuration. Call after any write that did
+     * not go through {@link #setQuota}, so the change takes effect on this node
+     * immediately rather than after {@link #QUOTA_CACHE_TTL}.
+     */
+    public void invalidateQuotaCache(String tenantId) {
+        if (quotaCache != null && tenantId != null) {
+            quotaCache.remove(tenantId);
+        }
     }
 
     /**
@@ -103,7 +186,7 @@ public class TenantQuotaService {
      * counter and returns OK.
      */
     public QuotaCheckResult acquireConversationSlot(String tenantId) {
-        TenantQuota quota = quotaStore.getQuota(tenantId);
+        TenantQuota quota = quotaFor(tenantId);
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }
@@ -137,7 +220,7 @@ public class TenantQuotaService {
      * the counter and returns OK.
      */
     public QuotaCheckResult acquireApiCallSlot(String tenantId) {
-        TenantQuota quota = quotaStore.getQuota(tenantId);
+        TenantQuota quota = quotaFor(tenantId);
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }
@@ -181,7 +264,7 @@ public class TenantQuotaService {
      *            excluding the agent being deployed
      */
     public QuotaCheckResult checkAgentQuota(String tenantId, int currentDistinctAgents) {
-        TenantQuota quota = quotaStore.getQuota(tenantId);
+        TenantQuota quota = quotaFor(tenantId);
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }
@@ -220,7 +303,7 @@ public class TenantQuotaService {
      * needed here.
      */
     public QuotaCheckResult checkCostBudget(String tenantId) {
-        TenantQuota quota = quotaStore.getQuota(tenantId);
+        TenantQuota quota = quotaFor(tenantId);
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }
@@ -271,7 +354,7 @@ public class TenantQuotaService {
      * effects than its name suggests.
      */
     public QuotaCheckResult recordCost(String tenantId, double cost) {
-        TenantQuota quota = quotaStore.getQuota(tenantId);
+        TenantQuota quota = quotaFor(tenantId);
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/TenantQuotaService.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/TenantQuotaService.java
@@ -48,7 +48,13 @@ public class TenantQuotaService {
     ICacheFactory cacheFactory;
 
     /** Name of the short-TTL cache behind {@link #quotaFor}. */
-    static final String QUOTA_CACHE_NAME = "tenantQuotas";
+    /**
+     * Public for the reason {@code GdprComplianceService.RESTRICTION_CACHE_NAME}
+     * is: {@code CacheFactory.CACHE_SIZES} keys the sizing on this string and
+     * {@code CacheFactoryTest} binds the two, so a rename fails a test instead of
+     * silently reverting the cache to the default size.
+     */
+    public static final String QUOTA_CACHE_NAME = "tenantQuotas";
 
     /**
      * How long a tenant's quota configuration is reused before it is read again.
@@ -118,8 +124,15 @@ public class TenantQuotaService {
 
     /**
      * The tenant's quota configuration, from the short-TTL cache when possible.
+     * <p>
+     * Nothing is cached when the store cannot answer — only a non-null result is
+     * put — so a refusal is re-derived on the next turn rather than pinned for the
+     * TTL.
      *
      * @return the quota, or null when the tenant has none configured
+     * @throws QuotaAccountingUnavailableException
+     *             when the store could not be reached; every gate below turns that
+     *             into a counted {@link QuotaCheckResult}
      */
     private TenantQuota quotaFor(String tenantId) {
         if (tenantId == null || quotaCache == null) {
@@ -169,6 +182,29 @@ public class TenantQuotaService {
         return defaultTenantId;
     }
 
+    /**
+     * Refuse a request whose tenant configuration could not be read, and count it
+     * as the outage it is.
+     * <p>
+     * {@link ITenantQuotaStore#getQuota} raises
+     * {@link QuotaAccountingUnavailableException} rather than returning something,
+     * because {@code null} there already means "no quota configured" — i.e.
+     * unlimited. Converting it back into a {@link QuotaCheckResult} here keeps
+     * every gate's contract intact (callers still branch on {@code allowed()} and
+     * {@code accountingUnavailable()}) and routes it through {@link #recordDenial},
+     * so the READ half of a store outage lands on
+     * {@code eddi.tenant.quota.unavailable} and answers 503 exactly as the WRITE
+     * half already did. Before this, whichever call happened to fail first decided
+     * the outcome: the read is always first, so an outage exited as an opaque 500
+     * (MongoDB) or bypassed enforcement entirely (PostgreSQL), and the wrapped
+     * mutators were only reachable in the partial case where reads still worked.
+     */
+    private QuotaCheckResult quotaUnreadable(String tenantId, String type) {
+        QuotaCheckResult result = ITenantQuotaStore.accountingUnavailable();
+        recordDenial(result, tenantId, type);
+        return result;
+    }
+
     // ─── Atomic Slot Acquisition ───
 
     /**
@@ -186,7 +222,12 @@ public class TenantQuotaService {
      * counter and returns OK.
      */
     public QuotaCheckResult acquireConversationSlot(String tenantId) {
-        TenantQuota quota = quotaFor(tenantId);
+        TenantQuota quota;
+        try {
+            quota = quotaFor(tenantId);
+        } catch (QuotaAccountingUnavailableException e) {
+            return quotaUnreadable(tenantId, "conversation");
+        }
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }
@@ -198,8 +239,7 @@ public class TenantQuotaService {
             quotaAllowedCounter.increment();
             meterRegistry.counter("eddi.tenant.usage.conversations", "tenant", tenantId).increment();
         } else {
-            meterRegistry.counter("eddi.tenant.quota.denied", "tenant", tenantId, "type", "conversation").increment();
-            LOGGER.warn(result.reason());
+            recordDenial(result, tenantId, "conversation");
         }
 
         return result;
@@ -220,7 +260,12 @@ public class TenantQuotaService {
      * the counter and returns OK.
      */
     public QuotaCheckResult acquireApiCallSlot(String tenantId) {
-        TenantQuota quota = quotaFor(tenantId);
+        TenantQuota quota;
+        try {
+            quota = quotaFor(tenantId);
+        } catch (QuotaAccountingUnavailableException e) {
+            return quotaUnreadable(tenantId, "api_call");
+        }
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }
@@ -232,8 +277,7 @@ public class TenantQuotaService {
             quotaAllowedCounter.increment();
             meterRegistry.counter("eddi.tenant.usage.api_calls", "tenant", tenantId).increment();
         } else {
-            meterRegistry.counter("eddi.tenant.quota.denied", "tenant", tenantId, "type", "api_call").increment();
-            LOGGER.warn(result.reason());
+            recordDenial(result, tenantId, "api_call");
         }
 
         return result;
@@ -264,7 +308,12 @@ public class TenantQuotaService {
      *            excluding the agent being deployed
      */
     public QuotaCheckResult checkAgentQuota(String tenantId, int currentDistinctAgents) {
-        TenantQuota quota = quotaFor(tenantId);
+        TenantQuota quota;
+        try {
+            quota = quotaFor(tenantId);
+        } catch (QuotaAccountingUnavailableException e) {
+            return quotaUnreadable(tenantId, "agent");
+        }
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }
@@ -303,7 +352,12 @@ public class TenantQuotaService {
      * needed here.
      */
     public QuotaCheckResult checkCostBudget(String tenantId) {
-        TenantQuota quota = quotaFor(tenantId);
+        TenantQuota quota;
+        try {
+            quota = quotaFor(tenantId);
+        } catch (QuotaAccountingUnavailableException e) {
+            return quotaUnreadable(tenantId, "cost");
+        }
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }
@@ -354,7 +408,12 @@ public class TenantQuotaService {
      * effects than its name suggests.
      */
     public QuotaCheckResult recordCost(String tenantId, double cost) {
-        TenantQuota quota = quotaFor(tenantId);
+        TenantQuota quota;
+        try {
+            quota = quotaFor(tenantId);
+        } catch (QuotaAccountingUnavailableException e) {
+            return quotaUnreadable(tenantId, "cost");
+        }
         if (quota == null || !quota.enabled()) {
             return QuotaCheckResult.OK;
         }
@@ -364,11 +423,32 @@ public class TenantQuotaService {
         meterRegistry.counter("eddi.tenant.usage.cost", "tenant", tenantId).increment(cost);
 
         if (!result.allowed()) {
-            meterRegistry.counter("eddi.tenant.quota.denied", "tenant", tenantId, "type", "cost").increment();
-            LOGGER.warn(result.reason());
+            recordDenial(result, tenantId, "cost");
         }
 
         return result;
+    }
+
+    /**
+     * Count a refused request on the metric that describes what actually happened.
+     * <p>
+     * A store that cannot answer refuses the request for safety, which is right,
+     * but it is not a quota breach. Counting it on {@code eddi.tenant.quota.denied}
+     * made an accounting outage indistinguishable from a tenant burning through its
+     * allowance — the graph an operator uses to decide whether to raise a limit
+     * spiked for a database problem — and the WARN level buried an infrastructure
+     * fault among ordinary rate-limit noise. {@code eddi.tenant.quota.unavailable}
+     * carries the same {tenant, type} tags, so a dashboard can show them side by
+     * side.
+     */
+    private void recordDenial(QuotaCheckResult result, String tenantId, String type) {
+        if (result.accountingUnavailable()) {
+            meterRegistry.counter("eddi.tenant.quota.unavailable", "tenant", tenantId, "type", type).increment();
+            LOGGER.error(result.reason());
+            return;
+        }
+        meterRegistry.counter("eddi.tenant.quota.denied", "tenant", tenantId, "type", type).increment();
+        LOGGER.warn(result.reason());
     }
 
     // ─── Usage Reporting ───

--- a/src/main/java/ai/labs/eddi/engine/tenancy/TenantUsageCounters.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/TenantUsageCounters.java
@@ -6,10 +6,11 @@ package ai.labs.eddi.engine.tenancy;
 
 import ai.labs.eddi.engine.tenancy.model.UsageSnapshot;
 
-import java.time.Duration;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Mutable per-tenant usage counters. Package-private — used only by
@@ -18,11 +19,17 @@ import java.time.ZoneOffset;
  * All fields are plain (non-atomic) because callers synchronize externally.
  * This makes the atomic check+increment semantics explicit at the store level
  * rather than hiding them behind AtomicInteger's CAS operations.
+ * <p>
+ * <strong>Windows are wall-clock aligned</strong> —
+ * {@code truncatedTo(MINUTES)}, {@code truncatedTo(DAYS)}, {@code YearMonth} —
+ * which is what the two DB-backed stores have always used. These counters used
+ * to run their windows from the first hit instead (first call + 60s, first call
+ * + 24h), so identical configuration enforced a different limit depending on
+ * which backend was selected, and neither of the two matched the "sliding
+ * window" the model documented. Calendar alignment is the one semantics a
+ * multi-instance deployment can agree on without shared state.
  */
 class TenantUsageCounters {
-
-    private static final Duration MINUTE_WINDOW = Duration.ofMinutes(1);
-    private static final Duration DAY_WINDOW = Duration.ofDays(1);
 
     private int conversationsToday;
     private int apiCallsThisMinute;
@@ -31,11 +38,23 @@ class TenantUsageCounters {
     private Instant dayStart;
     private YearMonth costMonth;
 
+    /**
+     * Source of "now". Production always gets {@link Clock#systemUTC()}; a test
+     * pins it so a window boundary is something it can step across deliberately
+     * rather than occasionally trip over. Same reasoning as the DB-backed stores.
+     */
+    private final Clock clock;
+
     TenantUsageCounters() {
-        Instant now = Instant.now();
-        this.minuteWindowStart = now;
-        this.dayStart = now;
-        this.costMonth = YearMonth.now(ZoneOffset.UTC);
+        this(Clock.systemUTC());
+    }
+
+    TenantUsageCounters(Clock clock) {
+        this.clock = clock;
+        Instant now = clock.instant();
+        this.minuteWindowStart = now.truncatedTo(ChronoUnit.MINUTES);
+        this.dayStart = now.truncatedTo(ChronoUnit.DAYS);
+        this.costMonth = YearMonth.now(clock.withZone(ZoneOffset.UTC));
     }
 
     int getConversationsToday() {
@@ -67,19 +86,22 @@ class TenantUsageCounters {
      * as the check+increment to ensure atomicity.
      * <p>
      * Resets: per-minute API call counter, daily conversation counter, and monthly
-     * cost accumulator (on calendar month boundary, UTC).
+     * cost accumulator — all on calendar boundaries in UTC, matching the DB-backed
+     * stores.
      */
     void resetExpiredWindows() {
-        Instant now = Instant.now();
-        if (Duration.between(minuteWindowStart, now).compareTo(MINUTE_WINDOW) > 0) {
+        Instant now = clock.instant();
+        Instant currentMinuteStart = now.truncatedTo(ChronoUnit.MINUTES);
+        if (minuteWindowStart.isBefore(currentMinuteStart)) {
             apiCallsThisMinute = 0;
-            minuteWindowStart = now;
+            minuteWindowStart = currentMinuteStart;
         }
-        if (Duration.between(dayStart, now).compareTo(DAY_WINDOW) > 0) {
+        Instant currentDayStart = now.truncatedTo(ChronoUnit.DAYS);
+        if (dayStart.isBefore(currentDayStart)) {
             conversationsToday = 0;
-            dayStart = now;
+            dayStart = currentDayStart;
         }
-        YearMonth currentMonth = YearMonth.now(ZoneOffset.UTC);
+        YearMonth currentMonth = YearMonth.now(clock.withZone(ZoneOffset.UTC));
         if (!currentMonth.equals(costMonth)) {
             monthlyCostUsd = 0.0;
             costMonth = currentMonth;
@@ -90,10 +112,10 @@ class TenantUsageCounters {
         conversationsToday = 0;
         apiCallsThisMinute = 0;
         monthlyCostUsd = 0.0;
-        Instant now = Instant.now();
-        minuteWindowStart = now;
-        dayStart = now;
-        costMonth = YearMonth.now(ZoneOffset.UTC);
+        Instant now = clock.instant();
+        minuteWindowStart = now.truncatedTo(ChronoUnit.MINUTES);
+        dayStart = now.truncatedTo(ChronoUnit.DAYS);
+        costMonth = YearMonth.now(clock.withZone(ZoneOffset.UTC));
     }
 
     /**

--- a/src/main/java/ai/labs/eddi/engine/tenancy/model/QuotaCheckResult.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/model/QuotaCheckResult.java
@@ -11,12 +11,36 @@ package ai.labs.eddi.engine.tenancy.model;
  *            whether the operation is permitted
  * @param reason
  *            human-readable reason for denial (null if allowed)
+ * @param accountingUnavailable
+ *            true when the denial is the store failing to answer rather than
+ *            the tenant being over a limit. Both fail closed, but they are
+ *            different events: an over-quota denial is 429 with
+ *            {@code Retry-After: 60} and belongs on
+ *            {@code eddi.tenant.quota.denied}, while an accounting outage is
+ *            503 and must not make a tenant's quota graph spike as if they had
+ *            burned through their allowance. Only the wording of the reason
+ *            used to differ, so neither monitoring nor a client could tell the
+ *            two apart.
  */
-public record QuotaCheckResult(boolean allowed, String reason) {
+public record QuotaCheckResult(boolean allowed, String reason, boolean accountingUnavailable) {
 
-    public static final QuotaCheckResult OK = new QuotaCheckResult(true, null);
+    public static final QuotaCheckResult OK = new QuotaCheckResult(true, null, false);
 
+    /** Compatibility constructor for the original two-component shape. */
+    public QuotaCheckResult(boolean allowed, String reason) {
+        this(allowed, reason, false);
+    }
+
+    /** The tenant is over a limit. */
     public static QuotaCheckResult denied(String reason) {
-        return new QuotaCheckResult(false, reason);
+        return new QuotaCheckResult(false, reason, false);
+    }
+
+    /**
+     * The store could not answer, so the request is refused for safety — not
+     * because any limit was reached.
+     */
+    public static QuotaCheckResult unavailable(String reason) {
+        return new QuotaCheckResult(false, reason, true);
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/model/TenantQuota.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/model/TenantQuota.java
@@ -11,13 +11,23 @@ package ai.labs.eddi.engine.tenancy.model;
  * @param tenantId
  *            tenant identifier ("default" for single-tenant mode)
  * @param maxConversationsPerDay
- *            max new conversations per day (-1 = unlimited)
+ *            max new conversations per UTC calendar day (-1 = unlimited)
  * @param maxAgentsPerTenant
  *            max deployed agents (-1 = unlimited)
  * @param maxApiCallsPerMinute
- *            sliding window rate limit for say/sayStreaming (-1 = unlimited)
+ *            max say/sayStreaming calls per UTC calendar minute (-1 =
+ *            unlimited). A calendar-aligned window, not a sliding one: that is
+ *            what all three stores implement, so a burst spanning a minute
+ *            boundary can consume two windows worth of allowance.
  * @param maxMonthlyCostUsd
- *            max monthly tool cost budget (-1 = unlimited)
+ *            max monthly tool cost budget (-1 = unlimited). <strong>Not
+ *            enforced yet.</strong> The gate exists
+ *            ({@code TenantQuotaService.checkCostBudget}) but the accumulator
+ *            it reads is only written by {@code recordCost}, which has no
+ *            production caller — so the recorded cost is always 0 and the gate
+ *            always allows. A tenant can be configured with a budget and spend
+ *            past it; {@code PUT /administration/quotas/&#123;id&#125;} logs a
+ *            warning saying so rather than pretending otherwise.
  * @param enabled
  *            whether quota enforcement is active for this tenant
  */

--- a/src/main/java/ai/labs/eddi/engine/tenancy/rest/QuotaAccountingUnavailableExceptionMapper.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/rest/QuotaAccountingUnavailableExceptionMapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.tenancy.rest;
+
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.Map;
+
+/**
+ * Maps {@link QuotaAccountingUnavailableException} to HTTP 503 Service
+ * Unavailable with the {@code quota_accounting_unavailable} error code.
+ * <p>
+ * Without it the exception is handled by
+ * {@code RejectedExecutionExceptionMapper} — it extends
+ * {@link java.util.concurrent.RejectedExecutionException}, so the status is
+ * already right — but the body reads {@code "error": "capacity_exceeded"},
+ * which is the wrong event: nothing is saturated, the quota store could not
+ * answer. That is what
+ * {@code POST /agents/&#123;environment&#125;/&#123;agentId&#125;} returned
+ * during a quota-store outage, because
+ * {@code RestAgentEngine.startConversationWithContext} catches only the three
+ * conditions it reports itself and lets everything else reach a mapper — while
+ * {@code docs/metrics.md} and the dashboard both promise the honest code on
+ * that path.
+ * <p>
+ * JAX-RS selects the mapper whose exception type is nearest the thrown class,
+ * so this one wins over the {@code RejectedExecutionException} mapper wherever
+ * both apply; the {@code AsyncResponse}-based {@code say} endpoints reach
+ * neither and keep their explicit branch in {@code RestAgentEngine}.
+ *
+ * @author ginccc
+ * @since 6.0.0
+ */
+@Provider
+public class QuotaAccountingUnavailableExceptionMapper implements ExceptionMapper<QuotaAccountingUnavailableException> {
+
+    @Override
+    public Response toResponse(QuotaAccountingUnavailableException exception) {
+        return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                .entity(Map.of(
+                        "error", "quota_accounting_unavailable",
+                        "message", exception.getMessage() != null ? exception.getMessage() : "Quota accounting unavailable"))
+                .type(MediaType.APPLICATION_JSON)
+                .header("Retry-After", "5")
+                .build();
+    }
+}

--- a/src/main/java/ai/labs/eddi/engine/tenancy/rest/QuotaAccountingUnavailableExceptionMapper.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/rest/QuotaAccountingUnavailableExceptionMapper.java
@@ -45,9 +45,32 @@ public class QuotaAccountingUnavailableExceptionMapper implements ExceptionMappe
         return Response.status(Response.Status.SERVICE_UNAVAILABLE)
                 .entity(Map.of(
                         "error", "quota_accounting_unavailable",
-                        "message", exception.getMessage() != null ? exception.getMessage() : "Quota accounting unavailable"))
+                        "message", messageOf(exception)))
                 .type(MediaType.APPLICATION_JSON)
                 .header("Retry-After", "5")
                 .build();
+    }
+
+    /**
+     * The body's {@code message}, never null.
+     * <p>
+     * Shared with the {@code AsyncResponse} branches in
+     * {@code RestAgentEngine.sayInternal} and
+     * {@code RestAgentEngineStreaming.buildKnownConditionOrOpaqueErrorEvent}, which
+     * cannot reach this mapper and so reproduce its body themselves. The streaming
+     * branch echoed {@code getMessage()} raw, so a thrower that supplies no message
+     * emitted {@code "message":""} there while the other two surfaces said "Quota
+     * accounting unavailable" — one outage described two ways to clients keying on
+     * the error contract. Mirrors
+     * {@code ProcessingRestrictionUnavailableExceptionMapper.messageOf}, which
+     * exists for the same reason.
+     *
+     * @param exception
+     *            the failure being reported
+     * @return the exception's own message, or a fixed fallback when it has none
+     */
+    public static String messageOf(QuotaAccountingUnavailableException exception) {
+        String message = exception.getMessage();
+        return message != null ? message : "Quota accounting unavailable";
     }
 }

--- a/src/main/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuota.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuota.java
@@ -10,16 +10,22 @@ import ai.labs.eddi.engine.tenancy.model.TenantQuota;
 import ai.labs.eddi.engine.tenancy.model.UsageSnapshot;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
 
 import java.util.List;
+
+import static ai.labs.eddi.utils.LogSanitizer.sanitize;
 
 /**
  * REST implementation for tenant quota management.
  */
 @ApplicationScoped
 public class RestTenantQuota implements IRestTenantQuota {
+
+    private static final Logger LOGGER = Logger.getLogger(RestTenantQuota.class);
 
     private final ITenantQuotaStore quotaStore;
     private final TenantQuotaService quotaService;
@@ -46,12 +52,82 @@ public class RestTenantQuota implements IRestTenantQuota {
 
     @Override
     public Response updateQuota(String tenantId, TenantQuota quota) {
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new BadRequestException("tenantId must not be blank");
+        }
+        if (quota == null) {
+            // An empty request body used to reach the dereference below and surface
+            // as a 500.
+            throw new BadRequestException("A quota body is required");
+        }
+        // Every store treats "< 0" as unlimited, so -5 was accepted and silently
+        // behaved as unlimited — the opposite of what an admin typing a negative
+        // number means.
+        requireLimit("maxConversationsPerDay", quota.maxConversationsPerDay());
+        requireLimit("maxAgentsPerTenant", quota.maxAgentsPerTenant());
+        requireLimit("maxApiCallsPerMinute", quota.maxApiCallsPerMinute());
+        requireCostLimit(quota.maxMonthlyCostUsd());
+
         // Ensure tenantId consistency
         var storedQuota = new TenantQuota(tenantId, quota.maxConversationsPerDay(), quota.maxAgentsPerTenant(), quota.maxApiCallsPerMinute(),
                 quota.maxMonthlyCostUsd(), quota.enabled());
-        quotaStore.setQuota(storedQuota);
+
+        warnIfCostBudgetIsUnenforceable(storedQuota);
+
+        // Through the service, not straight to the store: the enforcement gates read
+        // configuration through a short-TTL cache, and the service write-through is
+        // what drops the stale entry so the new limits apply to the very next turn.
+        quotaService.setQuota(storedQuota);
         return Response.ok(storedQuota).build();
     }
+
+    /**
+     * Say out loud that a monthly cost budget is accepted but not enforced.
+     * <p>
+     * {@code TenantQuotaService.checkCostBudget} reads an accumulator only
+     * {@code recordCost} writes, and {@code recordCost} has no production caller —
+     * so the recorded cost is always 0 and the gate always allows. Storing the
+     * value silently let an admin set a budget, see it in the UI, and believe a
+     * tenant was capped. The value is still stored (it is configuration a future
+     * release will enforce, and rejecting it would break existing rows); the
+     * operator is simply told.
+     */
+    private static void warnIfCostBudgetIsUnenforceable(TenantQuota quota) {
+        if (quota.enabled() && quota.maxMonthlyCostUsd() != UNLIMITED) {
+            LOGGER.warnf("Tenant '%s' was given maxMonthlyCostUsd=%.2f, but the monthly cost budget is NOT enforced yet "
+                    + "(nothing records tool cost against it). The limit is stored and will apply once cost recording is wired.",
+                    sanitize(quota.tenantId()), quota.maxMonthlyCostUsd());
+        }
+    }
+
+    /**
+     * A limit is either {@code -1} (unlimited) or a non-negative count. Any other
+     * negative value is rejected rather than quietly read as unlimited.
+     */
+    private static void requireLimit(String field, int value) {
+        if (value < UNLIMITED) {
+            throw new BadRequestException(field + " must be -1 (unlimited) or >= 0, was " + value);
+        }
+    }
+
+    /**
+     * The {@code double} twin of {@link #requireLimit}, and it needs a different
+     * predicate. {@code value < -1} leaves the whole open interval between the
+     * sentinel and zero open: {@code -0.5} is not less than {@code -1}, so it was
+     * accepted although the rejection message says "-1 (unlimited) or >= 0" — and
+     * every store reads any negative as unlimited, so it silently disabled the
+     * budget. The integer overload has the same shape but no reachable gap, because
+     * no integer sits strictly between -1 and 0.
+     */
+    private static void requireCostLimit(double value) {
+        boolean unlimited = value == UNLIMITED;
+        if (Double.isNaN(value) || (!unlimited && value < 0)) {
+            throw new BadRequestException("maxMonthlyCostUsd must be -1 (unlimited) or >= 0, was " + value);
+        }
+    }
+
+    /** The sentinel every store reads as "no limit". */
+    private static final int UNLIMITED = -1;
 
     @Override
     public UsageSnapshot getUsage(String tenantId) {

--- a/src/main/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuota.java
+++ b/src/main/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuota.java
@@ -72,12 +72,16 @@ public class RestTenantQuota implements IRestTenantQuota {
         var storedQuota = new TenantQuota(tenantId, quota.maxConversationsPerDay(), quota.maxAgentsPerTenant(), quota.maxApiCallsPerMinute(),
                 quota.maxMonthlyCostUsd(), quota.enabled());
 
-        warnIfCostBudgetIsUnenforceable(storedQuota);
-
         // Through the service, not straight to the store: the enforcement gates read
         // configuration through a short-TTL cache, and the service write-through is
         // what drops the stale entry so the new limits apply to the very next turn.
         quotaService.setQuota(storedQuota);
+
+        // After the write returns, not before it. The warning asserts that the limit
+        // *is* stored and will apply once cost recording is wired; emitted first, a
+        // store failure left that claim in the log with nothing written behind it —
+        // the operator reading it would go looking for a row that does not exist.
+        warnIfCostBudgetIsUnenforceable(storedQuota);
         return Response.ok(storedQuota).build();
     }
 

--- a/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopRunner.java
+++ b/src/main/java/ai/labs/eddi/modules/llm/impl/ToolLoopRunner.java
@@ -605,7 +605,16 @@ class ToolLoopRunner {
         if (tenantQuotaService != null) {
             var costCheck = tenantQuotaService.checkCostBudget(tenantQuotaService.getDefaultTenantId());
             if (!costCheck.allowed()) {
-                LOGGER.warnf("Tenant cost budget exceeded during tool call: %s", costCheck.reason());
+                // The reason string already distinguishes the two, but the log line
+                // in front of it did not: an operator grepping for "cost budget
+                // exceeded" was told a tenant had spent its allowance when in fact
+                // the quota store could not answer.
+                if (costCheck.accountingUnavailable()) {
+                    LOGGER.warnf("Tenant cost accounting unavailable during tool call, refusing: %s",
+                            costCheck.reason());
+                } else {
+                    LOGGER.warnf("Tenant cost budget exceeded during tool call: %s", costCheck.reason());
+                }
 
                 Map<String, Object> quotaStep = new HashMap<>();
                 quotaStep.put("type", "tool_error");

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreUnitTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreUnitTest.java
@@ -9,6 +9,7 @@ import ai.labs.eddi.engine.audit.model.AuditEntry;
 import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -115,6 +116,106 @@ class PostgresAuditStoreUnitTest {
         verify(statement).execute("ALTER TABLE audit_ledger ADD COLUMN IF NOT EXISTS agent_signature TEXT");
     }
 
+    /**
+     * Findings c1 and 01. {@code agentVersion} is a nullable {@link Integer}
+     * precisely because "unknown" is a value the rest of the system produces: the
+     * GDPR compliance entries have no conversation and no agent at all, and the
+     * HITL and group oversight entries know the conversation but not the agent
+     * version. This backend bound it with
+     * {@code ps.setInt(4, entry.agentVersion())}, which auto-unboxes — so every one
+     * of those entries threw an NPE before the statement was even sent,
+     * {@code appendBatch}'s {@code SQLException|IOException} catch did not see it,
+     * and the escaping exception took the ledger's whole flush batch down. On
+     * PostgreSQL that repeated every time an approval was cancelled, a paused
+     * conversation was ended, a group HITL decision was recorded or a facilitator
+     * emitted a checkpoint.
+     */
+    @Test
+    void appendEntry_acceptsANullAgentVersion() throws Exception {
+        AuditEntry entry = new AuditEntry("id-1", "conv-1", null, null, "user-1", "production",
+                0, "task-1", "hitl.approval", 0, 100L, null, null, null, null, null, 0.0, Instant.now(), "hmac", null, 0L);
+        when(jsonSerialization.serialize(any())).thenReturn("{}");
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        assertDoesNotThrow(() -> store.appendEntry(entry));
+        verify(preparedStatement).setObject(4, null, Types.INTEGER);
+    }
+
+    /**
+     * The three columns those entries leave empty were {@code NOT NULL}, so even
+     * once the binding is fixed an existing ledger would reject the row. Dropping a
+     * constraint a column does not have is a no-op in PostgreSQL, so the ALTERs are
+     * idempotent and safe on every start.
+     */
+    @Test
+    void ensureSchema_relaxesTheNotNullConstraintsOnExistingLedgers() throws Exception {
+        when(jsonSerialization.serialize(any())).thenReturn("{}");
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        store.appendEntry(createEntry());
+
+        verify(statement).execute("ALTER TABLE audit_ledger ALTER COLUMN conversation_id DROP NOT NULL");
+        verify(statement).execute("ALTER TABLE audit_ledger ALTER COLUMN AGENT_ID DROP NOT NULL");
+        verify(statement).execute("ALTER TABLE audit_ledger ALTER COLUMN AGENT_VERSION DROP NOT NULL");
+    }
+
+    /**
+     * Finding 02: the ledger recovers from a failed bulk write by retrying the
+     * batch one entry at a time, and a JDBC batch in autocommit stops at the first
+     * failing statement having already committed the ones before it. Without
+     * {@code ON CONFLICT (id) DO NOTHING} that retry collides with the rows that
+     * did land, so every entry fails again and the whole batch is dead-lettered —
+     * exactly the outcome the per-entry fallback exists to avoid.
+     */
+    @Test
+    void insert_isIdempotentSoThePerEntryRetryCanReofferRowsThatLanded() throws Exception {
+        when(jsonSerialization.serialize(any())).thenReturn("{}");
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        store.appendEntry(createEntry());
+
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        verify(connection).prepareStatement(sql.capture());
+        assertTrue(sql.getValue().contains("ON CONFLICT (id) DO NOTHING"),
+                "the single-entry insert must accept a row the aborted batch already committed: " + sql.getValue());
+    }
+
+    /**
+     * Finding 09: GDPR export and erasure both select on {@code user_id}, and the
+     * ledger is the largest never-pruned table in the system.
+     */
+    @Test
+    void ensureSchema_indexesUserIdForTheGdprScans() throws Exception {
+        when(jsonSerialization.serialize(any())).thenReturn("{}");
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        store.appendEntry(createEntry());
+
+        verify(statement).execute("CREATE INDEX IF NOT EXISTS idx_audit_user ON audit_ledger (user_id)");
+    }
+
+    /**
+     * Finding 03: seeding a sequence counter from {@code MAX(sequence)} rather than
+     * a row count is what stops a dead-lettered gap turning into a re-issued
+     * position, which {@code /auditstore/verify} grades as {@code BROKEN}. SQL
+     * {@code MAX} over an empty set is NULL, which {@code getLong} reports as 0 —
+     * indistinguishable from a real position 0 without {@code wasNull()}.
+     */
+    @Test
+    void maxSequence_distinguishesAnEmptyChainFromPositionZero() throws Exception {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+
+        when(resultSet.getLong(1)).thenReturn(9L);
+        when(resultSet.wasNull()).thenReturn(false);
+        assertEquals(9L, store.maxSequence("conv-1"));
+
+        when(resultSet.getLong(1)).thenReturn(0L);
+        when(resultSet.wasNull()).thenReturn(true);
+        assertEquals(AuditEntry.UNSEQUENCED, store.maxSequence("conv-1"),
+                "an empty chain must not look like a chain whose position 0 is taken");
+    }
+
     @Test
     void supportsSequence_isTrueSoTheChainIsActuallyChecked() {
         assertTrue(store.supportsSequence(),
@@ -210,6 +311,33 @@ class PostgresAuditStoreUnitTest {
         List<AuditEntry> entries = store.getEntries("conv-1", 0, 10);
         assertEquals(1, entries.size());
         assertEquals("conv-1", entries.get(0).conversationId());
+        assertEquals(1, entries.get(0).agentVersion(), "the stored agent version must survive the round trip");
+    }
+
+    /**
+     * The read half of the null-agentVersion fix, and the half nothing asserted.
+     * <p>
+     * {@code getInt} maps SQL NULL to {@code 0}, so every entry the system
+     * legitimately stores without a version — GDPR compliance events, HITL
+     * approvals, group oversight, facilitator checkpoints — read back as version 0.
+     * The HMAC canonical form renders {@code null} and {@code 0} differently, so
+     * {@code /auditstore/verify} would grade every one of those rows as tampered,
+     * permanently, and precisely on the EU-AI-Act human-oversight records the
+     * ledger exists to hold.
+     */
+    @Test
+    void getEntries_mapsASqlNullAgentVersionToNullNotZero() throws Exception {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, false);
+        mockAuditResultSet();
+        // A row written by one of the six call sites that have no agent version.
+        when(resultSet.getObject("AGENT_VERSION", Integer.class)).thenReturn(null);
+
+        List<AuditEntry> entries = store.getEntries("conv-1", 0, 10);
+
+        assertEquals(1, entries.size());
+        assertNull(entries.get(0).agentVersion(),
+                "a stored SQL NULL must read back as null; 0 is a different HMAC input and verifies as tampered");
     }
 
     @Test
@@ -237,6 +365,7 @@ class PostgresAuditStoreUnitTest {
 
         List<AuditEntry> entries = store.getEntriesByAgent("agent-1", 1, 0, 10);
         assertEquals(1, entries.size());
+        assertEquals(1, entries.get(0).agentVersion(), "the stored agent version must survive the round trip");
     }
 
     @Test
@@ -247,6 +376,7 @@ class PostgresAuditStoreUnitTest {
 
         List<AuditEntry> entries = store.getEntriesByAgent("agent-1", null, 0, 10);
         assertEquals(1, entries.size());
+        assertEquals(1, entries.get(0).agentVersion(), "the stored agent version must survive the round trip");
     }
 
     // ─── countByConversation ───
@@ -276,6 +406,7 @@ class PostgresAuditStoreUnitTest {
 
         List<AuditEntry> entries = store.getEntriesByUserId("user-1", 0, 10);
         assertEquals(1, entries.size());
+        assertEquals(1, entries.get(0).agentVersion(), "the stored agent version must survive the round trip");
     }
 
     // ─── GDPR: pseudonymizeByUserId ───
@@ -308,7 +439,12 @@ class PostgresAuditStoreUnitTest {
         when(resultSet.getString("id")).thenReturn("entry-1");
         when(resultSet.getString("conversation_id")).thenReturn("conv-1");
         when(resultSet.getString("AGENT_ID")).thenReturn("agent-1");
-        when(resultSet.getInt("AGENT_VERSION")).thenReturn(1);
+        // getObject, not getInt: fromRow reads the nullable Integer through
+        // getObject("AGENT_VERSION", Integer.class). The getInt stub this fixture
+        // used to carry was dead — Mockito is not in strict-stubs mode here, so it
+        // was silent — and every test built on the fixture quietly round-tripped
+        // agentVersion = null while claiming to exercise version 1.
+        when(resultSet.getObject("AGENT_VERSION", Integer.class)).thenReturn(1);
         when(resultSet.getString("user_id")).thenReturn("user-1");
         when(resultSet.getString("environment")).thenReturn("production");
         when(resultSet.getInt("step_index")).thenReturn(0);

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreUnitTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresAuditStoreUnitTest.java
@@ -216,6 +216,82 @@ class PostgresAuditStoreUnitTest {
                 "an empty chain must not look like a chain whose position 0 is taken");
     }
 
+    /**
+     * A driver that returns no row at all (rather than one NULL row) must reach the
+     * same verdict as an empty chain. Reading a stale local variable, or falling
+     * off the method, would hand the ledger a position it never verified — and the
+     * seed derived from it decides where the next signed entry sits in the chain.
+     */
+    @Test
+    void maxSequence_anEmptyResultSetIsAnEmptyChain() throws Exception {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(false);
+
+        assertEquals(AuditEntry.UNSEQUENCED, store.maxSequence("conv-1"));
+        verify(resultSet, never()).getLong(1);
+    }
+
+    /**
+     * The seed must never be guessed. A failed read has to propagate so
+     * {@code AuditLedgerService.prewarmSequenceCounter} can fall back to
+     * {@code UNSEQUENCED} — returning 0 here would re-issue position 0 for a
+     * conversation that already has one, and the chain verifier grades a duplicate
+     * exactly like a deletion.
+     */
+    @Test
+    void maxSequence_aFailedReadThrowsRatherThanGuessingAPosition() throws Exception {
+        when(preparedStatement.executeQuery()).thenThrow(new SQLException("connection reset"));
+
+        var thrown = assertThrows(RuntimeException.class, () -> store.maxSequence("conv-1"));
+
+        assertEquals("Failed to read max audit sequence", thrown.getMessage());
+        assertInstanceOf(SQLException.class, thrown.getCause(),
+                "the driver failure has to stay attached or the outage is undiagnosable");
+    }
+
+    /**
+     * The ledger is the busiest reader in the system — {@code maxSequence} runs
+     * once per conversation and {@code getEntries} backs both the verify endpoint
+     * and the GDPR export — so a {@code ResultSet} left open here leaks a cursor
+     * per call until the pool starves. Every read path must close it, and on a mock
+     * only {@code verify(close())} can say so: a missing try-with-resources changes
+     * nothing else observable, which is exactly why nothing caught it.
+     */
+    @Test
+    void maxSequence_closesTheResultSet() throws Exception {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getLong(1)).thenReturn(9L);
+
+        store.maxSequence("conv-1");
+
+        verify(resultSet).close();
+    }
+
+    /** The same guard on the row-reading path. */
+    @Test
+    void getEntries_closesTheResultSet() throws Exception {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, false);
+        mockAuditResultSet();
+
+        store.getEntries("conv-1", 0, 10);
+
+        verify(resultSet).close();
+    }
+
+    /** And on the path that counts, which returns before any row is read. */
+    @Test
+    void countByConversation_closesTheResultSet() throws Exception {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getLong(1)).thenReturn(5L);
+
+        store.countByConversation("conv-1");
+
+        verify(resultSet).close();
+    }
+
     @Test
     void supportsSequence_isTrueSoTheChainIsActuallyChecked() {
         assertTrue(store.supportsSequence(),

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
@@ -718,7 +718,12 @@ class PostgresUserMemoryStoreUnitTest {
                     "the raw userId reached an erasure log line, so the log now holds the identifier the "
                             + "erasure existed to remove; offending value: " + value);
         }
-        assertTrue(captured.stream().anyMatch(value -> value.contains(AuditHmac.GDPR_PSEUDONYM_PREFIX)),
+        // The whole value, not merely the prefix. A prefix match proves only that
+        // something pseudonym-shaped was logged: a digest taken over a sanitised or
+        // truncated userId would satisfy it while failing the contract this
+        // assertion states, because it would not equal what the erasure cascade
+        // writes into the audit ledger and the two could not be correlated.
+        assertTrue(captured.stream().anyMatch(value -> value.contains(AuditHmac.pseudonymFor(poisoned))),
                 "the erasure log must carry the same pseudonym the cascade writes into the audit ledger, so "
                         + "an operator can still correlate the two; captured: " + captured);
         for (String value : captured) {

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
@@ -26,6 +26,7 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.ArrayList;
 import java.util.List;
+import ai.labs.eddi.engine.audit.AuditHmac;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -689,6 +690,17 @@ class PostgresUserMemoryStoreUnitTest {
         assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing - the logger was not open");
         assertTrue(captured.stream().anyMatch(value -> value.contains("GDPR delete-all")),
                 "the line under test did not fire; captured: " + captured);
+        // The stronger contract (CWE-532): this line records an ERASURE, so the raw
+        // identifier must not survive in the log at all - not merely survive with its
+        // newlines stripped. Logs outlive the database and travel further than it does.
+        for (String value : captured) {
+            assertFalse(value.contains("user1"),
+                    "the raw userId reached an erasure log line, so the log now holds the identifier the "
+                            + "erasure existed to remove; offending value: " + value);
+        }
+        assertTrue(captured.stream().anyMatch(value -> value.contains(AuditHmac.GDPR_PSEUDONYM_PREFIX)),
+                "the erasure log must carry the same pseudonym the cascade writes into the audit ledger, so "
+                        + "an operator can still correlate the two; captured: " + captured);
         for (String value : captured) {
             assertFalse(value.contains("\n") || value.contains("\r"),
                     "a CR/LF reached the log, so a caller can forge records (CWE-117); offending value: " + value);

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
@@ -644,6 +644,26 @@ class PostgresUserMemoryStoreUnitTest {
     }
 
     /**
+     * The failure path must not undo what the success path pseudonymised. A caller
+     * that logs or serialises this exception would otherwise persist the identifier
+     * the erasure exists to remove, and a failed erasure is exactly when someone
+     * reads the exception.
+     */
+    @Test
+    void deleteAllForUser_failureMessageCarriesThePseudonymNotTheUserId() throws Exception {
+        when(preparedStatement.executeUpdate()).thenThrow(new SQLException("DB error"));
+
+        var thrown = assertThrows(IResourceStore.ResourceStoreException.class,
+                () -> sut.deleteAllForUser("user1"));
+
+        assertFalse(thrown.getMessage().contains("user1"),
+                "the raw userId reached the erasure failure message: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains(AuditHmac.pseudonymFor("user1")),
+                "the failure must name the same pseudonym the success path logs, or the two cannot be "
+                        + "correlated: " + thrown.getMessage());
+    }
+
+    /**
      * A userId is whatever the erasure caller supplied, and it reaches this INFO
      * line directly. Without sanitising, a CR/LF in it writes forged lines into the
      * operator's log (CWE-117) - on the GDPR erasure path, which is exactly where a

--- a/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
+++ b/src/test/java/ai/labs/eddi/datastore/postgres/PostgresUserMemoryStoreUnitTest.java
@@ -20,6 +20,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -634,6 +640,59 @@ class PostgresUserMemoryStoreUnitTest {
         // when/then
         assertThrows(IResourceStore.ResourceStoreException.class,
                 () -> sut.deleteAllForUser("user1"));
+    }
+
+    /**
+     * A userId is whatever the erasure caller supplied, and it reaches this INFO
+     * line directly. Without sanitising, a CR/LF in it writes forged lines into the
+     * operator's log (CWE-117) - on the GDPR erasure path, which is exactly where a
+     * log has to be trustworthy.
+     */
+    @Test
+    void deleteAllForUser_cannotForgeALogRecordThroughTheUserId() throws Exception {
+        String poisoned = "user1\r\n2026-01-01 00:00:00,000 INFO  [io.quarkus] Forged admin login succeeded";
+        when(preparedStatement.executeUpdate()).thenReturn(3);
+
+        List<String> captured = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                captured.add(String.valueOf(record.getMessage()));
+                if (record.getParameters() != null) {
+                    for (Object parameter : record.getParameters()) {
+                        captured.add(String.valueOf(parameter));
+                    }
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        // logging.properties turns ai.labs.eddi OFF for plain unit tests, so the
+        // logger has to be opened or nothing is captured and this passes vacuously.
+        Logger julLogger = Logger.getLogger(PostgresUserMemoryStore.class.getName());
+        Level previous = julLogger.getLevel();
+        julLogger.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+        try {
+            sut.deleteAllForUser(poisoned);
+        } finally {
+            julLogger.removeHandler(handler);
+            julLogger.setLevel(previous);
+        }
+
+        assertFalse(captured.isEmpty(), "nothing was captured, so this proves nothing - the logger was not open");
+        assertTrue(captured.stream().anyMatch(value -> value.contains("GDPR delete-all")),
+                "the line under test did not fire; captured: " + captured);
+        for (String value : captured) {
+            assertFalse(value.contains("\n") || value.contains("\r"),
+                    "a CR/LF reached the log, so a caller can forge records (CWE-117); offending value: " + value);
+        }
     }
 
     // ─── countEntries SQL exception ─────────────────────────────

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditDeadLetterImageProvisioningTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditDeadLetterImageProvisioningTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.audit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Ties the audit ledger's default dead-letter path to the shipped container
+ * image.
+ * <p>
+ * {@code StandardOpenOption.CREATE} creates the file, never its parent
+ * directory. The default {@code eddi.audit.dead-letter-path} lives under
+ * {@code /opt/eddi/data}, which the image did not create and which {@code UID
+ * 185} cannot create under {@code /opt} at runtime — so on the documented
+ * {@code docker run} / docker-compose quick start every dead-letter write threw
+ * {@code NoSuchFileException} into a swallowed catch, and the audit entries the
+ * ledger had to abandon were gone outright rather than recoverable. Only the
+ * Kubernetes manifests mount a volume there. That is the sink
+ * {@code AuditLedgerService.undeliveredSequences} calls "the durable evidence"
+ * and that {@code docs/incident-response.md} tells an operator to go and read.
+ * <p>
+ * A Dockerfile is not unit-testable in the sense of running it, but the
+ * invariant that matters is structural and the repository already tests project
+ * files this way (see {@code ai.labs.eddi.docs.MetricsDashboardCoverageTest},
+ * which scans the Java sources to keep a dashboard honest). The default path is
+ * read out of {@link AuditLedgerService} rather than hard-coded here, so moving
+ * the default without provisioning the new location fails the build instead of
+ * shipping a silently unwritable sink.
+ */
+@DisplayName("audit dead-letter sink — container image provisioning")
+class AuditDeadLetterImageProvisioningTest {
+
+    private static final Path DOCKERFILE = Path.of("src", "main", "docker", "Dockerfile");
+    private static final Path LEDGER_SOURCE = Path.of("src", "main", "java", "ai", "labs", "eddi",
+            "engine", "audit", "AuditLedgerService.java");
+
+    /** The {@code @ConfigProperty} default for the dead-letter file. */
+    private static final Pattern DEAD_LETTER_DEFAULT = Pattern.compile(
+            "\"eddi\\.audit\\.dead-letter-path\"\\s*,\\s*defaultValue\\s*=\\s*\"([^\"]+)\"");
+
+    /**
+     * The UID the image finally drops to — everything it writes must be writable by
+     * it.
+     */
+    private static final Pattern RUNTIME_USER = Pattern.compile("(?m)^USER\\s+(\\d+)\\s*$");
+
+    @Test
+    @DisplayName("the image creates the default dead-letter directory and hands it to the runtime user")
+    void imageProvisionsTheDefaultDeadLetterDirectory() throws IOException {
+        String dockerfile = Files.readString(DOCKERFILE, StandardCharsets.UTF_8);
+        String defaultPath = defaultDeadLetterPath();
+
+        // The parent is what has to exist; the file itself is created on first write.
+        String directory = defaultPath.substring(0, defaultPath.lastIndexOf('/'));
+        assertTrue(directory.startsWith("/"),
+                "the default must be an absolute path so the image can provision it, was: " + defaultPath);
+
+        assertTrue(dockerfile.contains("mkdir -p " + directory),
+                "the image must create " + directory + " — the runtime user cannot create it under /opt itself");
+
+        String runtimeUid = runtimeUid(dockerfile);
+        assertTrue(coversDirectory(dockerfile, "chown -R " + runtimeUid + ":0 ", directory),
+                "and give " + directory + " (or an ancestor) to UID " + runtimeUid + ", the user the image drops to");
+        assertTrue(coversDirectory(dockerfile, "chmod -R 775 ", directory),
+                "with group-write, matching how /deployments/tmp is provisioned for the same reason");
+    }
+
+    /**
+     * Whether a {@code RUN} step applies {@code command} recursively to the
+     * directory or to one of its ancestors — {@code chown -R 185:0 /opt/eddi}
+     * covers {@code /opt/eddi/data}.
+     */
+    private static boolean coversDirectory(String dockerfile, String command, String directory) {
+        Matcher m = Pattern.compile(Pattern.quote(command) + "(\\S+)").matcher(dockerfile);
+        while (m.find()) {
+            String target = m.group(1);
+            if (directory.equals(target) || directory.startsWith(target + "/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The provisioning has to happen while the image is still {@code root} and
+     * before the final {@code USER}; a {@code mkdir} under {@code /opt} after the
+     * drop would fail the build, and one before {@code USER root} would run as
+     * whatever the base image left behind.
+     */
+    @Test
+    @DisplayName("the directory is created as root, before the image drops privileges")
+    void directoryIsCreatedWhileStillRoot() throws IOException {
+        String dockerfile = Files.readString(DOCKERFILE, StandardCharsets.UTF_8);
+        String defaultPath = defaultDeadLetterPath();
+        String directory = defaultPath.substring(0, defaultPath.lastIndexOf('/'));
+
+        int rootAt = dockerfile.indexOf("USER root");
+        int mkdirAt = dockerfile.indexOf("mkdir -p " + directory);
+        Matcher user = RUNTIME_USER.matcher(dockerfile);
+        assertTrue(user.find(), "the image must drop to a non-root UID");
+        int dropAt = user.start();
+
+        assertTrue(rootAt >= 0 && rootAt < mkdirAt, "the mkdir must come after USER root");
+        assertTrue(mkdirAt < dropAt, "and before the image drops to UID " + user.group(1));
+    }
+
+    private static String defaultDeadLetterPath() throws IOException {
+        Matcher m = DEAD_LETTER_DEFAULT.matcher(Files.readString(LEDGER_SOURCE, StandardCharsets.UTF_8));
+        assertTrue(m.find(), "eddi.audit.dead-letter-path must declare a defaultValue in AuditLedgerService");
+        return m.group(1);
+    }
+
+    private static String runtimeUid(String dockerfile) {
+        Matcher m = RUNTIME_USER.matcher(dockerfile);
+        assertTrue(m.find(), "the image must declare the UID it runs as");
+        String uid = m.group(1);
+        assertEquals("185", uid, "the Red Hat UBI runtime user; change this test deliberately if the image moves");
+        return uid;
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
@@ -17,9 +17,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 
@@ -63,6 +66,18 @@ class AuditLedgerServiceBranchTest {
         var svc = AuditLedgerService.createForTesting(auditStore, enabled, 60, masterKey, meterRegistry);
         svc.init();
         return svc;
+    }
+
+    /**
+     * A store that is genuinely unavailable refuses the batch <em>and</em> the
+     * per-entry retry the ledger falls back to. Stubbing only {@code appendBatch}
+     * leaves {@code appendEntry} answering successfully on the mock, so the entry
+     * is quietly stored by the recovery path and the re-queue / dead-letter branch
+     * these tests exist to cover is never reached.
+     */
+    private void storeIsDown() {
+        doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(anyList());
+        doThrow(new RuntimeException("db error")).when(auditStore).appendEntry(any());
     }
 
     // ==================== scrubSecrets — null maps ====================
@@ -284,8 +299,12 @@ class AuditLedgerServiceBranchTest {
     void flushSuccessResetsFailures() throws Exception {
         var service = createSimple(true, null);
 
-        // First flush fails
+        // First flush fails on BOTH write paths — the batch and the per-entry retry
+        // it falls back to — which is what an unavailable store looks like. The
+        // second flush finds the batch path healthy again and never reaches the
+        // per-entry stub.
         doThrow(new RuntimeException("fail")).doNothing().when(auditStore).appendBatch(any());
+        doThrow(new RuntimeException("fail")).when(auditStore).appendEntry(any());
         service.submit(entry("1", "c1", "a1"));
         service.flush(); // fail 1
 
@@ -294,6 +313,9 @@ class AuditLedgerServiceBranchTest {
         // Second flush succeeds
         service.flush();
         assertEquals(0, service.getQueueSize());
+        verify(auditStore, times(2)).appendBatch(any());
+        assertEquals(0.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "a recovered store must not have dropped anything");
     }
 
     // ==================== writeToDeadLetter — NATS path ====================
@@ -317,7 +339,7 @@ class AuditLedgerServiceBranchTest {
         service.init();
 
         // Make flush fail 3 times to trigger dead letter
-        doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());
+        storeIsDown();
 
         service.submit(entry("1", "c1", "a1"));
         service.flush(); // fail 1
@@ -325,6 +347,8 @@ class AuditLedgerServiceBranchTest {
         service.flush(); // fail 3 → drop → writeToDeadLetter
 
         verify(js).publish(eq("eddi.deadletter.audit"), any(byte[].class));
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "the abandoned entry must be counted as dropped, not silently stored by the per-entry retry");
 
         service.shutdown();
     }
@@ -353,14 +377,60 @@ class AuditLedgerServiceBranchTest {
                 true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
-        doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());
+        storeIsDown();
 
         service.submit(entry("1", "c1", "a1"));
         service.flush();
         service.flush();
         service.flush(); // triggers dead letter
 
+        verify(js).publish(eq("eddi.deadletter.audit"), any(byte[].class));
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "the dead-letter path must actually have been reached");
+
         // Should not throw even though both NATS and file fail
+        service.shutdown();
+    }
+
+    /**
+     * Finding 26. {@code StandardOpenOption.CREATE} creates the file, never its
+     * parent — and the default {@code eddi.audit.dead-letter-path} lives under
+     * {@code /opt/eddi/data}, which the shipped image does not create and UID 185
+     * cannot create at runtime. So on the documented docker quick start every
+     * dead-letter write threw {@code NoSuchFileException} into a swallowed catch
+     * and the entries the ledger abandoned were gone outright, while the class's
+     * own Javadoc rests its INCOMPLETE-not-BROKEN verdict on that sink being
+     * "durable evidence". {@code init()} now creates the directory up front and the
+     * write re-creates it if it went away in between.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("writeToDeadLetter creates the parent directory rather than silently writing nothing")
+    void deadLetterWriteCreatesItsMissingParentDirectory(@TempDir Path tempDir) throws Exception {
+        Instance<Connection> natsInstance = mock(Instance.class);
+        doReturn(false).when(natsInstance).isResolvable();
+
+        Path deadLetterFile = tempDir.resolve("opt").resolve("eddi").resolve("data").resolve("audit-deadletter.jsonl");
+        var service = new AuditLedgerService(auditStore, true, 60,
+                Optional.empty(), deadLetterFile.toString(), false, "default", AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE,
+                true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
+        service.init();
+
+        assertTrue(Files.isDirectory(deadLetterFile.getParent()),
+                "startup must report — and provision — the sink before the incident that needs it");
+        // Take it away again, so the write itself has to cope.
+        Files.delete(deadLetterFile.getParent());
+
+        storeIsDown();
+        service.submit(entry("dl-1", "c1", "a1"));
+        service.flush();
+        service.flush();
+        service.flush(); // triggers dead letter
+
+        assertTrue(Files.exists(deadLetterFile), "the abandoned entry must actually reach the sink");
+        assertTrue(Files.readString(deadLetterFile).contains("\"conversationId\":\"c1\""),
+                "and it must be the entry that was abandoned");
+
         service.shutdown();
     }
 
@@ -380,12 +450,17 @@ class AuditLedgerServiceBranchTest {
                 true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
-        doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());
+        storeIsDown();
 
         service.submit(entry("1", "c1", "a1"));
         service.flush();
         service.flush();
         service.flush(); // triggers dead letter
+
+        verify(natsInstance).isResolvable();
+        verify(natsInstance, never()).get(); // unresolvable → straight to the file branch
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "the dead-letter path must actually have been reached");
 
         // Should handle file write failure gracefully
         service.shutdown();
@@ -458,13 +533,15 @@ class AuditLedgerServiceBranchTest {
                 true, 500, meterRegistry, natsInstance, null, new ObjectMapper());
         service.init();
 
-        doThrow(new RuntimeException("fail")).when(auditStore).appendBatch(any());
+        storeIsDown();
 
         service.submit(entry("1", "c1", "a1"));
         service.flush();
         service.flush();
         service.flush();
 
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "the dead-letter path must actually have been reached");
         // Should not call jetStream since connection is CLOSED
         verify(conn, never()).jetStream();
 

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceBranchTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -59,8 +60,19 @@ class AuditLedgerServiceBranchTest {
      * fallback's SUCCESS path while claiming to cover its failure path, and left a
      * junk file in the build directory.
      */
-    private String unwritableDeadLetterPath() {
-        return tempDir.resolve("no-such-dir").resolve("deadletter.jsonl").toString();
+    private String unwritableDeadLetterPath() throws IOException {
+        // A MISSING parent directory is no longer unwritable: writeToDeadLetter now
+        // calls Files.createDirectories on it, deliberately, so a missing directory
+        // cannot cost an audit record (see
+        // deadLetterWriteCreatesItsMissingParentDirectory).
+        // Blocking the path therefore needs something createDirectories cannot resolve:
+        // a regular FILE where the parent directory has to go, which fails with
+        // FileAlreadyExistsException on every OS.
+        Path blocker = tempDir.resolve("blocked-by-a-regular-file");
+        if (!Files.exists(blocker)) {
+            Files.writeString(blocker, "not a directory");
+        }
+        return blocker.resolve("deadletter.jsonl").toString();
     }
 
     @BeforeEach

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceExtendedTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceExtendedTest.java
@@ -53,6 +53,18 @@ class AuditLedgerServiceExtendedTest {
                 null, null, List.of("action1"), 0.0, Instant.now(), null, null);
     }
 
+    /**
+     * A store that is genuinely unavailable refuses the batch <em>and</em> the
+     * per-entry retry the ledger falls back to. Stubbing only {@code appendBatch}
+     * leaves {@code appendEntry} answering successfully on the mock, so the entry
+     * is quietly stored by the recovery path and the re-queue / dead-letter branch
+     * these tests exist to cover is never reached.
+     */
+    private void storeIsDown() {
+        doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(anyList());
+        doThrow(new RuntimeException("db error")).when(auditStore).appendEntry(any());
+    }
+
     // ==================== scrubSecrets — nested maps and lists
     // ====================
 
@@ -242,8 +254,12 @@ class AuditLedgerServiceExtendedTest {
         void retryCounterResets() {
             var service = createService(true, null);
 
-            // First: fail once
+            // First: fail once, on BOTH write paths — the batch and the per-entry
+            // retry it falls back to. Stubbing only the batch would let the mock's
+            // default appendEntry store the entry and there would be nothing to
+            // re-queue.
             doThrow(new RuntimeException("db error")).doNothing().when(auditStore).appendBatch(any());
+            doThrow(new RuntimeException("db error")).when(auditStore).appendEntry(any());
 
             service.submit(entry("1", "conv1", "agent1"));
             service.flush(); // Failure 1 — requeue
@@ -253,23 +269,31 @@ class AuditLedgerServiceExtendedTest {
             // Second flush should succeed and reset counter
             service.flush();
             assertEquals(0, service.getQueueSize());
+            assertEquals(0.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                    "a recovered store must not have dropped anything");
         }
 
         @Test
         @DisplayName("multiple entries all dropped after max retries")
         void multipleEntriesDropped() {
             var service = createService(true, null);
-            doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(any());
+            storeIsDown();
 
             service.submit(entry("1", "c1", "a1"));
             service.submit(entry("2", "c2", "a2"));
             service.submit(entry("3", "c3", "a3"));
 
             service.flush(); // Failure 1
+            assertEquals(3, service.getQueueSize(), "all three come back for retry while attempts remain");
             service.flush(); // Failure 2
+            assertEquals(3, service.getQueueSize());
             service.flush(); // Failure 3 — drops all
 
             assertEquals(0, service.getQueueSize());
+            // An empty queue on its own is also what "everything was stored" looks
+            // like, which is exactly how this test went vacuous. Pin the drop.
+            assertEquals(3.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                    "all three entries must be counted as dropped, not quietly stored by the per-entry retry");
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceTest.java
@@ -16,6 +16,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -32,6 +34,27 @@ class AuditLedgerServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         meterRegistry = new SimpleMeterRegistry();
+        // "The store holds no chain position for this conversation." A bare Mockito
+        // mock would answer 0 for a long-returning method, which the seed reads as
+        // "position 0 is taken" and turns into a first sequence of 1. Tests that
+        // care about the seed override this.
+        when(auditStore.maxSequence(anyString())).thenReturn(AuditEntry.UNSEQUENCED);
+    }
+
+    /**
+     * A store that is genuinely unavailable refuses the batch <em>and</em> the
+     * per-entry retry the ledger falls back to. Stubbing only {@code appendBatch}
+     * would exercise the recovery path instead of the outage.
+     */
+    private void storeIsDown() {
+        doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(anyList());
+        doThrow(new RuntimeException("db error")).when(auditStore).appendEntry(any());
+    }
+
+    /** Undo {@link #storeIsDown()} — both write paths accept again. */
+    private void storeIsUp() {
+        doNothing().when(auditStore).appendBatch(anyList());
+        doNothing().when(auditStore).appendEntry(any());
     }
 
     private AuditLedgerService createService(boolean enabled, String masterKey) {
@@ -356,7 +379,7 @@ class AuditLedgerServiceTest {
         // A store outage dead-letters this conversation, so position 0 is
         // consumed but never persisted. Its counter is pinned from here on: the
         // store count can no longer tell us where the chain resumes.
-        doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(anyList());
+        storeIsDown();
         service.submit(entry("pinned-1", "pinned", "agent1"));
         service.flush();
         service.flush();
@@ -365,7 +388,7 @@ class AuditLedgerServiceTest {
                 "precondition: the outage left an unattributed position for this conversation");
 
         // Store recovers. Fill the table with conversations that DO persist.
-        doAnswer(invocation -> null).when(auditStore).appendBatch(anyList());
+        storeIsUp();
         for (int i = 0; i < AuditLedgerService.MAX_TRACKED_CONVERSATIONS + 5; i++) {
             service.submit(entry("fill-" + i, "filler-" + i, "agent1"));
         }
@@ -412,7 +435,7 @@ class AuditLedgerServiceTest {
     @DisplayName("flush — retries on failure (less than MAX_FLUSH_RETRIES)")
     void flushRetriesOnFailure() {
         service = createService(true, null);
-        doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(any());
+        storeIsDown();
 
         service.submit(entry("1", "conv1", "agent1"));
         service.flush(); // First failure — requeues
@@ -424,14 +447,227 @@ class AuditLedgerServiceTest {
     @DisplayName("flush — drops entries after MAX_FLUSH_RETRIES consecutive failures")
     void flushDropsAfterMaxRetries() {
         service = createService(true, null);
-        doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(any());
+        storeIsDown();
 
         service.submit(entry("1", "conv1", "agent1"));
         service.flush(); // Failure 1 — requeue
+        assertEquals(1, service.getQueueSize());
         service.flush(); // Failure 2 — requeue
+        assertEquals(1, service.getQueueSize());
         service.flush(); // Failure 3 — drop + dead letter
 
         assertEquals(0, service.getQueueSize()); // Dropped
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count());
+    }
+
+    /**
+     * The point of the per-entry fallback (finding 02). A bulk write is atomic in
+     * neither backend, so re-offering the whole batch punished every entry for one
+     * bad row: the rows that HAD landed were carried back into the store as
+     * duplicate keys, nothing new was written, and after three flush windows every
+     * record in them — from unrelated conversations — was dead-lettered together.
+     */
+    @Test
+    @DisplayName("one unstorable entry does not take its whole batch down with it")
+    void aPoisonEntryOnlyCostsItself() {
+        service = createService(true, null);
+        // The batch write always fails; the per-entry retry accepts everything
+        // except the poison row. That is exactly the shape of a NOT NULL violation
+        // on one entry inside a JDBC batch.
+        doThrow(new RuntimeException("batch aborted")).when(auditStore).appendBatch(anyList());
+        doAnswer(invocation -> {
+            AuditEntry e = invocation.getArgument(0);
+            if ("poison".equals(e.id())) {
+                throw new RuntimeException("null value in column violates not-null constraint");
+            }
+            return null;
+        }).when(auditStore).appendEntry(any());
+
+        service.submit(entry("good-1", "conv-a", "agent-1"));
+        service.submit(entry("poison", "conv-b", "agent-1"));
+        service.submit(entry("good-2", "conv-c", "agent-1"));
+        service.flush();
+
+        var captor = ArgumentCaptor.forClass(AuditEntry.class);
+        verify(auditStore, times(3)).appendEntry(captor.capture());
+        assertEquals(List.of("good-1", "poison", "good-2"), captor.getAllValues().stream().map(AuditEntry::id).toList(),
+                "every entry of the failed batch must be retried on its own");
+
+        assertEquals(1, service.getQueueSize(), "only the entry that genuinely could not be stored comes back");
+        assertEquals(0.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "the good entries landed, so nothing is dropped on the first failure");
+    }
+
+    /**
+     * Finding 06: the final flush has no next attempt, so re-queuing loses the
+     * entries silently — no dead-letter record, no dropped-counter increment, and
+     * the queue is never drained again.
+     */
+    @Test
+    @DisplayName("shutdown — a failing final flush dead-letters instead of re-queuing")
+    void shutdownDeadLettersInsteadOfRequeuing() {
+        service = createService(true, null);
+        storeIsDown();
+
+        service.submit(entry("1", "conv1", "agent1"));
+        service.shutdown();
+
+        assertEquals(0, service.getQueueSize(), "nothing may be left in a queue that will never be drained");
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "an abandoned entry must be counted, not lost between a re-queue and the JVM exiting");
+    }
+
+    /**
+     * Finding 07. The re-queue loop ran backwards under a comment claiming it put
+     * entries "at the front" — which a {@code ConcurrentLinkedQueue} has no way to
+     * do, so all it achieved was reversing the batch. The next flush then persisted
+     * the retried entries in reverse submission order.
+     */
+    @Test
+    @DisplayName("a re-queued batch keeps its submission order")
+    void requeuedEntriesKeepTheirSubmissionOrder() {
+        service = createService(true, null);
+        storeIsDown();
+
+        service.submit(entry("1", "conv1", "agent1"));
+        service.submit(entry("2", "conv1", "agent1"));
+        service.submit(entry("3", "conv1", "agent1"));
+        service.flush(); // fails on both paths — all three come back
+
+        storeIsUp();
+        service.flush();
+
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(auditStore, times(2)).appendBatch(captor.capture());
+        @SuppressWarnings("unchecked")
+        List<AuditEntry> retried = (List<AuditEntry>) captor.getAllValues().get(1);
+        assertEquals(List.of("1", "2", "3"), retried.stream().map(AuditEntry::id).toList(),
+                "the retry must not reverse the batch");
+    }
+
+    /**
+     * The per-entry fallback must not turn an outage into an unbounded blocking
+     * loop. It runs on the writer thread inside {@code synchronized flush()} — the
+     * monitor the {@code @PreDestroy} final flush also waits on — so an uncapped
+     * pass over a queue grown toward the 100k bound, against a PostgreSQL whose
+     * connect timeout is measured in tens of seconds, would hold both for hours,
+     * where the old whole-batch retry failed once per flush window.
+     */
+    @Test
+    @DisplayName("the per-entry retry stops calling a store that has refused N entries in a row")
+    void perEntryRetryGivesUpOnAStoreThatIsSimplyDown() {
+        service = createService(true, null);
+        storeIsDown();
+
+        int batchSize = AuditLedgerService.MAX_CONSECUTIVE_ENTRY_FAILURES + 5;
+        for (int i = 0; i < batchSize; i++) {
+            service.submit(entry("id-" + i, "conv-" + i, "agent-1"));
+        }
+        service.flush();
+
+        verify(auditStore, times(AuditLedgerService.MAX_CONSECUTIVE_ENTRY_FAILURES)).appendEntry(any());
+        assertEquals(batchSize, service.getQueueSize(),
+                "the entries the pass skipped must still come back for the next flush, not be lost");
+    }
+
+    /**
+     * An entry submitted while the final flush is draining the queue is still
+     * perfectly storable, but nothing scheduled will ever pick it up. Recording it
+     * as dropped without offering it to a healthy store once more turns a clean
+     * shutdown into avoidable audit loss.
+     */
+    @Test
+    @DisplayName("shutdown — an entry submitted during the final flush is stored, not dead-lettered")
+    void shutdownStoresEntriesSubmittedDuringTheFinalFlush() {
+        service = createService(true, null);
+        var lateSubmissionDone = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            if (lateSubmissionDone.compareAndSet(false, true)) {
+                // Arrives after the final flush has already drained the queue.
+                service.submit(entry("late", "conv1", "agent1"));
+            }
+            return null;
+        }).when(auditStore).appendBatch(anyList());
+
+        service.submit(entry("1", "conv1", "agent1"));
+        service.shutdown();
+
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(auditStore, times(2)).appendBatch(captor.capture());
+        @SuppressWarnings("unchecked")
+        List<AuditEntry> lastBatch = (List<AuditEntry>) captor.getAllValues().get(1);
+        assertEquals(List.of("late"), lastBatch.stream().map(AuditEntry::id).toList(),
+                "the late entry must be offered to the store, not written straight to the dead-letter sink");
+        assertEquals(0, service.getQueueSize());
+        assertEquals(0.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "a healthy store means nothing was dropped");
+    }
+
+    /**
+     * The window {@code drainQueueToDeadLetter} actually exists for, and the one no
+     * test reached. {@link #shutdownStoresEntriesSubmittedDuringTheFinalFlush}
+     * covers an entry that arrives during the FIRST final flush — the second flush
+     * stores it and the drain finds nothing, which is why that test asserts
+     * {@code dropped == 0}. An entry that arrives during the SECOND flush has no
+     * flush left: the executor is already down and the scheduled task will never
+     * run again, so the drain is the only thing standing between it and silent
+     * loss.
+     * <p>
+     * Both halves of the drain are pinned, because either could be deleted without
+     * any existing test noticing: the {@code droppedCounter} increment (an operator
+     * has to be able to see that the ledger abandoned something) and the sink write
+     * — asserted through {@code undeliveredSequences}, which only
+     * {@code writeToDeadLetter} populates, so a drain that counted the entry and
+     * threw it away would still fail here.
+     */
+    @Test
+    @DisplayName("shutdown — an entry submitted during the SECOND final flush is drained to the dead-letter sink")
+    void shutdownDrainsEntriesSubmittedDuringTheSecondFinalFlush() {
+        // A store that assigns chain positions, so the abandoned entry has a sequence
+        // for undeliveredSequences to record — an UNSEQUENCED entry is skipped there
+        // by design and the sink assertion below could not tell that apart from a
+        // drain that never wrote.
+        when(auditStore.supportsSequence()).thenReturn(true);
+        service = createService(true, null);
+        var flushes = new AtomicInteger();
+        doAnswer(invocation -> {
+            switch (flushes.incrementAndGet()) {
+                // Arrives after the first final flush drained the queue; the second
+                // flush is still to come, so this one is storable.
+                case 1 -> service.submit(entry("late", "conv1", "agent1"));
+                // Arrives after the SECOND flush drained the queue. Nothing will ever
+                // flush again.
+                case 2 -> service.submit(entry("very-late", "conv1", "agent1"));
+                default -> {
+                }
+            }
+            return null;
+        }).when(auditStore).appendBatch(anyList());
+
+        service.submit(entry("1", "conv1", "agent1"));
+        service.shutdown();
+
+        verify(auditStore, times(2)).appendBatch(anyList());
+        assertEquals(0, service.getQueueSize(),
+                "nothing may be left in a queue that will never be drained again");
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "the entry the ledger abandoned must be counted, not lost between the last flush and the JVM exiting");
+        assertEquals(1, service.undeliveredSequences("conv1").size(),
+                "and it must actually reach the dead-letter sink — undelivered is only populated by writeToDeadLetter");
+    }
+
+    /**
+     * Finding 24: an operator setting 0 in the hope of "flush immediately" used to
+     * abort startup with {@code IllegalArgumentException("period <= 0")} thrown
+     * from inside the executor API — a stack trace that never names the property.
+     */
+    @Test
+    @DisplayName("a non-positive flush interval falls back to the default instead of failing startup")
+    void nonPositiveFlushIntervalFallsBackToTheDefault() {
+        var svc = AuditLedgerService.createForTesting(auditStore, true, 0, null, meterRegistry);
+        assertDoesNotThrow(svc::init);
+        assertEquals(AuditLedgerService.DEFAULT_FLUSH_INTERVAL_SECONDS, svc.getFlushIntervalSeconds());
+        svc.shutdown();
     }
 
     // ==================== scrub secrets ====================
@@ -461,6 +697,71 @@ class AuditLedgerServiceTest {
         String json = service.serializeDeadLetterEntry(e, "audit_dead_letter");
         assertTrue(json.contains("\"type\":\"audit_dead_letter\""));
         assertTrue(json.contains("\"conversationId\":\"conv1\""));
+    }
+
+    /**
+     * Finding 05. The record used to be five fields — timestamp of the drop,
+     * conversationId, agentId, taskId, taskType. With no {@code sequence} in it an
+     * operator who restarted after a dead-letter event could not prove which
+     * positions the ledger itself had abandoned, so every self-inflicted gap read
+     * as {@code BROKEN} forever; and the audit content, the HMAC and the agent
+     * signature were gone outright, which is not the "durable evidence"
+     * {@code undeliveredSequences} rests its verdict on.
+     */
+    @Test
+    @DisplayName("serializeDeadLetterEntry — carries the whole entry, not a five-field summary")
+    void deadLetterRecordIsReplayable() {
+        service = createService(true, null);
+        Instant written = Instant.parse("2026-01-02T03:04:05Z");
+        var e = new AuditEntry("dl-1", "conv1", "agent1", 1, "user1", "production",
+                2, "taskId", "LlmTask", 3, 100L,
+                Map.of("text", "hello"), Map.of("text", "response"),
+                Map.of("model", "gpt"), Map.of("tool", "calc"), List.of("action1"), 0.25, written,
+                "v4:abcdef", "sig-1", 42L);
+
+        String json = service.serializeDeadLetterEntry(e, "audit_dead_letter");
+
+        assertTrue(json.contains("\"id\":\"dl-1\""), json);
+        assertTrue(json.contains("\"sequence\":42"), json);
+        assertTrue(json.contains("\"hmac\":\"v4:abcdef\""), json);
+        assertTrue(json.contains("\"agentSignature\":\"sig-1\""), json);
+        assertTrue(json.contains("\"entryTimestamp\":\"2026-01-02T03:04:05Z\""), json);
+        assertTrue(json.contains("\"llmDetail\""), json);
+        assertTrue(json.contains("\"toolCalls\""), json);
+        // The wrapper fields existing consumers already read are unchanged.
+        assertTrue(json.contains("\"conversationId\":\"conv1\""), json);
+        assertTrue(json.contains("\"type\":\"audit_dead_letter\""), json);
+    }
+
+    /**
+     * The price of making the record replayable, pinned so it stays a deliberate
+     * decision. Widening the record from five metadata fields to the whole entry
+     * put the user id and the verbatim prompts and responses into a plaintext JSONL
+     * file on disk — content the old record did not contain — and the GDPR erasure
+     * cascade pseudonymises the ledger and the database logs but touches nothing
+     * under {@code eddi.audit.dead-letter-path}. So an Art. 17 erasure now leaves
+     * user content behind unless the operator handles that file, which is why
+     * {@code docs/audit-ledger.md} and {@code docs/gdpr-compliance.md} both say so.
+     * <p>
+     * Assert it explicitly rather than leaving it implied by "the whole entry":
+     * whoever next changes what goes into this record should have to change a test
+     * that names the retention obligation.
+     */
+    @Test
+    @DisplayName("serializeDeadLetterEntry — the sink holds personal data, which erasure does not reach")
+    void deadLetterRecordCarriesPersonalDataAndIsOutsideTheErasureCascade() {
+        service = createService(true, null);
+        var e = new AuditEntry("dl-2", "conv1", "agent1", 1, "subject-42", "production",
+                0, "taskId", "LlmTask", 0, 100L,
+                Map.of("text", "my name is Alice"), Map.of("text", "hello Alice"),
+                null, null, List.of(), 0.0, Instant.now(), null, null, 7L);
+
+        String json = service.serializeDeadLetterEntry(e, null);
+
+        assertTrue(json.contains("\"userId\":\"subject-42\""),
+                "the sink identifies the data subject, so it is in scope for Art. 17: " + json);
+        assertTrue(json.contains("my name is Alice"), "and carries their verbatim prompt: " + json);
+        assertTrue(json.contains("hello Alice"), "and the verbatim response: " + json);
     }
 
     @Test
@@ -578,6 +879,9 @@ class AuditLedgerServiceTest {
             svc.submit(entry("late-2", "conv-1", "agent-1"));
             throw new RuntimeException("store down");
         }).when(auditStore).appendBatch(anyList());
+        // The store is down, so the per-entry retry the ledger falls back to
+        // refuses as well; only then is the batch re-offered to the queue.
+        doThrow(new RuntimeException("store down")).when(auditStore).appendEntry(any());
 
         svc.submit(entry("id-1", "conv-1", "agent-1")); // sequence 0
         svc.submit(entry("id-2", "conv-1", "agent-1")); // sequence 1
@@ -595,7 +899,7 @@ class AuditLedgerServiceTest {
         when(auditStore.supportsSequence()).thenReturn(true);
         when(auditStore.countByConversation("conv-1")).thenReturn(0L);
         service = createService(true, "master-key-1234567890");
-        doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(anyList());
+        storeIsDown();
 
         service.submit(entry("id-1", "conv-1", "agent-1"));
         service.flush(); // failure 1 — requeue
@@ -659,8 +963,13 @@ class AuditLedgerServiceTest {
         assertEquals(0L, written.get(2).sequence(), "a different conversation has its own chain");
     }
 
+    /**
+     * The fallback path: a store that cannot answer {@link IAuditStore#maxSequence}
+     * (it returns {@code UNSEQUENCED}) is seeded from the row count, which is what
+     * the ledger did for every store before finding 03.
+     */
     @Test
-    @DisplayName("the sequence continues from what is already stored")
+    @DisplayName("the sequence continues from the row count when the store cannot report a max")
     void sequenceIsSeededFromTheStore() {
         when(auditStore.supportsSequence()).thenReturn(true);
         when(auditStore.countByConversation("conv-a")).thenReturn(7L);
@@ -674,6 +983,35 @@ class AuditLedgerServiceTest {
         @SuppressWarnings("unchecked")
         List<AuditEntry> written = captor.getValue();
         assertEquals(7L, written.getFirst().sequence());
+    }
+
+    /**
+     * Finding 03. {@code countByConversation} counts rows that landed, which stops
+     * matching the next free position the moment one was handed out and never
+     * stored. Sequences 0-9 issued with 3 and 5 dead-lettered leaves a count of 8
+     * while the next free position is 10 — so a restart (or a second cluster node)
+     * seeded from the count re-issues 8 and 9, and {@code /auditstore/verify}
+     * grades a duplicate exactly like a deletion: {@code BROKEN}. Seeding from
+     * {@code max + 1} cannot do that, and unlike the in-memory "undelivered" pin it
+     * survives the process.
+     */
+    @Test
+    @DisplayName("the sequence is seeded from max+1, so a dead-lettered gap is never re-issued")
+    void sequenceIsSeededFromMaxNotCount() {
+        when(auditStore.supportsSequence()).thenReturn(true);
+        when(auditStore.countByConversation("conv-a")).thenReturn(8L); // 3 and 5 never landed
+        when(auditStore.maxSequence("conv-a")).thenReturn(9L);
+        service = createService(true, "master-key-1234567890");
+
+        service.submit(entry("id-1", "conv-a", "agent-1"));
+        service.flush();
+
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(auditStore).appendBatch(captor.capture());
+        @SuppressWarnings("unchecked")
+        List<AuditEntry> written = captor.getValue();
+        assertEquals(10L, written.getFirst().sequence(),
+                "the chain must resume past the highest stored position, not at the row count");
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditLedgerServiceTest.java
@@ -7,17 +7,29 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -571,6 +583,218 @@ class AuditLedgerServiceTest {
     }
 
     /**
+     * Running out of the per-entry time budget is not a store failure.
+     * <p>
+     * The budget bounds how long one flush may spend on the per-entry fallback, and
+     * it has to: an unreachable store costs a connection-acquisition timeout per
+     * call, on the monitor the {@code @PreDestroy} final flush waits on. But the
+     * abandoned tail came back as "unstorable" regardless of whether anything had
+     * actually been refused, so it incremented {@code consecutiveFailures} exactly
+     * like a refusal — and a store that was merely SLOW (a large backlog at a few
+     * ms per insert) had its still-unoffered backlog dead-lettered on the third
+     * flush and counted on {@code eddi_audit_entries_dropped_total}, while it had
+     * accepted every single entry it was handed.
+     * <p>
+     * The two earlier flushes here put the failure counter at 2 — the interesting
+     * boundary — so the assertion is about what the third one does when the store
+     * has started accepting again, slowly.
+     */
+    @Test
+    @DisplayName("a slow-but-accepting store defers its backlog instead of having it dead-lettered")
+    void budgetExhaustionIsNotCountedAsAStoreFailure() {
+        service = createService(true, null);
+        // The batch path never works, so every flush falls through to the per-entry
+        // pass — the shape of a bulk write that one bad row aborts.
+        doThrow(new RuntimeException("batch aborted")).when(auditStore).appendBatch(anyList());
+        doThrow(new RuntimeException("db error")).when(auditStore).appendEntry(any());
+
+        int submitted = 6;
+        for (int i = 0; i < submitted; i++) {
+            service.submit(entry("id-" + i, "conv-" + i, "agent-1"));
+        }
+
+        service.flush(); // genuine refusals — failure 1
+        service.flush(); // genuine refusals — failure 2
+        assertEquals(submitted, service.getQueueSize(), "two failures re-queue, they do not drop");
+        assertEquals(0.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count());
+
+        // The store recovers, but the first insert is slower than the whole budget,
+        // so the pass stores one entry and never gets to offer the rest.
+        var firstCall = new AtomicBoolean(true);
+        doAnswer(invocation -> {
+            if (firstCall.compareAndSet(true, false)) {
+                Thread.sleep(AuditLedgerService.ENTRY_RETRY_BUDGET.toMillis() + 300);
+            }
+            return null;
+        }).when(auditStore).appendEntry(any());
+
+        service.flush(); // third flush — with the bug, this dead-letters the tail
+
+        assertEquals(0.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "nothing was refused in this pass, so nothing may be dropped — the store took what it was offered");
+        assertEquals(submitted - 1, service.getQueueSize(),
+                "the entries the budget never reached must come back for the next flush");
+        verify(auditStore, times(AuditLedgerService.MAX_CONSECUTIVE_ENTRY_FAILURES * 2 + 1)).appendEntry(any());
+    }
+
+    /**
+     * The operator-facing half of the same boundary.
+     * <p>
+     * Refusing and running out of wall clock are not alternatives: a pass may
+     * refuse one or two entries — below {@code MAX_CONSECUTIVE_ENTRY_FAILURES}, so
+     * it keeps going — and only then hit the deadline. The message opened with
+     * "accepted what it was offered" in that case too, which reads as an all-clear
+     * about the store while the same flush is handing those refusals to
+     * {@code handlePersistentFailures}. Whoever is watching the ledger during an
+     * incident has to be told the refusals happened, and that the two groups leave
+     * by different doors.
+     */
+    @Test
+    @DisplayName("the budget-exhaustion log names the refusals that happened in the same pass")
+    void budgetExhaustionMessageDoesNotHideRefusals() {
+        String withRefusals = AuditLedgerService.budgetExhaustedMessage(2, 7);
+
+        assertFalse(withRefusals.contains("accepted what it was offered"),
+                "two entries were refused in this very pass — claiming the store took everything sends the operator "
+                        + "past the rows the same flush is about to re-queue or dead-letter");
+        assertTrue(withRefusals.contains("refused 2"), "the refusal count must be in the message: " + withRefusals);
+        assertTrue(withRefusals.contains("7"), "the deferred tail is still worth naming: " + withRefusals);
+
+        // The clean case keeps its wording — it is accurate there, and it is what the
+        // slow-but-healthy store diagnosis depends on.
+        String clean = AuditLedgerService.budgetExhaustedMessage(0, 7);
+        assertTrue(clean.contains("accepted what it was offered"), clean);
+        assertTrue(clean.contains("7"), clean);
+    }
+
+    /**
+     * The classification the log sentence has to agree with.
+     * <p>
+     * A deferral promises "the next flush takes these". Three stop conditions
+     * cannot keep that promise and must abandon the tail to
+     * {@code handlePersistentFailures} instead, each with its own sentence: a
+     * refusing store, a SIGTERM landing mid-pass (there is no next flush at all —
+     * the message used to say "(shutdown started) — deferring ... to the next
+     * flush", twelve lines below a comment stating that during shutdown there is no
+     * next flush), and a budget that expired against a store which had accepted
+     * nothing. Only the last of the four — the store took something, it is merely
+     * slow — defers.
+     */
+    @Test
+    @DisplayName("the abandoned-tail classification defers only a store that has actually stored something")
+    void abandonedTailIsClassifiedByWhatThePassObserved() {
+        // Refusing store: the failure cap fired.
+        String refusing = AuditLedgerService.abandonedTailReason(true, false, 0, 3, 7);
+        assertNotNull(refusing, "a refusing store's tail is at the same risk as the refusals — it may not be deferred");
+        assertTrue(refusing.contains("7"), refusing);
+
+        // SIGTERM mid-pass: no next flush exists, so this cannot be a deferral.
+        String shuttingDown = AuditLedgerService.abandonedTailReason(false, true, 4, 0, 7);
+        assertNotNull(shuttingDown, "there is no next flush during shutdown, so the tail must be dead-lettered");
+        assertFalse(shuttingDown.contains("to the next flush"),
+                "the shutdown message must not promise a flush that will never run: " + shuttingDown);
+        assertTrue(shuttingDown.contains("dead-lettered"), shuttingDown);
+
+        // Budget expired and the store had accepted nothing: unavailable, not slow.
+        // Against a store whose per-call timeout exceeds the budget this is the ONLY
+        // signal there is — the failure cap is unreachable because one call spends
+        // the whole budget.
+        String tookNothing = AuditLedgerService.abandonedTailReason(false, false, 0, 1, 5);
+        assertNotNull(tookNothing,
+                "a pass that offered one entry, had it refused and then ran out of clock has met an unreachable store; "
+                        + "deferring its tail circulates the backlog instead of escalating it");
+        assertTrue(tookNothing.contains("5"), tookNothing);
+
+        // The genuinely slow store — it stored something — still defers.
+        assertNull(AuditLedgerService.abandonedTailReason(false, false, 1, 0, 7),
+                "a store that accepted an entry in this pass is slow, not down: its unoffered tail has failed at nothing");
+        assertNull(AuditLedgerService.abandonedTailReason(false, false, 1, 2, 7),
+                "one poison row does not make a store that is still accepting unavailable");
+        assertNull(AuditLedgerService.abandonedTailReason(false, false, 0, 0, 7),
+                "a pass that offered nothing at all has observed nothing to escalate on");
+    }
+
+    /**
+     * The store shape {@code ENTRY_RETRY_BUDGET}'s own Javadoc names, driven end to
+     * end: unreachable rather than refusing, so every call costs a full
+     * connection-acquisition timeout (Agroal's default is 5s) before it throws.
+     * <p>
+     * {@code MAX_CONSECUTIVE_ENTRY_FAILURES} is unreachable against it — the first
+     * call spends the entire 2s budget, so the pass stops at the second entry with
+     * a failure count of 1. Classifying that tail as merely "deferred" put it
+     * straight back on the queue every flush while only the single refused entry
+     * advanced {@code consecutiveFailures}: exactly one entry reached the sink per
+     * three flushes, the rest circulated forever, every flush held the
+     * {@code synchronized flush()} monitor for a full acquisition timeout, and once
+     * the queue reached {@code eddi.audit.max-queue-size} every entry submitted in
+     * between was discarded at {@code submit()} with a dropped-counter tick and no
+     * dead-letter record — unattributable loss in the evidence store, which the
+     * chain verifier grades {@code BROKEN}. The whole-batch retry it replaced
+     * dead-lettered the abandoned tail on the third flush, so that classification
+     * was a regression against both the previous code and the queue bound.
+     */
+    @Test
+    @DisplayName("a store whose calls outlast the budget escalates its whole backlog, instead of circulating it forever")
+    void aStoreSlowerThanTheBudgetStillEscalatesItsBacklog(@TempDir Path tempDir) {
+        // A sequenced store, so the abandoned positions are recorded in
+        // `undelivered` — the only in-process proof that writeToDeadLetter ran.
+        when(auditStore.supportsSequence()).thenReturn(true);
+        Path sink = tempDir.resolve("eddi-audit-deadletter.jsonl");
+        service = AuditLedgerService.createForTesting(auditStore, true, 60, null, meterRegistry,
+                AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE, sink.toString());
+        service.init();
+
+        doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(anyList());
+        doAnswer(invocation -> {
+            // One connection-acquisition timeout, scaled down but still longer than
+            // the whole per-entry budget — which is the entire point of this shape.
+            Thread.sleep(AuditLedgerService.ENTRY_RETRY_BUDGET.toMillis() + 300);
+            throw new RuntimeException("db unreachable");
+        }).when(auditStore).appendEntry(any());
+
+        int submitted = 6;
+        for (int i = 0; i < submitted; i++) {
+            service.submit(entry("id-" + i, "conv1", "agent-1"));
+        }
+
+        service.flush(); // failure 1
+        service.flush(); // failure 2
+        service.flush(); // failure 3 — MAX_FLUSH_RETRIES, so the sink
+
+        assertEquals(0, service.getQueueSize(),
+                "after MAX_FLUSH_RETRIES against an unreachable store the backlog belongs in the sink, not back on a "
+                        + "queue that will drop later submissions unrecorded once it fills");
+        assertEquals((double) submitted, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "every abandoned entry must be counted, not just the one the pass got as far as offering");
+        assertEquals(submitted, service.undeliveredSequences("conv1").size(),
+                "and every abandoned chain position must be attributable — an unrecorded gap is graded BROKEN, "
+                        + "which accuses the deployment of deleting rows the ledger itself never wrote");
+        // The budget did its other job: one call per flush, not one per entry.
+        verify(auditStore, times(3)).appendEntry(any());
+    }
+
+    /**
+     * The other half of the same boundary: a store that is genuinely refusing must
+     * still escalate to the dead letter, or the bound above would turn every outage
+     * into an unbounded re-queue loop.
+     */
+    @Test
+    @DisplayName("genuine refusals still reach the dead letter after MAX_FLUSH_RETRIES")
+    void refusalsStillEscalate() {
+        service = createService(true, null);
+        storeIsDown();
+
+        service.submit(entry("1", "conv1", "agent1"));
+        service.flush();
+        service.flush();
+        service.flush();
+
+        assertEquals(0, service.getQueueSize());
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "a store that refuses is still declared unavailable on the third flush");
+    }
+
+    /**
      * An entry submitted while the final flush is draining the queue is still
      * perfectly storable, but nothing scheduled will ever pick it up. Recording it
      * as dropped without offering it to a healthy store once more turns a clean
@@ -964,6 +1188,146 @@ class AuditLedgerServiceTest {
     }
 
     /**
+     * A SIGTERM landing while a per-entry pass is already running.
+     * <p>
+     * {@code shuttingDown} is re-read on every iteration precisely because a
+     * scheduled flush can be inside this loop when the signal arrives, holding the
+     * monitor the {@code @PreDestroy} final flush waits on. Against a store that is
+     * unreachable rather than refusing, every further call costs a full
+     * connection-acquisition timeout — {@code shutdown()} then runs two flushes
+     * around a 5s await before the queue drain, and the shipped Kubernetes
+     * manifests give it 30s, so the pod was SIGKILLed inside this loop and the
+     * drain never ran. Stopping mid-pass and dead-lettering the rest is what keeps
+     * the shutdown inside its grace period; the sink carries the full entry, so
+     * nothing the store would have taken is lost.
+     * <p>
+     * The flag is set from inside the store call rather than by calling
+     * {@code shutdown()}, which would deadlock on the very monitor {@code flush()}
+     * holds — this reproduces the interleaving deterministically instead of racing
+     * for it.
+     */
+    @Test
+    @DisplayName("a SIGTERM mid-pass stops offering entries and dead-letters the batch, instead of timing out per entry")
+    void aShutdownArrivingMidPassAbandonsTheRestOfTheBatch(@TempDir Path tempDir) throws Exception {
+        when(auditStore.supportsSequence()).thenReturn(true);
+        Path sink = tempDir.resolve("eddi-audit-deadletter.jsonl");
+        service = AuditLedgerService.createForTesting(auditStore, true, 60, null, meterRegistry,
+                AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE, sink.toString());
+        service.init();
+
+        var shuttingDown = AuditLedgerService.class.getDeclaredField("shuttingDown");
+        shuttingDown.setAccessible(true);
+
+        doThrow(new RuntimeException("batch aborted")).when(auditStore).appendBatch(anyList());
+        var firstCall = new AtomicBoolean(true);
+        doAnswer(invocation -> {
+            if (firstCall.compareAndSet(true, false)) {
+                shuttingDown.setBoolean(service, true); // the signal lands here
+            }
+            throw new RuntimeException("db unreachable");
+        }).when(auditStore).appendEntry(any());
+
+        for (int i = 0; i < 5; i++) {
+            service.submit(entry("id-" + i, "conv1", "agent-1"));
+        }
+
+        service.flush();
+
+        verify(auditStore, times(1)).appendEntry(any());
+        assertEquals(0, service.getQueueSize(),
+                "there is no next flush to defer to, so nothing may be re-queued");
+        assertEquals(5.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "every entry of the batch is accounted for, including the four never offered");
+        String sinkContents = Files.readString(sink);
+        for (int i = 0; i < 5; i++) {
+            assertTrue(sinkContents.contains("\"id\":\"id-" + i + "\""),
+                    "entry id-" + i + " must be recoverable from the sink: " + sinkContents);
+        }
+        assertEquals(5, service.undeliveredSequences("conv1").size(),
+                "and every abandoned chain position must be attributable, or the gap is graded BROKEN");
+    }
+
+    /**
+     * A compliance or oversight entry has no conversation, and an entry submitted
+     * with a blank one is the same case: there is no chain to join. Neither may
+     * cost a store round trip in the pre-warm, and neither may be handed a position
+     * — the sequence is part of the signed payload, so a store that drops it would
+     * make every such row read as tampered.
+     */
+    @Test
+    @DisplayName("an entry with no conversation is neither pre-warmed nor sequenced")
+    void anEntryWithoutAConversationIsNeverSequenced() {
+        when(auditStore.supportsSequence()).thenReturn(true);
+        service = createService(true, "master-key-1234567890");
+
+        service.submit(entry("id-1", "   ", "agent-1"));
+        service.submit(entry("id-2", null, "agent-1"));
+        service.flush();
+
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(auditStore).appendBatch(captor.capture());
+        @SuppressWarnings("unchecked")
+        List<AuditEntry> written = captor.getValue();
+        assertEquals(2, written.size());
+        assertTrue(written.stream().allMatch(e -> e.sequence() == AuditEntry.UNSEQUENCED),
+                "a chainless entry signed with a position the store cannot round-trip reads as tampered forever");
+        verify(auditStore, never()).maxSequence(anyString());
+        verify(auditStore, never()).countByConversation(anyString());
+    }
+
+    /**
+     * The interface default, exercised through a real implementation rather than a
+     * Mockito mock — a mock answers 0 for a {@code long} method, which is precisely
+     * the value {@code UNSEQUENCED} exists to be distinguishable from. A store that
+     * does not implement {@code maxSequence} must fall back to the row count; if
+     * the default answered 0 instead, every such chain would be seeded at 1 and its
+     * first position would be skipped forever.
+     */
+    @Test
+    @DisplayName("a store that does not implement maxSequence reports UNSEQUENCED, not position 0")
+    void theMaxSequenceDefaultReportsUnsequenced() {
+        IAuditStore storeWithoutSequenceSupport = new IAuditStore() {
+            @Override
+            public void appendEntry(AuditEntry entry) {
+            }
+
+            @Override
+            public void appendBatch(List<AuditEntry> entries) {
+            }
+
+            @Override
+            public List<AuditEntry> getEntries(String conversationId, int skip, int limit) {
+                return List.of();
+            }
+
+            @Override
+            public List<AuditEntry> getEntriesByAgent(String agentId, Integer agentVersion, int skip, int limit) {
+                return List.of();
+            }
+
+            @Override
+            public long countByConversation(String conversationId) {
+                return 0;
+            }
+
+            @Override
+            public List<AuditEntry> getEntriesByUserId(String userId, int skip, int limit) {
+                return List.of();
+            }
+
+            @Override
+            public long pseudonymizeByUserId(String userId, String pseudonym) {
+                return 0;
+            }
+        };
+
+        assertEquals(AuditEntry.UNSEQUENCED, storeWithoutSequenceSupport.maxSequence("conv-a"),
+                "0 would read as 'position 0 is taken' and silently shift the whole chain");
+        assertFalse(storeWithoutSequenceSupport.supportsSequence(),
+                "and such a store must not be handed sequences at all");
+    }
+
+    /**
      * The fallback path: a store that cannot answer {@link IAuditStore#maxSequence}
      * (it returns {@code UNSEQUENCED}) is seeded from the row count, which is what
      * the ledger did for every store before finding 03.
@@ -1035,6 +1399,171 @@ class AuditLedgerServiceTest {
         verify(auditStore, never()).countByConversation(anyString());
     }
 
+    /**
+     * The pre-warm is an optimisation, not the seed's only chance.
+     * <p>
+     * It exists to move the store round trip off the sequence lock, and it
+     * deliberately swallows a failure — but the entry still has to get a real chain
+     * position, so the assignment path re-seeds inline when the pre-warm left no
+     * counter behind. Losing that fallback would silently downgrade the first entry
+     * of every conversation that raced a store blip to {@code UNSEQUENCED}, and an
+     * unsequenced entry does not participate in the chain the verifier checks.
+     * <p>
+     * Both calls are on the caller's thread and the seed is resolved outside the
+     * {@code computeIfAbsent} mapping function, so a failing pre-warm costs one
+     * extra read and nothing else.
+     */
+    @Test
+    @DisplayName("a pre-warm that fails is retried inline, so the entry still gets its chain position")
+    void aFailedPrewarmIsRecoveredByTheInlineSeed() {
+        when(auditStore.supportsSequence()).thenReturn(true);
+        when(auditStore.maxSequence("conv-a"))
+                .thenThrow(new RuntimeException("connection reset"))
+                .thenReturn(4L);
+        service = createService(true, "master-key-1234567890");
+
+        service.submit(entry("id-1", "conv-a", "agent-1"));
+        // Asserted before the flush on purpose: the flush does a maxSequence read of
+        // its own to detect a second replica allocating for this conversation, and
+        // the two reads asserted here are the failed pre-warm and the inline retry.
+        verify(auditStore, times(2)).maxSequence("conv-a");
+
+        service.flush();
+
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(auditStore).appendBatch(captor.capture());
+        @SuppressWarnings("unchecked")
+        List<AuditEntry> written = captor.getValue();
+        assertEquals(5L, written.getFirst().sequence(),
+                "the inline seed must resume from max+1 exactly as the pre-warm would have");
+    }
+
+    /**
+     * Sequence allocation is not cluster-safe — seeding reads {@code MAX(sequence)}
+     * instead of atomically reserving a position, so a multi-replica deployment
+     * without conversation affinity produces duplicate positions and
+     * {@code /auditstore/verify} grades those conversations {@code BROKEN}. The
+     * atomic allocator that would remove the limitation is deliberately deferred
+     * (see {@code IAuditStore.maxSequence}), so the condition must at least be
+     * <em>operationally detectable</em> rather than silent until verify time.
+     * <p>
+     * Here this node seeds from an empty store and hands out position 0, so its
+     * next free position is 1 — but once the batch has landed the store reports 4.
+     * Positions 1-4 were written by another replica serving the same conversation,
+     * so every position this node still has to hand out is already taken.
+     */
+    @Test
+    @DisplayName("a chain position allocated by another replica is warned about and counted")
+    void aForeignChainPositionIsDetectedAndCounted() {
+        when(auditStore.supportsSequence()).thenReturn(true);
+        when(auditStore.maxSequence("conv-a"))
+                .thenReturn(AuditEntry.UNSEQUENCED)
+                .thenReturn(4L);
+        service = createService(true, "master-key-1234567890");
+
+        service.submit(entry("id-1", "conv-a", "agent-1"));
+        service.flush();
+
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_sequence_collisions_total").count(),
+                "an operator running multi-replica without conversation affinity has to see this in metrics, "
+                        + "not discover it as a BROKEN verdict at verify time");
+
+        // And the chain continues past the foreign rows rather than re-issuing
+        // positions that are already taken.
+        service.submit(entry("id-2", "conv-a", "agent-1"));
+        service.flush();
+
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(auditStore, times(2)).appendBatch(captor.capture());
+        @SuppressWarnings("unchecked")
+        List<AuditEntry> secondBatch = (List<AuditEntry>) captor.getValue();
+        assertEquals(5L, secondBatch.getFirst().sequence(),
+                "the next entry must resume above the foreign rows, not duplicate them");
+    }
+
+    /**
+     * The other half: the detector must stay silent for the deployment everyone
+     * actually runs. A single writer's own rows are always at or below the position
+     * it last handed out, so the healthy path never touches the counter — a
+     * detector that cried wolf every flush would be worse than none.
+     */
+    @Test
+    @DisplayName("a node's own stored rows are not reported as a foreign chain position")
+    void theSingleWriterPathReportsNoCollision() {
+        when(auditStore.supportsSequence()).thenReturn(true);
+        // Empty at seed time; afterwards the store holds exactly the position this
+        // node just wrote.
+        when(auditStore.maxSequence("conv-a"))
+                .thenReturn(AuditEntry.UNSEQUENCED)
+                .thenReturn(0L);
+        service = createService(true, "master-key-1234567890");
+
+        service.submit(entry("id-1", "conv-a", "agent-1"));
+        service.flush();
+
+        assertEquals(0.0, meterRegistry.counter("eddi_audit_sequence_collisions_total").count(),
+                "the rows this node wrote itself are not evidence of a second writer");
+    }
+
+    /**
+     * Deferral is a promise that the next flush will take these entries, and the
+     * bounded queue can break that promise.
+     * <p>
+     * A pass that runs out of wall clock hands its unoffered tail back to the queue
+     * — correct, because the store accepted everything it was actually offered. But
+     * the queue has a bound, and turns submitted while the flush was blocked can
+     * have taken the space back. An entry that does not fit has already consumed
+     * its chain position, so dropping it silently leaves a gap that
+     * {@code /auditstore/verify} grades exactly like a deletion. It has to reach
+     * the dead-letter sink instead, which is the one place abandoned evidence is
+     * recoverable and attributable from.
+     * <p>
+     * The sleep is what makes the outcome certain rather than uncertain: after
+     * blocking for longer than the whole budget the deadline has provably passed,
+     * so the pass provably defers. Same shape as
+     * {@code aStoreSlowerThanTheBudgetStillEscalatesItsBacklog}, which is the only
+     * seam the budget offers.
+     */
+    @Test
+    @DisplayName("a deferred entry that no longer fits on the queue is dead-lettered, not dropped")
+    void aDeferredEntryThatDoesNotFitReachesTheSink(@TempDir Path tempDir) throws IOException {
+        when(auditStore.supportsSequence()).thenReturn(true);
+        Path sink = tempDir.resolve("eddi-audit-deadletter.jsonl");
+        // A queue of exactly 2, so refilling it during the flush leaves the deferred
+        // entry nowhere to go.
+        service = AuditLedgerService.createForTesting(auditStore, true, 60, null, meterRegistry, 2, sink.toString());
+        service.init();
+
+        doThrow(new RuntimeException("batch aborted")).when(auditStore).appendBatch(anyList());
+        var firstCall = new AtomicBoolean(true);
+        doAnswer(invocation -> {
+            if (firstCall.compareAndSet(true, false)) {
+                // Two turns land while the writer is blocked on this insert and refill
+                // the queue the flush had just drained.
+                service.submit(entry("id-2", "conv1", "agent-1"));
+                service.submit(entry("id-3", "conv1", "agent-1"));
+                Thread.sleep(AuditLedgerService.ENTRY_RETRY_BUDGET.toMillis() + 250);
+            }
+            return null;
+        }).when(auditStore).appendEntry(any());
+
+        service.submit(entry("id-0", "conv1", "agent-1"));
+        service.submit(entry("id-1", "conv1", "agent-1"));
+
+        service.flush();
+
+        assertEquals(2, service.getQueueSize(), "the two turns that arrived mid-flush keep their slots");
+        assertTrue(service.undeliveredSequences("conv1").contains(1L),
+                "the deferred entry's chain position must be recorded as undelivered, or its gap is graded BROKEN");
+        assertEquals(1.0, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "exactly the one entry that did not fit is counted — the store accepted what it was offered");
+        String sinkContents = Files.readString(sink);
+        assertTrue(sinkContents.contains("\"id\":\"id-1\""),
+                "the abandoned entry has to be recoverable from the sink, not merely counted: " + sinkContents);
+        assertFalse(sinkContents.contains("\"id\":\"id-0\""),
+                "the entry the store accepted must not also be dead-lettered");
+    }
+
     @Test
     @DisplayName("a signed entry verifies through the service")
     void signedEntryVerifies() {
@@ -1077,5 +1606,355 @@ class AuditLedgerServiceTest {
 
         AuditEntry pseudonymised = stored.withUserId(AuditHmac.pseudonymFor("user1"));
         assertEquals(AuditVerificationStatus.VALID, service.verifyEntry(pseudonymised));
+    }
+
+    // ==================== shutdown budget (finding r1) ====================
+
+    /**
+     * The per-entry retry must not run during shutdown.
+     * <p>
+     * {@code shutdown()} runs two flushes around a 5s {@code awaitTermination}
+     * before {@code drainQueueToDeadLetter}, and the shipped Kubernetes manifests
+     * set {@code terminationGracePeriodSeconds: 30}. With the per-entry pass
+     * calling an unreachable store once per entry — each call costing a
+     * connection-acquisition timeout rather than a prompt refusal — a rolling
+     * deploy during a database failover was SIGKILLed inside this loop, so the
+     * drain that finding 06 added never ran and every queued entry was lost with
+     * neither a dead-letter record nor a dropped-counter increment. That is the
+     * exact scenario the drain exists for.
+     * <p>
+     * There is nothing left to protect at that point: a failure after
+     * {@code shutdown()} has begun has no later attempt, so the entries belong in
+     * the sink immediately. The store here refuses the batch instantly and blocks
+     * on every single-entry call — which is how an unreachable store behaves, and
+     * how a mock that fails instantly does not.
+     */
+    @Test
+    @DisplayName("shutdown — the per-entry retry does not run, so a blocking store cannot outlast the grace period")
+    void shutdownDoesNotRetryEntryByEntryAgainstABlockingStore() {
+        service = createService(true, null);
+        doThrow(new RuntimeException("db error")).when(auditStore).appendBatch(anyList());
+        doAnswer(invocation -> {
+            // One connection-acquisition timeout, scaled down so the test is quick.
+            Thread.sleep(400);
+            throw new RuntimeException("db unreachable");
+        }).when(auditStore).appendEntry(any());
+
+        int submitted = AuditLedgerService.MAX_CONSECUTIVE_ENTRY_FAILURES + 5;
+        for (int i = 0; i < submitted; i++) {
+            service.submit(entry("id-" + i, "conv-" + i, "agent-1"));
+        }
+
+        long startedAt = System.nanoTime();
+        service.shutdown();
+        long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000;
+
+        verify(auditStore, never()).appendEntry(any());
+        assertTrue(elapsedMs < 1_000,
+                "shutdown must not spend its grace period retrying a dead store one entry at a time, took " + elapsedMs + "ms");
+        assertEquals(0, service.getQueueSize(), "nothing may be left in a queue that will never be drained");
+        assertEquals((double) submitted, meterRegistry.counter("eddi_audit_entries_dropped_total").count(),
+                "every abandoned entry must be counted and dead-lettered, not left to the SIGKILL");
+    }
+
+    // ==================== dead-letter sink probe (finding r8) ====================
+
+    /**
+     * Finding 26 asked for the sink's unavailability to be discovered at startup
+     * rather than during the incident that needs it. Checking that the directory
+     * <em>exists</em> does not do that: a root-owned mount, a
+     * {@code readOnlyRootFilesystem} pod with no volume at the path, and a
+     * {@code dead-letter-path} that names a directory all pass an existence check
+     * and then fail at {@code Files.write} into the same swallowed catch. So the
+     * check now performs the operation it is checking for.
+     */
+    @Test
+    @DisplayName("startup check — a sink path that cannot be written is reported, not merely resolved")
+    void deadLetterSinkCheckReportsAPathThatCannotBeWritten(@TempDir Path tempDir) throws IOException {
+        // The classic misconfiguration: the path names an existing directory. Its
+        // parent exists and is writable, so an existence check sees nothing wrong.
+        Path sinkThatIsADirectory = Files.createDirectory(tempDir.resolve("eddi-audit-deadletter.jsonl"));
+
+        var svc = AuditLedgerService.createForTesting(auditStore, true, 60, null, meterRegistry,
+                AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE, sinkThatIsADirectory.toString());
+
+        assertTrue(Files.isDirectory(sinkThatIsADirectory.getParent()), "precondition: the parent directory exists");
+        assertFalse(svc.checkDeadLetterSinkReachable(),
+                "an unwritable sink must be reported at startup, not discovered during the incident");
+    }
+
+    @Test
+    @DisplayName("startup check — a writable sink passes and leaves no empty probe file behind")
+    void deadLetterSinkCheckLeavesNoProbeFile(@TempDir Path tempDir) {
+        Path sink = tempDir.resolve("nested").resolve("eddi-audit-deadletter.jsonl");
+
+        var svc = AuditLedgerService.createForTesting(auditStore, true, 60, null, meterRegistry,
+                AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE, sink.toString());
+
+        assertTrue(svc.checkDeadLetterSinkReachable());
+        assertTrue(Files.isDirectory(sink.getParent()), "the check creates the directory it needs");
+        assertFalse(Files.exists(sink), "an empty dead-letter file reads as an incident to anyone watching for one");
+    }
+
+    /**
+     * Finding f2-03. "Delete the file only if the probe created it" has to fail in
+     * one direction only, and {@code Files.exists} does not: it answers false both
+     * for a missing file and for any I/O error while reading attributes. Where the
+     * stat fails but the append-open succeeds — a Windows ACL granting
+     * {@code FILE_APPEND_DATA} without {@code FILE_READ_ATTRIBUTES}, a transient
+     * failure on a network mount — the probe deleted a real dead-letter file, which
+     * is the one place abandoned audit evidence is recoverable from.
+     */
+    @Test
+    @DisplayName("startup check — an existing dead-letter file survives a stat the filesystem cannot answer")
+    void deadLetterSinkCheckKeepsAFileWhoseExistenceCannotBeDetermined(@TempDir Path tempDir) throws IOException {
+        Path sink = tempDir.resolve("eddi-audit-deadletter.jsonl");
+        String abandoned = "{\"id\":\"abandoned-1\"}\n";
+        Files.writeString(sink, abandoned);
+
+        var svc = AuditLedgerService.createForTesting(auditStore, true, 60, null, meterRegistry,
+                AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE, sink.toString());
+
+        try (MockedStatic<Files> files = mockStatic(Files.class, CALLS_REAL_METHODS)) {
+            // Exactly what an unanswerable stat looks like from the caller's side:
+            // BOTH answers are false, because neither can be proven. Stubbing only
+            // exists() would pin "the probe does not call Files.exists" rather than
+            // the behaviour named above, and would go green again if the guard were
+            // rewritten around some other predicate that also collapses on error.
+            files.when(() -> Files.exists(any(Path.class))).thenReturn(false);
+            files.when(() -> Files.notExists(any(Path.class))).thenReturn(false);
+
+            assertTrue(svc.checkDeadLetterSinkReachable(),
+                    "the append-open still succeeds, so the sink really is usable");
+        }
+
+        assertTrue(Files.exists(sink),
+                "an undeterminable stat must never be read as 'the probe created this file'");
+        assertEquals(abandoned, Files.readString(sink), "and the abandoned entries must still be there");
+    }
+
+    // ==================== a sink path with no parent directory
+    // ====================
+
+    /**
+     * Both places that touch the sink guard {@code getParent()} against null, and
+     * null is not an impossible state: it is exactly what
+     * {@code eddi.audit.dead-letter-path} produces when an operator points it at a
+     * filesystem root — {@code "/"} in a container, {@code "C:\"} on a developer
+     * machine — which is an ordinary fat-fingered config value, not a state the
+     * runtime cannot reach.
+     * <p>
+     * What the guard buys is <em>which failure gets reported</em>. The verdict is
+     * false either way, because an unguarded {@code Files.isDirectory(null)} throws
+     * into the same catch that the append-open's own failure lands in, so
+     * {@code assertFalse} on its own passes with the guard deleted. The difference
+     * is the sentence: with the guard the operator is handed the filesystem's
+     * answer about the path they configured, and without it they are handed a null
+     * dereference inside EDDI — a bug report instead of a fix.
+     */
+    @Test
+    @DisplayName("startup check — a sink path with no parent reports what the filesystem said, not a null dereference")
+    void deadLetterSinkCheckReportsTheFilesystemsAnswerForAPathWithNoParent() {
+        String root = Path.of("/").toAbsolutePath().toString();
+        assertNull(Path.of(root).toAbsolutePath().getParent(),
+                "precondition: a filesystem root has no parent directory to create");
+
+        var svc = AuditLedgerService.createForTesting(auditStore, true, 60, null, meterRegistry,
+                AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE, root);
+
+        var reported = new ArrayList<String>();
+        boolean reachable = withLedgerLogCaptured(reported, svc::checkDeadLetterSinkReachable);
+
+        assertFalse(reachable, "a directory cannot be opened for append, so the sink is not usable");
+        assertEquals(1, reported.size(), "one verdict, one line: " + reported);
+        // The line carries the path twice: once as the sink that was checked, and
+        // once as the reason, because the filesystem's exception for a refused open
+        // names the file it refused. An unguarded Files.isDirectory(null) throws
+        // before the open is ever attempted, so the reason becomes a null-dereference
+        // message from inside EDDI and the path appears exactly once.
+        assertEquals(2, occurrencesOf(root, reported.getFirst()),
+                "the reason has to be the filesystem's own answer about the configured path — a null dereference "
+                        + "inside the probe tells the operator to file a bug instead of fixing the path; saw: " + reported);
+    }
+
+    /**
+     * The same null parent on the write path, reached the way an operator reaches
+     * it: the store is down, the batch is abandoned, and the sink it is abandoned
+     * to cannot be written either.
+     * <p>
+     * Two things have to survive that. The ledger's own account of what it dropped
+     * — {@code undeliveredSequences} is what keeps a self-inflicted gap graded
+     * {@code INCOMPLETE} rather than {@code BROKEN} — is recorded before the write
+     * is attempted and must not be lost with it. And the error line has to name the
+     * sink the filesystem refused, not a null dereference from
+     * {@code Files.createDirectories(null)}: this line is the operator's only
+     * notice that audit evidence was lost outright.
+     */
+    @Test
+    @DisplayName("dead-letter write — a sink path with no parent still records the gap and names the sink that refused")
+    void deadLetterWriteReportsTheFilesystemsAnswerForAPathWithNoParent() {
+        when(auditStore.supportsSequence()).thenReturn(true);
+        when(auditStore.countByConversation("conv-1")).thenReturn(0L);
+        String root = Path.of("/").toAbsolutePath().toString();
+
+        var svc = AuditLedgerService.createForTesting(auditStore, true, 60, null, meterRegistry,
+                AuditLedgerService.DEFAULT_MAX_QUEUE_SIZE, root);
+        svc.init();
+        storeIsDown();
+
+        svc.submit(entry("id-1", "conv-1", "agent-1")); // sequence 0
+
+        var reported = new ArrayList<String>();
+        withLedgerLogCaptured(reported, () -> {
+            svc.flush(); // failure 1 — requeue
+            svc.flush(); // failure 2 — requeue
+            svc.flush(); // failure 3 — dead-letter
+            return null;
+        });
+
+        assertEquals(0, svc.getQueueSize(), "the batch was abandoned, not left on the queue");
+        assertEquals(Set.of(0L), svc.undeliveredSequences("conv-1"),
+                "an unwritable sink must not also cost the ledger its record of which position it dropped");
+
+        String failure = reported.stream().filter(line -> line.contains("Failed to write to dead-letter log"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("the one notice that evidence was lost outright: " + reported));
+        // The only argument this line carries is the failure's own message, and the
+        // filesystem's exception for a refused write names the file. A null
+        // dereference from createDirectories(null) names nothing the operator can act
+        // on, so the path is absent altogether.
+        assertEquals(1, occurrencesOf(root, failure),
+                "the operator has to be told which sink the filesystem refused; a null dereference from "
+                        + "createDirectories(null) names nothing they can act on; saw: " + failure);
+    }
+
+    /** How many times {@code needle} occurs in {@code haystack}. */
+    private static int occurrencesOf(String needle, String haystack) {
+        int count = 0;
+        for (int at = haystack.indexOf(needle); at >= 0; at = haystack.indexOf(needle, at + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * Runs {@code action} with a handler attached to {@link AuditLedgerService}'s
+     * logger, collecting every WARN and ERROR into {@code records}.
+     * <p>
+     * {@code src/test/resources/logging.properties} silences the whole
+     * {@code ai.labs.eddi} namespace, so the level is raised for the duration and
+     * the parent handlers are detached — which also keeps the deliberately alarming
+     * lines out of the surefire output. Everything is put back afterwards: the
+     * logger is process-wide.
+     */
+    private <T> T withLedgerLogCaptured(List<String> records, Supplier<T> action) {
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+                    // Kept whole: whether the backend pre-formats a printf/MessageFormat
+                    // call or leaves the arguments beside the pattern is a property of
+                    // the JBoss Logging backend on the classpath, not of what was logged.
+                    records.add(record.getMessage() + " " + Arrays.toString(record.getParameters()));
+                }
+            }
+
+            @Override
+            public void flush() {
+                // nothing is buffered
+            }
+
+            @Override
+            public void close() {
+                // nothing to release
+            }
+        };
+        Logger ledgerLogger = Logger.getLogger(AuditLedgerService.class.getName());
+        Level previousLevel = ledgerLogger.getLevel();
+        boolean previousUseParentHandlers = ledgerLogger.getUseParentHandlers();
+        ledgerLogger.setLevel(Level.ALL);
+        ledgerLogger.setUseParentHandlers(false);
+        ledgerLogger.addHandler(handler);
+        try {
+            return action.get();
+        } finally {
+            ledgerLogger.removeHandler(handler);
+            ledgerLogger.setLevel(previousLevel);
+            ledgerLogger.setUseParentHandlers(previousUseParentHandlers);
+        }
+    }
+
+    // ==================== dead-letter degradation (finding r12)
+    // ====================
+
+    /**
+     * The entry most likely to reach the serialization catch is the one carrying a
+     * payload Jackson cannot render — which is also the one the store most likely
+     * rejected, so it is precisely the entry an operator needs in order to
+     * attribute the chain gap and replay it. Collapsing the whole record to
+     * {@code {"error":"serialization_failed"}} threw away its id, its sequence and
+     * its conversation along with the payload that caused the failure, and a gap
+     * with no attribution is graded {@code BROKEN} rather than {@code INCOMPLETE}.
+     */
+    @Test
+    @DisplayName("serializeDeadLetterEntry — an unserialisable payload degrades to metadata, it does not erase the record")
+    void deadLetterRecordDegradesToMetadataWhenThePayloadCannotBeSerialized() {
+        service = createService(true, null);
+        // normalizeMap deliberately keeps a value it cannot convert "as-is", so an
+        // object Jackson refuses to write really does reach the sink.
+        var e = new AuditEntry("dl-9", "conv-9", "agent-1", 1, "user1", "production",
+                0, "taskId", "LlmTask", 0, 100L,
+                Map.of("payload", new Unserialisable()), null, null, null, List.of("a1"), 0.0,
+                Instant.parse("2026-01-02T03:04:05Z"), "v4:abcdef", "sig-9", 13L);
+
+        String json = service.serializeDeadLetterEntry(e, "audit_dead_letter");
+
+        assertTrue(json.contains("\"id\":\"dl-9\""), json);
+        assertTrue(json.contains("\"sequence\":13"), json);
+        assertTrue(json.contains("\"conversationId\":\"conv-9\""), json);
+        assertTrue(json.contains("\"hmac\":\"v4:abcdef\""), json);
+        assertTrue(json.contains("payloadError"), "the operator has to be told the payload is missing: " + json);
+    }
+
+    /** A bean whose only property throws, so Jackson cannot serialize it. */
+    public static class Unserialisable {
+        public String getBoom() {
+            throw new IllegalStateException("this value cannot be rendered");
+        }
+    }
+
+    // ==================== entry id stamping (finding r13) ====================
+
+    /**
+     * {@code ON CONFLICT (id) DO NOTHING} and MongoDB's tolerated {@code E11000}
+     * are what make the per-entry retry safe, and both key on the entry id. While
+     * the id was minted inside {@code PostgresAuditStore.setEntryParams} instead, a
+     * null-id entry received a different primary key on the batch attempt and on
+     * the retry, so a row the aborted batch had already committed was stored a
+     * second time — and the verifier grades a duplicate sequence exactly like a
+     * deletion.
+     */
+    @Test
+    @DisplayName("submit — a null entry id is stamped once, so a retry cannot store the same entry twice")
+    void aNullEntryIdIsStampedOnceSoARetryCannotDuplicateTheRow() {
+        service = createService(true, null);
+        doThrow(new RuntimeException("batch aborted")).when(auditStore).appendBatch(anyList());
+
+        var withoutId = new AuditEntry(null, "conv-1", "agent-1", 1, "user1", "production",
+                0, "taskId", "LlmTask", 0, 100L, Map.of("text", "hi"), null, null, null,
+                List.of("a1"), 0.0, Instant.now(), null, null);
+        service.submit(withoutId);
+        service.flush(); // the batch fails, the per-entry retry succeeds
+
+        var batched = ArgumentCaptor.forClass(List.class);
+        verify(auditStore).appendBatch(batched.capture());
+        @SuppressWarnings("unchecked")
+        List<AuditEntry> batch = (List<AuditEntry>) batched.getValue();
+        var retried = ArgumentCaptor.forClass(AuditEntry.class);
+        verify(auditStore).appendEntry(retried.capture());
+
+        assertNotNull(batch.getFirst().id(), "the ledger must not hand the store an entry with no conflict key");
+        assertEquals(batch.getFirst().id(), retried.getValue().id(),
+                "batch and retry must present the same id, or ON CONFLICT (id) DO NOTHING stores the entry twice");
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditStoreTest.java
@@ -5,16 +5,26 @@
 package ai.labs.eddi.engine.audit;
 
 import ai.labs.eddi.engine.audit.model.AuditEntry;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
+import com.mongodb.bulk.BulkWriteError;
+import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.result.UpdateResult;
+import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
 import java.util.*;
@@ -49,28 +59,131 @@ class AuditStoreTest {
 
     // ==================== appendBatch ====================
 
+    /**
+     * Unordered, deliberately: an ordered {@code insertMany} persists the prefix
+     * and abandons everything behind the first rejected document, which combined
+     * with the ledger's whole-batch retry meant a single bad entry discarded three
+     * flush windows of unrelated conversations' records.
+     */
     @Test
-    @DisplayName("appendBatch — inserts multiple documents")
+    @DisplayName("appendBatch — inserts multiple documents, unordered")
     void appendBatch() {
         List<AuditEntry> entries = List.of(
                 createEntry("conv-1", "agent-1"),
                 createEntry("conv-2", "agent-2"));
         store.appendBatch(entries);
-        verify(collection).insertMany(anyList());
+
+        var options = ArgumentCaptor.forClass(InsertManyOptions.class);
+        verify(collection).insertMany(anyList(), options.capture());
+        assertFalse(options.getValue().isOrdered(), "one rejected document must not stop the ones behind it");
     }
 
     @Test
     @DisplayName("appendBatch — skips null input")
     void appendBatchNull() {
         store.appendBatch(null);
-        verify(collection, never()).insertMany(anyList());
+        verify(collection, never()).insertMany(anyList(), any(InsertManyOptions.class));
     }
 
     @Test
     @DisplayName("appendBatch — skips empty input")
     void appendBatchEmpty() {
         store.appendBatch(List.of());
-        verify(collection, never()).insertMany(anyList());
+        verify(collection, never()).insertMany(anyList(), any(InsertManyOptions.class));
+    }
+
+    /**
+     * The ledger retries a failed batch entry by entry, and a bulk write is atomic
+     * in neither backend — so the retry necessarily re-offers documents that
+     * already landed. Treating {@code E11000} as success is what makes that
+     * possible; the PostgreSQL insert carries {@code ON CONFLICT (id) DO NOTHING}
+     * for the same reason.
+     */
+    @Test
+    @DisplayName("appendEntry — a duplicate id is accepted, not raised")
+    void appendEntryToleratesDuplicates() {
+        doThrow(writeException(11000)).when(collection).insertOne(any(Document.class));
+        assertDoesNotThrow(() -> store.appendEntry(createEntry("conv-1", "agent-1")));
+    }
+
+    @Test
+    @DisplayName("appendEntry — any other write error still propagates")
+    void appendEntryPropagatesRealFailures() {
+        doThrow(writeException(121)).when(collection).insertOne(any(Document.class));
+        assertThrows(MongoWriteException.class, () -> store.appendEntry(createEntry("conv-1", "agent-1")));
+    }
+
+    @Test
+    @DisplayName("appendBatch — duplicate-key errors are ignored, other errors are not")
+    void appendBatchToleratesDuplicatesOnly() {
+        List<AuditEntry> entries = List.of(createEntry("conv-1", "agent-1"));
+
+        doThrow(bulkWriteException(11000)).when(collection).insertMany(anyList(), any(InsertManyOptions.class));
+        assertDoesNotThrow(() -> store.appendBatch(entries));
+
+        doThrow(bulkWriteException(121)).when(collection).insertMany(anyList(), any(InsertManyOptions.class));
+        assertThrows(MongoBulkWriteException.class, () -> store.appendBatch(entries),
+                "a genuinely broken store must not be hidden behind the duplicate tolerance");
+    }
+
+    /**
+     * Finding 03: a sequence counter has to be seeded from the highest position the
+     * store holds, not from a row count — with a dead-lettered gap the two are
+     * different numbers, and the count re-issues positions already handed out.
+     */
+    @Test
+    @DisplayName("maxSequence — reads the highest stored position, UNSEQUENCED when there is none")
+    void maxSequenceReadsTheHighestPosition() {
+        FindIterable<Document> iterable = mock(FindIterable.class);
+        when(collection.find(any(Document.class))).thenReturn(iterable);
+        when(iterable.sort(any(Bson.class))).thenReturn(iterable);
+        when(iterable.projection(any(Bson.class))).thenReturn(iterable);
+        when(iterable.limit(anyInt())).thenReturn(iterable);
+
+        when(iterable.first()).thenReturn(new Document("sequence", 9L));
+        assertEquals(9L, store.maxSequence("conv-1"));
+
+        when(iterable.first()).thenReturn(null);
+        assertEquals(AuditEntry.UNSEQUENCED, store.maxSequence("conv-1"));
+    }
+
+    /**
+     * GDPR export and erasure both select on {@code userId}, and per-conversation
+     * reads filter on {@code conversationId} and sort by timestamp — the ledger is
+     * the largest never-pruned collection in the system, so both were full scans.
+     * <p>
+     * The third index is the one {@link AuditStore#maxSequence} needs, and it sits
+     * on the submit hot path: seeding a conversation's chain counter now asks for
+     * the highest stored sequence instead of a row count, and without an index that
+     * descending sort is a collection scan on the largest collection in the system
+     * — once per conversation, inline on the pipeline thread.
+     */
+    @Test
+    @DisplayName("the constructor indexes userId, (conversationId, timestamp) and (conversationId, sequence)")
+    void indexesCoverTheGdprAndConversationReads() {
+        var indexes = ArgumentCaptor.forClass(Bson.class);
+        verify(collection, atLeastOnce()).createIndex(indexes.capture());
+        // Indexes.compoundIndex has no useful toString; render the key document.
+        List<String> created = indexes.getAllValues().stream()
+                .map(bson -> bson.toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry()).toJson())
+                .toList();
+
+        assertTrue(created.stream().anyMatch(i -> i.contains("userId")), "GDPR export/erasure scan by userId: " + created);
+        assertTrue(created.stream().anyMatch(i -> i.contains("conversationId") && i.contains("timestamp")),
+                "per-conversation reads filter and sort together: " + created);
+        assertTrue(created.stream().anyMatch(i -> i.contains("conversationId") && i.contains("sequence")),
+                "maxSequence sorts by sequence within a conversation on the submit path: " + created);
+    }
+
+    private static MongoWriteException writeException(int code) {
+        return new MongoWriteException(new WriteError(code, "write error", new BsonDocument()), new ServerAddress(), Set.of());
+    }
+
+    private static MongoBulkWriteException bulkWriteException(int code) {
+        return new MongoBulkWriteException(
+                BulkWriteResult.acknowledged(0, 0, 0, 0, List.of(), List.of()),
+                List.of(new BulkWriteError(code, "write error", new BsonDocument(), 0)),
+                null, new ServerAddress(), Set.of());
     }
 
     // ==================== getEntries ====================

--- a/src/test/java/ai/labs/eddi/engine/audit/AuditStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/AuditStoreTest.java
@@ -12,6 +12,7 @@ import com.mongodb.ServerAddress;
 import com.mongodb.WriteError;
 import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.bulk.WriteConcernError;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
@@ -179,11 +180,62 @@ class AuditStoreTest {
         return new MongoWriteException(new WriteError(code, "write error", new BsonDocument()), new ServerAddress(), Set.of());
     }
 
+    /**
+     * The failover shape: {@code w=majority} could not be acknowledged, so the
+     * driver raises {@code MongoBulkWriteException} with an EMPTY write-error list
+     * and a write-concern error. Filtering only the per-document errors treated
+     * that as success — the ledger cleared its in-flight batch, reset its failure
+     * counter and left the chain counters past positions a rollback could still
+     * erase: no retry, no dead-letter record, no dropped-counter increment, and
+     * {@code /auditstore/verify} reporting the conversation BROKEN later on. The
+     * production connection string sets {@code w=majority}, so this is the ordinary
+     * election shape rather than an exotic one.
+     */
+    @Test
+    @DisplayName("appendBatch — a write-concern failure with no document errors is not success")
+    void appendBatchPropagatesAWriteConcernError() {
+        List<AuditEntry> entries = List.of(createEntry("conv-1", "agent-1"));
+
+        doThrow(writeConcernFailure()).when(collection).insertMany(anyList(), any(InsertManyOptions.class));
+
+        assertThrows(MongoBulkWriteException.class, () -> store.appendBatch(entries),
+                "an unacknowledged batch must not be counted as persisted");
+    }
+
+    /**
+     * And the same shape alongside a tolerated duplicate: the duplicate is not what
+     * makes it safe to swallow.
+     */
+    @Test
+    @DisplayName("appendBatch — a write-concern failure propagates even when the only document error is a duplicate")
+    void appendBatchPropagatesAWriteConcernErrorEvenWithDuplicates() {
+        List<AuditEntry> entries = List.of(createEntry("conv-1", "agent-1"));
+
+        doThrow(new MongoBulkWriteException(
+                BulkWriteResult.acknowledged(0, 0, 0, 0, List.of(), List.of()),
+                List.of(new BulkWriteError(11000, "duplicate key", new BsonDocument(), 0)),
+                writeConcernError(), new ServerAddress(), Set.of()))
+                .when(collection).insertMany(anyList(), any(InsertManyOptions.class));
+
+        assertThrows(MongoBulkWriteException.class, () -> store.appendBatch(entries));
+    }
+
     private static MongoBulkWriteException bulkWriteException(int code) {
         return new MongoBulkWriteException(
                 BulkWriteResult.acknowledged(0, 0, 0, 0, List.of(), List.of()),
                 List.of(new BulkWriteError(code, "write error", new BsonDocument(), 0)),
                 null, new ServerAddress(), Set.of());
+    }
+
+    private static MongoBulkWriteException writeConcernFailure() {
+        return new MongoBulkWriteException(
+                BulkWriteResult.acknowledged(1, 0, 0, 0, List.of(), List.of()),
+                List.of(), writeConcernError(), new ServerAddress(), Set.of());
+    }
+
+    /** 64 is {@code WriteConcernFailed} — what a majority write times out with. */
+    private static WriteConcernError writeConcernError() {
+        return new WriteConcernError(64, "WriteConcernFailed", "waiting for replication timed out", new BsonDocument());
     }
 
     // ==================== getEntries ====================

--- a/src/test/java/ai/labs/eddi/engine/audit/rest/RestAuditStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/audit/rest/RestAuditStoreTest.java
@@ -76,6 +76,35 @@ class RestAuditStoreTest {
         verify(auditStore).getEntriesByAgent("agent-1", 1, 0, 100);
     }
 
+    /**
+     * Finding 08. The read endpoints used to pass the query parameter through
+     * untouched, and the two backends disagree about what an out-of-range value
+     * means: MongoDB reads {@code limit <= 0} as "no limit" and materialises every
+     * audit entry ever written for the scope — millions of rows carrying full
+     * prompts — into one response on the request thread, while PostgreSQL answers a
+     * 500 for a negative {@code LIMIT} or {@code OFFSET}. The verification
+     * endpoints in the same class already clamped for exactly this reason.
+     */
+    @Test
+    @DisplayName("getAuditTrail clamps an unusable limit instead of returning the whole collection")
+    void getAuditTrail_clampsSkipAndLimit() {
+        restAuditStore.getAuditTrail("conv-1", -5, 0);
+        verify(auditStore).getEntries("conv-1", 0, RestAuditStore.DEFAULT_READ_LIMIT);
+
+        restAuditStore.getAuditTrail("conv-1", 0, 10_000);
+        verify(auditStore).getEntries("conv-1", 0, RestAuditStore.MAX_READ_LIMIT);
+    }
+
+    @Test
+    @DisplayName("getAuditTrailByAgent clamps the same way")
+    void getAuditTrailByAgent_clampsSkipAndLimit() {
+        restAuditStore.getAuditTrailByAgent("agent-1", 1, -1, -1);
+        verify(auditStore).getEntriesByAgent("agent-1", 1, 0, RestAuditStore.DEFAULT_READ_LIMIT);
+
+        restAuditStore.getAuditTrailByAgent("agent-1", 1, 0, 999_999);
+        verify(auditStore).getEntriesByAgent("agent-1", 1, 0, RestAuditStore.MAX_READ_LIMIT);
+    }
+
     @Test
     @DisplayName("getAuditTrailByAgent with null version delegates correctly")
     void getAuditTrailByAgent_nullVersion_delegatesToStore() {

--- a/src/test/java/ai/labs/eddi/engine/caching/CacheFactoryTest.java
+++ b/src/test/java/ai/labs/eddi/engine/caching/CacheFactoryTest.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.engine.caching;
 
+import ai.labs.eddi.engine.gdpr.GdprComplianceService;
+import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -317,5 +319,55 @@ class CacheFactoryTest {
             assertDoesNotThrow(() -> factory.getCache("channel-thread-locks", Duration.ofHours(24)));
             assertDoesNotThrow(() -> factory.getCache("nonce-replay-protection", Duration.ofMillis(390_000)));
         }
+    }
+
+    /**
+     * Finding r9. Both caches were added without an entry in
+     * {@code CacheFactory.CACHE_SIZES}, so they fell back to the 1,000 default. The
+     * restriction cache is keyed by userId — the same shape as "userConversations",
+     * which is sized 10,000 for exactly this reason — so a deployment with a few
+     * thousand concurrently active users thrashes it precisely under load, and
+     * Caffeine's W-TinyLFU admission then rejects the newly inserted key rather
+     * than an old one. Nothing logs it, because a cache miss is not an error: the
+     * per-turn store round trip on the hottest path in the system would simply come
+     * back.
+     */
+    @Test
+    @DisplayName("the per-user restriction cache is sized for active users, not left on the 1,000 default")
+    void perUserCachesAreNotLeftOnTheDefaultSize() {
+        // Asked for by the NAME THE SERVICE ACTUALLY USES, not by a matching literal.
+        // With both sides written out by hand, renaming the constant left this test
+        // green while the cache it names silently fell back to DEFAULT_MAX_SIZE —
+        // which is the very defect the sizing entries were added for, and a cache
+        // miss logs nothing.
+        assertEquals(10_000L,
+                CacheFactory.maximumSizeFor(GdprComplianceService.RESTRICTION_CACHE_NAME, Duration.ofSeconds(30)),
+                "a userId-keyed cache on the 1,000 default reinstates the per-turn store read under load");
+        assertEquals(CacheFactory.maximumSizeFor("userConversations", null),
+                CacheFactory.maximumSizeFor(GdprComplianceService.RESTRICTION_CACHE_NAME, Duration.ofSeconds(30)),
+                "same keyspace shape as userConversations, so the same size");
+        // The tenant cache is deliberately sized AT the default, so the number alone
+        // proves nothing — delete its CACHE_SIZES entry and an assertEquals(1_000L)
+        // stays green while the sizing silently reverts to inheritance, which is the
+        // regression these entries exist to prevent. Assert the entry, then the value.
+        assertTrue(CacheFactory.hasExplicitSize(TenantQuotaService.QUOTA_CACHE_NAME),
+                "the tenant cache must carry its own entry — at the default value, its sizing is otherwise unrecorded");
+        assertEquals(1_000L, CacheFactory.maximumSizeFor(TenantQuotaService.QUOTA_CACHE_NAME, Duration.ofSeconds(5)),
+                "tenants are few, so the recorded size is deliberately the same number as the default");
+    }
+
+    /**
+     * The binding above only bites if these names are genuinely the ones the
+     * services request their caches under — assert that too, so the constants
+     * cannot drift apart from {@code CacheFactory.CACHE_SIZES} in either direction.
+     */
+    @Test
+    @DisplayName("the sized entries are keyed on the names the services actually request")
+    void sizedEntriesUseTheServicesOwnCacheNames() {
+        assertNotEquals(CacheFactory.maximumSizeFor(GdprComplianceService.RESTRICTION_CACHE_NAME, Duration.ofSeconds(30)),
+                CacheFactory.maximumSizeFor("a-name-nothing-sizes", Duration.ofSeconds(30)),
+                "the restriction cache must have its own entry, not the default");
+        assertEquals("gdprProcessingRestrictions", GdprComplianceService.RESTRICTION_CACHE_NAME);
+        assertEquals("tenantQuotas", TenantQuotaService.QUOTA_CACHE_NAME);
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -416,6 +417,58 @@ class GdprComplianceServiceTest {
         assertEquals("conv-ok", export.conversations().getFirst().conversationId());
     }
 
+    /**
+     * Finding 12. The conversation block and the attachment block each called
+     * {@code getConversationIdsByUserId} — a second full lookup of the same list on
+     * an operation that is already the heaviest read in the system.
+     */
+    @Test
+    void exportUserData_resolvesTheConversationIdListOnce() throws Exception {
+        when(userMemoryStore.getAllEntries(USER_ID)).thenReturn(List.of());
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID)).thenReturn(List.of("conv-1"));
+        when(conversationMemoryStore.loadConversationMemorySnapshot("conv-1")).thenReturn(null);
+        when(userConversationStore.getAllForUser(USER_ID)).thenReturn(List.of());
+        when(auditStore.getEntriesByUserId(eq(USER_ID), anyInt(), anyInt())).thenReturn(List.of());
+        when(attachmentStorageInstance.isResolvable()).thenReturn(true);
+        when(attachmentStorageInstance.get()).thenReturn(attachmentStore);
+        when(attachmentStore.listByConversation("conv-1")).thenReturn(List.of());
+
+        newService(attachmentStorageInstance).exportUserData(USER_ID);
+
+        verify(conversationMemoryStore, times(1)).getConversationIdsByUserId(USER_ID);
+    }
+
+    /**
+     * Finding 12. Each snapshot is a full document load and the whole bundle is
+     * assembled in memory on the request thread, so the same cap that already
+     * bounded the audit half of the response now bounds the conversation half. A
+     * user with thousands of conversations otherwise held a JAX-RS worker for
+     * minutes and produced a response measured in hundreds of megabytes.
+     */
+    @Test
+    void exportUserData_capsTheNumberOfConversationSnapshots() throws Exception {
+        var manyIds = new ArrayList<String>();
+        for (int i = 0; i < GdprComplianceService.CONVERSATION_EXPORT_LIMIT + 25; i++) {
+            manyIds.add("conv-" + i);
+        }
+        var snapshot = new ConversationMemorySnapshot();
+        snapshot.setAgentId("agent-1");
+        snapshot.setAgentVersion(1);
+        snapshot.setConversationState(ConversationState.READY);
+
+        when(userMemoryStore.getAllEntries(USER_ID)).thenReturn(List.of());
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID)).thenReturn(manyIds);
+        when(conversationMemoryStore.loadConversationMemorySnapshot(anyString())).thenReturn(snapshot);
+        when(userConversationStore.getAllForUser(USER_ID)).thenReturn(List.of());
+        when(auditStore.getEntriesByUserId(eq(USER_ID), anyInt(), anyInt())).thenReturn(List.of());
+
+        UserDataExport export = service.exportUserData(USER_ID);
+
+        assertEquals(GdprComplianceService.CONVERSATION_EXPORT_LIMIT, export.conversations().size());
+        verify(conversationMemoryStore, times(GdprComplianceService.CONVERSATION_EXPORT_LIMIT))
+                .loadConversationMemorySnapshot(anyString());
+    }
+
     @Test
     void exportUserData_handlesMemoryStoreFailure() throws Exception {
         // Given — memory store throws
@@ -618,14 +671,85 @@ class GdprComplianceServiceTest {
         assertTrue(service.isProcessingRestricted(USER_ID));
     }
 
+    /**
+     * Still fail-closed — the turn does not proceed — but no longer fail-dishonest.
+     * Returning {@code true} here made every turn for every user a {@code 403}
+     * carrying "Processing is restricted for this user (GDPR Art. 18)" whenever the
+     * store hiccuped: a false legal statement about the user, and a status code
+     * that hides the outage from monitoring keyed on 5xx. The distinct exception is
+     * mapped to 503.
+     */
     @Test
-    void isProcessingRestricted_failsClosedOnException() throws Exception {
+    void isProcessingRestricted_failsClosedButHonestlyOnException() throws Exception {
         // Given — store throws
         when(userMemoryStore.getByKey(eq(USER_ID), any()))
                 .thenThrow(new RuntimeException("Connection refused"));
 
-        // When/Then — should return true (fail-closed) for safety
-        assertTrue(service.isProcessingRestricted(USER_ID));
+        // When/Then — processing is still blocked, but as an availability failure
+        assertThrows(ProcessingRestrictionUnavailableException.class,
+                () -> service.isProcessingRestricted(USER_ID));
+    }
+
+    /**
+     * The flag is read at conversation start and again on every say/sayStreaming,
+     * so an uncached lookup is a store round trip per turn on the hottest path in
+     * the system — for a value only an admin endpoint ever changes.
+     */
+    @Test
+    void isProcessingRestricted_isCachedAcrossTurns() throws Exception {
+        when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
+                .thenReturn(Optional.empty());
+
+        assertFalse(service.isProcessingRestricted(USER_ID));
+        assertFalse(service.isProcessingRestricted(USER_ID));
+        assertFalse(service.isProcessingRestricted(USER_ID));
+
+        verify(userMemoryStore, times(1)).getByKey(USER_ID, "_gdpr_processing_restricted");
+    }
+
+    /**
+     * A cache that outlived a restriction would keep processing a user an admin has
+     * just restricted, so both admin endpoints have to publish through it.
+     */
+    @Test
+    void restrictProcessing_takesEffectImmediatelyDespiteTheCache() throws Exception {
+        when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
+                .thenReturn(Optional.empty());
+        assertFalse(service.isProcessingRestricted(USER_ID), "precondition: cached as unrestricted");
+
+        service.restrictProcessing(USER_ID);
+
+        assertTrue(service.isProcessingRestricted(USER_ID),
+                "the restriction must apply to the very next turn, not after the cache TTL");
+    }
+
+    /**
+     * The other direction, and the one the caching change actually regressed. A
+     * cached {@code true} that outlives the lift keeps answering "restricted" for
+     * up to {@code RESTRICTION_CACHE_TTL} on that node, so a user whose Art. 18
+     * restriction an admin has just removed keeps receiving 403 "Processing is
+     * restricted for this user (GDPR Art. 18)" on every turn — a false legal
+     * statement about someone the admin has already cleared.
+     * <p>
+     * The store deliberately keeps answering "restricted" below: only the cache
+     * publish in {@code unrestrictProcessing} can make the next read come back
+     * false, so nothing else can satisfy this assertion.
+     */
+    @Test
+    void unrestrictProcessing_takesEffectImmediatelyDespiteTheCache() throws Exception {
+        var flag = new UserMemoryEntry(
+                "entry-id", USER_ID, "_gdpr_processing_restricted", "true",
+                "gdpr", Property.Visibility.global,
+                null, List.of(), null, false, 0,
+                Instant.now(), Instant.now());
+        when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
+                .thenReturn(Optional.of(flag));
+        assertTrue(service.isProcessingRestricted(USER_ID), "precondition: cached as restricted");
+
+        service.unrestrictProcessing(USER_ID);
+
+        assertFalse(service.isProcessingRestricted(USER_ID),
+                "the lift must apply to the very next turn, not after the cache TTL");
     }
 
     @Test
@@ -659,6 +783,116 @@ class GdprComplianceServiceTest {
         // Then — conversations count is 0, but cascade continued
         assertEquals(0, result.conversationsDeleted());
         verify(userConversationStore).deleteAllForUser(USER_ID);
+
+        // ...and the caller can tell that 0 from "the user had no conversations".
+        // Without this an admin files the Art. 17 request as fulfilled while the
+        // conversations are still there.
+        assertFalse(result.complete());
+        assertEquals(List.of("conversations"), result.failedSteps());
+    }
+
+    /**
+     * The clean run is the other half of the same contract: nothing failed, so
+     * nothing may be reported as failed.
+     */
+    @Test
+    void deleteUserData_reportsCompleteWhenNothingFailed() throws Exception {
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(1L);
+        when(conversationMemoryStore.deleteConversationsByUserId(USER_ID)).thenReturn(1L);
+        when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(0L);
+        when(databaseLogs.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+        when(auditStore.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+
+        GdprDeletionResult result = service.deleteUserData(USER_ID);
+
+        assertTrue(result.complete());
+        assertEquals(List.of(), result.failedSteps());
+    }
+
+    /**
+     * The count was assigned <em>before</em> the delete, so a delete that threw
+     * still reported N memories erased when zero were — the response claiming work
+     * the store never did.
+     */
+    @Test
+    void deleteUserData_doesNotClaimMemoriesItFailedToDelete() throws Exception {
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(42L);
+        doThrow(new RuntimeException("memory store unavailable")).when(userMemoryStore).deleteAllForUser(USER_ID);
+        when(conversationMemoryStore.deleteConversationsByUserId(USER_ID)).thenReturn(0L);
+        when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(0L);
+        when(databaseLogs.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+        when(auditStore.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+
+        GdprDeletionResult result = service.deleteUserData(USER_ID);
+
+        assertEquals(0, result.memoriesDeleted(), "nothing was deleted, so nothing may be reported as deleted");
+        assertFalse(result.complete());
+        assertTrue(result.failedSteps().contains("userMemories"));
+    }
+
+    /**
+     * Finding m1: the per-conversation loops used to sit inside one try, so the
+     * first conversation whose delete threw ended the sweep — every remaining
+     * conversation kept the PII the cascade exists to remove, and the response
+     * still looked plausible.
+     */
+    @Test
+    void deleteUserData_oneFailingConversationDoesNotStopTheCascade() throws Exception {
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(0L);
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID))
+                .thenReturn(List.of("conv-1", "conv-2", "conv-3"));
+        when(hitlToolJournalStore.deleteByConversationId("conv-1")).thenReturn(1L);
+        when(hitlToolJournalStore.deleteByConversationId("conv-2"))
+                .thenThrow(new RuntimeException("GridFS chunk missing"));
+        when(hitlToolJournalStore.deleteByConversationId("conv-3")).thenReturn(1L);
+        when(checkpointStore.deleteByConversationId(anyString())).thenReturn(1L);
+        when(conversationMemoryStore.deleteConversationsByUserId(USER_ID)).thenReturn(3L);
+        when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(0L);
+        when(databaseLogs.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+        when(auditStore.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+
+        GdprDeletionResult result = service.deleteUserData(USER_ID);
+
+        verify(hitlToolJournalStore).deleteByConversationId("conv-3");
+        verify(conversationDescriptorStore).deleteAllDescriptor("conv-3");
+        verify(checkpointStore).deleteByConversationId("conv-3");
+        assertEquals(2, result.journalEntriesDeleted(), "the conversations either side of the failure must still be erased");
+        assertEquals(3, result.checkpointsDeleted());
+        assertFalse(result.complete());
+        assertTrue(result.failedSteps().contains("hitlToolJournal"));
+    }
+
+    /**
+     * Finding 11: attachments, journal entries, checkpoints, group transcripts,
+     * artifacts and schedules were computed and written to the audit ledger but
+     * never returned, so the DPO producing an Art. 17 confirmation had to read the
+     * server log to learn whether they had been touched.
+     */
+    @Test
+    void deleteUserData_reportsEveryCounterItComputes() throws Exception {
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(0L);
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID)).thenReturn(List.of("conv-1"));
+        when(attachmentStorageInstance.isResolvable()).thenReturn(true);
+        when(attachmentStorageInstance.get()).thenReturn(attachmentStore);
+        when(attachmentStore.deleteByConversation("conv-1")).thenReturn(4L);
+        when(hitlToolJournalStore.deleteByConversationId("conv-1")).thenReturn(3L);
+        when(checkpointStore.deleteByConversationId("conv-1")).thenReturn(2L);
+        when(groupConversationStore.deleteAllForUser(USER_ID)).thenReturn(6L);
+        when(sharedArtifactStore.deleteAllForUser(USER_ID)).thenReturn(7L);
+        when(scheduleStore.deleteSchedulesByUserId(USER_ID)).thenReturn(8);
+        when(conversationMemoryStore.deleteConversationsByUserId(USER_ID)).thenReturn(1L);
+        when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(0L);
+        when(databaseLogs.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+        when(auditStore.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+
+        GdprDeletionResult result = newService(attachmentStorageInstance).deleteUserData(USER_ID);
+
+        assertEquals(4, result.attachmentsDeleted());
+        assertEquals(3, result.journalEntriesDeleted());
+        assertEquals(2, result.checkpointsDeleted());
+        assertEquals(6, result.groupConversationsDeleted());
+        assertEquals(7, result.sharedArtifactsDeleted());
+        assertEquals(8, result.schedulesDeleted());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
@@ -34,6 +34,7 @@ import jakarta.enterprise.inject.Instance;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -1370,6 +1371,55 @@ class GdprComplianceServiceTest {
     }
 
     /**
+     * A snapshot that fails to load is a conversation missing from the bundle, and
+     * it used to go missing silently: logged at WARN, dropped, and every
+     * completeness marker in the payload still saying the bundle was whole. Well
+     * inside the cap, so {@code conversationsTruncated} — the only signal there was
+     * — stayed false, and the DPO handed the data subject an Art. 15 answer the
+     * code knew was short.
+     * <p>
+     * The cap keeps its own marker: the two are different omissions and a caller
+     * chasing 998 of 1,000 needs to know which happened.
+     */
+    @Test
+    void exportUserData_namesTheConversationsItCouldNotLoad() throws Exception {
+        var snapshot = new ConversationMemorySnapshot();
+        snapshot.setAgentId("agent-1");
+        snapshot.setAgentVersion(1);
+        snapshot.setConversationState(ConversationState.READY);
+
+        when(userMemoryStore.getAllEntries(USER_ID)).thenReturn(List.of());
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID))
+                .thenReturn(List.of("conv-1", "conv-2", "conv-3"));
+        when(conversationMemoryStore.loadConversationMemorySnapshot("conv-1")).thenReturn(snapshot);
+        when(conversationMemoryStore.loadConversationMemorySnapshot("conv-2"))
+                .thenThrow(new RuntimeException("GridFS chunk missing"));
+        // Absent rather than throwing: the id came from the same store moments ago,
+        // so the document was removed between the two reads and the conversation is
+        // just as missing from the bundle.
+        when(conversationMemoryStore.loadConversationMemorySnapshot("conv-3")).thenReturn(null);
+        when(userConversationStore.getAllForUser(USER_ID)).thenReturn(List.of());
+        when(auditStore.getEntriesByUserId(eq(USER_ID), anyInt(), anyInt())).thenReturn(List.of());
+
+        UserDataExport export = service.exportUserData(USER_ID);
+
+        assertEquals(1, export.conversations().size(), "the conversations that did load are still exported");
+        assertEquals(List.of("conv-2", "conv-3"), export.failedConversationIds(),
+                "a bundle that lost conversations has to name them, or nobody can tell it is short");
+        assertFalse(export.conversationsTruncated(),
+                "the cap did not bite — overloading its marker would make the two omissions indistinguishable");
+        assertEquals(3, export.totalConversations());
+
+        // The ledger entry is the evidence this export happened; "1 of 3 exported"
+        // with nothing to explain the other two is a discrepancy nobody can account
+        // for afterwards.
+        ArgumentCaptor<AuditEntry> entryCaptor = ArgumentCaptor.forClass(AuditEntry.class);
+        verify(auditLedgerService).submit(entryCaptor.capture());
+        assertEquals(2, entryCaptor.getValue().output().get("conversationsFailed"),
+                "the compliance record has to say how many conversations the bundle lost");
+    }
+
+    /**
      * Finding r7. The read path is not atomic with {@code restrictProcessing}: T1
      * reads "not restricted" from the store, T2 (an admin applying an Art. 18
      * restriction) writes the row and publishes {@code true}, and T1 then
@@ -1597,6 +1647,53 @@ class GdprComplianceServiceTest {
 
         assertFalse(result.complete());
         assertTrue(result.failedSteps().contains("conversationMappingCache"), result.failedSteps().toString());
+    }
+
+    /**
+     * The Art. 18 restriction eviction is its own step, not part of the memory
+     * delete.
+     * <p>
+     * It used to sit inside the memory step's try, between the delete and the
+     * assignment that records how many entries it removed. An eviction that threw
+     * there therefore reported {@code memoriesDeleted=0} and named
+     * {@code userMemories} as the failed step — for a delete that had already
+     * succeeded. The DPO re-runs an erasure whose memory half was done and cannot
+     * tell from the response that the only thing left undone is a cache.
+     */
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void deleteUserData_aFailedRestrictionEvictionDoesNotDisownTheMemoriesItDeleted() throws Exception {
+        ICache<String, Boolean> restrictionCache = mock(ICache.class);
+        doThrow(new IllegalStateException("cache closed")).when(restrictionCache).remove(anyString());
+        var failingCacheFactory = mock(CacheFactory.class);
+        when(failingCacheFactory.getCache(anyString())).thenReturn(mock(ICache.class));
+        when(failingCacheFactory.getCache(anyString(), any())).thenReturn((ICache) restrictionCache);
+
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(42L);
+        when(conversationMemoryStore.deleteConversationsByUserId(USER_ID)).thenReturn(0L);
+        when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(0L);
+        when(databaseLogs.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+        when(auditStore.pseudonymizeByUserId(eq(USER_ID), anyString())).thenReturn(0L);
+
+        var serviceWithFailingCache = new GdprComplianceService(
+                userMemoryStore, conversationMemoryStore,
+                userConversationStore, databaseLogs, auditStore,
+                auditLedgerService, attachmentStorageInstance, hitlToolJournalStore,
+                conversationDescriptorStore, checkpointStore,
+                groupConversationStoreInstance, sharedArtifactStoreInstance, scheduleStore,
+                failingCacheFactory, 30L);
+
+        GdprDeletionResult result = serviceWithFailingCache.deleteUserData(USER_ID);
+
+        verify(userMemoryStore).deleteAllForUser(USER_ID);
+        assertEquals(42, result.memoriesDeleted(),
+                "the delete succeeded, so the response must not report zero memories erased");
+        assertFalse(result.failedSteps().contains("userMemories"),
+                "the memory store did not fail; naming it sends the DPO to re-run a step that ran: "
+                        + result.failedSteps());
+        assertTrue(result.failedSteps().contains("restrictionCache"),
+                "a stale 'restricted' verdict left in the cache is still a failure, and has to be named as "
+                        + "its own: " + result.failedSteps());
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
@@ -13,6 +13,7 @@ import ai.labs.eddi.engine.audit.AuditLedgerService;
 import ai.labs.eddi.engine.audit.IAuditStore;
 import ai.labs.eddi.engine.attachments.IAttachmentStore;
 import ai.labs.eddi.engine.caching.CacheFactory;
+import ai.labs.eddi.engine.caching.ICache;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.memory.IConversationCheckpointStore;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
@@ -38,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -104,13 +106,23 @@ class GdprComplianceServiceTest {
         service = newService(attachmentStorageInstance);
     }
 
+    /**
+     * A service with restriction caching switched <em>on</em>
+     * ({@code eddi.gdpr.restriction-cache-ttl-seconds=30}) — the single-node /
+     * conversation-affinity optimisation, which is opt-in and not the shipped
+     * default. The cache semantics below (publish on restrict, publish on
+     * unrestrict, monotone-toward-restriction on a concurrent miss) only exist when
+     * it is switched on, so they are pinned against a service that has it. The
+     * default is pinned separately, by
+     * {@code isProcessingRestricted_defaultConfiguration_*}.
+     */
     private GdprComplianceService newService(Instance<IAttachmentStore> attachments) {
         return new GdprComplianceService(
                 userMemoryStore, conversationMemoryStore,
                 userConversationStore, databaseLogs, auditStore,
                 auditLedgerService, attachments, hitlToolJournalStore,
                 conversationDescriptorStore, checkpointStore,
-                groupConversationStoreInstance, sharedArtifactStoreInstance, scheduleStore, cacheFactory);
+                groupConversationStoreInstance, sharedArtifactStoreInstance, scheduleStore, cacheFactory, 30L);
     }
 
     @Test
@@ -752,6 +764,154 @@ class GdprComplianceServiceTest {
                 "the lift must apply to the very next turn, not after the cache TTL");
     }
 
+    /**
+     * A service with {@code eddi.gdpr.restriction-cache-ttl-seconds=0}, the setting
+     * a multi-replica deployment without conversation affinity is expected to use.
+     */
+    private GdprComplianceService newServiceWithoutRestrictionCache() {
+        return new GdprComplianceService(
+                userMemoryStore, conversationMemoryStore,
+                userConversationStore, databaseLogs, auditStore,
+                auditLedgerService, attachmentStorageInstance, hitlToolJournalStore,
+                conversationDescriptorStore, checkpointStore,
+                groupConversationStoreInstance, sharedArtifactStoreInstance, scheduleStore,
+                cacheFactory, 0L);
+    }
+
+    /**
+     * The cache is node-local with no cross-node invalidation, so a cached negative
+     * verdict is what lets node B keep processing a user node A has just restricted
+     * — for the whole TTL. Setting the TTL to 0 has to remove the cache outright,
+     * not merely shorten it: every call reads the store.
+     */
+    @Test
+    void isProcessingRestricted_cachingDisabled_readsTheStoreOnEveryTurn() throws Exception {
+        var uncached = newServiceWithoutRestrictionCache();
+        when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
+                .thenReturn(Optional.empty());
+
+        assertFalse(uncached.isProcessingRestricted(USER_ID));
+        assertFalse(uncached.isProcessingRestricted(USER_ID));
+        assertFalse(uncached.isProcessingRestricted(USER_ID));
+
+        verify(userMemoryStore, times(3)).getByKey(USER_ID, "_gdpr_processing_restricted");
+    }
+
+    /**
+     * The behaviour the previous test protects, stated as the reviewer's scenario:
+     * another node applies the Art. 18 restriction — this node never saw the admin
+     * call, so nothing invalidates anything here — and the very next turn must be
+     * blocked rather than served from a cached {@code false}.
+     */
+    @Test
+    void isProcessingRestricted_cachingDisabled_seesAnotherNodesRestrictionOnTheNextTurn() throws Exception {
+        var uncached = newServiceWithoutRestrictionCache();
+        var flag = new UserMemoryEntry(
+                "entry-id", USER_ID, "_gdpr_processing_restricted", "true",
+                "gdpr", Property.Visibility.global,
+                null, List.of(), null, false, 0,
+                Instant.now(), Instant.now());
+        // First turn: not restricted anywhere. Then another node writes the flag.
+        when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(flag));
+
+        assertFalse(uncached.isProcessingRestricted(USER_ID), "precondition: not restricted yet");
+
+        assertTrue(uncached.isProcessingRestricted(USER_ID),
+                "a restriction applied on another node must bite on the next turn, not after a TTL");
+    }
+
+    /**
+     * A service built the way CDI builds it when nothing sets
+     * {@code eddi.gdpr.restriction-cache-ttl-seconds} — i.e. carrying the shipped
+     * default of that property, whatever it is.
+     */
+    private GdprComplianceService newServiceWithDefaultConfiguration() {
+        return new GdprComplianceService(
+                userMemoryStore, conversationMemoryStore,
+                userConversationStore, databaseLogs, auditStore,
+                auditLedgerService, attachmentStorageInstance, hitlToolJournalStore,
+                conversationDescriptorStore, checkpointStore,
+                groupConversationStoreInstance, sharedArtifactStoreInstance, scheduleStore, cacheFactory);
+    }
+
+    /**
+     * The two tests above only hold for a deployment that has explicitly set the
+     * TTL to 0. This one pins the <strong>shipped default</strong>, which is the
+     * setting almost every deployment actually runs: out of the box, no restriction
+     * verdict may be cached, because the cache is node-local with no cross-node
+     * invalidation and a cached {@code false} therefore suspends an Art. 18 legal
+     * control on every other replica for the length of the TTL.
+     * <p>
+     * The scenario is the reviewer's: this node answers one turn while the user is
+     * unrestricted, another node applies the restriction (nothing invalidates
+     * anything here — this node never saw the admin call), and the very next turn
+     * on this node must be blocked. A default TTL above 0 fails this: the second
+     * call is served from the cache and returns {@code false}.
+     */
+    @Test
+    void isProcessingRestricted_defaultConfiguration_doesNotServeAStaleUnrestrictedVerdict() throws Exception {
+        var shipped = newServiceWithDefaultConfiguration();
+        var flag = new UserMemoryEntry(
+                "entry-id", USER_ID, "_gdpr_processing_restricted", "true",
+                "gdpr", Property.Visibility.global,
+                null, List.of(), null, false, 0,
+                Instant.now(), Instant.now());
+        when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(flag));
+
+        assertFalse(shipped.isProcessingRestricted(USER_ID), "precondition: not restricted yet");
+
+        assertTrue(shipped.isProcessingRestricted(USER_ID),
+                "with the shipped default, a restriction applied on another replica must bite on the "
+                        + "very next turn — the default must not cache a negative verdict");
+        verify(userMemoryStore, times(2)).getByKey(USER_ID, "_gdpr_processing_restricted");
+    }
+
+    /**
+     * The other half of the same finding: while a negative verdict is cached the
+     * node keeps processing straight through a store outage, because it never asks
+     * the store. With the cache off, an outage always surfaces as the availability
+     * failure it is — which is what fail-closed means here.
+     */
+    @Test
+    void isProcessingRestricted_cachingDisabled_failsClosedOnAnOutageAfterASuccessfulRead() throws Exception {
+        var uncached = newServiceWithoutRestrictionCache();
+        when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
+                .thenReturn(Optional.empty())
+                .thenThrow(new RuntimeException("Connection refused"));
+
+        assertFalse(uncached.isProcessingRestricted(USER_ID), "precondition: one good read");
+
+        assertThrows(ProcessingRestrictionUnavailableException.class,
+                () -> uncached.isProcessingRestricted(USER_ID),
+                "a cached false must not absorb the outage");
+    }
+
+    /**
+     * Switching the cache off must not break the admin writes, which publish
+     * through it on the default setting.
+     */
+    @Test
+    void restrictAndUnrestrict_cachingDisabled_stillWriteTheStore() throws Exception {
+        var uncached = newServiceWithoutRestrictionCache();
+        var flag = new UserMemoryEntry(
+                "entry-id", USER_ID, "_gdpr_processing_restricted", "true",
+                "gdpr", Property.Visibility.global,
+                null, List.of(), null, false, 0,
+                Instant.now(), Instant.now());
+        when(userMemoryStore.getByKey(USER_ID, "_gdpr_processing_restricted"))
+                .thenReturn(Optional.of(flag));
+
+        assertDoesNotThrow(() -> uncached.restrictProcessing(USER_ID));
+        assertDoesNotThrow(() -> uncached.unrestrictProcessing(USER_ID));
+
+        verify(userMemoryStore).upsert(any(UserMemoryEntry.class));
+        verify(userMemoryStore).deleteEntry("entry-id");
+    }
+
     @Test
     void isProcessingRestricted_returnsFalseWhenValueIsNotTrue() throws Exception {
         // Given — value is "false" not "true"
@@ -1153,5 +1313,320 @@ class GdprComplianceServiceTest {
         assertDoesNotThrow(() -> service.deleteUserData(USER_ID));
 
         verify(sharedArtifactStore, never()).deleteAllForUser(any());
+    }
+
+    /**
+     * Finding r4. The cap was reported in the server log only, so a data
+     * portability request for a user with 1,200 conversations returned 200 OK and a
+     * bundle silently missing 200 of them — an arbitrary 200 on MongoDB, whose
+     * natural order is not insertion order. A DPO hands that to the data subject
+     * believing it complete, which is the same misreporting the erasure half of
+     * this class answers 207 for.
+     */
+    @Test
+    void exportUserData_marksTheBundleTruncatedWhenTheCapBites() throws Exception {
+        var manyIds = new ArrayList<String>();
+        int total = GdprComplianceService.CONVERSATION_EXPORT_LIMIT + 25;
+        for (int i = 0; i < total; i++) {
+            manyIds.add("conv-" + i);
+        }
+        var snapshot = new ConversationMemorySnapshot();
+        snapshot.setAgentId("agent-1");
+        snapshot.setAgentVersion(1);
+        snapshot.setConversationState(ConversationState.READY);
+
+        when(userMemoryStore.getAllEntries(USER_ID)).thenReturn(List.of());
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID)).thenReturn(manyIds);
+        when(conversationMemoryStore.loadConversationMemorySnapshot(anyString())).thenReturn(snapshot);
+        when(userConversationStore.getAllForUser(USER_ID)).thenReturn(List.of());
+        when(auditStore.getEntriesByUserId(eq(USER_ID), anyInt(), anyInt())).thenReturn(List.of());
+
+        UserDataExport export = service.exportUserData(USER_ID);
+
+        assertTrue(export.conversationsTruncated(),
+                "an incomplete Art. 15 bundle must say so in the payload, not only in the server log");
+        assertEquals(total, export.totalConversations(),
+                "the caller has to be able to see how much is missing");
+    }
+
+    /** A bundle inside the cap is complete, and says so. */
+    @Test
+    void exportUserData_isNotMarkedTruncatedWithinTheCap() throws Exception {
+        var snapshot = new ConversationMemorySnapshot();
+        snapshot.setAgentId("agent-1");
+        snapshot.setAgentVersion(1);
+        snapshot.setConversationState(ConversationState.READY);
+
+        when(userMemoryStore.getAllEntries(USER_ID)).thenReturn(List.of());
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID)).thenReturn(List.of("conv-1", "conv-2"));
+        when(conversationMemoryStore.loadConversationMemorySnapshot(anyString())).thenReturn(snapshot);
+        when(userConversationStore.getAllForUser(USER_ID)).thenReturn(List.of());
+        when(auditStore.getEntriesByUserId(eq(USER_ID), anyInt(), anyInt())).thenReturn(List.of());
+
+        UserDataExport export = service.exportUserData(USER_ID);
+
+        assertFalse(export.conversationsTruncated());
+        assertEquals(2, export.totalConversations());
+    }
+
+    /**
+     * Finding r7. The read path is not atomic with {@code restrictProcessing}: T1
+     * reads "not restricted" from the store, T2 (an admin applying an Art. 18
+     * restriction) writes the row and publishes {@code true}, and T1 then
+     * overwrites it with the stale {@code false}. The node keeps processing a
+     * restricted user for up to RESTRICTION_CACHE_TTL — 30 seconds of processing
+     * someone whose processing must be halted, which is a legal control, not a
+     * cache-freshness preference.
+     * <p>
+     * The interleaving is driven deterministically: the store lookup itself applies
+     * the restriction, exactly as a concurrent admin call would between the read
+     * and the write that follows it.
+     */
+    @Test
+    void isProcessingRestricted_doesNotOverwriteARestrictionAppliedDuringTheRead() throws Exception {
+        when(userMemoryStore.getByKey(eq(USER_ID), anyString())).thenAnswer(invocation -> {
+            // Stands in for the admin call landing between this read and its cache
+            // write. restrictProcessing publishes "true" through the same cache.
+            service.restrictProcessing(USER_ID);
+            return Optional.empty();
+        });
+
+        boolean firstAnswer = service.isProcessingRestricted(USER_ID);
+
+        assertTrue(firstAnswer, "the administrative write is newer than a read that started before it");
+        // And the published verdict must survive: the second call is a cache hit, so
+        // a stale false written here would keep answering for the whole TTL.
+        reset(userMemoryStore);
+        assertTrue(service.isProcessingRestricted(USER_ID),
+                "a restriction masked in the cache is a restriction not enforced");
+        verify(userMemoryStore, never()).getByKey(anyString(), anyString());
+    }
+
+    /**
+     * Finding G1/f1-01. {@code isProcessingRestricted} is itself a cache writer, so
+     * two turns for the same user can both miss and both publish. T2 misses, reads
+     * "not restricted" and publishes {@code false}; T1 misses, reads {@code true}
+     * from the store — a DPO applied the Art. 18 restriction on another node, and
+     * nothing invalidates this node's cache — and must return its own fresh
+     * {@code true}, not the sibling's stale {@code false}.
+     * <p>
+     * A plain {@code putIfAbsent} is refused here and hands T1 back the
+     * {@code false}, so T1 processes a turn its own store read said must be blocked
+     * and the node keeps answering {@code false} for the rest of the TTL. That is a
+     * fail-open on a legal control.
+     * <p>
+     * The interleaving is driven deterministically: T1's store lookup runs the
+     * whole sibling read inline, exactly where a concurrent one would land.
+     */
+    @Test
+    void isProcessingRestricted_prefersItsOwnFreshRestrictionOverAConcurrentReadersStaleFalse()
+            throws Exception {
+        var restrictedEntry = new UserMemoryEntry(
+                "entry-id", USER_ID, "_gdpr_processing_restricted", "true",
+                "gdpr", Property.Visibility.global,
+                null, List.of(), null, false, 0,
+                Instant.now(), Instant.now());
+        var siblingRan = new AtomicBoolean(false);
+
+        when(userMemoryStore.getByKey(eq(USER_ID), anyString())).thenAnswer(invocation -> {
+            if (siblingRan.compareAndSet(false, true)) {
+                // T2: a second in-flight turn for the same user. It misses the same
+                // empty cache, reads "not restricted", and its publish lands first.
+                assertFalse(service.isProcessingRestricted(USER_ID),
+                        "precondition: the sibling really did observe and publish 'not restricted'");
+                return Optional.of(restrictedEntry);
+            }
+            // The sibling's own store read.
+            return Optional.empty();
+        });
+
+        assertTrue(service.isProcessingRestricted(USER_ID),
+                "a reader must never return a sibling's stale false over the restriction it read itself");
+
+        // And that verdict has to be what the node serves for the rest of the TTL —
+        // otherwise every following turn is a cache hit on the stale false.
+        reset(userMemoryStore);
+        assertTrue(service.isProcessingRestricted(USER_ID),
+                "a restriction masked in the cache is a restriction not enforced");
+        verify(userMemoryStore, never()).getByKey(anyString(), anyString());
+    }
+
+    /**
+     * Finding r14. {@code recordFailure} is called from inside the per-conversation
+     * loops, so with a stack trace on every call a user with 5,000 conversations
+     * produced 20,000 ERROR traces for one erasure request and buried the one line
+     * that matters. Repeats are still reported, at WARN, without the identical
+     * trace.
+     */
+    @Test
+    void recordFailure_logsTheStackTraceOncePerStepAndStillRecordsRepeats() {
+        var failedSteps = new ArrayList<String>();
+        var boom = new RuntimeException("store down");
+
+        assertTrue(GdprComplianceService.recordFailure(failedSteps, "attachments", boom, "pseudo"),
+                "the first failure of a step carries the trace");
+        assertFalse(GdprComplianceService.recordFailure(failedSteps, "attachments", boom, "pseudo"),
+                "the 4,999 identical traces after it do not");
+        assertTrue(GdprComplianceService.recordFailure(failedSteps, "checkpoints", boom, "pseudo"),
+                "a different step is a different failure and carries its own trace");
+
+        assertEquals(List.of("attachments", "checkpoints"), failedSteps,
+                "each failing step is still named exactly once for the caller");
+    }
+
+    /**
+     * Finding m1, attachment half. The attachment sweep isolates EACH conversation,
+     * so the store refusing one must not cost the others their erasure — and the
+     * step still has to be named in {@code failedSteps}, or a DPO files the Art. 17
+     * request as fulfilled while one conversation's uploads are still on disk.
+     */
+    @Test
+    void deleteUserData_oneFailingAttachmentDeleteDoesNotStopTheSweep() throws Exception {
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(0L);
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID))
+                .thenReturn(List.of("conv-1", "conv-2"));
+        when(attachmentStorageInstance.isResolvable()).thenReturn(true);
+        when(attachmentStorageInstance.get()).thenReturn(attachmentStore);
+        when(attachmentStore.deleteByConversation("conv-1"))
+                .thenThrow(new RuntimeException("GridFS bucket unavailable"));
+        when(attachmentStore.deleteByConversation("conv-2")).thenReturn(3L);
+
+        GdprDeletionResult result = newService(attachmentStorageInstance).deleteUserData(USER_ID);
+
+        verify(attachmentStore).deleteByConversation("conv-2");
+        assertEquals(3, result.attachmentsDeleted(),
+                "only the conversation that actually failed may be missing from the count");
+        assertFalse(result.complete());
+        assertEquals(List.of("attachments"), result.failedSteps(),
+                "one step name, however many conversations failed inside it");
+    }
+
+    /**
+     * The outer guard of the same step: a CDI {@code Instance} that cannot even be
+     * resolved throws before the loop is entered, and that has to be reported as an
+     * attachment failure rather than aborting the whole cascade — every later step
+     * still has to run.
+     */
+    @Test
+    void deleteUserData_unresolvableAttachmentStoreIsReportedNotFatal() throws Exception {
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(0L);
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID)).thenReturn(List.of("conv-1"));
+        when(attachmentStorageInstance.isResolvable())
+                .thenThrow(new IllegalStateException("no attachment storage bean"));
+        when(conversationMemoryStore.deleteConversationsByUserId(USER_ID)).thenReturn(1L);
+
+        GdprDeletionResult result = newService(attachmentStorageInstance).deleteUserData(USER_ID);
+
+        assertTrue(result.failedSteps().contains("attachments"), result.failedSteps().toString());
+        assertEquals(1, result.conversationsDeleted(),
+                "the cascade must carry on past a step that could not start");
+        verify(auditStore).pseudonymizeByUserId(eq(USER_ID), anyString());
+    }
+
+    /**
+     * Descriptors are what the conversation list in the UI reads, so one that
+     * survives erasure keeps the user's conversation titles visible. Isolated per
+     * conversation for the same reason as the attachment sweep.
+     */
+    @Test
+    void deleteUserData_oneFailingDescriptorDeleteIsRecordedAndTheRestStillGo() throws Exception {
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(0L);
+        when(conversationMemoryStore.getConversationIdsByUserId(USER_ID))
+                .thenReturn(List.of("conv-1", "conv-2"));
+        doThrow(new RuntimeException("descriptor store unavailable"))
+                .when(conversationDescriptorStore).deleteAllDescriptor("conv-1");
+
+        GdprDeletionResult result = service.deleteUserData(USER_ID);
+
+        verify(conversationDescriptorStore).deleteAllDescriptor("conv-2");
+        assertFalse(result.complete());
+        assertTrue(result.failedSteps().contains("conversationDescriptors"),
+                "an undeleted descriptor still shows the user's conversation titles: " + result.failedSteps());
+    }
+
+    /**
+     * The intents are read before the rows are deleted precisely because the cache
+     * is keyed by intent — once the rows are gone there is no way to work out which
+     * keys to evict. A failure to read them therefore gets its own step name: the
+     * mappings are still deleted, but the cache goes on serving them.
+     */
+    @Test
+    void deleteUserData_reportsAFailureToReadTheMappedIntents() throws Exception {
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(0L);
+        when(userConversationStore.getAllForUser(USER_ID))
+                .thenThrow(new RuntimeException("mapping store unavailable"));
+        when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(2L);
+
+        GdprDeletionResult result = service.deleteUserData(USER_ID);
+
+        assertEquals(2, result.conversationMappingsDeleted(), "the rows themselves were still erased");
+        assertFalse(result.complete());
+        assertTrue(result.failedSteps().contains("conversationMappingIntents"),
+                "an unevictable cache keeps serving erased mappings, and the response has to say so: "
+                        + result.failedSteps());
+    }
+
+    /**
+     * And the eviction itself. The cache has no TTL, so a failure here means
+     * {@code readUserConversation} serves erased data for as long as the process
+     * lives — the one outcome an Art. 17 confirmation must never hide.
+     */
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void deleteUserData_reportsAFailedCacheEviction() throws Exception {
+        ICache<String, UserConversation> cache = mock(ICache.class);
+        doThrow(new IllegalStateException("cache closed")).when(cache).remove(anyString());
+        var failingCacheFactory = mock(CacheFactory.class);
+        when(failingCacheFactory.getCache(anyString())).thenReturn((ICache) cache);
+        when(failingCacheFactory.getCache(anyString(), any())).thenReturn(mock(ICache.class));
+
+        var mapping = new UserConversation();
+        mapping.setIntent("support");
+        when(userMemoryStore.countEntries(USER_ID)).thenReturn(0L);
+        when(userConversationStore.getAllForUser(USER_ID)).thenReturn(List.of(mapping));
+        when(userConversationStore.deleteAllForUser(USER_ID)).thenReturn(1L);
+
+        var serviceWithFailingCache = new GdprComplianceService(
+                userMemoryStore, conversationMemoryStore,
+                userConversationStore, databaseLogs, auditStore,
+                auditLedgerService, attachmentStorageInstance, hitlToolJournalStore,
+                conversationDescriptorStore, checkpointStore,
+                groupConversationStoreInstance, sharedArtifactStoreInstance, scheduleStore, failingCacheFactory);
+
+        GdprDeletionResult result = serviceWithFailingCache.deleteUserData(USER_ID);
+
+        assertFalse(result.complete());
+        assertTrue(result.failedSteps().contains("conversationMappingCache"), result.failedSteps().toString());
+    }
+
+    /**
+     * Caffeine rejects a null key outright, so the restriction cache must not be
+     * asked about one. A null user is "not restricted" — there is nothing to look
+     * up and nothing to cache — rather than an exception on the hottest path in the
+     * system.
+     */
+    @Test
+    void isProcessingRestricted_nullUserIsNotRestrictedAndIsNeverLookedUp() throws Exception {
+        assertFalse(service.isProcessingRestricted(null));
+
+        verify(userMemoryStore, never()).getByKey(any(), anyString());
+    }
+
+    /**
+     * The Art. 18 write refuses a null subject before it touches any store, and
+     * says why.
+     * <p>
+     * Worth pinning because it is what makes {@code forgetRestriction}'s own null
+     * guard unreachable: every mutating entry point derives a pseudonym first, and
+     * that derivation rejects null. Were this to become lenient, the catch blocks
+     * that call {@code forgetRestriction} would start handing Caffeine a null key,
+     * and the resulting NPE would replace the failure they exist to report.
+     */
+    @Test
+    void restrictProcessing_rejectsANullSubjectBeforeTouchingAnyStore() throws Exception {
+        var thrown = assertThrows(RuntimeException.class, () -> service.restrictProcessing(null));
+
+        assertEquals("userId must not be null when deriving a GDPR pseudonym", thrown.getMessage());
+        verify(userMemoryStore, never()).upsert(any());
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/GdprComplianceServiceTest.java
@@ -1629,4 +1629,22 @@ class GdprComplianceServiceTest {
         assertEquals("userId must not be null when deriving a GDPR pseudonym", thrown.getMessage());
         verify(userMemoryStore, never()).upsert(any());
     }
+
+    /**
+     * The two halves of the restriction-cache default must stay equal.
+     * <p>
+     * A {@code @ConfigProperty} default has to be a compile-time String, and the
+     * CDI-free constructor needs the number, so the value exists twice. Changing
+     * one and not the other would silently give the annotated constructor a
+     * different default from the plain one - the shipped default from Quarkus, and
+     * something else everywhere the class is built directly, including these tests.
+     */
+    @Test
+    void theTwoDefaultConstantsAgree() {
+        assertEquals(GdprComplianceService.RESTRICTION_CACHE_TTL_DEFAULT,
+                Long.toString(GdprComplianceService.RESTRICTION_CACHE_TTL_DEFAULT_SECONDS),
+                "the @ConfigProperty default and the constructor default are the same number or the class "
+                        + "has two different shipped defaults depending on how it was built");
+    }
+
 }

--- a/src/test/java/ai/labs/eddi/engine/gdpr/GdprDeletionResultTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/GdprDeletionResultTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.gdpr;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code complete()} is the single field a DPO acts on: false means some of the
+ * subject's data may still exist and the Art. 17 request must not be filed as
+ * fulfilled. Two things can quietly break that.
+ * <p>
+ * It is a derived method rather than a record component, so Jackson left it out
+ * of the REST entity entirely while {@code McpGdprTools} put it into the MCP
+ * payload by hand — the same result reported in two shapes, and a client
+ * written against the MCP JSON reading null from the REST one. And
+ * {@code failedSteps} arriving absent (a deserialized or hand-built result)
+ * must become an empty list rather than a null the caller dereferences.
+ */
+@DisplayName("GdprDeletionResult")
+class GdprDeletionResultTest {
+
+    private static final Instant COMPLETED_AT = Instant.parse("2026-01-02T03:04:05Z");
+
+    @Test
+    @DisplayName("an absent failedSteps list is normalised to empty, and the result reads as complete")
+    void absentFailedStepsBecomesAnEmptyList() {
+        var result = new GdprDeletionResult("user-1", 1, 2, 3, 4, 5,
+                0, 0, 0, 0, 0, 0, null, COMPLETED_AT);
+
+        assertNotNull(result.failedSteps(), "a null here is dereferenced by every caller that reports the outcome");
+        assertTrue(result.failedSteps().isEmpty());
+        assertTrue(result.complete());
+    }
+
+    @Test
+    @DisplayName("a supplied failedSteps list is defensively copied, so a later mutation cannot flip complete()")
+    void suppliedFailedStepsIsCopied() {
+        var steps = new ArrayList<>(List.of("userMemories"));
+        var result = new GdprDeletionResult("user-1", 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, steps, COMPLETED_AT);
+
+        steps.clear();
+
+        assertEquals(List.of("userMemories"), result.failedSteps());
+        assertFalse(result.complete());
+        assertThrows(UnsupportedOperationException.class, () -> result.failedSteps().add("attachments"));
+    }
+
+    /**
+     * The compatibility constructor is what pre-cascade callers use; it must report
+     * a complete erasure rather than an unknown one.
+     */
+    @Test
+    @DisplayName("the seven-argument constructor reports a complete cascade")
+    void compatibilityConstructorIsComplete() {
+        var result = new GdprDeletionResult("user-1", 5, 3, 2, 10, 15, COMPLETED_AT);
+
+        assertTrue(result.failedSteps().isEmpty());
+        assertTrue(result.complete());
+        assertEquals(5, result.memoriesDeleted());
+        assertEquals(COMPLETED_AT, result.completedAt());
+    }
+
+    /**
+     * The regression the {@code @JsonProperty} annotation fixes: without it the
+     * REST entity carried no {@code complete} field at all, while the MCP tool put
+     * one in — so the two surfaces disagreed about the only field that decides
+     * whether an erasure may be reported as fulfilled.
+     */
+    @Test
+    @DisplayName("complete() is serialised into the REST entity, matching the MCP payload")
+    void completeIsSerialised() throws Exception {
+        var failed = new GdprDeletionResult("user-1", 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, List.of("attachments"), COMPLETED_AT);
+
+        String json = new ObjectMapper().findAndRegisterModules().writeValueAsString(failed);
+
+        assertTrue(json.contains("\"complete\":false"),
+                "a client reading the REST bundle must see the same verdict the MCP tool reports: " + json);
+    }
+
+    /**
+     * And it must stay read-only: {@code complete} is derived, so the canonical
+     * record constructor has no component for it and a payload carrying one would
+     * otherwise fail to deserialize.
+     */
+    @Test
+    @DisplayName("complete is read-only, so a round-tripped payload still deserializes")
+    void completeIsReadOnly() throws Exception {
+        assertEquals(JsonProperty.Access.READ_ONLY,
+                GdprDeletionResult.class.getMethod("complete").getAnnotation(JsonProperty.class).access());
+
+        var mapper = new ObjectMapper().findAndRegisterModules();
+        var original = new GdprDeletionResult("user-1", 1, 2, 3, 4, 5,
+                0, 0, 0, 0, 0, 0, List.of("attachments"), COMPLETED_AT);
+
+        var roundTripped = mapper.readValue(mapper.writeValueAsString(original), GdprDeletionResult.class);
+
+        assertEquals(List.of("attachments"), roundTripped.failedSteps());
+        assertFalse(roundTripped.complete());
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/gdpr/ProcessingRestrictionUnavailableExceptionMapperTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/ProcessingRestrictionUnavailableExceptionMapperTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.gdpr;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The mapper shipped with no test at all, which mattered because it is the only
+ * thing standing between an unreadable Art. 18 flag and a 403 saying the user's
+ * processing is restricted when nobody restricted it.
+ * <p>
+ * It fires only on the synchronous entry points — {@code say} and
+ * {@code sayStreaming} are resumed through an {@code AsyncResponse} and carry
+ * explicit branches instead — so this test pins the shape those branches have
+ * to reproduce. See
+ * {@code RestAgentEngineTest.gdprRestrictionStatusUnavailable}.
+ */
+@DisplayName("ProcessingRestrictionUnavailableExceptionMapper")
+class ProcessingRestrictionUnavailableExceptionMapperTest {
+
+    private final ProcessingRestrictionUnavailableExceptionMapper mapper = new ProcessingRestrictionUnavailableExceptionMapper();
+
+    @Test
+    @DisplayName("maps to 503 with a retryable, machine-readable body — not the 403 the fail-closed path used to answer")
+    void mapsToServiceUnavailable() {
+        var exception = new ProcessingRestrictionUnavailableException(
+                "Cannot determine processing-restriction status right now; the request was not processed",
+                new RuntimeException("connection refused"));
+
+        Response response = mapper.toResponse(exception);
+
+        assertEquals(503, response.getStatus(), "403 would be a false legal statement about the user");
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+        assertEquals("5", response.getHeaderString("Retry-After"), "the flag is unreadable now, not forever");
+        assertEquals(Map.of("error", "restriction_status_unavailable",
+                "message", "Cannot determine processing-restriction status right now; the request was not processed"),
+                response.getEntity());
+    }
+
+    /**
+     * {@code Map.of} throws {@link NullPointerException} on a null value, so a
+     * thrower that supplies no message would make this mapper throw — and a mapper
+     * that throws produces exactly the opaque 500 the class exists to replace. The
+     * guard matters more on the {@code AsyncResponse} branch in
+     * {@code RestAgentEngine.sayInternal}: an exception raised inside a catch
+     * clause is not seen by the sibling catches, so the response would never be
+     * resumed and the request would hang to its timeout.
+     * <p>
+     * Unreachable today — the exception's only constructor takes
+     * {@code (String, Throwable)} and its single call site passes a literal — which
+     * is why it is pinned here rather than left to the day a second thrower is
+     * added.
+     */
+    @Test
+    @DisplayName("a null message falls back to a fixed text instead of throwing out of the mapper")
+    void nullMessageFallsBackToAFixedText() {
+        var exception = new ProcessingRestrictionUnavailableException(null, new RuntimeException("connection refused"));
+
+        Response response = mapper.toResponse(exception);
+
+        assertEquals(503, response.getStatus());
+        assertEquals(Map.of("error", "restriction_status_unavailable",
+                "message", "Processing-restriction status unavailable"), response.getEntity());
+        assertEquals("Processing-restriction status unavailable",
+                ProcessingRestrictionUnavailableExceptionMapper.messageOf(exception),
+                "the two AsyncResponse branches reproduce this body through the accessor, so it has to agree");
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/gdpr/RestGdprAdminTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/RestGdprAdminTest.java
@@ -5,6 +5,7 @@
 package ai.labs.eddi.engine.gdpr;
 
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -70,10 +71,30 @@ class RestGdprAdminTest {
                 Instant.now());
         when(gdprService.deleteUserData("user-1")).thenReturn(expected);
 
-        GdprDeletionResult result = restAdmin.deleteUserData("user-1");
+        Response response = restAdmin.deleteUserData("user-1");
 
-        assertSame(expected, result);
+        assertEquals(200, response.getStatus());
+        assertSame(expected, response.getEntity());
         verify(gdprService).deleteUserData("user-1");
+    }
+
+    /**
+     * A cascade that lost a step must not answer 200. An admin who sees 200 with
+     * {@code conversationsDeleted=0} cannot tell "the user had none" from "the
+     * delete threw", and files the Art. 17 request as fulfilled either way.
+     */
+    @Test
+    void deleteUserData_reports207WhenACascadeStepFailed() {
+        var incomplete = new GdprDeletionResult("user-1", 5, 0, 2, 10, 15,
+                0, 0, 0, 0, 0, 0, List.of("conversations"), Instant.now());
+        when(gdprService.deleteUserData("user-1")).thenReturn(incomplete);
+
+        Response response = restAdmin.deleteUserData("user-1");
+
+        assertEquals(RestGdprAdmin.MULTI_STATUS, response.getStatus());
+        assertSame(incomplete, response.getEntity());
+        assertFalse(incomplete.complete());
+        assertEquals(List.of("conversations"), incomplete.failedSteps());
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/gdpr/RestGdprAdminTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/RestGdprAdminTest.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.engine.gdpr;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -103,10 +105,48 @@ class RestGdprAdminTest {
                 List.of(), List.of(), List.of(), List.of());
         when(gdprService.exportUserData("user-1")).thenReturn(expected);
 
-        UserDataExport result = restAdmin.exportUserData("user-1");
+        Response response = restAdmin.exportUserData("user-1");
 
-        assertSame(expected, result);
+        assertEquals(200, response.getStatus());
+        assertSame(expected, response.getEntity());
         verify(gdprService).exportUserData("user-1");
+    }
+
+    /**
+     * Finding r4. A bundle the conversation cap truncated is an INCOMPLETE Art.
+     * 15/20 response, and it used to be indistinguishable from a complete one: 200
+     * OK, no marker in the payload, the warning in the server log only. The same
+     * distinction the 207 above draws for erasure.
+     */
+    @Test
+    void exportUserData_reports206WhenTheConversationCapTruncatedTheBundle() {
+        var truncated = new UserDataExport("user-1", Instant.now(),
+                List.of(), List.of(), List.of(), List.of(), List.of(), 1_200, true);
+        when(gdprService.exportUserData("user-1")).thenReturn(truncated);
+
+        Response response = restAdmin.exportUserData("user-1");
+
+        assertEquals(RestGdprAdmin.PARTIAL_CONTENT, response.getStatus());
+        assertSame(truncated, response.getEntity());
+    }
+
+    /**
+     * Finding r15. {@code complete()} is a derived method, not a record component
+     * and not a bean getter, so Jackson left it out of the REST entity while
+     * {@code McpGdprTools} puts it into the MCP payload explicitly — the same
+     * result in two different shapes, and a client written against the MCP JSON
+     * reading null from the REST one.
+     */
+    @Test
+    void deleteUserData_restBodyCarriesCompleteJustLikeTheMcpPayload() throws Exception {
+        var incomplete = new GdprDeletionResult("user-1", 5, 0, 2, 10, 15,
+                0, 0, 0, 0, 0, 0, List.of("conversations"), Instant.now());
+
+        String json = new ObjectMapper().registerModule(new JavaTimeModule()).writeValueAsString(incomplete);
+
+        assertTrue(json.contains("\"complete\":false"),
+                "the REST and MCP surfaces must report the same result in the same shape: " + json);
+        assertTrue(json.contains("\"failedSteps\":[\"conversations\"]"), json);
     }
 
     // ==================== Restriction endpoints ====================

--- a/src/test/java/ai/labs/eddi/engine/gdpr/RestGdprAdminTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/RestGdprAdminTest.java
@@ -107,7 +107,6 @@ class RestGdprAdminTest {
 
         Response response = restAdmin.exportUserData("user-1");
 
-        assertEquals(200, response.getStatus());
         assertSame(expected, response.getEntity());
         verify(gdprService).exportUserData("user-1");
     }
@@ -116,18 +115,65 @@ class RestGdprAdminTest {
      * Finding r4. A bundle the conversation cap truncated is an INCOMPLETE Art.
      * 15/20 response, and it used to be indistinguishable from a complete one: 200
      * OK, no marker in the payload, the warning in the server log only. The same
-     * distinction the 207 above draws for erasure.
+     * distinction the 207 above draws for erasure — and now literally the same
+     * status, because 206 Partial Content is a range status and RFC 9110 wants a
+     * {@code Content-Range} with it that this endpoint neither reads nor produces.
      */
     @Test
-    void exportUserData_reports206WhenTheConversationCapTruncatedTheBundle() {
+    void exportUserData_reports207WhenTheConversationCapTruncatedTheBundle() {
         var truncated = new UserDataExport("user-1", Instant.now(),
                 List.of(), List.of(), List.of(), List.of(), List.of(), 1_200, true);
         when(gdprService.exportUserData("user-1")).thenReturn(truncated);
 
         Response response = restAdmin.exportUserData("user-1");
 
-        assertEquals(RestGdprAdmin.PARTIAL_CONTENT, response.getStatus());
+        assertEquals(RestGdprAdmin.MULTI_STATUS, response.getStatus());
         assertSame(truncated, response.getEntity());
+        assertFalse(truncated.complete());
+    }
+
+    /**
+     * The conversation cap used to be the ONLY completeness check, while this
+     * exporter has never covered group transcripts, shared artifacts, schedules or
+     * HITL journal entries — categories the erasure half deletes as this user's
+     * personal data. So a user with fewer conversations than the cap, and in the
+     * limit a user whose data lives <em>only</em> in those four, received a 200
+     * documented as "Complete export bundle": an Art. 20 portability answer
+     * overstating itself to the one reader who cannot check it.
+     */
+    @Test
+    void exportUserData_reports207WhileWholeCategoriesAreOmitted() {
+        var untruncated = new UserDataExport("user-1", Instant.now(),
+                List.of(), List.of(), List.of(), List.of(), List.of(), 0, false);
+        when(gdprService.exportUserData("user-1")).thenReturn(untruncated);
+
+        Response response = restAdmin.exportUserData("user-1");
+
+        assertEquals(RestGdprAdmin.MULTI_STATUS, response.getStatus(),
+                "nothing was truncated, but four whole categories are missing — that is not a complete bundle");
+        assertFalse(untruncated.complete());
+        assertEquals(List.of("groupConversations", "sharedArtifacts", "schedules", "journalEntries"),
+                untruncated.omittedCategories(),
+                "and the caller is told which categories, not merely that something is missing");
+    }
+
+    /**
+     * Finding r15 again, for the export half. {@code complete()} and
+     * {@code omittedCategories()} are derived methods — neither record components
+     * nor bean getters — so without the annotation Jackson drops them from the REST
+     * entity, {@code McpGdprTools} still puts them in the MCP payload, and the
+     * status code becomes the only place the REST client is told about the gap.
+     */
+    @Test
+    void exportUserData_restBodyCarriesCompletenessAndOmittedCategories() throws Exception {
+        var export = new UserDataExport("user-1", Instant.now(),
+                List.of(), List.of(), List.of(), List.of(), List.of(), 0, false);
+
+        String json = new ObjectMapper().registerModule(new JavaTimeModule()).writeValueAsString(export);
+
+        assertTrue(json.contains("\"complete\":false"),
+                "a bundle whose incompleteness lives only in the status line gets filed as complete: " + json);
+        assertTrue(json.contains("\"omittedCategories\":[\"groupConversations\""), json);
     }
 
     /**

--- a/src/test/java/ai/labs/eddi/engine/gdpr/UserDataExportTest.java
+++ b/src/test/java/ai/labs/eddi/engine/gdpr/UserDataExportTest.java
@@ -60,4 +60,35 @@ class UserDataExportTest {
         assertEquals("v", audit.llmDetail().get("k"));
         assertNotNull(audit.timestamp());
     }
+
+    /**
+     * The truncation marker is what separates a bundle a DPO may hand a data
+     * subject as a complete Art. 15 answer from one they may not, so the
+     * compatibility constructor has to state it — and state it as complete, because
+     * that shape carries every conversation it was given.
+     */
+    @Test
+    void backwardCompatibleConstructor_reportsTheBundleAsComplete() {
+        var conv = new UserDataExport.ConversationExportEntry("conv-1", "agent-1", 1, ConversationState.READY, List.of());
+
+        var export = new UserDataExport("user-1", Instant.now(), List.of(), List.of(conv), List.of(), List.of(), List.of());
+
+        assertFalse(export.conversationsTruncated(),
+                "a bundle nobody capped must not be reported as incomplete");
+        assertEquals(1, export.totalConversations(),
+                "the total has to match what the bundle actually carries, or the marker is unreadable");
+    }
+
+    /**
+     * The same constructor with no conversation list at all reports a total of 0
+     * rather than throwing. It is handed whatever the store returned, and an export
+     * endpoint that 500s is strictly worse than one that reports an empty bundle.
+     */
+    @Test
+    void backwardCompatibleConstructor_toleratesAbsentConversations() {
+        var export = new UserDataExport("user-1", Instant.now(), List.of(), null, List.of(), List.of(), List.of());
+
+        assertEquals(0, export.totalConversations());
+        assertFalse(export.conversationsTruncated());
+    }
 }

--- a/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceDeepBranchTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/ConversationServiceDeepBranchTest.java
@@ -31,7 +31,9 @@ import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.runtime.IConversationCoordinator;
 import ai.labs.eddi.engine.runtime.IConversationSetup;
 import ai.labs.eddi.engine.runtime.IRuntime;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.QuotaRefusal;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
@@ -47,6 +49,7 @@ import org.mockito.Mock;
 import java.util.*;
 import java.util.HashSet;
 import java.util.Stack;
+import java.util.concurrent.RejectedExecutionException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -117,6 +120,8 @@ class ConversationServiceDeepBranchTest {
     private static final String CONVERSATION_ID = "112233445566778899aabbcc";
     private static final String USER_ID = "user-deep-test";
     private static final int AGENT_TIMEOUT = 60;
+    /** The reason string every store uses for an accounting outage. */
+    private static final String ACCOUNTING_UNAVAILABLE = "Quota accounting unavailable — denying request for safety";
 
     @SuppressWarnings("unchecked")
     @BeforeEach
@@ -388,6 +393,37 @@ class ConversationServiceDeepBranchTest {
             assertThrows(QuotaExceededException.class,
                     () -> conversationService.startConversation(ENV, AGENT_ID, USER_ID, Map.of()));
         }
+
+        /**
+         * A quota STORE OUTAGE is not an over-quota denial. Both refuse the turn, but
+         * the exception decides the status the caller sees: 429 with
+         * {@code Retry-After: 60} tells a client to back off for a minute on the
+         * strength of a limit the tenant never reached, while
+         * {@code QuotaAccountingUnavailableException} is answered 503
+         * {@code quota_accounting_unavailable}. Before the split only the reason string
+         * differed — which no client and no dashboard reads.
+         */
+        @Test
+        @DisplayName("startConversation — accounting unavailable throws the outage type, not QuotaExceededException")
+        void quotaAccountingUnavailable() throws Exception {
+            when(conversationSetup.computeAnonymousUserIdIfEmpty(any(), any()))
+                    .thenReturn(USER_ID);
+            IAgent mockAgent = mock(IAgent.class);
+            when(agentFactory.getLatestReadyAgent(ENV, AGENT_ID)).thenReturn(mockAgent);
+            when(tenantQuotaService.acquireConversationSlot())
+                    .thenReturn(QuotaCheckResult.unavailable(ACCOUNTING_UNAVAILABLE));
+
+            var ex = assertThrows(QuotaAccountingUnavailableException.class,
+                    () -> conversationService.startConversation(ENV, AGENT_ID, USER_ID, Map.of()));
+
+            assertEquals(ACCOUNTING_UNAVAILABLE, ex.getMessage());
+            assertNotEquals(QuotaExceededException.class, ex.getClass(),
+                    "answering 429 for an outage sends the wrong Retry-After and spikes the wrong metric");
+            assertInstanceOf(QuotaRefusal.class, ex,
+                    "the group engines abort on the marker, so an outage must still carry it");
+            assertInstanceOf(RejectedExecutionException.class, ex,
+                    "every surface that already answers 503 for backpressure must answer 503 for this without enumerating it");
+        }
     }
 
     // ==================== isUndoAvailable / isRedoAvailable ====================
@@ -567,6 +603,32 @@ class ConversationServiceDeepBranchTest {
                             false, false, List.of(),
                             new InputData("hello", Map.of()), false, handler));
         }
+
+        /**
+         * See {@code startConversation}'s twin: the API-call gate splits the same way.
+         */
+        @Test
+        @DisplayName("say — accounting unavailable throws the outage type, not QuotaExceededException")
+        void sayQuotaAccountingUnavailable() throws Exception {
+            var snapshot = createSnapshot();
+            when(conversationMemoryStore.loadConversationMemorySnapshot(CONVERSATION_ID))
+                    .thenReturn(snapshot);
+            IAgent mockAgent = mock(IAgent.class);
+            when(agentFactory.getAgent(ENV, AGENT_ID, 1)).thenReturn(mockAgent);
+            when(tenantQuotaService.acquireApiCallSlot())
+                    .thenReturn(QuotaCheckResult.unavailable(ACCOUNTING_UNAVAILABLE));
+
+            var handler = mock(ConversationResponseHandler.class);
+
+            var ex = assertThrows(QuotaAccountingUnavailableException.class,
+                    () -> conversationService.say(ENV, AGENT_ID, CONVERSATION_ID,
+                            false, false, List.of(),
+                            new InputData("hello", Map.of()), false, handler));
+
+            assertEquals(ACCOUNTING_UNAVAILABLE, ex.getMessage());
+            assertNotEquals(QuotaExceededException.class, ex.getClass());
+            assertInstanceOf(QuotaRefusal.class, ex);
+        }
     }
 
     // ==================== sayStreaming — validation branches ====================
@@ -624,6 +686,36 @@ class ConversationServiceDeepBranchTest {
                     () -> conversationService.sayStreaming(ENV, AGENT_ID, CONVERSATION_ID,
                             false, false, List.of(),
                             new InputData("hello", Map.of()), handler));
+        }
+
+        /**
+         * The streaming twin. It matters independently because
+         * {@code RestAgentEngineStreaming.buildErrorEvent} branches on the concrete
+         * type to pick {@code quota_accounting_unavailable} over
+         * {@code quota_exceeded}; if this gate collapsed the two, that branch could
+         * never fire.
+         */
+        @Test
+        @DisplayName("sayStreaming — accounting unavailable throws the outage type, not QuotaExceededException")
+        void quotaAccountingUnavailable() throws Exception {
+            var snapshot = createSnapshot();
+            when(conversationMemoryStore.loadConversationMemorySnapshot(CONVERSATION_ID))
+                    .thenReturn(snapshot);
+            IAgent mockAgent = mock(IAgent.class);
+            when(agentFactory.getAgent(ENV, AGENT_ID, 1)).thenReturn(mockAgent);
+            when(tenantQuotaService.acquireApiCallSlot())
+                    .thenReturn(QuotaCheckResult.unavailable(ACCOUNTING_UNAVAILABLE));
+
+            var handler = mock(StreamingResponseHandler.class);
+
+            var ex = assertThrows(QuotaAccountingUnavailableException.class,
+                    () -> conversationService.sayStreaming(ENV, AGENT_ID, CONVERSATION_ID,
+                            false, false, List.of(),
+                            new InputData("hello", Map.of()), handler));
+
+            assertEquals(ACCOUNTING_UNAVAILABLE, ex.getMessage());
+            assertNotEquals(QuotaExceededException.class, ex.getClass());
+            assertInstanceOf(QuotaRefusal.class, ex);
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceQuotaRefusalTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceQuotaRefusalTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.internal;
+
+import ai.labs.eddi.configs.groups.IAgentGroupStore;
+import ai.labs.eddi.configs.groups.IGroupConversationStore;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ContextScope;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionPhase;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.DiscussionStyle;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.GroupMember;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.PhaseType;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.ProtocolConfig;
+import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration.TurnOrder;
+import ai.labs.eddi.configs.groups.model.GroupConversation;
+import ai.labs.eddi.configs.groups.model.GroupConversation.GroupConversationState;
+import ai.labs.eddi.configs.groups.model.GroupConversation.TranscriptEntryType;
+import ai.labs.eddi.configs.groups.model.SharedTaskList;
+import ai.labs.eddi.configs.groups.model.SharedTaskList.TaskItem;
+import ai.labs.eddi.datastore.serialization.IJsonSerialization;
+import ai.labs.eddi.engine.api.IConversationService;
+import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionEventListener;
+import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
+import ai.labs.eddi.engine.runtime.IAgent;
+import ai.labs.eddi.engine.runtime.IAgentFactory;
+import ai.labs.eddi.engine.security.CallerIdentityContext;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
+import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.QuotaRefusal;
+import ai.labs.eddi.modules.templating.ITemplatingEngine;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+/**
+ * The two group engines that decide whether a phase survives a member failure
+ * must treat <em>every</em> quota refusal as fatal to the whole discussion, not
+ * just {@link QuotaExceededException}.
+ * <p>
+ * {@code QuotaAccountingUnavailableException} had to extend
+ * {@code RejectedExecutionException} (so every surface that already answers 503
+ * for backpressure answers 503 for it), which means it is a <em>sibling</em> of
+ * {@code QuotaExceededException}, not a subclass. The moment
+ * {@code ConversationService} started throwing it for accounting outages, the
+ * {@code instanceof QuotaExceededException} guards in
+ * {@code PhaseExecutionEngine} and {@code TaskForceEngine} silently stopped
+ * matching: under the default SKIP policy a quota-store outage became a
+ * transcript full of ERROR/SKIPPED entries and a discussion reported complete,
+ * and under RETRY it became {@code maxRetries} attempts per member against a
+ * store that cannot answer. Both guards now match the {@code QuotaRefusal}
+ * marker, and these tests hold them to it.
+ * <p>
+ * Deliberately driven through the private phase methods by reflection, the same
+ * way {@code GroupConversationServiceConcurrencyTest} does: the guards live
+ * inside the fan-out, which no public entry point lets a test reach without
+ * standing up a whole discussion.
+ */
+@DisplayName("GroupConversationService — a quota refusal aborts the phase")
+class GroupConversationServiceQuotaRefusalTest {
+
+    private static final String OUTAGE_REASON = "Quota accounting unavailable — denying request for safety";
+
+    @Mock
+    private IAgentGroupStore groupStore;
+    @Mock
+    private IGroupConversationStore conversationStore;
+    @Mock
+    private IConversationService conversationService;
+    @Mock
+    private IAgentFactory agentFactory;
+    @Mock
+    private ITemplatingEngine templatingEngine;
+    @Mock
+    private IJsonSerialization jsonSerialization;
+    @Mock
+    private IAgent agent;
+
+    private GroupConversationService service;
+
+    private static final String QUESTION = "What should we do?";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        service = new GroupConversationService(
+                groupStore, conversationStore, conversationService,
+                agentFactory, templatingEngine, jsonSerialization,
+                new SimpleMeterRegistry(), null, null, null, null, null,
+                new CallerIdentityContext(null, null), "default", 3);
+
+        doReturn(agent).when(agentFactory).getLatestReadyAgent(any(), any());
+    }
+
+    /**
+     * The parallel-opinion path: the refusal is raised inside a {@code supplyAsync}
+     * body, wrapped in a {@code CompletionException}, and has to be recognised
+     * again after {@code Future.get()} rewraps it in an {@code ExecutionException}.
+     * Both hops are the changed lines.
+     */
+    @Test
+    @Timeout(90)
+    @DisplayName("parallel phase: a quota-store outage propagates out instead of becoming an error transcript entry")
+    void parallelPhase_accountingUnavailable_abortsTheDiscussion() throws Exception {
+        var gc = groupConversation("gc-parallel-quota-outage");
+        List<GroupMember> members = List.of(member(0), member(1));
+
+        doThrow(new QuotaAccountingUnavailableException(OUTAGE_REASON))
+                .when(conversationService).startConversation(any(), any(), any(), any());
+
+        var thrown = assertThrows(GroupDiscussionException.class,
+                () -> invoke(phaseMethod("executeParallelPhase"), gc, config(members), members,
+                        phase(PhaseType.OPINION, TurnOrder.PARALLEL), protocol(30), QUESTION, 0, null,
+                        new AtomicInteger(0), 50));
+
+        assertInstanceOf(QuotaAccountingUnavailableException.class, thrown.getCause(),
+                "the outage must reach the caller intact, so the REST layer can answer 503 rather than 'discussion complete'");
+        assertTrue(thrown.getMessage().contains("accounting unavailable"), thrown.getMessage());
+        assertFalse(thrown.getMessage().contains("Tenant quota exceeded"),
+                "the abort must not claim the tenant went over a limit");
+        assertTrue(gc.getTranscript().stream().noneMatch(e -> e.type() == TranscriptEntryType.ERROR),
+                "a quota refusal is not one member's failure, so it must not be written up as one: " + gc.getTranscript());
+    }
+
+    /**
+     * The over-limit half of the same guard, which the marker interface must not
+     * have broken while widening it.
+     */
+    @Test
+    @Timeout(90)
+    @DisplayName("parallel phase: an over-limit denial still aborts")
+    void parallelPhase_quotaExceeded_stillAborts() throws Exception {
+        var gc = groupConversation("gc-parallel-quota-exceeded");
+        List<GroupMember> members = List.of(member(0));
+
+        doThrow(new QuotaExceededException("Daily conversation limit reached (1000)"))
+                .when(conversationService).startConversation(any(), any(), any(), any());
+
+        var thrown = assertThrows(GroupDiscussionException.class,
+                () -> invoke(phaseMethod("executeParallelPhase"), gc, config(members), members,
+                        phase(PhaseType.OPINION, TurnOrder.PARALLEL), protocol(30), QUESTION, 0, null,
+                        new AtomicInteger(0), 50));
+
+        assertInstanceOf(QuotaExceededException.class, thrown.getCause());
+        assertTrue(thrown.getMessage().startsWith("Tenant quota exceeded"), thrown.getMessage());
+    }
+
+    /**
+     * The TASK_FORCE wave: the refusal is collected into the wave's error list by
+     * the worker and re-thrown by the wave loop, which is a second, independent
+     * {@code QuotaRefusal} guard. Under SKIP — the default — the wave would
+     * otherwise mark the task FAILED and carry on.
+     */
+    @Test
+    @Timeout(90)
+    @DisplayName("task-force wave: a quota-store outage aborts the wave rather than failing the task")
+    void taskExecutionPhase_accountingUnavailable_abortsTheWave() throws Exception {
+        var gc = groupConversation("gc-taskforce-quota-outage");
+        var member = member(0);
+        var taskList = new SharedTaskList();
+        var task = taskList.addTask(new TaskItem("Task A", "do A", 0));
+        taskList.assignTask(task.id(), member.agentId(), member.displayName());
+        gc.setTaskList(taskList);
+
+        doThrow(new QuotaAccountingUnavailableException(OUTAGE_REASON))
+                .when(conversationService).startConversation(any(), any(), any(), any());
+
+        var thrown = assertThrows(GroupDiscussionException.class,
+                () -> invoke(phaseMethod("executeTaskExecutionPhase"), gc, config(List.of(member)), List.of(member),
+                        phase(PhaseType.EXECUTE, TurnOrder.PARALLEL), protocol(30), QUESTION, 0, null,
+                        new AtomicInteger(0), 50));
+
+        assertInstanceOf(QuotaAccountingUnavailableException.class, thrown.getCause(),
+                "the wave must surface the outage, not swallow it into a FAILED task under the SKIP policy");
+        assertEquals(1, gc.getTaskList().all().size());
+        assertFalse(thrown.getMessage().contains("Tenant quota exceeded"), thrown.getMessage());
+    }
+
+    /**
+     * The other side of the guard, and the reason it is a guard rather than a
+     * blanket abort: an ordinary member failure is one agent's problem, so it
+     * becomes an ERROR entry in the transcript and the remaining speakers still
+     * run. Widening the match to the {@code QuotaRefusal} marker must not have
+     * widened it to every {@code GroupDiscussionException}.
+     */
+    @Test
+    @Timeout(90)
+    @DisplayName("parallel phase: an ordinary member failure is recorded, not propagated")
+    void parallelPhase_ordinaryFailure_isRecordedAsAnErrorEntry() throws Exception {
+        var gc = groupConversation("gc-parallel-ordinary-failure");
+        List<GroupMember> members = List.of(member(0), member(1));
+
+        // ABORT is what makes executeAgentTurn raise a GroupDiscussionException at
+        // the same call site the quota guard sits on — with a cause that is not a
+        // quota refusal.
+        var abortOnFailure = new ProtocolConfig(30, ProtocolConfig.MemberFailurePolicy.ABORT, 0,
+                ProtocolConfig.MemberUnavailablePolicy.SKIP);
+        doThrow(new IllegalStateException("agent backend exploded"))
+                .when(conversationService).startConversation(any(), any(), any(), any());
+
+        invoke(phaseMethod("executeParallelPhase"), gc, config(members), members,
+                phase(PhaseType.OPINION, TurnOrder.PARALLEL), abortOnFailure, QUESTION, 0, null,
+                new AtomicInteger(0), 50);
+
+        assertEquals(2, gc.getTranscript().size(),
+                "both members must be accounted for rather than the phase unwinding on the first failure");
+        assertTrue(gc.getTranscript().stream().allMatch(e -> e.type() == TranscriptEntryType.ERROR),
+                "a non-quota failure belongs in the transcript: " + gc.getTranscript());
+    }
+
+    /**
+     * The task-force twin, and the case that separates the two guards. Under ABORT
+     * an ordinary member failure reaches the same {@code catch} the quota guard
+     * sits in, and must fall through it: the task is written up as FAILED and the
+     * wave's own ABORT policy — not the quota guard — is what ends it. Widening the
+     * match to the {@code QuotaRefusal} marker must not have turned every member
+     * failure into an immediate wave abort that skips {@code recordTaskFailure} and
+     * leaves the task in flight.
+     */
+    @Test
+    @Timeout(90)
+    @DisplayName("task-force wave: an ordinary member failure is written up before the ABORT policy ends the wave")
+    void taskExecutionPhase_ordinaryFailure_isRecordedBeforeAbort() throws Exception {
+        var gc = groupConversation("gc-taskforce-ordinary-failure");
+        var member = member(0);
+        var taskList = new SharedTaskList();
+        var task = taskList.addTask(new TaskItem("Task A", "do A", 0));
+        taskList.assignTask(task.id(), member.agentId(), member.displayName());
+        gc.setTaskList(taskList);
+
+        var abortOnFailure = new ProtocolConfig(30, ProtocolConfig.MemberFailurePolicy.ABORT, 0,
+                ProtocolConfig.MemberUnavailablePolicy.SKIP);
+        doThrow(new RuntimeException("agent backend exploded"))
+                .when(conversationService).startConversation(any(), any(), any(), any());
+
+        var thrown = assertThrows(GroupDiscussionException.class,
+                () -> invoke(phaseMethod("executeTaskExecutionPhase"), gc, config(List.of(member)), List.of(member),
+                        phase(PhaseType.EXECUTE, TurnOrder.PARALLEL), abortOnFailure, QUESTION, 0, null,
+                        new AtomicInteger(0), 50));
+
+        assertFalse(thrown.getCause() instanceof QuotaRefusal,
+                "the wave must end on the member's own failure, not be re-labelled as a quota refusal");
+        assertFalse(thrown.getMessage().contains("quota"), thrown.getMessage());
+        assertEquals(SharedTaskList.TaskStatus.FAILED, gc.getTaskList().all().getFirst().status(),
+                "the task the failing member held must be written up, not left in flight");
+    }
+
+    // ==================== helpers ====================
+
+    private GroupConversation groupConversation(String id) {
+        var gc = new GroupConversation();
+        gc.setId(id);
+        gc.setGroupId("group-quota-refusal");
+        gc.setUserId("user-quota-refusal");
+        gc.setState(GroupConversationState.IN_PROGRESS);
+        gc.setOriginalQuestion(QUESTION);
+        gc.setTranscript(new ArrayList<>());
+        gc.setMemberConversationIds(new ConcurrentHashMap<>());
+        return gc;
+    }
+
+    private GroupMember member(int index) {
+        return new GroupMember("agent-" + index, "Agent " + index, index, null);
+    }
+
+    private AgentGroupConfiguration config(List<GroupMember> members) {
+        var config = new AgentGroupConfiguration();
+        config.setName("Quota Refusal Group");
+        config.setStyle(DiscussionStyle.CUSTOM);
+        config.setMembers(members);
+        return config;
+    }
+
+    private DiscussionPhase phase(PhaseType type, TurnOrder turnOrder) {
+        return new DiscussionPhase("P-" + type, type, "ALL", turnOrder, ContextScope.FULL, false, null, 1, false);
+    }
+
+    /**
+     * SKIP is the default failure policy — the one the broken guard fell through
+     * to.
+     */
+    private ProtocolConfig protocol(int agentTimeoutSeconds) {
+        return new ProtocolConfig(agentTimeoutSeconds, ProtocolConfig.MemberFailurePolicy.SKIP, 0,
+                ProtocolConfig.MemberUnavailablePolicy.SKIP);
+    }
+
+    private Method phaseMethod(String name) throws NoSuchMethodException {
+        Method m = GroupConversationService.class.getDeclaredMethod(name,
+                GroupConversation.class, AgentGroupConfiguration.class, List.class, DiscussionPhase.class,
+                ProtocolConfig.class, String.class, int.class, GroupDiscussionEventListener.class,
+                AtomicInteger.class, int.class);
+        m.setAccessible(true);
+        return m;
+    }
+
+    private void invoke(Method m, Object... args) throws Exception {
+        try {
+            m.invoke(service, args);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof Exception ex) {
+                throw ex;
+            }
+            throw e;
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTaskForceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/GroupConversationServiceTaskForceTest.java
@@ -28,6 +28,7 @@ import ai.labs.eddi.datastore.serialization.IJsonSerialization;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.api.IGroupConversationService.GroupDiscussionException;
 import ai.labs.eddi.engine.runtime.IAgent;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.modules.templating.ITemplatingEngine;
@@ -513,6 +514,86 @@ class GroupConversationServiceTaskForceTest {
             // i.e. it described how the test called the code, not what the code does.
             assertInstanceOf(QuotaExceededException.class, ex.getCause());
             // Verify say() was called exactly once (no retries)
+            verify(conversationService, times(1)).say(any(), eq("agent-1"), eq("existing-conv"),
+                    any(), any(), any(), any(), anyBoolean(), any());
+        }
+
+        /**
+         * A quota-store OUTAGE must abort exactly like an over-limit denial.
+         * <p>
+         * {@code QuotaAccountingUnavailableException} extends
+         * {@code RejectedExecutionException} rather than {@code QuotaExceededException}
+         * — so the moment {@code ConversationService} started throwing it for
+         * {@code accountingUnavailable} denials, every
+         * {@code instanceof QuotaExceededException} guard in the group engines stopped
+         * matching and the outage arrived here as an ordinary member failure: a SKIPPED
+         * transcript entry under the default policy, with the discussion reported
+         * complete. The guards match {@link ai.labs.eddi.engine.tenancy.QuotaRefusal}
+         * now, so a new refusal type is covered the day it is added.
+         */
+        @Test
+        @DisplayName("a quota-store outage on startConversation aborts, it does not become a SKIPPED entry")
+        void startConversation_accountingUnavailable_throwsGroupDiscussionException() throws Exception {
+
+            var member = new GroupMember("agent-1", "Agent One", 0, "MEMBER");
+            var gc = new GroupConversation();
+            gc.setTranscript(new ArrayList<>());
+            gc.setMemberConversationIds(new ConcurrentHashMap<>());
+
+            // SKIP is the DEFAULT failure policy — the one that silently swallowed it.
+            var protocol = new AgentGroupConfiguration.ProtocolConfig(
+                    60, AgentGroupConfiguration.ProtocolConfig.MemberFailurePolicy.SKIP, 2,
+                    AgentGroupConfiguration.ProtocolConfig.MemberUnavailablePolicy.SKIP);
+            var phase = new DiscussionPhase("Execute", PhaseType.EXECUTE, "ALL",
+                    AgentGroupConfiguration.TurnOrder.PARALLEL, AgentGroupConfiguration.ContextScope.TASK_ONLY,
+                    false, null, 1);
+
+            when(agentFactory.getLatestReadyAgent(any(), eq("agent-1"))).thenReturn(mock(IAgent.class));
+            when(conversationService.startConversation(any(), eq("agent-1"), any(), any()))
+                    .thenThrow(new QuotaAccountingUnavailableException(
+                            "Quota accounting unavailable — denying request for safety"));
+
+            var ex = assertThrows(GroupDiscussionException.class,
+                    () -> memberTurnExecutor.executeAgentTurn(member, gc, "test input", protocol, 0, phase, null, null));
+
+            assertInstanceOf(QuotaAccountingUnavailableException.class, ex.getCause());
+            assertTrue(ex.getMessage().contains("accounting unavailable"),
+                    "the abort must name the outage, not report the tenant as over quota: " + ex.getMessage());
+            assertFalse(ex.getMessage().contains("Tenant quota exceeded"),
+                    "'Tenant quota exceeded: Quota accounting unavailable' is false in its first half");
+        }
+
+        /**
+         * The retry half of the same regression: with RETRY policy each member was
+         * re-attempted {@code maxRetries} times against a store that cannot answer,
+         * paying a connection-acquisition timeout per attempt on the phase thread.
+         */
+        @Test
+        @DisplayName("a quota-store outage on say() is not retried either")
+        void say_accountingUnavailable_notRetried() throws Exception {
+
+            var member = new GroupMember("agent-1", "Agent One", 0, "MEMBER");
+            var gc = new GroupConversation();
+            gc.setTranscript(new ArrayList<>());
+            gc.setMemberConversationIds(new ConcurrentHashMap<>(
+                    Map.of("agent-1", "existing-conv")));
+
+            var protocol = new AgentGroupConfiguration.ProtocolConfig(
+                    60, AgentGroupConfiguration.ProtocolConfig.MemberFailurePolicy.RETRY, 5,
+                    AgentGroupConfiguration.ProtocolConfig.MemberUnavailablePolicy.SKIP);
+            var phase = new DiscussionPhase("Execute", PhaseType.EXECUTE, "ALL",
+                    AgentGroupConfiguration.TurnOrder.PARALLEL, AgentGroupConfiguration.ContextScope.TASK_ONLY,
+                    false, null, 1);
+
+            when(agentFactory.getLatestReadyAgent(any(), eq("agent-1"))).thenReturn(mock(IAgent.class));
+            doThrow(new QuotaAccountingUnavailableException("Quota accounting unavailable — denying request for safety"))
+                    .when(conversationService).say(any(), eq("agent-1"), eq("existing-conv"),
+                            any(), any(), any(), any(), anyBoolean(), any());
+
+            var ex = assertThrows(GroupDiscussionException.class,
+                    () -> memberTurnExecutor.executeAgentTurn(member, gc, "test input", protocol, 0, phase, null, null));
+
+            assertInstanceOf(QuotaAccountingUnavailableException.class, ex.getCause());
             verify(conversationService, times(1)).say(any(), eq("agent-1"), eq("existing-conv"),
                     any(), any(), any(), any(), anyBoolean(), any());
         }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationQuotaTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentAdministrationQuotaTest.java
@@ -18,6 +18,7 @@ import ai.labs.eddi.engine.runtime.IAgentFactory;
 import ai.labs.eddi.engine.runtime.IRuntime;
 import ai.labs.eddi.engine.runtime.internal.IDeploymentListener;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
@@ -118,6 +119,30 @@ class RestAgentAdministrationQuotaTest {
             // try block, catch(Exception) would have rethrown InternalServerErrorException
             // and this would fail — which is exactly the 429-becomes-500 regression.
             assertEquals("Agent limit (2) reached", thrown.getMessage());
+            verify(runtime, never()).submitCallable(any(Callable.class), any());
+        }
+
+        /**
+         * Finding f1-02. A quota store that cannot answer is not a tenant over its
+         * limit. Both refuse the deploy, but only one of them is the tenant's fault:
+         * answering 429 {@code quota_exceeded} with {@code Retry-After: 60} for an
+         * outage tells the operator (and any MCP client driving the deploy) to undeploy
+         * an agent that is not the problem, while the dashboard counts the very same
+         * request on {@code eddi.tenant.quota.unavailable{type=agent}}. The three gates
+         * in {@code ConversationService} already split the two; this one did not.
+         */
+        @Test
+        @DisplayName("an accounting outage throws QuotaAccountingUnavailableException (503), not QuotaExceededException (429)")
+        void accountingOutageIsNotReportedAsOverQuota() throws Exception {
+            when(deploymentStore.readDeploymentInfos(any())).thenReturn(List.of(deployed("agent-a", 1)));
+            when(tenantQuotaService.checkAgentQuota(eq(TENANT), eq(1)))
+                    .thenReturn(QuotaCheckResult.unavailable("Quota accounting unavailable - denying request for safety"));
+
+            QuotaAccountingUnavailableException thrown = assertThrows(QuotaAccountingUnavailableException.class,
+                    () -> admin.deployAgent(Deployment.Environment.production, NEW_AGENT, 1, true, false));
+
+            assertEquals("Quota accounting unavailable - denying request for safety", thrown.getMessage());
+            // Still fails closed: nothing is deployed while the store cannot be read.
             verify(runtime, never()).submitCallable(any(Callable.class), any());
         }
     }

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
@@ -808,6 +808,25 @@ class RestAgentEngineStreamingTest {
             assertFalse(payload.contains("Internal server error"), payload);
         }
 
+        /**
+         * The quota twin of
+         * {@code restrictionStatusUnavailableWithoutAMessageUsesTheSharedFallback}.
+         * Echoing {@code getMessage()} raw is null-safe here — it goes through
+         * {@code escapeJson} — but it emitted {@code "message":""} for a thrower with
+         * no message, while {@code QuotaAccountingUnavailableExceptionMapper} and the
+         * synchronous twin both answer "Quota accounting unavailable". One outage, two
+         * error contracts, decided by nothing but whether the client asked for SSE.
+         */
+        @Test
+        @DisplayName("a quota outage carrying no message streams the shared fallback text, not an empty one")
+        void quotaAccountingUnavailableWithoutAMessageUsesTheSharedFallback() throws Exception {
+            String payload = errorPayloadFor(new QuotaAccountingUnavailableException(null));
+
+            assertTrue(payload.contains("\"code\":\"quota_accounting_unavailable\""), payload);
+            assertTrue(payload.contains("Quota accounting unavailable"), payload);
+            assertFalse(payload.contains("\"message\":\"\""), payload);
+        }
+
         @Test
         @DisplayName("anything else stays opaque: fixed message + correlationId, no code")
         void unknownExceptionsStayOpaque() throws Exception {

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineStreamingTest.java
@@ -4,6 +4,8 @@
  */
 package ai.labs.eddi.engine.internal;
 
+import ai.labs.eddi.engine.gdpr.ProcessingRestrictionUnavailableException;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ai.labs.eddi.engine.api.IConversationService;
 import ai.labs.eddi.engine.lifecycle.TaskId;
@@ -750,6 +752,60 @@ class RestAgentEngineStreamingTest {
             assertTrue(payload.contains("\"code\":\"agent_mismatch\""), payload);
             assertTrue(payload.contains("Agent version mismatch"), payload);
             assertFalse(payload.contains("agent-7"), payload);
+        }
+
+        /**
+         * The honest-503 fix reached the synchronous start endpoint only. On this path
+         * a store failover surfaced as {@code {"message":"Internal server error"}} on
+         * every streamed turn, with an ERROR stack trace and a fresh correlation id
+         * behind each one — the twin answers 503
+         * {@code restriction_status_unavailable}.
+         */
+        @Test
+        @DisplayName("restriction status unreadable → code=restriction_status_unavailable, not an opaque internal error")
+        void restrictionStatusUnavailableIsTyped() throws Exception {
+            String payload = errorPayloadFor(new ProcessingRestrictionUnavailableException(
+                    "Cannot determine processing-restriction status right now; the request was not processed",
+                    new RuntimeException("connection refused")));
+
+            assertTrue(payload.contains("\"code\":\"restriction_status_unavailable\""), payload);
+            assertFalse(payload.contains("Internal server error"), payload);
+            // The cause's message can name replica-set members; only the fixed
+            // template above is echoed.
+            assertFalse(payload.contains("connection refused"), payload);
+        }
+
+        /**
+         * The third surface of the same body. Echoing {@code getMessage()} here is
+         * null-safe (it goes through {@code escapeJson}), but it produced
+         * {@code "message":""} for a thrower with no message while the mapper and the
+         * synchronous twin now answer a fixed sentence — three surfaces the mapper's
+         * Javadoc says to change together must not disagree about what an SSE client is
+         * shown.
+         */
+        @Test
+        @DisplayName("a restriction failure carrying no message streams the shared fallback text, not an empty one")
+        void restrictionStatusUnavailableWithoutAMessageUsesTheSharedFallback() throws Exception {
+            String payload = errorPayloadFor(
+                    new ProcessingRestrictionUnavailableException(null, new RuntimeException("connection refused")));
+
+            assertTrue(payload.contains("\"code\":\"restriction_status_unavailable\""), payload);
+            assertTrue(payload.contains("Processing-restriction status unavailable"), payload);
+            assertFalse(payload.contains("\"message\":\"\""), payload);
+        }
+
+        /**
+         * Same distinction the twin draws with a 503 instead of a 429: a quota store
+         * that cannot answer is not a tenant over its allowance.
+         */
+        @Test
+        @DisplayName("quota accounting unavailable → code=quota_accounting_unavailable")
+        void quotaAccountingUnavailableIsTyped() throws Exception {
+            String payload = errorPayloadFor(new QuotaAccountingUnavailableException(
+                    "Quota accounting unavailable — denying request for safety"));
+
+            assertTrue(payload.contains("\"code\":\"quota_accounting_unavailable\""), payload);
+            assertFalse(payload.contains("Internal server error"), payload);
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
+++ b/src/test/java/ai/labs/eddi/engine/internal/RestAgentEngineTest.java
@@ -12,6 +12,7 @@ import ai.labs.eddi.engine.api.IConversationService.ConversationNotFoundExceptio
 import ai.labs.eddi.engine.api.IConversationService.*;
 import ai.labs.eddi.engine.api.IGroupConversationService;
 import ai.labs.eddi.engine.gdpr.ProcessingRestrictedException;
+import ai.labs.eddi.engine.gdpr.ProcessingRestrictionUnavailableException;
 import ai.labs.eddi.engine.hitl.HitlAccessGuard;
 import ai.labs.eddi.engine.hitl.tools.IHitlToolJournalStore;
 import ai.labs.eddi.engine.memory.IConversationMemoryStore;
@@ -23,7 +24,9 @@ import ai.labs.eddi.engine.model.Deployment;
 import ai.labs.eddi.engine.model.InputData;
 import ai.labs.eddi.engine.security.ConversationAccessGuard;
 import ai.labs.eddi.engine.security.OwnershipValidator;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
 import ai.labs.eddi.engine.tenancy.QuotaExceededException;
+import ai.labs.eddi.engine.tenancy.rest.QuotaAccountingUnavailableExceptionMapper;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.ws.rs.InternalServerErrorException;
@@ -346,6 +349,178 @@ class RestAgentEngineTest {
             var captor = ArgumentCaptor.forClass(Response.class);
             verify(asyncResponse).resume(captor.capture());
             assertEquals(403, captor.getValue().getStatus());
+        }
+
+        /**
+         * The honest-503 fix landed on the synchronous start endpoint only. {@code say}
+         * is resumed through an {@code AsyncResponse}, which never reaches an
+         * {@code ExceptionMapper}, so during a store failover the hottest path in the
+         * system answered 500 "An internal error occurred" — not the promised 503
+         * {@code restriction_status_unavailable} — and wrote two ERROR stack traces per
+         * turn per user. Monitoring keyed on 5xx saw a code bug rather than an outage.
+         */
+        @Test
+        @DisplayName("should resume with 503 restriction_status_unavailable, not 500, when the Art. 18 flag cannot be read")
+        void gdprRestrictionStatusUnavailable() throws Exception {
+            var asyncResponse = mock(AsyncResponse.class);
+            var inputData = new InputData("Hello", Map.of());
+
+            doThrow(new ProcessingRestrictionUnavailableException(
+                    "Cannot determine processing-restriction status right now; the request was not processed",
+                    new RuntimeException("connection refused")))
+                    .when(conversationService).say(anyString(), any(), any(), any(), any(), anyBoolean(), any());
+
+            // Without the explicit catch this fell through to the generic handler,
+            // which THROWS InternalServerErrorException instead of resuming — so
+            // both assertions below fail on the old code.
+            restAgentEngine.sayWithinContext("conv-1", false, false,
+                    List.of(), inputData, asyncResponse);
+
+            var captor = ArgumentCaptor.forClass(Response.class);
+            verify(asyncResponse).resume(captor.capture());
+            Response resumed = captor.getValue();
+            assertEquals(503, resumed.getStatus());
+            assertEquals("5", resumed.getHeaderString("Retry-After"));
+            assertEquals(Map.of("error", "restriction_status_unavailable",
+                    "message", "Cannot determine processing-restriction status right now; the request was not processed"),
+                    resumed.getEntity());
+        }
+
+        /**
+         * The branch above built its body with {@code Map.of("message",
+         * e.getMessage())}, unguarded — unlike the quota branch two clauses down.
+         * {@code Map.of} throws {@link NullPointerException} on a null value, and an
+         * exception raised inside a catch clause is not seen by the sibling catches, so
+         * a thrower carrying no message would leave the {@code AsyncResponse} unresumed
+         * and the request hanging to its timeout: strictly worse than the 500 this
+         * branch was added to replace.
+         */
+        @Test
+        @DisplayName("a restriction failure carrying no message still resumes, with the mapper's fallback text")
+        void gdprRestrictionStatusUnavailableWithoutAMessageStillResumes() throws Exception {
+            var asyncResponse = mock(AsyncResponse.class);
+            var inputData = new InputData("Hello", Map.of());
+
+            doThrow(new ProcessingRestrictionUnavailableException(null, new RuntimeException("connection refused")))
+                    .when(conversationService).say(anyString(), any(), any(), any(), any(), anyBoolean(), any());
+
+            restAgentEngine.sayWithinContext("conv-1", false, false,
+                    List.of(), inputData, asyncResponse);
+
+            var captor = ArgumentCaptor.forClass(Response.class);
+            verify(asyncResponse).resume(captor.capture());
+            Response resumed = captor.getValue();
+            assertEquals(503, resumed.getStatus());
+            assertEquals(Map.of("error", "restriction_status_unavailable",
+                    "message", "Processing-restriction status unavailable"), resumed.getEntity());
+        }
+
+        /**
+         * A quota store that cannot answer refuses the turn for safety, which is right
+         * — but it is not the tenant being over a limit. Routing it through the
+         * ordinary denial path answered 429 with {@code Retry-After: 60} and spiked
+         * {@code eddi.tenant.quota.denied}, so neither the client nor the dashboard
+         * could tell a database outage from an exhausted allowance.
+         */
+        @Test
+        @DisplayName("should resume with 503 quota_accounting_unavailable, not 429, when the quota store cannot answer")
+        void quotaAccountingUnavailable() throws Exception {
+            var asyncResponse = mock(AsyncResponse.class);
+            var inputData = new InputData("Hello", Map.of());
+
+            doThrow(new QuotaAccountingUnavailableException("Quota accounting unavailable — denying request for safety"))
+                    .when(conversationService).say(anyString(), any(), any(), any(), any(), anyBoolean(), any());
+
+            restAgentEngine.sayWithinContext("conv-1", false, false,
+                    List.of(), inputData, asyncResponse);
+
+            var captor = ArgumentCaptor.forClass(Response.class);
+            verify(asyncResponse).resume(captor.capture());
+            Response resumed = captor.getValue();
+            assertEquals(503, resumed.getStatus());
+            assertEquals(Map.of("error", "quota_accounting_unavailable",
+                    "message", "Quota accounting unavailable — denying request for safety"),
+                    resumed.getEntity());
+        }
+
+        /**
+         * {@code Map.of} throws {@link NullPointerException} on a null value, and this
+         * branch runs inside a {@code catch} — an exception raised there is not seen by
+         * the sibling catches, so the {@code AsyncResponse} would never be resumed and
+         * the request would hang to its timeout rather than answering 503. The fallback
+         * text keeps the body identical to the one
+         * {@code QuotaAccountingUnavailableExceptionMapper} produces on the synchronous
+         * endpoints.
+         */
+        @Test
+        @DisplayName("a quota-outage refusal carrying no message still resumes, with a fixed body")
+        void quotaAccountingUnavailableWithoutAMessage() throws Exception {
+            var asyncResponse = mock(AsyncResponse.class);
+            var inputData = new InputData("Hello", Map.of());
+
+            doThrow(new QuotaAccountingUnavailableException(null))
+                    .when(conversationService).say(anyString(), any(), any(), any(), any(), anyBoolean(), any());
+
+            restAgentEngine.sayWithinContext("conv-1", false, false,
+                    List.of(), inputData, asyncResponse);
+
+            var captor = ArgumentCaptor.forClass(Response.class);
+            verify(asyncResponse).resume(captor.capture());
+            Response resumed = captor.getValue();
+            assertEquals(503, resumed.getStatus());
+            assertEquals(Map.of("error", "quota_accounting_unavailable",
+                    "message", "Quota accounting unavailable"), resumed.getEntity());
+        }
+
+        /**
+         * The branch exists because {@code say} is resumed through an
+         * {@code AsyncResponse} and so never reaches
+         * {@link QuotaAccountingUnavailableExceptionMapper}, which is what answers the
+         * synchronous endpoints. Two code paths, one outage: a client that retries
+         * {@code POST /agents/{env}/{agentId}} and then {@code POST
+         * /agents/{conversationId}} must not be told two different things, and the
+         * branch's own comment promises exactly that ("Body and headers mirror the
+         * mapper so both surfaces look identical to clients").
+         * <p>
+         * So the mapper is the oracle here rather than a second copy of its expected
+         * body — a duplicated literal drifts silently, while an equality against the
+         * mapper cannot. The header is the half nothing else pins and the half most
+         * likely to be wrong: the exception extends {@link RejectedExecutionException}
+         * and sits one clause above the backpressure branch, and the sibling quota
+         * branch two clauses up answers {@code Retry-After: 60}. A store failover
+         * clears in seconds, so telling a client to wait a minute — or omitting the
+         * header entirely and leaving the retry interval to the client — is a real
+         * behaviour change that the status and body assertions above would not notice.
+         */
+        @Test
+        @DisplayName("the async 503 for a quota-store outage is the mapper's own answer, Retry-After included")
+        void quotaAccountingUnavailableMirrorsTheSynchronousMapper() throws Exception {
+            var asyncResponse = mock(AsyncResponse.class);
+            var inputData = new InputData("Hello", Map.of());
+            var outage = new QuotaAccountingUnavailableException("Quota accounting unavailable — denying request for safety");
+
+            doThrow(outage).when(conversationService).say(anyString(), any(), any(), any(), any(), anyBoolean(), any());
+
+            restAgentEngine.sayWithinContext("conv-1", false, false,
+                    List.of(), inputData, asyncResponse);
+
+            var captor = ArgumentCaptor.forClass(Response.class);
+            verify(asyncResponse).resume(captor.capture());
+            Response resumed = captor.getValue();
+
+            Response synchronousAnswer = new QuotaAccountingUnavailableExceptionMapper().toResponse(outage);
+
+            assertEquals(synchronousAnswer.getStatus(), resumed.getStatus(),
+                    "the same outage must not be a 503 on one endpoint and something else on the other");
+            assertEquals(synchronousAnswer.getEntity(), resumed.getEntity(),
+                    "a client switching endpoints mid-outage parses one error code, not two");
+            assertEquals(synchronousAnswer.getMediaType(), resumed.getMediaType(),
+                    "a JSON body announced as text/plain is unparseable to the same client");
+            assertEquals(synchronousAnswer.getHeaderString("Retry-After"), resumed.getHeaderString("Retry-After"),
+                    "the retry interval is part of the answer, and the two surfaces have to agree on it");
+            assertEquals("5", resumed.getHeaderString("Retry-After"),
+                    "a store failover clears in seconds — 60 is the over-quota backoff and would idle every client "
+                            + "for a minute after the store came back");
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsBranchCoverageTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpAdminToolsBranchCoverageTest.java
@@ -13,6 +13,8 @@ import ai.labs.eddi.engine.runtime.internal.SchedulePollerService;
 import ai.labs.eddi.engine.schedule.IScheduleStore;
 import ai.labs.eddi.engine.schedule.model.ScheduleConfiguration;
 import ai.labs.eddi.engine.schedule.model.ScheduleFireLog;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
+import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -166,6 +168,47 @@ class McpAdminToolsBranchCoverageTest {
 
             String result = tools.deployAgent("agent1", 1, null);
             assertTrue(result.contains("error"));
+            assertTrue(result.contains("Check server logs"),
+                    "an unrecognised failure must NOT leak its own message to an MCP client");
+        }
+
+        /**
+         * An over-limit refusal is actionable ("undeploy an agent first"), so its
+         * reason is passed through verbatim rather than replaced by "check server logs"
+         * — which a model driving an MCP client cannot self-correct from and will retry
+         * in a loop.
+         */
+        @Test
+        @DisplayName("an over-quota refusal returns the quota reason verbatim")
+        void quotaExceededReturnsTheReason() {
+            when(agentAdmin.deployAgent(any(), anyString(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenThrow(new QuotaExceededException("Agent limit reached (5)"));
+
+            String result = tools.deployAgent("agent1", 1, null);
+
+            assertEquals("{\"error\":\"Agent limit reached (5)\"}", result);
+        }
+
+        /**
+         * The regression the {@code QuotaRefusal} marker exists for.
+         * {@code QuotaAccountingUnavailableException} is a sibling of
+         * {@code QuotaExceededException}, not a subclass, so the previous
+         * {@code catch (QuotaExceededException)} stopped matching it and a quota-store
+         * outage fell into the generic branch — reaching the client as "Failed to
+         * deploy agent. Check server logs for details."
+         */
+        @Test
+        @DisplayName("a quota-store outage also returns its reason, not the generic 'check server logs'")
+        void quotaAccountingUnavailableReturnsTheReason() {
+            when(agentAdmin.deployAgent(any(), anyString(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenThrow(new QuotaAccountingUnavailableException(
+                            "Quota accounting unavailable — denying request for safety"));
+
+            String result = tools.deployAgent("agent1", 1, null);
+
+            assertEquals("{\"error\":\"Quota accounting unavailable — denying request for safety\"}", result);
+            assertFalse(result.contains("Check server logs"),
+                    "a store outage is not an unknown failure; the MCP client must be told what happened");
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpGdprToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpGdprToolsTest.java
@@ -12,8 +12,11 @@ import io.quarkus.security.identity.SecurityIdentity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.mockito.ArgumentCaptor;
+
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -92,6 +95,61 @@ class McpGdprToolsTest {
         assertNotNull(result);
         assertTrue(result.contains("completed"));
         verify(gdprService).deleteUserData("user-1");
+    }
+
+    /**
+     * The MCP half of the "erasure filed as fulfilled while the data is still
+     * there" defect. {@code status} used to be the literal {@code "completed"}
+     * whatever the cascade actually did, so an admin — or an LLM agent acting on
+     * this tool's answer — closed an Art. 17 request for a run that lost a step.
+     * The REST surface answers 207 for the same run.
+     */
+    @Test
+    void deleteUserData_reportsPartialWhenACascadeStepFailed() throws Exception {
+        var partial = new GdprDeletionResult("user-1", 5, 0, 2, 10, 15,
+                0, 0, 0, 0, 0, 0, List.of("conversations", "attachments"), Instant.EPOCH);
+        when(gdprService.deleteUserData("user-1")).thenReturn(partial);
+
+        tools.deleteUserData("user-1", "CONFIRM");
+
+        Map<String, Object> body = capturedResponseBody();
+        assertEquals("partially_completed", body.get("status"),
+                "a cascade that lost a step must not be reported as completed");
+        assertEquals(Boolean.FALSE, body.get("complete"));
+        assertEquals(List.of("conversations", "attachments"), body.get("failedSteps"));
+    }
+
+    /**
+     * The six counters the cascade has always computed and written to the audit
+     * ledger but never returned here, so an MCP caller could not tell whether
+     * attachments, journal entries, checkpoints, group transcripts, artifacts or
+     * schedules had been touched.
+     */
+    @Test
+    void deleteUserData_reportsEveryCounterTheCascadeComputes() throws Exception {
+        var full = new GdprDeletionResult("user-1", 1, 2, 3, 4, 5,
+                6, 7, 8, 9, 10, 11, List.of(), Instant.EPOCH);
+        when(gdprService.deleteUserData("user-1")).thenReturn(full);
+
+        tools.deleteUserData("user-1", "CONFIRM");
+
+        Map<String, Object> body = capturedResponseBody();
+        assertEquals("completed", body.get("status"));
+        assertEquals(Boolean.TRUE, body.get("complete"));
+        assertEquals(6L, body.get("attachmentsDeleted"));
+        assertEquals(7L, body.get("journalEntriesDeleted"));
+        assertEquals(8L, body.get("checkpointsDeleted"));
+        assertEquals(9L, body.get("groupConversationsDeleted"));
+        assertEquals(10L, body.get("sharedArtifactsDeleted"));
+        assertEquals(11L, body.get("schedulesDeleted"));
+    }
+
+    /** The map the tool handed to the serializer, i.e. the response it produced. */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> capturedResponseBody() throws Exception {
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(jsonSerialization).serialize(captor.capture());
+        return (Map<String, Object>) captor.getValue();
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/mcp/McpGdprToolsTest.java
+++ b/src/test/java/ai/labs/eddi/engine/mcp/McpGdprToolsTest.java
@@ -14,9 +14,11 @@ import org.junit.jupiter.api.Test;
 
 import org.mockito.ArgumentCaptor;
 
+import java.lang.reflect.RecordComponent;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -142,6 +144,42 @@ class McpGdprToolsTest {
         assertEquals(9L, body.get("groupConversationsDeleted"));
         assertEquals(10L, body.get("sharedArtifactsDeleted"));
         assertEquals(11L, body.get("schedulesDeleted"));
+    }
+
+    /**
+     * The MCP payload is hand-built, one {@code put} per component, while REST
+     * returns the record itself. A component added to {@link GdprDeletionResult}
+     * therefore appears in the REST JSON and silently does not appear here — the
+     * same erasure reported in two shapes, which is precisely the defect
+     * {@code complete} was added to fix, one component later. The six counters this
+     * PR restored were missing for exactly that reason.
+     * <p>
+     * Compared as key sets, not value by value: the point is that nothing can be
+     * added to the record without this test noticing, which a per-field assertion
+     * cannot do.
+     */
+    @Test
+    void deleteUserData_mcpPayloadCarriesEveryKeyTheRestBodyDoes() throws Exception {
+        var full = new GdprDeletionResult("user-1", 1, 2, 3, 4, 5,
+                6, 7, 8, 9, 10, 11, List.of(), Instant.EPOCH);
+        when(gdprService.deleteUserData("user-1")).thenReturn(full);
+
+        // Sorted, so a mismatch reads as a diff rather than two shuffled lists.
+        var expected = new TreeSet<String>();
+        for (RecordComponent component : GdprDeletionResult.class.getRecordComponents()) {
+            expected.add(component.getName());
+        }
+        // Derived rather than a component, and on the REST body too — @JsonProperty
+        // on GdprDeletionResult.complete() is what puts it there.
+        expected.add("complete");
+        // MCP-only: the human-readable verdict REST expresses as 200 vs 207.
+        expected.add("status");
+
+        tools.deleteUserData("user-1", "CONFIRM");
+
+        assertEquals(expected, new TreeSet<>(capturedResponseBody().keySet()),
+                "the MCP and REST surfaces must report the same erasure in the same shape; a key here and "
+                        + "not there is a client reading null from one of them");
     }
 
     /** The map the tool handed to the serializer, i.e. the response it produced. */

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
@@ -11,6 +11,8 @@ import ai.labs.eddi.configs.descriptors.model.ResourceGrant;
 import ai.labs.eddi.configs.descriptors.model.ResourceVisibility;
 import ai.labs.eddi.datastore.IResourceStore;
 import io.quarkus.security.ForbiddenException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ServiceUnavailableException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -169,6 +171,30 @@ class ResourceSharingServiceTest {
 
         assertEquals(null, grantFor(descriptors.get(AGENT), Subjects.user("carol")));
         assertEquals(null, grantFor(descriptors.get(OWNED_CHILD), Subjects.user("carol")));
+    }
+
+    /**
+     * Finding c2. {@code ResourceStoreException} is the store's I/O failure type —
+     * a MongoDB failover, an exhausted PostgreSQL pool — not an access decision,
+     * and by the time the loader runs {@code accessGuard.requireAccess} has already
+     * settled the authorization question. Translating it into
+     * {@link ForbiddenException} told an operator during an outage that they were
+     * not allowed to view the sharing state of a resource they in fact own, and
+     * kept the outage out of any monitoring keyed on 5xx.
+     */
+    @Test
+    @DisplayName("a store failure is reported as unavailable, not as forbidden")
+    void storeFailureIsNotAnAccessDenial() throws Exception {
+        when(store.readDescriptor(eq(AGENT), anyInt()))
+                .thenThrow(new IResourceStore.ResourceStoreException("connection pool exhausted"));
+
+        assertThrows(ServiceUnavailableException.class, () -> service.describe(AGENT));
+    }
+
+    @Test
+    @DisplayName("a missing resource is still a 404")
+    void missingResourceIsStillNotFound() {
+        assertThrows(NotFoundException.class, () -> service.describe("does-not-exist"));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/security/spaces/ResourceSharingServiceTest.java
@@ -68,8 +68,15 @@ class ResourceSharingServiceTest {
         descriptors.put(BORROWED_CHILD, descriptor("bob"));
 
         store = mock(IDocumentDescriptorStore.class);
-        // describe() resolves through readCurrentDescriptor; the mutating paths resolve
-        // the version explicitly so they can write back to the version they read.
+        // Every ResourceSharingService path — describe() included — loads through
+        // loadOrNull: getCurrentResourceId, then readDescriptor(id, version). The
+        // version is resolved explicitly so a write can go back to the version it
+        // read. readCurrentDescriptor is the *guard's* read (ResourceAccessGuard is
+        // its only caller in this package) and the guard is mocked here, so nothing
+        // in this fixture reaches that stub. This comment used to claim the opposite
+        // and sent a reviewer after the store-failure stub below, which is correctly
+        // on readDescriptor: injecting the failure on readCurrentDescriptor would
+        // make that test pass without ever reaching the code it names.
         when(store.readCurrentDescriptor(anyString())).thenAnswer(i -> {
             var d = descriptors.get(i.<String>getArgument(0));
             if (d == null) {

--- a/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/setup/AgentSetupServiceTest.java
@@ -18,6 +18,8 @@ import ai.labs.eddi.configs.rules.model.RuleSetConfiguration;
 import ai.labs.eddi.configs.workflows.IRestWorkflowStore;
 import ai.labs.eddi.configs.workflows.model.WorkflowConfiguration;
 import ai.labs.eddi.engine.model.Deployment;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
+import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -1062,7 +1064,45 @@ class AgentSetupServiceTest {
 
             var result = deployService.deployAndWait(Deployment.Environment.test, "agent1", 1);
             assertEquals(false, result.get("deployed"));
-            assertNotNull(result.get("deployError"));
+            assertEquals("Deployment failed. Check server logs for details.", result.get("deployError"),
+                    "an unrecognised failure must not leak its own message into the setup result");
+        }
+
+        /**
+         * {@code agentAdmin} is the CDI bean here, not an HTTP proxy, so no exception
+         * mapper runs and the quota reason would otherwise be replaced by "check the
+         * logs" — leaving an agent designer, or a model creating a sub-agent, with
+         * nothing to act on.
+         */
+        @Test
+        @DisplayName("an over-quota refusal surfaces its actionable reason verbatim")
+        void deployQuotaExceeded_surfacesTheReason() {
+            when(agentAdmin.deployAgent(any(), anyString(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenThrow(new QuotaExceededException("Agent limit reached (5); undeploy an agent first"));
+
+            var result = deployService.deployAndWait(Deployment.Environment.test, "agent1", 1);
+
+            assertEquals(false, result.get("deployed"));
+            assertEquals("Agent limit reached (5); undeploy an agent first", result.get("deployError"));
+        }
+
+        /**
+         * The {@code QuotaRefusal} marker regression: the accounting-outage refusal is
+         * a <em>sibling</em> of {@code QuotaExceededException} (it had to extend
+         * {@code RejectedExecutionException}), so a {@code catch} naming only the
+         * latter dropped a quota-store outage into the generic branch.
+         */
+        @Test
+        @DisplayName("a quota-store outage surfaces its reason too, not the generic message")
+        void deployQuotaAccountingUnavailable_surfacesTheReason() {
+            when(agentAdmin.deployAgent(any(), anyString(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenThrow(new QuotaAccountingUnavailableException(
+                            "Quota accounting unavailable — denying request for safety"));
+
+            var result = deployService.deployAndWait(Deployment.Environment.test, "agent1", 1);
+
+            assertEquals(false, result.get("deployed"));
+            assertEquals("Quota accounting unavailable — denying request for safety", result.get("deployError"));
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/tenancy/InMemoryTenantQuotaStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/InMemoryTenantQuotaStoreTest.java
@@ -175,6 +175,30 @@ class InMemoryTenantQuotaStoreTest {
         assertDoesNotThrow(() -> store.resetUsage("nonexistent"));
     }
 
+    /**
+     * The CDI constructor — the only one a deployment that has no datastore
+     * producer ever uses. It has to turn the five {@code eddi.tenant.quota.*}
+     * properties into the default tenant's stored quota, and it has to pin a UTC
+     * clock: the day and minute windows this store enforces are derived from it, so
+     * a null there would fail on the first increment rather than at startup.
+     */
+    @Test
+    void cdiConstructor_storesTheConfiguredDefaultQuotaAndAUsableClock() {
+        var configured = new InMemoryTenantQuotaStore("acme", true, 1000, 20, 60, 250.0);
+
+        TenantQuota quota = configured.getQuota("acme");
+        assertNotNull(quota, "the configured default tenant must exist before the first request");
+        assertEquals(1000, quota.maxConversationsPerDay());
+        assertEquals(20, quota.maxAgentsPerTenant());
+        assertEquals(60, quota.maxApiCallsPerMinute());
+        assertEquals(250.0, quota.maxMonthlyCostUsd());
+        assertTrue(quota.enabled());
+
+        // Proves the clock was wired: both counters resolve their window from it.
+        assertTrue(configured.tryIncrementConversations("acme", 1000).allowed());
+        assertEquals(1, configured.getUsage("acme").conversationsToday());
+    }
+
     // --- New tenant counters auto-created ---
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreTest.java
@@ -18,11 +18,13 @@ import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
@@ -507,6 +509,45 @@ class MongoTenantQuotaStoreTest {
             assertEquals(0, snapshot.conversationsToday());
         }
 
+        /**
+         * Finding 14. {@code ITenantQuotaStore.getUsage} documents that the snapshot
+         * "reflects current-window values only", and enforcement does roll the windows
+         * — but this read did not, so
+         * {@code GET /administration/quotas/&#123;id&#125;/usage} showed yesterday's
+         * {@code conversationsToday} and the last active minute's
+         * {@code apiCallsThisMinute} until the next increment happened to roll them. An
+         * operator saw a tenant "at its daily limit" the morning after while the very
+         * next request would have been allowed.
+         */
+        @Test
+        @DisplayName("expired windows read as zero, and the stored document is left untouched")
+        void expiredWindowsAreZeroedOnRead() {
+            Instant now = Instant.parse("2026-03-04T12:00:30Z");
+            var pinned = new MongoTenantQuotaStore(database, Clock.fixed(now, ZoneOffset.UTC));
+
+            Document doc = new Document()
+                    .append("tenantId", TENANT_ID)
+                    .append("conversationsToday", 5)
+                    .append("apiCallsThisMinute", 3)
+                    .append("monthlyCostUsd", 42.0)
+                    .append("minuteStart", Instant.parse("2026-03-04T11:59:00Z").toEpochMilli())
+                    .append("dayStart", Instant.parse("2026-03-03T00:00:00Z").toEpochMilli())
+                    .append("costMonth", "2026-02");
+
+            when(usageCollection.find(any(Bson.class))).thenReturn(findIterable);
+            when(findIterable.first()).thenReturn(doc);
+
+            UsageSnapshot snapshot = pinned.getUsage(TENANT_ID);
+
+            assertEquals(0, snapshot.conversationsToday(), "yesterday's daily counter is not today's");
+            assertEquals(0, snapshot.apiCallsThisMinute(), "the previous minute's rate counter is not this minute's");
+            assertEquals(0.0, snapshot.monthlyCostUsd(), "last month's spend is not this month's");
+            // A read must not write: the window starts are reported as stored so the
+            // caller can still see when the counters were last touched.
+            assertEquals(Instant.parse("2026-03-03T00:00:00Z"), snapshot.dayStart());
+            verify(usageCollection, never()).updateOne(any(Bson.class), any(Bson.class));
+        }
+
         @Test
         @DisplayName("should handle missing optional fields with defaults")
         void missingFields() {
@@ -641,6 +682,65 @@ class MongoTenantQuotaStoreTest {
             verify(quotasCollection, atLeastOnce()).findOneAndUpdate(
                     any(Bson.class), any(Bson.class), optionsCaptor.capture());
             assertTrue(optionsCaptor.getValue().isUpsert());
+        }
+
+        /**
+         * Finding 17, the branch this class never took. {@code bootstrapsAtomically}
+         * stubs {@code findOneAndUpdate} to return null — the first-boot path, where
+         * {@code $setOnInsert} applied the properties and there is nothing to warn
+         * about. The interesting case is the one an operator actually hits: a row that
+         * already exists, so the properties did nothing and the stored values silently
+         * win.
+         * <p>
+         * The pre-image is a raw stored document, and mapping it is where a field-shape
+         * mismatch would throw — inside a {@code @PostConstruct}-time bootstrap, i.e.
+         * only ever discovered at startup against a real database. Capturing the
+         * argument fences both halves at once: that the branch runs at all, and that
+         * {@code toQuota} read the document the way the collection writes it.
+         */
+        @Test
+        @DisplayName("an existing row is mapped from its pre-image and compared against the configured properties")
+        void warnsWhenAStoredRowAlreadyExists() {
+            Document preImage = new Document()
+                    .append("tenantId", "default")
+                    .append("maxConversationsPerDay", 25)
+                    .append("maxAgentsPerTenant", 3)
+                    .append("maxApiCallsPerMinute", 7)
+                    .append("maxMonthlyCostUsd", 12.5)
+                    .append("enabled", false);
+            when(quotasCollection.findOneAndUpdate(
+                    any(Bson.class), any(Bson.class), any(FindOneAndUpdateOptions.class))).thenReturn(preImage);
+
+            try (MockedStatic<TenantQuotaBootstrapCheck> check = mockStatic(TenantQuotaBootstrapCheck.class)) {
+                new MongoTenantQuotaStore(database, "default", true, 1000, 5, 60, 100.0);
+
+                ArgumentCaptor<TenantQuota> stored = ArgumentCaptor.forClass(TenantQuota.class);
+                ArgumentCaptor<TenantQuota> configured = ArgumentCaptor.forClass(TenantQuota.class);
+                check.verify(() -> TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(
+                        stored.capture(), configured.capture()));
+
+                assertEquals(new TenantQuota("default", 25, 3, 7, 12.5, false), stored.getValue(),
+                        "the pre-image must be mapped with the same field names the collection stores");
+                assertEquals(new TenantQuota("default", 1000, 5, 60, 100.0, true), configured.getValue(),
+                        "and compared against what eddi.tenant.quota.* asks for");
+            }
+        }
+
+        /**
+         * The first-boot half of the same contract: the insert just applied the
+         * properties, so there is nothing to tell the operator.
+         */
+        @Test
+        @DisplayName("a genuine first boot does not run the divergence check")
+        void silentOnFirstBoot() {
+            when(quotasCollection.findOneAndUpdate(
+                    any(Bson.class), any(Bson.class), any(FindOneAndUpdateOptions.class))).thenReturn(null);
+
+            try (MockedStatic<TenantQuotaBootstrapCheck> check = mockStatic(TenantQuotaBootstrapCheck.class)) {
+                new MongoTenantQuotaStore(database, "default", true, 1000, 5, 60, 100.0);
+
+                check.verifyNoInteractions();
+            }
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreTest.java
@@ -8,6 +8,7 @@ import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.tenancy.model.TenantQuota;
 import ai.labs.eddi.engine.tenancy.model.UsageSnapshot;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -267,6 +268,100 @@ class MongoTenantQuotaStoreTest {
             assertFalse(result.allowed());
             assertTrue(result.reason().contains("Daily conversation limit"));
             assertTrue(result.reason().contains("10"));
+        }
+    }
+
+    /**
+     * The honest-503 path was PostgreSQL-only, while {@code eddi.datastore.type}
+     * defaults to mongodb.
+     * <p>
+     * A {@link MongoException} escaping these three mutators is not a quota answer
+     * at all: it travelled through {@code TenantQuotaService} (which does not
+     * catch) into {@code ConversationService}'s generic handler and out as a 500
+     * with a stack trace, while the same outage on PostgreSQL produced 503
+     * {@code quota_accounting_unavailable}, a {@code Retry-After} and a tick on
+     * {@code eddi.tenant.quota.unavailable}. Failing closed is unchanged — the
+     * request is still refused — but it is now described correctly, and identically
+     * on both backends.
+     */
+    @Nested
+    @DisplayName("a driver failure is reported as an accounting outage, not as a denial or a 500")
+    class DriverFailures {
+
+        /**
+         * Finding f2-01. The three cases below fail the WRITE half, which a real outage
+         * never reaches: every gate in {@code TenantQuotaService} opens by reading the
+         * tenant's configuration, so {@code getQuota} is the call that throws.
+         * Unwrapped, it travelled out as an opaque 500 with no tick on
+         * {@code eddi.tenant.quota.unavailable} — and only a partial outage, reads up
+         * and writes down, ever exercised the wrapped mutators.
+         * <p>
+         * It cannot report the outage in its return value: {@code null} there already
+         * means "no quota configured", which the service treats as unlimited — i.e.
+         * exactly the silent bypass this must not become.
+         */
+        @Test
+        @DisplayName("getQuota — the call every gate makes first")
+        void quotaReadOutage() {
+            when(quotasCollection.find(any(Bson.class))).thenThrow(new MongoException("connection reset"));
+
+            var thrown = assertThrows(QuotaAccountingUnavailableException.class, () -> sut.getQuota(TENANT_ID));
+
+            assertEquals(ITenantQuotaStore.ACCOUNTING_UNAVAILABLE, thrown.getMessage(),
+                    "the same reason the mutators give, so the 503 body is identical whichever call failed");
+            assertInstanceOf(MongoException.class, thrown.getCause(),
+                    "the driver exception stays attached — a connection fault is not diagnosable without it");
+        }
+
+        @Test
+        @DisplayName("tryIncrementConversations")
+        void conversationsOutage() {
+            when(usageCollection.findOneAndUpdate(any(Bson.class), any(Bson.class), any()))
+                    .thenThrow(new MongoException("connection reset"));
+
+            QuotaCheckResult result = sut.tryIncrementConversations(TENANT_ID, 10);
+
+            assertFalse(result.allowed(), "fail closed — an unreadable counter is not permission to proceed");
+            assertTrue(result.accountingUnavailable(),
+                    "503 quota_accounting_unavailable, not 429 quota_exceeded: nothing is over a limit");
+            assertEquals(ITenantQuotaStore.ACCOUNTING_UNAVAILABLE, result.reason(),
+                    "the same reason PostgresTenantQuotaStore gives, so parity holds on the wire too");
+        }
+
+        @Test
+        @DisplayName("tryIncrementApiCalls")
+        void apiCallsOutage() {
+            when(usageCollection.findOneAndUpdate(any(Bson.class), any(Bson.class), any()))
+                    .thenThrow(new MongoException("connection reset"));
+
+            QuotaCheckResult result = sut.tryIncrementApiCalls(TENANT_ID, 60);
+
+            assertFalse(result.allowed());
+            assertTrue(result.accountingUnavailable());
+            assertEquals(ITenantQuotaStore.ACCOUNTING_UNAVAILABLE, result.reason());
+        }
+
+        @Test
+        @DisplayName("tryAddCost")
+        void costOutage() {
+            when(usageCollection.findOneAndUpdate(any(Bson.class), any(Bson.class), any()))
+                    .thenThrow(new MongoException("connection reset"));
+
+            QuotaCheckResult result = sut.tryAddCost(TENANT_ID, 10.0, 100.0);
+
+            assertFalse(result.allowed(), "a budget that cannot be read is not a budget with room left");
+            assertTrue(result.accountingUnavailable());
+        }
+
+        @Test
+        @DisplayName("an unlimited quota still short-circuits before touching the store")
+        void unlimitedNeverReachesTheFailingStore() {
+            when(usageCollection.findOneAndUpdate(any(Bson.class), any(Bson.class), any()))
+                    .thenThrow(new MongoException("connection reset"));
+
+            assertEquals(QuotaCheckResult.OK, sut.tryIncrementConversations(TENANT_ID, -1));
+            assertEquals(QuotaCheckResult.OK, sut.tryIncrementApiCalls(TENANT_ID, -1));
+            verify(usageCollection, never()).findOneAndUpdate(any(Bson.class), any(Bson.class), any());
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/MongoTenantQuotaStoreTest.java
@@ -352,6 +352,14 @@ class MongoTenantQuotaStoreTest {
 
             assertFalse(result.allowed(), "a budget that cannot be read is not a budget with room left");
             assertTrue(result.accountingUnavailable());
+            // Asserted like its two siblings above, and it was not: this gate phrased
+            // a reason of its own ("Cost accounting failed — denying request for
+            // safety") while every other outage path used the shared constant.
+            // ConversationService puts reason() verbatim into the
+            // QuotaAccountingUnavailableException the 503 body is built from, so one
+            // outage read differently depending on which gate happened to fail first.
+            assertEquals(ITenantQuotaStore.ACCOUNTING_UNAVAILABLE, result.reason(),
+                    "the same reason the other gates give, so the 503 body is identical whichever call failed");
         }
 
         @Test

--- a/src/test/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStoreTest.java
@@ -13,11 +13,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 
 import javax.sql.DataSource;
 import java.sql.*;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -389,8 +393,73 @@ class PostgresTenantQuotaStoreTest {
                     "the roll must reset to zero and let the increment statement do the counting, was: " + upsert);
         }
 
+        /**
+         * Finding m3. The fast path matched the window with {@code day_start = ?}, so a
+         * stored window that is <em>ahead</em> of the caller's clock was unmatchable in
+         * every direction: the fast path missed (M+1 != M), the materialise-or-roll
+         * missed (its guard is {@code stored < now}), and the retry missed — so a node
+         * whose clock stepped backwards (NTP correction, VM suspend/resume) or lagged
+         * another instance by a minute denied every single request with "limit reached"
+         * until wall-clock time caught up. MongoDB's equivalent predicate is
+         * {@code gte} and allowed the same request.
+         */
         @Test
-        @DisplayName("should return denied on SQL exception")
+        @DisplayName("the fast-path window match tolerates a stored window ahead of this node's clock")
+        void fastPathWindowMatchIsInclusive() throws Exception {
+            when(resultSet.next()).thenReturn(false);
+
+            sut.tryIncrementConversations(TENANT_ID, 10);
+
+            String increment = capturedStatement(connection, "conversations_today = conversations_today + 1");
+            assertTrue(increment.contains("day_start >= ?"),
+                    "an exact match denies every request on a clock-skewed node, was: " + increment);
+        }
+
+        /**
+         * The cost of finding m3's fix, pinned so it is a decision rather than a
+         * surprise.
+         * <p>
+         * The fast path now counts into a window that is <em>ahead</em> of this node's
+         * clock ({@code day_start >= ?}), while the materialise-or-roll still only ever
+         * moves a window <em>forward</em> ({@code tenant_usage.day_start < ?}). For
+         * ordinary skew that is exactly right — a window an instant ahead is the
+         * current window, and MongoDB has always treated it that way. For a row whose
+         * {@code day_start} is far in the future (a corrupted or badly skewed write)
+         * the two clauses combine into a trap: the counter is incremented but never
+         * reset, so once it reaches the limit the tenant sits at "Daily conversation
+         * limit reached" until wall-clock time passes the stored date.
+         * <p>
+         * That is still strictly better than the old behaviour, which denied
+         * <em>immediately</em> on any future window rather than only after the limit
+         * was spent, and it matches the MongoDB backend. But it is a new failure mode,
+         * so both halves are asserted together: change either clause in isolation and
+         * this test says which invariant moved.
+         */
+        @Test
+        @DisplayName("a window ahead of the clock is counted into, and is never rolled backwards")
+        void aFutureWindowIsCountedIntoButNeverRolledBack() throws Exception {
+            when(resultSet.next()).thenReturn(false);
+
+            sut.tryIncrementConversations(TENANT_ID, 10);
+
+            String increment = capturedStatement(connection, "conversations_today = conversations_today + 1");
+            String upsert = capturedStatement(connection, "ON CONFLICT (tenant_id) DO UPDATE");
+
+            assertTrue(increment.contains("day_start >= ?"),
+                    "a future window is treated as current and counted into, was: " + increment);
+            assertTrue(upsert.contains("WHERE tenant_usage.day_start < ?"),
+                    "and it is never rolled back, so the counter it holds is never reset, was: " + upsert);
+        }
+
+        /**
+         * Finding 18. Still fail-closed on a store error — a lost increment silently
+         * voids a limit that IS configured — but the reason must not be "Daily
+         * conversation limit reached (10)". That told the caller a 429 with
+         * {@code Retry-After} for what is an infrastructure fault and spiked the
+         * denied-counter metric as if the tenant were over quota.
+         */
+        @Test
+        @DisplayName("a SQL exception denies with an accounting-unavailable reason, not a fake limit breach")
         void sqlException() throws Exception {
             when(dataSource.getConnection())
                     .thenReturn(connection) // schema init
@@ -399,7 +468,9 @@ class PostgresTenantQuotaStoreTest {
             QuotaCheckResult result = sut.tryIncrementConversations(TENANT_ID, 10);
 
             assertFalse(result.allowed());
-            assertTrue(result.reason().contains("Daily conversation limit"));
+            assertEquals(PostgresTenantQuotaStore.ACCOUNTING_UNAVAILABLE, result.reason());
+            assertFalse(result.reason().contains("Daily conversation limit"),
+                    "an outage must be distinguishable from a tenant that is genuinely over quota");
         }
     }
 
@@ -455,8 +526,29 @@ class PostgresTenantQuotaStoreTest {
                     "the roll must reset to zero and let the increment statement do the counting, was: " + upsert);
         }
 
+        /**
+         * The per-minute twin of
+         * {@code TryIncrementConversations.fastPathWindowMatchIsInclusive} — finding m3
+         * relaxed both predicates but only the daily one was fenced. This is the one
+         * that bites first: a minute of clock skew between two instances is ordinary,
+         * and with an exact match the lagging node denied every {@code say} with "API
+         * rate limit reached" until wall-clock time caught up.
+         */
         @Test
-        @DisplayName("should return denied on SQL exception")
+        @DisplayName("the fast-path window match tolerates a stored minute window ahead of this node's clock")
+        void fastPathWindowMatchIsInclusive() throws Exception {
+            when(resultSet.next()).thenReturn(false);
+
+            sut.tryIncrementApiCalls(TENANT_ID, 60);
+
+            String increment = capturedStatement(connection, "api_calls_this_minute = api_calls_this_minute + 1");
+            assertTrue(increment.contains("minute_start >= ?"),
+                    "an exact match denies every request on a clock-skewed node, was: " + increment);
+        }
+
+        /** See {@code TryIncrementConversations.sqlException} — finding 18. */
+        @Test
+        @DisplayName("a SQL exception denies with an accounting-unavailable reason, not a fake rate-limit breach")
         void sqlException() throws Exception {
             when(dataSource.getConnection())
                     .thenReturn(connection) // schema init
@@ -465,7 +557,9 @@ class PostgresTenantQuotaStoreTest {
             QuotaCheckResult result = sut.tryIncrementApiCalls(TENANT_ID, 10);
 
             assertFalse(result.allowed());
-            assertTrue(result.reason().contains("API rate limit"));
+            assertEquals(PostgresTenantQuotaStore.ACCOUNTING_UNAVAILABLE, result.reason());
+            assertFalse(result.reason().contains("API rate limit"),
+                    "an outage must be distinguishable from a tenant that is genuinely over quota");
         }
     }
 
@@ -555,21 +649,64 @@ class PostgresTenantQuotaStoreTest {
         @Test
         @DisplayName("should return snapshot when tenant has usage data")
         void usageFound() throws Exception {
+            // Windows in the CURRENT period — the fixture used to hold 1000L/2000L,
+            // millis in 1970, i.e. windows that expired half a century ago, which the
+            // read now zeroes out. "Now" is pinned rather than taken from the wall
+            // clock: with a system-clock store, a minute (or midnight UTC) rolling
+            // between the stub and the read would expire the window this test declares
+            // current and fail it at random.
+            Instant now = Instant.parse("2026-03-04T12:00:30Z");
+            var pinned = new PostgresTenantQuotaStore(dataSourceInstance, Clock.fixed(now, ZoneOffset.UTC));
             when(resultSet.next()).thenReturn(true);
             when(resultSet.getInt("conversations_today")).thenReturn(5);
             when(resultSet.getInt("api_calls_this_minute")).thenReturn(3);
             when(resultSet.getDouble("monthly_cost_usd")).thenReturn(42.0);
-            when(resultSet.getLong("minute_start")).thenReturn(1000L);
-            when(resultSet.getLong("day_start")).thenReturn(2000L);
-            when(resultSet.getString("cost_month")).thenReturn(YearMonth.now(ZoneOffset.UTC).toString());
+            when(resultSet.getLong("minute_start")).thenReturn(now.truncatedTo(ChronoUnit.MINUTES).toEpochMilli());
+            when(resultSet.getLong("day_start")).thenReturn(now.truncatedTo(ChronoUnit.DAYS).toEpochMilli());
+            when(resultSet.getString("cost_month")).thenReturn(YearMonth.from(now.atOffset(ZoneOffset.UTC)).toString());
 
-            UsageSnapshot snapshot = sut.getUsage(TENANT_ID);
+            UsageSnapshot snapshot = pinned.getUsage(TENANT_ID);
 
             assertNotNull(snapshot);
             assertEquals(TENANT_ID, snapshot.tenantId());
             assertEquals(5, snapshot.conversationsToday());
             assertEquals(3, snapshot.apiCallsThisMinute());
             assertEquals(42.0, snapshot.monthlyCostUsd());
+        }
+
+        /**
+         * Finding 14. {@code ITenantQuotaStore.getUsage} documents that the snapshot
+         * "reflects current-window values only", and enforcement does roll the windows
+         * — but this read did not, so
+         * {@code GET /administration/quotas/&#123;id&#125;/usage} showed yesterday's
+         * {@code conversationsToday} and the last active minute's
+         * {@code apiCallsThisMinute} until the next increment happened to roll them. An
+         * operator saw a tenant "at its daily limit" the morning after while the very
+         * next request would have been allowed.
+         */
+        @Test
+        @DisplayName("expired windows read as zero, and the stored row is left untouched")
+        void expiredWindowsAreZeroedOnRead() throws Exception {
+            Instant now = Instant.parse("2026-03-04T12:00:30Z");
+            var pinned = new PostgresTenantQuotaStore(dataSourceInstance, Clock.fixed(now, ZoneOffset.UTC));
+
+            when(resultSet.next()).thenReturn(true);
+            when(resultSet.getInt("conversations_today")).thenReturn(5);
+            when(resultSet.getInt("api_calls_this_minute")).thenReturn(3);
+            when(resultSet.getDouble("monthly_cost_usd")).thenReturn(42.0);
+            when(resultSet.getLong("minute_start")).thenReturn(Instant.parse("2026-03-04T11:59:00Z").toEpochMilli());
+            when(resultSet.getLong("day_start")).thenReturn(Instant.parse("2026-03-03T00:00:00Z").toEpochMilli());
+            when(resultSet.getString("cost_month")).thenReturn("2026-02");
+
+            UsageSnapshot snapshot = pinned.getUsage(TENANT_ID);
+
+            assertEquals(0, snapshot.conversationsToday(), "yesterday's daily counter is not today's");
+            assertEquals(0, snapshot.apiCallsThisMinute(), "the previous minute's rate counter is not this minute's");
+            assertEquals(0.0, snapshot.monthlyCostUsd(), "last month's spend is not this month's");
+            // A read must not write: the window starts are reported as stored so the
+            // caller can still see when the counters were last touched.
+            assertEquals(Instant.parse("2026-03-03T00:00:00Z"), snapshot.dayStart());
+            verify(preparedStatement, never()).executeUpdate();
         }
 
         @Test
@@ -738,6 +875,71 @@ class PostgresTenantQuotaStoreTest {
             verify(connection, atLeastOnce()).prepareStatement(sqlCaptor.capture());
             assertTrue(sqlCaptor.getAllValues().stream()
                     .anyMatch(sql -> sql.contains("ON CONFLICT (tenant_id) DO NOTHING")));
+        }
+
+        /**
+         * Finding 17 on the PostgreSQL side. {@code ON CONFLICT DO NOTHING} means the
+         * properties take effect exactly once, on the first start against an empty
+         * database; an operator who later enables quotas or raises a limit by
+         * environment variable and redeploys changes nothing. The {@code inserted == 0}
+         * branch is what tells them so, and it happened to run in
+         * {@link #bootstrapsAtomically} only because Mockito's default
+         * {@code executeUpdate()} is 0 — nothing verified the extra SELECT or the
+         * comparison, so the whole branch could have been deleted silently.
+         */
+        @Test
+        @DisplayName("an existing row is re-read and compared against the configured properties")
+        void warnsWhenAStoredRowAlreadyExists() throws Exception {
+            // 0 rows inserted — ON CONFLICT DO NOTHING fired, the row was already there.
+            when(preparedStatement.executeUpdate()).thenReturn(0);
+            // First next() answers the bootstrap re-read; the second answers the
+            // getQuota("any") call that triggers ensureSchema.
+            when(resultSet.next()).thenReturn(true, false);
+            when(resultSet.getString("tenant_id")).thenReturn("default");
+            when(resultSet.getInt("max_conversations_per_day")).thenReturn(25);
+            when(resultSet.getInt("max_agents_per_tenant")).thenReturn(3);
+            when(resultSet.getInt("max_api_calls_per_minute")).thenReturn(7);
+            when(resultSet.getDouble("max_monthly_cost_usd")).thenReturn(12.5);
+            when(resultSet.getBoolean("enabled")).thenReturn(false);
+
+            try (MockedStatic<TenantQuotaBootstrapCheck> check = mockStatic(TenantQuotaBootstrapCheck.class)) {
+                var bootstrapStore = new PostgresTenantQuotaStore(
+                        dataSourceInstance, "default", true, 1000, 5, 60, 100.0);
+                bootstrapStore.getQuota("any");
+
+                ArgumentCaptor<TenantQuota> stored = ArgumentCaptor.forClass(TenantQuota.class);
+                ArgumentCaptor<TenantQuota> configured = ArgumentCaptor.forClass(TenantQuota.class);
+                check.verify(() -> TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(
+                        stored.capture(), configured.capture()));
+
+                assertEquals(new TenantQuota("default", 25, 3, 7, 12.5, false), stored.getValue(),
+                        "the stored row must be re-read with the same column names the INSERT writes");
+                assertEquals(new TenantQuota("default", 1000, 5, 60, 100.0, true), configured.getValue(),
+                        "and compared against what eddi.tenant.quota.* asks for");
+            }
+
+            assertEquals("SELECT * FROM tenant_quotas WHERE tenant_id = ?",
+                    capturedStatement(connection, "SELECT * FROM tenant_quotas"),
+                    "the divergence check needs the row, so the branch costs one extra SELECT per start");
+        }
+
+        /**
+         * The first-boot half: the INSERT applied the properties, so there is nothing
+         * to tell the operator.
+         */
+        @Test
+        @DisplayName("a genuine first boot does not run the divergence check")
+        void silentOnFirstBoot() throws Exception {
+            when(preparedStatement.executeUpdate()).thenReturn(1);
+            when(resultSet.next()).thenReturn(false);
+
+            try (MockedStatic<TenantQuotaBootstrapCheck> check = mockStatic(TenantQuotaBootstrapCheck.class)) {
+                var bootstrapStore = new PostgresTenantQuotaStore(
+                        dataSourceInstance, "default", true, 1000, 5, 60, 100.0);
+                bootstrapStore.getQuota("any");
+
+                check.verifyNoInteractions();
+            }
         }
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStoreTest.java
@@ -665,7 +665,15 @@ class PostgresTenantQuotaStoreTest {
             QuotaCheckResult result = sut.tryAddCost(TENANT_ID, 10.0, 100.0);
 
             assertFalse(result.allowed());
-            assertTrue(result.reason().contains("Cost accounting failed"));
+            // Both fields, and the shared constant rather than a substring of a
+            // wording private to this gate. reason() reaches the client verbatim
+            // (ConversationService builds the 503 body from it), so a cost outage that
+            // reads differently from a conversation outage is the same outage
+            // described two ways. The substring assertion could not see that.
+            assertTrue(result.accountingUnavailable(),
+                    "503 quota_accounting_unavailable, not 429 quota_exceeded: nothing is over a limit");
+            assertEquals(PostgresTenantQuotaStore.ACCOUNTING_UNAVAILABLE, result.reason(),
+                    "the same reason MongoTenantQuotaStore gives, so parity holds on the wire too");
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStoreTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/PostgresTenantQuotaStoreTest.java
@@ -108,12 +108,23 @@ class PostgresTenantQuotaStoreTest {
             verify(statement, times(2)).execute(anyString());
         }
 
+        /**
+         * Schema init runs before every method and takes a connection, so on a database
+         * unreachable since startup this — not the method the caller invoked — is where
+         * the outage surfaces. A plain {@code RuntimeException} here slipped past
+         * {@code TenantQuotaService}'s gates, which match the refusal type, and left
+         * that window answering an opaque 500 while the same outage a moment later
+         * answered 503.
+         */
         @Test
-        @DisplayName("should throw RuntimeException when schema creation fails")
+        @DisplayName("should refuse as an accounting outage when schema creation fails")
         void ensureSchema_failsWithSQLException() throws Exception {
             when(connection.createStatement()).thenThrow(new SQLException("DB down"));
 
-            assertThrows(RuntimeException.class, () -> sut.getQuota(TENANT_ID));
+            var thrown = assertThrows(QuotaAccountingUnavailableException.class, () -> sut.getQuota(TENANT_ID));
+
+            assertInstanceOf(SQLException.class, thrown.getCause(),
+                    "a schema failure is unreadable without the driver's own stack");
         }
     }
 
@@ -155,17 +166,28 @@ class PostgresTenantQuotaStoreTest {
             assertNull(quota);
         }
 
+        /**
+         * Finding f2-01. This used to assert {@code null}, i.e. fail-open — and
+         * {@code null} from {@code getQuota} means "no quota configured", which
+         * {@code TenantQuotaService} treats as unlimited. So one outage produced two
+         * opposite policies depending on which call happened to fail first: the read
+         * silently switched enforcement off for every tenant, the write refused with an
+         * honest 503. The read runs first at every gate, so fail-open won in practice
+         * and the write-side refusal was mostly unreachable.
+         */
         @Test
-        @DisplayName("should return null and log on SQLException")
+        @DisplayName("should refuse honestly, not fail open, on SQLException")
         void getQuota_sqlException() throws Exception {
             // After schema init, the second getConnection call throws
             when(dataSource.getConnection())
                     .thenReturn(connection) // for ensureSchema
                     .thenThrow(new SQLException("connection error"));
 
-            TenantQuota result = sut.getQuota(TENANT_ID);
+            var thrown = assertThrows(QuotaAccountingUnavailableException.class, () -> sut.getQuota(TENANT_ID));
 
-            assertNull(result);
+            assertEquals(ITenantQuotaStore.ACCOUNTING_UNAVAILABLE, thrown.getMessage(),
+                    "the same reason MongoTenantQuotaStore gives, so the 503 body is identical on both backends");
+            assertInstanceOf(SQLException.class, thrown.getCause(), "the driver exception stays attached");
         }
     }
 
@@ -471,6 +493,11 @@ class PostgresTenantQuotaStoreTest {
             assertEquals(PostgresTenantQuotaStore.ACCOUNTING_UNAVAILABLE, result.reason());
             assertFalse(result.reason().contains("Daily conversation limit"),
                     "an outage must be distinguishable from a tenant that is genuinely over quota");
+            // Wording alone is not a signal anything reads: without the flag this
+            // still incremented eddi.tenant.quota.denied and answered 429 with
+            // Retry-After: 60, exactly like an exhausted allowance.
+            assertTrue(result.accountingUnavailable(),
+                    "the refusal must be machine-distinguishable, not just differently worded");
         }
     }
 
@@ -560,6 +587,8 @@ class PostgresTenantQuotaStoreTest {
             assertEquals(PostgresTenantQuotaStore.ACCOUNTING_UNAVAILABLE, result.reason());
             assertFalse(result.reason().contains("API rate limit"),
                     "an outage must be distinguishable from a tenant that is genuinely over quota");
+            assertTrue(result.accountingUnavailable(),
+                    "the refusal must be machine-distinguishable, not just differently worded");
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaBootstrapCheckTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaBootstrapCheckTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.tenancy;
+
+import ai.labs.eddi.engine.tenancy.model.TenantQuota;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Finding 17. Both DB-backed stores bootstrap the default tenant's quota
+ * insert-only ({@code $setOnInsert} / {@code ON CONFLICT DO NOTHING}), so
+ * {@code eddi.tenant.quota.*} takes effect exactly once — on the first start
+ * against an empty database. An operator who later enables quotas or raises a
+ * limit by environment variable and redeploys changes nothing, and nothing used
+ * to say so: the stored row silently won and the configuration surface was
+ * effectively write-once. (The in-memory store always reflects the properties,
+ * so the same configuration behaved differently per backend.)
+ */
+class TenantQuotaBootstrapCheckTest {
+
+    private static final String TENANT_ID = "default";
+
+    @Test
+    @DisplayName("a stored row that no longer matches the configured properties is reported")
+    void warnsWhenTheStoredRowDivergesFromConfig() {
+        var stored = new TenantQuota(TENANT_ID, -1, -1, -1, -1, false);
+        var configured = new TenantQuota(TENANT_ID, 1000, -1, 60, -1, true);
+
+        assertTrue(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(stored, configured),
+                "an operator who enabled quotas by env var must be told the stored row wins");
+    }
+
+    @Test
+    @DisplayName("no warning when the stored row already is what the properties ask for")
+    void silentWhenTheyAgree() {
+        var quota = new TenantQuota(TENANT_ID, 1000, -1, 60, -1, true);
+
+        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(quota, quota));
+    }
+
+    @Test
+    @DisplayName("no warning on a genuine first boot, where nothing was stored yet")
+    void silentOnFirstBoot() {
+        var configured = new TenantQuota(TENANT_ID, 1000, -1, 60, -1, true);
+
+        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(null, configured),
+                "the insert just applied the properties; there is nothing to warn about");
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaBootstrapCheckTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaBootstrapCheckTest.java
@@ -5,11 +5,18 @@
 package ai.labs.eddi.engine.tenancy;
 
 import ai.labs.eddi.engine.tenancy.model.TenantQuota;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigBuilder;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Finding 17. Both DB-backed stores bootstrap the default tenant's quota
@@ -31,7 +38,7 @@ class TenantQuotaBootstrapCheckTest {
         var stored = new TenantQuota(TENANT_ID, -1, -1, -1, -1, false);
         var configured = new TenantQuota(TENANT_ID, 1000, -1, 60, -1, true);
 
-        assertTrue(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(stored, configured),
+        assertTrue(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(stored, configured, true),
                 "an operator who enabled quotas by env var must be told the stored row wins");
     }
 
@@ -40,7 +47,7 @@ class TenantQuotaBootstrapCheckTest {
     void silentWhenTheyAgree() {
         var quota = new TenantQuota(TENANT_ID, 1000, -1, 60, -1, true);
 
-        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(quota, quota));
+        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(quota, quota, true));
     }
 
     @Test
@@ -48,7 +55,293 @@ class TenantQuotaBootstrapCheckTest {
     void silentOnFirstBoot() {
         var configured = new TenantQuota(TENANT_ID, 1000, -1, 60, -1, true);
 
-        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(null, configured),
+        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(null, configured, true),
                 "the insert just applied the properties; there is nothing to warn about");
+    }
+
+    /**
+     * Finding r16. An operator who set the quota through {@code PUT
+     * /administration/quotas/{id}} and left {@code eddi.tenant.quota.*} at its
+     * defaults has expressed nothing for the stored row to contradict — and used to
+     * get this warning on every single restart, forever, which is how the one
+     * warning that matters gets tuned out.
+     */
+    @Test
+    @DisplayName("no warning when the properties are at their defaults — the operator asked for nothing")
+    void silentWhenTheConfigCarriesNoIntent() {
+        var storedViaRest = new TenantQuota(TENANT_ID, 5000, 20, 300, 100.0, true);
+        var untouchedConfig = TenantQuota.unlimited(TENANT_ID);
+
+        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(storedViaRest, untouchedConfig, false),
+                "warning every restart about a quota nobody configured by property is pure noise");
+    }
+
+    /**
+     * The case the r16 silence swallowed. {@code eddi.tenant.quota.enabled}
+     * <em>ships</em> as false with every limit at -1, so an operator who
+     * deliberately sets {@code EDDI_TENANT_QUOTA_ENABLED=false} to switch
+     * enforcement off hands this check byte-for-byte the same {@code configured}
+     * object as one who touched nothing — and a stored {@code enabled=true} row
+     * then goes on enforcing against their explicit instruction, silently, with the
+     * INFO line not even naming the PUT that would fix it.
+     * <p>
+     * Only the provenance of the property can separate the two, which is why the
+     * decision takes it as an input rather than inferring it from the values.
+     */
+    @Test
+    @DisplayName("an explicitly configured 'quotas off' still warns when the stored row enforces")
+    void warnsWhenEnforcementWasExplicitlyTurnedOff() {
+        var storedEnforcing = new TenantQuota(TENANT_ID, 5000, 20, 300, 100.0, true);
+        var explicitlyDisabled = TenantQuota.unlimited(TENANT_ID);
+
+        assertTrue(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(storedEnforcing, explicitlyDisabled, true),
+                "the operator turned enforcement off by property and the stored row is still enforcing — say so");
+    }
+
+    /**
+     * And the provenance itself: with nothing but the shipped
+     * {@code application.properties} supplying these values, the deployment has
+     * expressed no intent.
+     * <p>
+     * Asserted against a configuration handed in, not against
+     * {@code ConfigProvider}. Reading the ambient one made this the only test in
+     * the suite whose answer depended on the machine: a developer or CI runner that
+     * exports {@code EDDI_TENANT_QUOTA_ENABLED} — plausible on a host that also
+     * runs the docker-compose stack from a {@code .env} — supplies a value at
+     * ordinal 300 and the "no intent" baseline fails for a reason that has nothing
+     * to do with the code. Both sides of the 250 boundary are pinned here instead,
+     * so lowering {@code BUNDLED_PROPERTIES_ORDINAL} fails the first case and
+     * raising it fails the second.
+     */
+    @Test
+    @DisplayName("only a source that outranks the bundled application.properties counts as intent")
+    void onlyASourceAboveTheBundledOrdinalCountsAsExplicitConfiguration() {
+        assertFalse(TenantQuotaBootstrapCheck.quotaPropertiesWereSet(configWith("false", 250)),
+                "the shipped application.properties (ordinal 250) is not the deployment saying anything");
+        assertTrue(TenantQuotaBootstrapCheck.quotaPropertiesWereSet(configWith("false", 300)),
+                "an environment variable (ordinal 300) outranks the bundled application.properties (250) — "
+                        + "and it carries the SAME value, which is exactly why provenance and not the value decides");
+        assertFalse(TenantQuotaBootstrapCheck.quotaPropertiesWereSet(configWith(null, 400)),
+                "a source that outranks the bundle but supplies no value has still said nothing");
+    }
+
+    /**
+     * A {@link Config} that does not know the property at all answers {@code null}
+     * rather than a {@link ConfigValue} carrying a null value, and the guard has to
+     * survive that too — an NPE here would abort the store's bootstrap insert,
+     * which runs before the deployment's first quota check.
+     */
+    @Test
+    @DisplayName("a configuration that does not know the property at all is not intent either")
+    void anAbsentConfigValueIsNotIntent() {
+        var config = mock(Config.class);
+        when(config.getConfigValue(anyString())).thenReturn(null);
+
+        assertFalse(TenantQuotaBootstrapCheck.quotaPropertiesWereSet(config));
+    }
+
+    /**
+     * The ambient entry point has to fail <em>silent</em>, not loud: an
+     * unanswerable "where did this value come from?" must not turn into a warning
+     * on every restart, which is precisely the noise the provenance check was added
+     * to remove. Forced by swapping the MicroProfile resolver, because no ordinary
+     * configuration can make {@code ConfigProvider.getConfig()} throw.
+     */
+    @Test
+    @DisplayName("a configuration that cannot be read at all answers 'no intent' instead of propagating")
+    void unreadableConfigurationIsTreatedAsNoIntent() {
+        var original = ConfigProviderResolver.instance();
+        ConfigProviderResolver.setInstance(new ThrowingConfigProviderResolver());
+        try {
+            assertFalse(TenantQuotaBootstrapCheck.quotaPropertiesWereSet(),
+                    "an unanswerable question must not become a warning on every restart");
+        } finally {
+            ConfigProviderResolver.setInstance(original);
+        }
+    }
+
+    /**
+     * The one-argument overload is what both DB-backed stores actually call, and
+     * the only thing it adds over the three-argument form is resolving the
+     * provenance itself. So it is driven over the one pair whose verdict provenance
+     * alone decides — a stored row that enforces against a {@code configured}
+     * object byte-for-byte identical to the shipped defaults — with the ambient
+     * configuration swapped underneath it, once on each side of the answer.
+     * <p>
+     * Both directions are needed. Pinned only where the properties carry intent, a
+     * hard-wired {@code true} passes; pinned only where they do not, a hard-wired
+     * {@code false} passes. Together nothing constant survives, and the delegation
+     * is what is actually being asserted rather than merely executed.
+     * <p>
+     * The ambient configuration is replaced rather than read, because reading it
+     * asserts about the machine: a developer or CI runner exporting
+     * {@code EDDI_TENANT_QUOTA_ENABLED} — plausible on a host that also runs the
+     * docker-compose stack from a {@code .env} — supplies a value at ordinal 300
+     * and flips the "no intent" half for a reason that has nothing to do with the
+     * code.
+     */
+    @Test
+    @DisplayName("the store-facing overload resolves provenance itself — the same pair warns or stays silent by where the properties came from")
+    void storeFacingOverloadResolvesProvenanceItself() {
+        var storedEnforcing = new TenantQuota(TENANT_ID, 5000, 20, 300, 100.0, true);
+        var indistinguishableFromTheShippedDefaults = TenantQuota.unlimited(TENANT_ID);
+
+        // Precondition: this pair really is decided by provenance and nothing else,
+        // so the two assertions below cannot both be satisfied by one constant.
+        assertTrue(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(
+                storedEnforcing, indistinguishableFromTheShippedDefaults, true));
+        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(
+                storedEnforcing, indistinguishableFromTheShippedDefaults, false));
+
+        withAmbientConfig(configWith("false", 300), () -> assertTrue(
+                TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(
+                        storedEnforcing, indistinguishableFromTheShippedDefaults),
+                "the deployment turned enforcement off by environment variable and the stored row is still "
+                        + "enforcing — the overload has to consult that, not assume it"));
+
+        withAmbientConfig(configWith("false", 250), () -> assertFalse(
+                TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(
+                        storedEnforcing, indistinguishableFromTheShippedDefaults),
+                "the same two quotas, with nothing but the shipped application.properties behind them, are an "
+                        + "operator who configured the quota by PUT — warning them on every restart forever is the "
+                        + "noise this check was tuned to remove"));
+    }
+
+    /**
+     * And the store-facing overload must survive the state a store reaches when it
+     * could not build a configured quota at all: silent, rather than dereferencing
+     * it. This runs before the deployment's first quota check, so an NPE here
+     * aborts the bootstrap insert.
+     */
+    @Test
+    @DisplayName("the store-facing overload stays silent with nothing to compare")
+    void storeFacingOverloadIsSilentWithoutAConfiguredQuota() {
+        var stored = new TenantQuota(TENANT_ID, 5000, 20, 300, 100.0, true);
+
+        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(stored, null));
+        assertFalse(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(null, null));
+    }
+
+    /**
+     * Runs {@code assertion} with
+     * {@link org.eclipse.microprofile.config.ConfigProvider} answering
+     * {@code config}, and puts the real resolver back afterwards —
+     * {@code setInstance} is process-wide, and a leaked one would change what every
+     * later test in this fork considers configured.
+     */
+    private static void withAmbientConfig(Config config, Runnable assertion) {
+        var original = ConfigProviderResolver.instance();
+        ConfigProviderResolver.setInstance(new FixedConfigProviderResolver(config));
+        try {
+            assertion.run();
+        } finally {
+            ConfigProviderResolver.setInstance(original);
+        }
+    }
+
+    /** A resolver that hands out one fixed configuration. */
+    private static final class FixedConfigProviderResolver extends ConfigProviderResolver {
+
+        private final Config config;
+
+        private FixedConfigProviderResolver(Config config) {
+            this.config = config;
+        }
+
+        @Override
+        public Config getConfig() {
+            return config;
+        }
+
+        @Override
+        public Config getConfig(ClassLoader loader) {
+            return config;
+        }
+
+        @Override
+        public ConfigBuilder getBuilder() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void registerConfig(Config config, ClassLoader classLoader) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseConfig(Config config) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /** A resolver whose {@code getConfig} always fails. */
+    private static final class ThrowingConfigProviderResolver extends ConfigProviderResolver {
+        @Override
+        public Config getConfig() {
+            throw new IllegalStateException("no configuration available");
+        }
+
+        @Override
+        public Config getConfig(ClassLoader loader) {
+            throw new IllegalStateException("no configuration available");
+        }
+
+        @Override
+        public ConfigBuilder getBuilder() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void registerConfig(Config config, ClassLoader classLoader) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseConfig(Config config) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * A configuration in which every {@code eddi.tenant.quota.*} property resolves
+     * to {@code value} from a source of the given ordinal.
+     */
+    private static Config configWith(String value, int ordinal) {
+        var configValue = mock(ConfigValue.class);
+        when(configValue.getValue()).thenReturn(value);
+        when(configValue.getSourceOrdinal()).thenReturn(ordinal);
+        var config = mock(Config.class);
+        when(config.getConfigValue(anyString())).thenReturn(configValue);
+        return config;
+    }
+
+    /**
+     * The ambient-configuration entry point still has to reach the same decision —
+     * a system property is ordinal 400, which outranks the bundle on any machine,
+     * so this half is deterministic where the "no intent" baseline was not.
+     */
+    @Test
+    @DisplayName("a system property outranks the bundled application.properties and counts as intent")
+    void systemPropertyCountsAsExplicitConfiguration() {
+        System.setProperty("eddi.tenant.quota.enabled", "false");
+        try {
+            assertTrue(TenantQuotaBootstrapCheck.quotaPropertiesWereSet(),
+                    "a system property (ordinal 400) outranks the bundled application.properties (250)");
+        } finally {
+            System.clearProperty("eddi.tenant.quota.enabled");
+        }
+    }
+
+    /**
+     * And the case finding 17 was actually about still warns: the properties say
+     * something, and the stored row is not it.
+     */
+    @Test
+    @DisplayName("still warns when the properties say something the stored row ignores")
+    void warnsWhenTheConfigCarriesIntent() {
+        var stored = new TenantQuota(TENANT_ID, 5000, 20, 300, 100.0, true);
+        var configured = new TenantQuota(TENANT_ID, 1000, -1, 60, -1, true);
+
+        assertTrue(TenantQuotaBootstrapCheck.warnIfStoredQuotaDiffersFromConfig(stored, configured, false));
     }
 }

--- a/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaServiceTest.java
@@ -266,6 +266,12 @@ class TenantQuotaServiceTest {
 
     // --- Dynamic quota update ---
 
+    /**
+     * The gates read quota configuration through a short-TTL cache (it used to be a
+     * store round trip per turn, twice per request on the hottest path in the
+     * system), so a tightened limit reaches enforcement through the service's
+     * write-through — the path {@code RestTenantQuota} uses.
+     */
     @Test
     @DisplayName("should enforce tightened quota at runtime")
     void shouldUpdateQuotaAtRuntime() {
@@ -275,11 +281,50 @@ class TenantQuotaServiceTest {
         assertTrue(quotaService.acquireApiCallSlot().allowed());
 
         // Tighten the limit to 1
-        quotaStore.setQuota(new TenantQuota(TENANT_ID, -1, -1, 1, -1, true));
+        quotaService.setQuota(new TenantQuota(TENANT_ID, -1, -1, 1, -1, true));
 
         // Now exceeded (1 already acquired)
         QuotaCheckResult result = quotaService.acquireApiCallSlot();
         assertFalse(result.allowed());
+        assertEquals(1, quotaStore.getQuota(TENANT_ID).maxApiCallsPerMinute(),
+                "the write must reach the store, not just drop a cache entry");
+    }
+
+    /**
+     * Finding 16. {@code ConversationService} calls a gate at conversation start
+     * and again on every say/sayStreaming, and each one opened with
+     * {@code quotaStore.getQuota(tenantId)} — a pooled-connection checkout per turn
+     * on PostgreSQL, usually only to learn that quotas are disabled.
+     */
+    @Test
+    @DisplayName("quota configuration is read once per tenant, not once per turn")
+    void quotaConfigurationIsCachedAcrossTurns() {
+        var countingStore = new CountingQuotaStore(new TenantQuota(TENANT_ID, -1, -1, -1, -1, false));
+        var service = new TenantQuotaService(countingStore, meterRegistry, TENANT_ID);
+
+        for (int turn = 0; turn < 10; turn++) {
+            assertTrue(service.acquireApiCallSlot().allowed());
+        }
+
+        assertEquals(1, countingStore.reads,
+                "the disabled-quota short-circuit must not cost a store round trip per turn");
+    }
+
+    /**
+     * Counts {@code getQuota} calls; everything else is the in-memory store.
+     */
+    private static final class CountingQuotaStore extends InMemoryTenantQuotaStore {
+        private int reads;
+
+        private CountingQuotaStore(TenantQuota defaultQuota) {
+            super(defaultQuota);
+        }
+
+        @Override
+        public TenantQuota getQuota(String tenantId) {
+            reads++;
+            return super.getQuota(tenantId);
+        }
     }
 
     // --- Metrics ---

--- a/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaServiceTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaServiceTest.java
@@ -4,6 +4,7 @@
  */
 package ai.labs.eddi.engine.tenancy;
 
+import ai.labs.eddi.engine.caching.CacheFactory;
 import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
 import ai.labs.eddi.engine.tenancy.model.TenantQuota;
 import ai.labs.eddi.engine.tenancy.model.UsageSnapshot;
@@ -311,6 +312,86 @@ class TenantQuotaServiceTest {
     }
 
     /**
+     * The CDI wiring itself. {@code init()} is what attaches the cache in a real
+     * deployment — the test constructor attaches its own, so a regression that
+     * dropped the line from {@code init()} would be invisible to every other test
+     * here and would put a store round trip back on every turn in production.
+     */
+    @Test
+    @DisplayName("@PostConstruct wires the cache, so a CDI-built service reads the store once per tenant")
+    void postConstructAttachesTheQuotaCache() {
+        var countingStore = new CountingQuotaStore(new TenantQuota(TENANT_ID, -1, -1, -1, -1, false));
+        var service = new TenantQuotaService();
+        service.quotaStore = countingStore;
+        service.meterRegistry = meterRegistry;
+        service.cacheFactory = new CacheFactory();
+        service.defaultTenantId = TENANT_ID;
+
+        service.init();
+
+        for (int turn = 0; turn < 5; turn++) {
+            assertTrue(service.acquireApiCallSlot().allowed());
+        }
+        assertEquals(1, countingStore.reads,
+                "without the cache attached in init() every turn pays a pooled-connection checkout");
+    }
+
+    /**
+     * Caffeine rejects a null key outright, so an unidentified tenant must bypass
+     * the cache and ask the store directly rather than throwing on the hottest path
+     * in the system. The store has no row for it, which is the "unlimited" case, so
+     * the turn is allowed — and, because nothing was cached, the next unidentified
+     * turn asks again rather than being served a pinned answer.
+     */
+    @Test
+    @DisplayName("a null tenant bypasses the cache instead of throwing, and is never cached")
+    void nullTenantBypassesTheCache() {
+        // Both DB-backed stores answer "no row" for a null tenant (a find/SELECT on
+        // tenant_id = NULL matches nothing); the in-memory one is a ConcurrentHashMap
+        // and would throw, which is not the contract under test here.
+        var countingStore = new NullTolerantQuotaStore(new TenantQuota(TENANT_ID, -1, -1, -1, -1, false));
+        var service = new TenantQuotaService(countingStore, meterRegistry, TENANT_ID);
+
+        assertTrue(service.acquireConversationSlot(null).allowed());
+        assertTrue(service.acquireConversationSlot(null).allowed());
+
+        assertEquals(2, countingStore.reads, "a null key cannot be cached, so both turns read the store");
+    }
+
+    /** Answers "no row" for a null tenant, as both DB-backed stores do. */
+    private static final class NullTolerantQuotaStore extends InMemoryTenantQuotaStore {
+        private int reads;
+
+        private NullTolerantQuotaStore(TenantQuota defaultQuota) {
+            super(defaultQuota);
+        }
+
+        @Override
+        public TenantQuota getQuota(String tenantId) {
+            reads++;
+            return tenantId == null ? null : super.getQuota(tenantId);
+        }
+    }
+
+    /**
+     * A tenant with no quota row is the "unlimited" case and is deliberately NOT
+     * cached — a {@code ConcurrentMap} cannot hold a null, and pinning "no quota"
+     * would delay a newly bootstrapped row by the TTL.
+     */
+    @Test
+    @DisplayName("a tenant with no quota row is allowed and its absence is not cached")
+    void anUnknownTenantIsAllowedAndNotCached() {
+        var countingStore = new CountingQuotaStore(new TenantQuota(TENANT_ID, -1, -1, -1, -1, false));
+        var service = new TenantQuotaService(countingStore, meterRegistry, TENANT_ID);
+
+        assertTrue(service.acquireConversationSlot("tenant-with-no-row").allowed());
+        assertTrue(service.acquireConversationSlot("tenant-with-no-row").allowed());
+
+        assertEquals(2, countingStore.reads,
+                "caching a null would mean a quota created a second later did not apply until the TTL expired");
+    }
+
+    /**
      * Counts {@code getQuota} calls; everything else is the in-memory store.
      */
     private static final class CountingQuotaStore extends InMemoryTenantQuotaStore {
@@ -498,6 +579,158 @@ class TenantQuotaServiceTest {
             long allowed = results.stream().filter(QuotaCheckResult::allowed).count();
             assertEquals(limit, allowed,
                     "Exactly " + limit + " API call slots should have been acquired, but got " + allowed);
+        }
+    }
+
+    /**
+     * An accounting outage refuses the request for safety, which is right — but it
+     * is not the tenant being over a limit. Counting it on
+     * {@code eddi.tenant.quota.denied} made a database failure look exactly like an
+     * exhausted allowance on the very graph an operator uses to decide whether to
+     * raise a limit, and only the reason string distinguished them.
+     */
+    @Test
+    @DisplayName("an accounting outage is counted apart from an over-quota denial")
+    void accountingOutageIsNotCountedAsAQuotaDenial() {
+        var failingStore = new ITenantQuotaStore() {
+            @Override
+            public TenantQuota getQuota(String tenantId) {
+                return new TenantQuota(TENANT_ID, 1000, -1, -1, -1, true);
+            }
+
+            @Override
+            public void setQuota(TenantQuota quota) {
+            }
+
+            @Override
+            public void deleteQuota(String tenantId) {
+            }
+
+            @Override
+            public List<TenantQuota> listQuotas() {
+                return List.of();
+            }
+
+            @Override
+            public QuotaCheckResult tryIncrementConversations(String tenantId, int limit) {
+                return QuotaCheckResult.unavailable("Quota accounting unavailable — denying request for safety");
+            }
+
+            @Override
+            public QuotaCheckResult tryIncrementApiCalls(String tenantId, int limit) {
+                return QuotaCheckResult.OK;
+            }
+
+            @Override
+            public QuotaCheckResult tryAddCost(String tenantId, double cost, double limit) {
+                return QuotaCheckResult.OK;
+            }
+
+            @Override
+            public double getMonthlyCost(String tenantId) {
+                return 0;
+            }
+
+            @Override
+            public UsageSnapshot getUsage(String tenantId) {
+                return null;
+            }
+
+            @Override
+            public void resetUsage(String tenantId) {
+            }
+        };
+        var service = new TenantQuotaService(failingStore, meterRegistry, TENANT_ID);
+
+        QuotaCheckResult result = service.acquireConversationSlot();
+
+        assertFalse(result.allowed(), "still fail closed");
+        assertTrue(result.accountingUnavailable(), "and say which kind of refusal it is");
+        assertNull(meterRegistry.find("eddi.tenant.quota.denied").counter(),
+                "a store outage must not spike the tenant's over-quota graph");
+        assertEquals(1.0, meterRegistry.counter("eddi.tenant.quota.unavailable",
+                "tenant", TENANT_ID, "type", "conversation").count());
+    }
+
+    /**
+     * Finding f2-01. The test above fails the store's <em>write</em> half, which is
+     * only reachable in a partial outage. In a real one the very first call fails —
+     * every gate opens by reading the tenant's configuration — and that call was
+     * unwrapped: {@code MongoTenantQuotaStore.getQuota} let the driver exception
+     * escape into {@code ConversationService}'s generic handler as an opaque 500
+     * with no tick on {@code eddi.tenant.quota.unavailable}, while
+     * {@code PostgresTenantQuotaStore.getQuota} returned null and thereby switched
+     * enforcement off for every tenant. One outage, two answers, neither of them
+     * the documented one.
+     */
+    @Test
+    @DisplayName("a configuration read that fails is an accounting outage at every gate — not a 500, not a bypass")
+    void unreadableQuotaConfigurationRefusesHonestlyAtEveryGate() {
+        var service = new TenantQuotaService(new UnreachableQuotaStore(), meterRegistry, TENANT_ID);
+
+        List<QuotaCheckResult> results = List.of(
+                service.acquireConversationSlot(),
+                service.acquireApiCallSlot(),
+                service.checkAgentQuota(TENANT_ID, 0),
+                service.checkCostBudget(TENANT_ID),
+                service.recordCost(TENANT_ID, 1.0));
+
+        for (QuotaCheckResult result : results) {
+            assertFalse(result.allowed(), "fail closed — a configuration nobody can read is not permission to proceed");
+            assertTrue(result.accountingUnavailable(),
+                    "503 quota_accounting_unavailable, not 429 quota_exceeded and not an escaping 500");
+            assertEquals(ITenantQuotaStore.ACCOUNTING_UNAVAILABLE, result.reason(),
+                    "the same reason both backends give for the write half, so parity holds on the wire too");
+        }
+
+        assertNull(meterRegistry.find("eddi.tenant.quota.denied").counter(),
+                "a store outage must not spike the tenant's over-quota graph");
+        assertEquals(1.0, meterRegistry.counter("eddi.tenant.quota.unavailable",
+                "tenant", TENANT_ID, "type", "conversation").count(), "conversation-start gate");
+        assertEquals(1.0, meterRegistry.counter("eddi.tenant.quota.unavailable",
+                "tenant", TENANT_ID, "type", "api_call").count(), "say / sayStreaming gate");
+        assertEquals(1.0, meterRegistry.counter("eddi.tenant.quota.unavailable",
+                "tenant", TENANT_ID, "type", "agent").count(), "deployment gate");
+        assertEquals(2.0, meterRegistry.counter("eddi.tenant.quota.unavailable",
+                "tenant", TENANT_ID, "type", "cost").count(), "the pre-call gate and the post-call accounting");
+    }
+
+    /**
+     * A refusal is not cached, so the next turn asks the store again instead of
+     * being pinned to the outage for {@code QUOTA_CACHE_TTL}.
+     */
+    @Test
+    @DisplayName("an unreadable configuration is not cached as a verdict")
+    void anOutageIsNotCachedAsAVerdict() {
+        var store = new UnreachableQuotaStore();
+        var service = new TenantQuotaService(store, meterRegistry, TENANT_ID);
+
+        assertTrue(service.acquireConversationSlot().accountingUnavailable());
+        store.reachable = true;
+
+        assertTrue(service.acquireConversationSlot().allowed(),
+                "the store came back; the gate must ask it again rather than serve a cached refusal");
+    }
+
+    /**
+     * A store that cannot be reached. {@code getQuota} cannot say so in its return
+     * value — {@code null} there already means "no quota configured", which the
+     * service reads as unlimited — so it raises the refusal instead.
+     */
+    private static final class UnreachableQuotaStore extends InMemoryTenantQuotaStore {
+
+        private boolean reachable;
+
+        private UnreachableQuotaStore() {
+            super(TenantQuota.unlimited(TENANT_ID));
+        }
+
+        @Override
+        public TenantQuota getQuota(String tenantId) {
+            if (!reachable) {
+                throw new QuotaAccountingUnavailableException(ITenantQuotaStore.ACCOUNTING_UNAVAILABLE);
+            }
+            return super.getQuota(tenantId);
         }
     }
 

--- a/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaStoreParityTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/TenantQuotaStoreParityTest.java
@@ -54,12 +54,21 @@ class TenantQuotaStoreParityTest extends MongoTestBase {
     private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-06-15T12:30:30Z"), ZoneOffset.UTC);
 
     static Stream<Arguments> stores() {
-        Supplier<ITenantQuotaStore> inMemory = () -> new InMemoryTenantQuotaStore(
-                new TenantQuota("unused", -1, -1, -1, -1.0, true));
         // Pinned, for the reason MongoTenantQuotaStoreContainerTest pins it: the
         // counter assertions below increment N times and expect N, which only holds
-        // if every call landed in the same wall-clock minute. The in-memory store has
-        // no windows at all, so it needs no clock and cannot drift.
+        // if every call landed in the same wall-clock window. That now applies to the
+        // in-memory store too — its windows used to run from the first hit, so N
+        // rapid increments could never straddle one; they are calendar-aligned like
+        // the DB-backed stores', so on the real clock a minute (or a day) ticking
+        // over mid-loop resets the counter and fails the assertion intermittently.
+        //
+        // Residue: a FIXED clock cannot be advanced, so these cases prove parity
+        // *within* one window only. Window ROLLOVER parity — that all three reset the
+        // counter at the same boundary, the behaviour that diverged in the first place
+        // — needs a mutable test clock the stores read per call, which is a change to
+        // their constructors rather than to this fixture.
+        Supplier<ITenantQuotaStore> inMemory = () -> new InMemoryTenantQuotaStore(
+                new TenantQuota("unused", -1, -1, -1, -1.0, true), FIXED_CLOCK);
         Supplier<ITenantQuotaStore> mongo = () -> new MongoTenantQuotaStore(getDatabase(), FIXED_CLOCK);
         Supplier<ITenantQuotaStore> postgres = () -> new PostgresTenantQuotaStore(
                 PostgresTestBase.createDataSourceInstance(), FIXED_CLOCK);

--- a/src/test/java/ai/labs/eddi/engine/tenancy/TenantUsageCountersTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/TenantUsageCountersTest.java
@@ -8,6 +8,11 @@ import ai.labs.eddi.engine.tenancy.model.UsageSnapshot;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -101,6 +106,90 @@ class TenantUsageCountersTest {
         assertEquals(1, counters.getConversationsToday());
         assertEquals(1, counters.getApiCallsThisMinute());
         assertEquals(0.5, counters.getMonthlyCostUsd(), 0.001);
+    }
+
+    /**
+     * Finding 15. These counters used to run their windows from the first hit
+     * (first call + 60s, first call + 24h) while both DB-backed stores truncate to
+     * the calendar minute and UTC day — so identical configuration enforced a
+     * different limit depending on which backend was selected, and neither matched
+     * the "sliding window" {@code TenantQuota} documented. Calendar alignment is
+     * the one semantics a multi-instance deployment can agree on without shared
+     * state.
+     */
+    @Test
+    @DisplayName("windows are aligned to the calendar minute and UTC day, not to the first hit")
+    void windowsAreCalendarAligned() {
+        var clock = new MutableClock(Instant.parse("2026-03-04T12:00:30Z"));
+        var counters = new TenantUsageCounters(clock);
+
+        assertEquals(Instant.parse("2026-03-04T12:00:00Z"), counters.toSnapshot("t").minuteWindowStart());
+        assertEquals(Instant.parse("2026-03-04T00:00:00Z"), counters.toSnapshot("t").dayStart());
+    }
+
+    @Test
+    @DisplayName("the minute window rolls at the calendar boundary, not 60s after the first call")
+    void minuteWindowRollsAtTheCalendarBoundary() {
+        var clock = new MutableClock(Instant.parse("2026-03-04T12:00:30Z"));
+        var counters = new TenantUsageCounters(clock);
+        counters.incrementApiCalls();
+
+        // 35 seconds later — same calendar minute, so the count stands. Under the
+        // old "first hit + 60s" rule it would also have stood, which is the point:
+        // the two rules only diverge at the boundary.
+        clock.set(Instant.parse("2026-03-04T12:00:55Z"));
+        counters.resetExpiredWindows();
+        assertEquals(1, counters.getApiCallsThisMinute());
+
+        // 5 seconds later still, but a new calendar minute: the window rolls here,
+        // where the DB-backed stores also roll it. "First hit + 60s" would have
+        // waited until 12:01:30.
+        clock.set(Instant.parse("2026-03-04T12:01:00Z"));
+        counters.resetExpiredWindows();
+        assertEquals(0, counters.getApiCallsThisMinute());
+        assertEquals(Instant.parse("2026-03-04T12:01:00Z"), counters.toSnapshot("t").minuteWindowStart());
+    }
+
+    @Test
+    @DisplayName("the daily window rolls at UTC midnight")
+    void dayWindowRollsAtUtcMidnight() {
+        var clock = new MutableClock(Instant.parse("2026-03-04T23:59:00Z"));
+        var counters = new TenantUsageCounters(clock);
+        counters.incrementConversations();
+
+        clock.set(Instant.parse("2026-03-05T00:00:00Z"));
+        counters.resetExpiredWindows();
+
+        assertEquals(0, counters.getConversationsToday());
+        assertEquals(Instant.parse("2026-03-05T00:00:00Z"), counters.toSnapshot("t").dayStart());
+    }
+
+    /** A {@link Clock} whose "now" a test can step forward deliberately. */
+    private static final class MutableClock extends Clock {
+        private volatile Instant now;
+
+        private MutableClock(Instant now) {
+            this.now = now;
+        }
+
+        private void set(Instant instant) {
+            this.now = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/tenancy/rest/QuotaAccountingUnavailableExceptionMapperTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/rest/QuotaAccountingUnavailableExceptionMapperTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.engine.tenancy.rest;
+
+import ai.labs.eddi.engine.exception.RejectedExecutionExceptionMapper;
+import ai.labs.eddi.engine.tenancy.QuotaAccountingUnavailableException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * The synchronous half of the honest-503 contract.
+ * <p>
+ * {@code QuotaAccountingUnavailableException} extends
+ * {@link RejectedExecutionException} so that every surface already answering
+ * 503 for backpressure answers 503 for a quota-store outage too. That got the
+ * status right everywhere and the <em>error code</em> right only on the two
+ * {@code AsyncResponse} endpoints that catch it explicitly:
+ * {@code POST /agents/&#123;environment&#125;/&#123;agentId&#125;} lets the
+ * exception reach a mapper, and the nearest one was
+ * {@link RejectedExecutionExceptionMapper} — which says
+ * {@code capacity_exceeded}. Nothing is saturated during a quota-store outage,
+ * and {@code docs/metrics.md} plus the dashboard panel both promise
+ * {@code quota_accounting_unavailable} on that path.
+ */
+class QuotaAccountingUnavailableExceptionMapperTest {
+
+    private final QuotaAccountingUnavailableExceptionMapper mapper = new QuotaAccountingUnavailableExceptionMapper();
+
+    @Test
+    @DisplayName("503 with the quota_accounting_unavailable code and a short Retry-After")
+    void mapsToServiceUnavailableWithTheHonestCode() {
+        Response response = mapper.toResponse(
+                new QuotaAccountingUnavailableException("Quota accounting unavailable — denying request for safety"));
+
+        assertEquals(503, response.getStatus());
+        assertEquals("5", response.getHeaderString("Retry-After"),
+                "an outage is retryable in seconds; the 60s of an over-quota denial would be the wrong signal");
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+        assertEquals(Map.of("error", "quota_accounting_unavailable",
+                "message", "Quota accounting unavailable — denying request for safety"),
+                response.getEntity());
+    }
+
+    /**
+     * The regression itself: the exception IS a {@link RejectedExecutionException},
+     * so without this mapper JAX-RS resolved it to the backpressure one and
+     * answered the wrong code with the right status.
+     */
+    @Test
+    @DisplayName("the code differs from the backpressure mapper it would otherwise fall through to")
+    void doesNotReportItAsCapacityExceeded() {
+        var exception = new QuotaAccountingUnavailableException("Quota accounting unavailable — denying request for safety");
+        assertInstanceOf(RejectedExecutionException.class, exception,
+                "this is why a dedicated mapper is needed at all");
+
+        Object viaBackpressureMapper = new RejectedExecutionExceptionMapper().toResponse(exception).getEntity();
+        assertEquals(Map.of("error", "capacity_exceeded",
+                "message", "Quota accounting unavailable — denying request for safety"), viaBackpressureMapper);
+        assertNotEquals(viaBackpressureMapper, mapper.toResponse(exception).getEntity(),
+                "a client keyed on the documented error code must not see capacity_exceeded for a store outage");
+    }
+
+    @Test
+    @DisplayName("a null message still produces a usable body")
+    void nullMessageFallsBackToAFixedText() {
+        Response response = mapper.toResponse(new QuotaAccountingUnavailableException(null));
+
+        assertEquals(Map.of("error", "quota_accounting_unavailable",
+                "message", "Quota accounting unavailable"), response.getEntity());
+    }
+}

--- a/src/test/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuotaTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuotaTest.java
@@ -9,10 +9,18 @@ import ai.labs.eddi.engine.tenancy.QuotaExceededException;
 import ai.labs.eddi.engine.tenancy.TenantQuotaService;
 import ai.labs.eddi.engine.tenancy.model.TenantQuota;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -66,6 +74,85 @@ class RestTenantQuotaTest {
         assertTrue(stored.enabled());
     }
 
+    /**
+     * Finding 21. {@code updateQuota} dereferenced the body with no null check and
+     * applied no range check, so an empty body was a 500 rather than a 400, and
+     * {@code maxConversationsPerDay=-5} was stored and — because every store reads
+     * only {@code limit < 0} as unlimited — behaved as <em>unlimited</em>, the
+     * opposite of what an admin typing a negative number means. A blank tenant id
+     * created a row nothing could reach.
+     */
+    @Test
+    void shouldRejectAnEmptyBodyWithBadRequestNot500() {
+        assertThrows(BadRequestException.class, () -> restTenantQuota.updateQuota(TENANT_ID, null));
+    }
+
+    @Test
+    void shouldRejectABlankTenantId() {
+        var valid = new TenantQuota(" ", 100, 10, 50, 500.0, true);
+        assertThrows(BadRequestException.class, () -> restTenantQuota.updateQuota(" ", valid));
+    }
+
+    @Test
+    void shouldRejectLimitsBelowTheUnlimitedSentinel() {
+        assertThrows(BadRequestException.class,
+                () -> restTenantQuota.updateQuota(TENANT_ID, new TenantQuota(TENANT_ID, -5, 10, 50, 500.0, true)));
+        assertThrows(BadRequestException.class,
+                () -> restTenantQuota.updateQuota(TENANT_ID, new TenantQuota(TENANT_ID, 100, -2, 50, 500.0, true)));
+        assertThrows(BadRequestException.class,
+                () -> restTenantQuota.updateQuota(TENANT_ID, new TenantQuota(TENANT_ID, 100, 10, -3, 500.0, true)));
+        assertThrows(BadRequestException.class,
+                () -> restTenantQuota.updateQuota(TENANT_ID, new TenantQuota(TENANT_ID, 100, 10, 50, -2.0, true)));
+        assertThrows(BadRequestException.class,
+                () -> restTenantQuota.updateQuota(TENANT_ID, new TenantQuota(TENANT_ID, 100, 10, 50, Double.NaN, true)));
+
+        assertEquals(-1, quotaStore.getQuota(TENANT_ID).maxConversationsPerDay(), "nothing may have been stored");
+    }
+
+    /**
+     * The gap the {@code value < -1} predicate left open. {@code -0.5} is not less
+     * than {@code -1}, so it passed a check whose own rejection message says "-1
+     * (unlimited) or >= 0" — and every store reads any negative as unlimited, so
+     * the admin got exactly the silent no-budget this validation exists to prevent.
+     * Only the {@code double} limit can reach it; no integer sits strictly between
+     * -1 and 0.
+     */
+    @Test
+    void shouldRejectAFractionalCostLimitBetweenTheSentinelAndZero() {
+        assertThrows(BadRequestException.class,
+                () -> restTenantQuota.updateQuota(TENANT_ID, new TenantQuota(TENANT_ID, 100, 10, 50, -0.5, true)));
+        assertThrows(BadRequestException.class,
+                () -> restTenantQuota.updateQuota(TENANT_ID, new TenantQuota(TENANT_ID, 100, 10, 50, -0.000001, true)));
+
+        assertEquals(-1, quotaStore.getQuota(TENANT_ID).maxConversationsPerDay(), "nothing may have been stored");
+    }
+
+    @Test
+    void shouldAcceptTheUnlimitedSentinelAndZero() {
+        try (Response response = restTenantQuota.updateQuota(TENANT_ID, new TenantQuota(TENANT_ID, -1, 0, -1, 0.0, true))) {
+            assertEquals(200, response.getStatus());
+        }
+        assertEquals(0, quotaStore.getQuota(TENANT_ID).maxAgentsPerTenant());
+    }
+
+    /**
+     * The enforcement gates read quota configuration through a short-TTL cache, so
+     * an admin's change has to drop the stale entry or it would not apply on this
+     * node until the TTL expired.
+     */
+    @Test
+    void shouldMakeAnUpdatedQuotaEffectiveImmediately() {
+        // Warm the cache with the permissive default.
+        assertTrue(quotaService.acquireApiCallSlot().allowed());
+
+        try (Response response = restTenantQuota.updateQuota(TENANT_ID, new TenantQuota(TENANT_ID, -1, -1, 1, -1, true))) {
+            assertEquals(200, response.getStatus());
+        }
+
+        assertTrue(quotaService.acquireApiCallSlot().allowed());
+        assertFalse(quotaService.acquireApiCallSlot().allowed(), "the tightened limit must apply to the very next turn");
+    }
+
     @Test
     void shouldReturnUsage() {
         // Enable quota so counters are tracked
@@ -103,6 +190,75 @@ class RestTenantQuotaTest {
         assertNotNull(quotas);
         assertEquals(1, quotas.size());
         assertEquals(TENANT_ID, quotas.getFirst().tenantId());
+    }
+
+    /**
+     * A budget that is accepted, stored and shown in the UI but never enforced is
+     * the kind of thing an operator only discovers from the bill.
+     * {@code TenantQuotaService.checkCostBudget} reads an accumulator only
+     * {@code recordCost} writes, and {@code recordCost} has no production caller,
+     * so the recorded cost is always 0 and the gate always allows. The value is
+     * still stored — it is configuration a later release will enforce — so the WARN
+     * is the only thing that tells anyone, which makes it worth a test rather than
+     * a hope.
+     * <p>
+     * Captured through a JUL handler on the class logger, the same way
+     * {@code ConnectionStartupGuardTest} asserts its startup findings.
+     * {@code src/test/resources/logging.properties} silences the whole
+     * {@code ai.labs.eddi} namespace, so the level has to be raised for the records
+     * to reach a handler at all.
+     */
+    @Test
+    void shouldWarnThatAMonthlyCostBudgetIsNotEnforcedYet() {
+        var records = new ArrayList<String>();
+        Logger restLogger = Logger.getLogger(RestTenantQuota.class.getName());
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                // warnf keeps its arguments out of the message, so both halves are kept.
+                records.add(record.getMessage() + " " + Arrays.toString(record.getParameters()));
+            }
+
+            @Override
+            public void flush() {
+                // nothing is buffered
+            }
+
+            @Override
+            public void close() {
+                // nothing to release
+            }
+        };
+        Level previousLevel = restLogger.getLevel();
+        boolean previousUseParentHandlers = restLogger.getUseParentHandlers();
+        restLogger.setLevel(Level.ALL);
+        restLogger.setUseParentHandlers(false);
+        restLogger.addHandler(handler);
+        try {
+            // Enabled, with a real (non-sentinel) budget — the combination that is
+            // silently unenforceable.
+            try (Response response = restTenantQuota.updateQuota(TENANT_ID,
+                    new TenantQuota(TENANT_ID, -1, -1, -1, 250.0, true))) {
+                assertEquals(200, response.getStatus());
+            }
+            assertTrue(records.stream().anyMatch(r -> r.contains("maxMonthlyCostUsd") && r.contains("NOT enforced")),
+                    "an admin who sets a budget must be told nothing records cost against it, was: " + records);
+            assertEquals(250.0, quotaStore.getQuota(TENANT_ID).maxMonthlyCostUsd(),
+                    "the value is still stored — it is configuration, not a rejected input");
+
+            records.clear();
+            // The sentinel means "no budget", so there is nothing to warn about.
+            try (Response response = restTenantQuota.updateQuota(TENANT_ID,
+                    new TenantQuota(TENANT_ID, -1, -1, -1, -1, true))) {
+                assertEquals(200, response.getStatus());
+            }
+            assertTrue(records.stream().noneMatch(r -> r.contains("NOT enforced")),
+                    "an unlimited budget must not produce the warning, was: " + records);
+        } finally {
+            restLogger.removeHandler(handler);
+            restLogger.setLevel(previousLevel);
+            restLogger.setUseParentHandlers(previousUseParentHandlers);
+        }
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuotaTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuotaTest.java
@@ -23,6 +23,9 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit tests for the tenant quota REST API.
@@ -282,6 +285,58 @@ class RestTenantQuotaTest {
                     "a disabled tenant must not produce the warning, was: " + records);
             assertEquals(250.0, quotaStore.getQuota(TENANT_ID).maxMonthlyCostUsd(),
                     "and the value is still stored, exactly as in the enabled case");
+        } finally {
+            restLogger.removeHandler(handler);
+            restLogger.setLevel(previousLevel);
+            restLogger.setUseParentHandlers(previousUseParentHandlers);
+        }
+    }
+
+    /**
+     * The warning above asserts that the limit <em>is</em> stored and will apply
+     * once cost recording is wired. It used to be emitted before {@code setQuota}
+     * was called at all, so a store that then threw left that claim standing in the
+     * log with nothing written behind it — and that one line is the only signal
+     * this feature has, so an operator reading it goes looking for a row that does
+     * not exist.
+     */
+    @Test
+    void shouldNotClaimAStoredBudgetWhenTheQuotaWriteFailed() {
+        var failingService = mock(TenantQuotaService.class);
+        doThrow(new IllegalStateException("quota store unreachable")).when(failingService).setQuota(any());
+        var restWithFailingStore = new RestTenantQuota(quotaStore, failingService);
+
+        var records = new ArrayList<String>();
+        Logger restLogger = Logger.getLogger(RestTenantQuota.class.getName());
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record.getMessage() + " " + Arrays.toString(record.getParameters()));
+            }
+
+            @Override
+            public void flush() {
+                // nothing is buffered
+            }
+
+            @Override
+            public void close() {
+                // nothing to release
+            }
+        };
+        Level previousLevel = restLogger.getLevel();
+        boolean previousUseParentHandlers = restLogger.getUseParentHandlers();
+        restLogger.setLevel(Level.ALL);
+        restLogger.setUseParentHandlers(false);
+        restLogger.addHandler(handler);
+        try {
+            // Enabled, with a real budget: the exact combination that warns, so the
+            // only thing keeping the line out of the log is the failed write.
+            assertThrows(IllegalStateException.class, () -> restWithFailingStore.updateQuota(TENANT_ID,
+                    new TenantQuota(TENANT_ID, -1, -1, -1, 250.0, true)));
+
+            assertTrue(records.stream().noneMatch(r -> r.contains("NOT enforced")),
+                    "the warning asserts a stored limit, so it must not outlive a write that never landed, was: " + records);
         } finally {
             restLogger.removeHandler(handler);
             restLogger.setLevel(previousLevel);

--- a/src/test/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuotaTest.java
+++ b/src/test/java/ai/labs/eddi/engine/tenancy/rest/RestTenantQuotaTest.java
@@ -93,6 +93,20 @@ class RestTenantQuotaTest {
         assertThrows(BadRequestException.class, () -> restTenantQuota.updateQuota(" ", valid));
     }
 
+    /**
+     * The other half of the same guard. A null path segment cannot arrive over
+     * HTTP, but this bean is also called in-process, and a null tenant id reaching
+     * the store would write a row no gate can ever read back — the quota would look
+     * saved in the UI and enforce nothing.
+     */
+    @Test
+    void shouldRejectANullTenantId() {
+        var valid = new TenantQuota(TENANT_ID, 100, 10, 50, 500.0, true);
+        assertThrows(BadRequestException.class, () -> restTenantQuota.updateQuota(null, valid));
+        assertEquals(-1, quotaStore.getQuota(TENANT_ID).maxConversationsPerDay(),
+                "a rejected request must not have written anything");
+    }
+
     @Test
     void shouldRejectLimitsBelowTheUnlimitedSentinel() {
         assertThrows(BadRequestException.class,
@@ -254,6 +268,20 @@ class RestTenantQuotaTest {
             }
             assertTrue(records.stream().noneMatch(r -> r.contains("NOT enforced")),
                     "an unlimited budget must not produce the warning, was: " + records);
+
+            records.clear();
+            // A budget on a tenant whose enforcement is switched off entirely. Nothing
+            // about it is enforced, budget included, so the specific "cost is not
+            // recorded" warning would be noise — and noise is how the case above stops
+            // being read.
+            try (Response response = restTenantQuota.updateQuota(TENANT_ID,
+                    new TenantQuota(TENANT_ID, -1, -1, -1, 250.0, false))) {
+                assertEquals(200, response.getStatus());
+            }
+            assertTrue(records.stream().noneMatch(r -> r.contains("NOT enforced")),
+                    "a disabled tenant must not produce the warning, was: " + records);
+            assertEquals(250.0, quotaStore.getQuota(TENANT_ID).maxMonthlyCostUsd(),
+                    "and the value is still stored, exactly as in the enabled case");
         } finally {
             restLogger.removeHandler(handler);
             restLogger.setLevel(previousLevel);

--- a/src/test/java/ai/labs/eddi/integration/GdprComplianceIT.java
+++ b/src/test/java/ai/labs/eddi/integration/GdprComplianceIT.java
@@ -58,10 +58,15 @@ public class GdprComplianceIT extends BaseIntegrationIT {
         // Export
         Response response = given().get(GDPR_BASE + TEST_USER_ID + "/export");
 
+        // 207, not 200: the bundle omits group transcripts, shared artifacts,
+        // schedules and HITL journal entries, so calling it complete would be an
+        // Art. 20 answer that is not true. 200 returns when those exporters land.
         response.then().assertThat()
-                .statusCode(200)
+                .statusCode(207)
                 .contentType(ContentType.JSON)
-                .body("userId", equalTo(TEST_USER_ID));
+                .body("userId", equalTo(TEST_USER_ID))
+                .body("complete", equalTo(false))
+                .body("omittedCategories", not(empty()));
     }
 
     @Test
@@ -72,9 +77,11 @@ public class GdprComplianceIT extends BaseIntegrationIT {
 
         given().get(GDPR_BASE + emptyUser + "/export")
                 .then().assertThat()
-                .statusCode(200)
+                .statusCode(207)
                 .contentType(ContentType.JSON)
-                .body("userId", equalTo(emptyUser));
+                .body("userId", equalTo(emptyUser))
+                .body("complete", equalTo(false))
+                .body("omittedCategories", not(empty()));
     }
 
     // ==================== Processing Restriction (Art. 18) ====================
@@ -167,10 +174,13 @@ public class GdprComplianceIT extends BaseIntegrationIT {
                 .then().statusCode(200);
 
         // Export — should have empty conversations
+        // Still 207: an erased user's bundle is empty AND still omits the four
+        // categories nothing exports yet.
         given().get(GDPR_BASE + userId + "/export")
                 .then().assertThat()
-                .statusCode(200)
-                .body("conversations", empty());
+                .statusCode(207)
+                .body("conversations", empty())
+                .body("complete", equalTo(false));
     }
 
     @Test

--- a/src/test/java/ai/labs/eddi/modules/llm/impl/ToolLoopRunnerTenantCostBudgetTest.java
+++ b/src/test/java/ai/labs/eddi/modules/llm/impl/ToolLoopRunnerTenantCostBudgetTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.modules.llm.impl;
+
+import ai.labs.eddi.engine.memory.IConversationMemory;
+import ai.labs.eddi.engine.tenancy.TenantQuotaService;
+import ai.labs.eddi.engine.tenancy.model.QuotaCheckResult;
+import ai.labs.eddi.modules.llm.guardrails.ToolResultGuardrail;
+import ai.labs.eddi.modules.llm.model.LlmConfiguration;
+import ai.labs.eddi.modules.llm.tools.ToolExecutionService;
+import ai.labs.eddi.modules.llm.tools.ToolInvocation;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.service.tool.ToolExecutor;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The tenant cost gate in {@code executeSingleToolCallResult} must refuse a
+ * tool call for BOTH kinds of quota refusal, and must not describe a
+ * quota-store outage as a tenant having spent its allowance.
+ * <p>
+ * {@code QuotaCheckResult} now carries {@code accountingUnavailable} beside
+ * {@code allowed}. Both refuse the call — that part was always right — but the
+ * operator-facing sentence in front of the refusal said "cost budget exceeded"
+ * in both cases, so an operator grepping the logs during a database outage was
+ * told a tenant was over budget. These tests pin that the refusal happens on
+ * both paths, that the reason the model is handed is the store's own reason
+ * string rather than a rewritten one, and that the tool never executes.
+ * <p>
+ * <strong>The sentence itself is asserted, not just the refusal.</strong> The
+ * refusal is identical on both paths and predates this change — everything
+ * downstream of the gate (the returned {@code "Error: <reason>"}, the trace
+ * entry, the un-run executor) reads the store's own {@code reason()} and was
+ * already correct. The <em>only</em> thing the branch decides is which of two
+ * sentences the operator sees, so a test that never looks at the log cannot
+ * fail when the branch is removed. Hence the handler: the assertions below
+ * match on the fixed part of each sentence, never on the interpolated reason,
+ * because the outage reason contains the words "accounting unavailable" itself
+ * and would satisfy a naive substring check under the old single-sentence code.
+ */
+class ToolLoopRunnerTenantCostBudgetTest {
+
+    private static final String OUTAGE_REASON = "Quota accounting unavailable — denying request for safety";
+    private static final String OVER_BUDGET_REASON = "Monthly cost budget reached ($10.00)";
+
+    /** The fixed part of each sentence — no reason string can produce either. */
+    private static final String OUTAGE_SENTENCE = "Tenant cost accounting unavailable during tool call, refusing";
+    private static final String OVER_BUDGET_SENTENCE = "Tenant cost budget exceeded during tool call";
+
+    private ToolExecutionService toolExecutionService;
+    private TenantQuotaService tenantQuotaService;
+    private ToolExecutor executor;
+    private ToolLoopRunner runner;
+    private LlmConfiguration.Task task;
+
+    private final List<String> warnings = new ArrayList<>();
+    private Logger runnerLogger;
+    private Handler logHandler;
+    private Level previousLevel;
+    private boolean previousUseParentHandlers;
+
+    @BeforeEach
+    void captureTheOperatorFacingLog() {
+        logHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                if (record.getLevel().intValue() < Level.WARNING.intValue()) {
+                    return;
+                }
+                // Printf-style calls may or may not be pre-formatted depending on the
+                // JBoss Logging backend in use, so both halves are kept. The
+                // assertions match on the fixed sentence only, which cannot come from
+                // the interpolated argument either way.
+                warnings.add(record.getMessage() + " " + Arrays.toString(record.getParameters()));
+            }
+
+            @Override
+            public void flush() {
+                // nothing is buffered
+            }
+
+            @Override
+            public void close() {
+                // nothing to release
+            }
+        };
+        // src/test/resources/logging.properties silences the whole ai.labs.eddi
+        // namespace, so without raising the level the records never reach a handler.
+        // Detaching the parent handlers keeps the refusal lines out of the surefire
+        // output.
+        runnerLogger = Logger.getLogger(ToolLoopRunner.class.getName());
+        previousLevel = runnerLogger.getLevel();
+        previousUseParentHandlers = runnerLogger.getUseParentHandlers();
+        runnerLogger.setLevel(Level.ALL);
+        runnerLogger.setUseParentHandlers(false);
+        runnerLogger.addHandler(logHandler);
+    }
+
+    @AfterEach
+    void releaseTheLogger() {
+        runnerLogger.removeHandler(logHandler);
+        runnerLogger.setLevel(previousLevel);
+        runnerLogger.setUseParentHandlers(previousUseParentHandlers);
+    }
+
+    @BeforeEach
+    void setUp() {
+        toolExecutionService = mock(ToolExecutionService.class);
+        // Straight-through, so a tool that DOES run is visible as an invocation of
+        // the executor rather than being swallowed by the wrapper's own gates.
+        lenient()
+                .when(toolExecutionService.executeToolWrapped(any(ToolInvocation.class), anyString(), nullable(String.class),
+                        nullable(String.class), any(), anyBoolean(), anyBoolean(), anyBoolean(), anyInt()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(4)).get());
+
+        var truncator = mock(ToolResponseTruncator.class);
+        lenient().when(truncator.truncateIfNeeded(anyString(), anyString(), any(), any(), any()))
+                .thenAnswer(i -> i.getArgument(1));
+
+        tenantQuotaService = mock(TenantQuotaService.class);
+        when(tenantQuotaService.getDefaultTenantId()).thenReturn("default");
+
+        executor = mock(ToolExecutor.class);
+        lenient().when(executor.execute(any(), nullable(String.class))).thenReturn("Order #7 shipped.");
+
+        // A real guardrail, not null: the allowed path runs the result through it,
+        // and a null collaborator would make "the tool ran" untestable.
+        runner = new ToolLoopRunner(toolExecutionService, truncator, tenantQuotaService, null, null, null, null,
+                new ToolResultGuardrail(new SimpleMeterRegistry()));
+
+        task = new LlmConfiguration.Task();
+        task.setId("llmTask-cost-gate");
+    }
+
+    private String execute(List<Map<String, Object>> trace) {
+        ToolExecutionRequest request = ToolExecutionRequest.builder().id("c1").name("get_order").arguments("{}").build();
+        Map<String, ToolExecutor> executors = new HashMap<>();
+        executors.put("get_order", executor);
+
+        return runner.executeSingleToolCallResult(request, mock(IConversationMemory.class), trace, executors,
+                Map.of(), Map.of(), Map.of("get_order", "http"), 100, null, "conv-1",
+                false, false, false, task, false, List.of(), new ArrayList<>());
+    }
+
+    /** Whether any captured WARN carries the given fixed sentence. */
+    private boolean warned(String sentence) {
+        return warnings.stream().anyMatch(warning -> warning.contains(sentence));
+    }
+
+    /**
+     * The regression the {@code accountingUnavailable} flag exists for: the store
+     * could not answer, so the call is refused — but the refusal must carry the
+     * outage's own reason, not a budget sentence.
+     * <p>
+     * The log assertion is the one that fails when the branch is removed: with a
+     * single {@code LOGGER.warnf("Tenant cost budget exceeded during tool call:
+     * %s", ...)} the refusal, the returned string and the trace entry are all
+     * byte-for-byte identical, and only the sentence in front of them changes.
+     */
+    @Test
+    @DisplayName("a quota-store outage refuses the tool call and reports the outage, not a spent budget")
+    void accountingUnavailable_refusesAndNamesTheOutage() {
+        when(tenantQuotaService.checkCostBudget("default")).thenReturn(QuotaCheckResult.unavailable(OUTAGE_REASON));
+        var trace = new ArrayList<Map<String, Object>>();
+
+        String result = execute(trace);
+
+        assertEquals("Error: " + OUTAGE_REASON, result,
+                "the model is handed the store's own reason so it can stop rather than retry a budget it has not spent");
+        verify(executor, never()).execute(any(), nullable(String.class));
+
+        var errors = trace.stream().filter(step -> "tool_error".equals(step.get("type"))).toList();
+        assertEquals(1, errors.size(), trace.toString());
+        assertEquals("get_order", errors.getFirst().get("tool"));
+        assertEquals(OUTAGE_REASON, errors.getFirst().get("error"));
+        assertTrue(((String) errors.getFirst().get("error")).contains("accounting unavailable"),
+                "the trace entry an auditor reads must not say the tenant went over a limit");
+
+        assertTrue(warned(OUTAGE_SENTENCE),
+                "the operator has to be able to tell a quota-store outage from a spent allowance; saw: " + warnings);
+        assertFalse(warned(OVER_BUDGET_SENTENCE),
+                "an operator grepping for 'cost budget exceeded' during a database outage must not find this turn; saw: "
+                        + warnings);
+        assertEquals(1, warnings.size(), "one refusal, one sentence: " + warnings);
+    }
+
+    /**
+     * The ordinary half of the same gate: a genuine over-budget denial. Asserted
+     * alongside the outage half so a branch that simply renamed the sentence for
+     * everybody — which would also make the test above pass — is caught here.
+     */
+    @Test
+    @DisplayName("an over-budget denial refuses the tool call and reports the budget")
+    void overBudget_refusesAndNamesTheBudget() {
+        when(tenantQuotaService.checkCostBudget("default")).thenReturn(QuotaCheckResult.denied(OVER_BUDGET_REASON));
+        var trace = new ArrayList<Map<String, Object>>();
+
+        String result = execute(trace);
+
+        assertEquals("Error: " + OVER_BUDGET_REASON, result);
+        verify(executor, never()).execute(any(), nullable(String.class));
+        assertEquals(OVER_BUDGET_REASON,
+                trace.stream().filter(step -> "tool_error".equals(step.get("type"))).findFirst().orElseThrow().get("error"));
+
+        assertTrue(warned(OVER_BUDGET_SENTENCE),
+                "a tenant that really did spend its allowance must still be reported as such; saw: " + warnings);
+        assertFalse(warned(OUTAGE_SENTENCE),
+                "nothing is unavailable here — the store answered; saw: " + warnings);
+        assertEquals(1, warnings.size(), "one refusal, one sentence: " + warnings);
+    }
+
+    /** An allowed check must leave the call alone — the gate is not a no-op. */
+    @Test
+    @DisplayName("an allowed cost check lets the tool run")
+    void allowed_executesTheTool() {
+        when(tenantQuotaService.checkCostBudget("default")).thenReturn(QuotaCheckResult.OK);
+        var trace = new ArrayList<Map<String, Object>>();
+
+        String result = execute(trace);
+
+        assertTrue(result.contains("Order #7 shipped."), result);
+        verify(executor).execute(any(), nullable(String.class));
+        assertTrue(trace.stream().noneMatch(step -> "tool_error".equals(step.get("type"))), trace.toString());
+        assertFalse(warned(OVER_BUDGET_SENTENCE), "a call that was allowed is not a refusal; saw: " + warnings);
+        assertFalse(warned(OUTAGE_SENTENCE), "a call that was allowed is not a refusal; saw: " + warnings);
+    }
+}


### PR DESCRIPTION
The subsystem a regulated buyer is actually paying for did not work on a supported backend.

## What was broken

**The PostgreSQL audit backend could not store entries EDDI legitimately produces.** `conversation_id`, `AGENT_ID` and `AGENT_VERSION` were `NOT NULL`, and the insert unboxed a nullable `agentVersion` with `setInt`, throwing an NPE that escaped `appendBatch`'s catch entirely. Six shipped call sites pass a literal `null` — ordinary HITL approvals and group turns among them — so a single compliance or oversight entry **discarded roughly three flush windows of unrelated conversations' audit data**, while the compliance event itself was never recorded.

On the read side, `getInt` mapped a stored SQL NULL to `0`, which the HMAC canonical form renders differently, so any such row would have verified as **tampered**.

The ledger is append-only evidence, not logs. Losing other conversations' entries because one entry is malformed is the worst available failure mode for it.

**GDPR erasure returned HTTP 200 and a "complete" result even when steps failed**, and reported memories as deleted before deleting them. The MCP admin surface for the same operation hardcoded `"status": "completed"`, so an operator — or an LLM agent invoking the tool — was told a lossy erasure had succeeded.

## What changed

Nullable columns are nullable, and the nullable integer is bound with `setObject`/`getObject` so a real NULL round-trips and verifies correctly. Erasure reports per-step outcomes and answers 207 when the cascade is partial, and the MCP tool is driven by the real result. Quota bootstrap warns when stored and configured values diverge instead of silently preferring one.

## How it is proven

Every behavioural change is pinned by a regression test **verified to fail with its fix reverted**.

Worth flagging for reviewers: on the first attempt at this branch, **three pre-existing tests were failing while the work reported itself green**. An independent reviewer caught it by running them. They are now genuinely closed, and closed the right way — the fixtures were corrected to stub what production actually calls, not relaxed. Five further tests in the same classes had begun passing *vacuously*, because the change bypassed the dead-letter branch they exist to cover; their stubs are restored so they exercise it again.

One item is deliberately left as a product gap rather than fixed here: `maxMonthlyCostUsd` is stored and displayed but never enforced, because `TenantQuotaService.recordCost` has no production caller. It now surfaces as an explicit warning instead of a silent no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GDPR exports now report completeness, omitted categories, totals, and truncation with `207 Multi-Status` responses.
  * GDPR deletion results include completion status, failed steps, and detailed counters.
  * Quota-store outages return clear `503` responses distinct from quota-limit denials.
  * Audit monitoring reports sequence collisions and dead-letter activity.
* **Bug Fixes**
  * Improved audit persistence, duplicate handling, nullable fields, sequencing, and bounded reads.
  * Resource-store failures now report service unavailability instead of access denials.
* **Documentation**
  * Added guidance for multi-replica auditing, GDPR coverage, quota behavior, and PostgreSQL upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->