### PR TITLE
docs: add Javadoc to config store interfaces #545

### DIFF
--- a/src/main/java/ai/labs/eddi/configs/channels/IChannelIntegrationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/channels/IChannelIntegrationStore.java
@@ -8,8 +8,10 @@ import ai.labs.eddi.configs.channels.model.ChannelIntegrationConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 
 /**
- * Store interface for channel integration configurations. Uses the DB-agnostic
- * {@code AbstractResourceStore} via {@code IResourceStorageFactory}.
+ * Persistence store for channel integration configurations (Slack and similar
+ * platforms). {@code ChannelTargetRouter} and the REST channel API load these
+ * to route incoming events onto agents or groups, independently of
+ * {@code AgentConfiguration}.
  *
  * @since 6.1.0
  */

--- a/src/main/java/ai/labs/eddi/configs/channels/IChannelIntegrationStore.java
+++ b/src/main/java/ai/labs/eddi/configs/channels/IChannelIntegrationStore.java
@@ -9,9 +9,11 @@ import ai.labs.eddi.datastore.IResourceStore;
 
 /**
  * Persistence store for channel integration configurations (Slack and similar
- * platforms). {@code ChannelTargetRouter} and the REST channel API load these
- * to route incoming events onto agents or groups, independently of
- * {@code AgentConfiguration}.
+ * platforms). The REST channel API manages them; {@code ChannelTargetRouter}
+ * loads them to route incoming events onto agents or groups. They replace the
+ * legacy {@code ChannelConnector} entries on {@code AgentConfiguration}: where
+ * an integration here covers a channel type and id, the legacy entries for that
+ * pair are ignored.
  *
  * @since 6.1.0
  */

--- a/src/main/java/ai/labs/eddi/configs/deployment/IDeploymentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/deployment/IDeploymentStore.java
@@ -11,7 +11,9 @@ import ai.labs.eddi.datastore.IResourceStore;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Persistence store for which agent versions are deployed in each environment.
+ * {@code AgentDeploymentManagement} and the administration REST API read and
+ * write these records when an agent is deployed, undeployed, or deleted.
  */
 public interface IDeploymentStore {
 

--- a/src/main/java/ai/labs/eddi/configs/descriptors/IDocumentDescriptorStore.java
+++ b/src/main/java/ai/labs/eddi/configs/descriptors/IDocumentDescriptorStore.java
@@ -12,7 +12,11 @@ import ai.labs.eddi.engine.security.spaces.AccessScope;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Persistence store for document descriptors — display name, ownership, sharing
+ * and timestamps listed in the Manager UI, kept separate from the configuration
+ * document itself. REST list endpoints and {@code ResourceAccessGuard} query
+ * this store, including the {@link AccessScope}-filtered overload for
+ * caller-visible results.
  */
 public interface IDocumentDescriptorStore extends IDescriptorStore<DocumentDescriptor> {
 

--- a/src/main/java/ai/labs/eddi/configs/groups/IAgentGroupStore.java
+++ b/src/main/java/ai/labs/eddi/configs/groups/IAgentGroupStore.java
@@ -8,10 +8,9 @@ import ai.labs.eddi.configs.groups.model.AgentGroupConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 
 /**
- * Store interface for group configurations. Uses the DB-agnostic
- * {@code AbstractResourceStore} via {@code IResourceStorageFactory}.
- *
- * @author ginccc
+ * Persistence store for multi-agent group configurations (members, discussion
+ * style, phases). {@code GroupConversationService} and the group REST API load
+ * these to run structured discussions.
  */
 public interface IAgentGroupStore extends IResourceStore<AgentGroupConfiguration> {
 }

--- a/src/main/java/ai/labs/eddi/configs/properties/IUserMemoryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/properties/IUserMemoryStore.java
@@ -25,7 +25,6 @@ import java.util.Optional;
  * Structured entry methods operate on the full {@code usermemories} collection
  * with visibility, categories, and agent scoping.
  *
- * @author ginccc
  * @since 6.0.0
  */
 public interface IUserMemoryStore {

--- a/src/main/java/ai/labs/eddi/configs/propertysetter/IPropertySetterStore.java
+++ b/src/main/java/ai/labs/eddi/configs/propertysetter/IPropertySetterStore.java
@@ -8,7 +8,10 @@ import ai.labs.eddi.configs.propertysetter.model.PropertySetterConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 
 /**
- * @author ginccc
+ * Persistence store for property-setter configurations, which assign
+ * conversation properties when named actions fire. Loaded by
+ * {@code ResourceClientLibrary} into the lifecycle pipeline and edited through
+ * the REST property-setter API.
  */
 public interface IPropertySetterStore extends IResourceStore<PropertySetterConfiguration> {
     // class for reflection purposes

--- a/src/main/java/ai/labs/eddi/configs/rag/IRagStore.java
+++ b/src/main/java/ai/labs/eddi/configs/rag/IRagStore.java
@@ -8,7 +8,10 @@ import ai.labs.eddi.configs.rag.model.RagConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 
 /**
- * Store interface for RAG (Knowledge Base) configurations.
+ * Persistence store for RAG knowledge-base configurations (embedding provider,
+ * vector store, and default retrieval). {@code ResourceClientLibrary} and the
+ * LLM task load these at execution time; the REST RAG API exposes CRUD and
+ * ingestion.
  */
 public interface IRagStore extends IResourceStore<RagConfiguration> {
 }

--- a/src/main/java/ai/labs/eddi/configs/snippets/IPromptSnippetStore.java
+++ b/src/main/java/ai/labs/eddi/configs/snippets/IPromptSnippetStore.java
@@ -10,9 +10,11 @@ import ai.labs.eddi.datastore.IResourceStore;
 import java.util.List;
 
 /**
- * Store interface for {@link PromptSnippet} configuration documents.
+ * Persistence store for reusable prompt-snippet documents.
+ * {@code PromptSnippetService} reads them into the LLM template data map so
+ * system prompts can pull in {@code {snippets.name}} fragments at task
+ * execution time.
  *
- * @author ginccc
  * @since 6.0.0
  */
 public interface IPromptSnippetStore extends IResourceStore<PromptSnippet> {

--- a/src/main/java/ai/labs/eddi/configs/snippets/IPromptSnippetStore.java
+++ b/src/main/java/ai/labs/eddi/configs/snippets/IPromptSnippetStore.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Persistence store for reusable prompt-snippet documents.
  * {@code PromptSnippetService} reads them into the LLM template data map so
- * system prompts can pull in {@code {snippets.name}} fragments at task
+ * system prompts can pull in {@code {snippets.<name>}} fragments at task
  * execution time.
  *
  * @since 6.0.0


### PR DESCRIPTION
Class-level Javadoc on the eight remaining config store interfaces.

I replaced leftover `@author` tags with purpose, who consumes the store, and the key behaviour. `IUserMemoryStore` already had docs; I only dropped `@author` there.

Closes #545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for channel integrations, deployments, document descriptors, agent groups, user memory, property setters, RAG knowledge bases, and prompt snippets.
  * Added context on how these configuration stores support administration, APIs, and runtime operations.
  * Removed outdated author references and legacy implementation details.
  * No functional behavior or public interfaces changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->