### PR TITLE
docs: correct 23 false documentation claims and pin them with a guard test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ Follow this order unless the user explicitly requests something different.
 | —     | LLM Provider Expansion   | Added Mistral, Azure OpenAI, Bedrock, Oracle GenAI (12 providers; see `docs/langchain.md`)                                     |
 | —     | Quarkus LTS              | LTS platform upgrade, Java 25 module fix (version pinned in `pom.xml`)                              |
 | 12    | CI/CD                    | GitHub Actions unified pipeline, Docker Hub push, CircleCI removed                                  |
+| —     | OpenTelemetry Tracing    | Per-task `eddi.pipeline.task` spans from `LifecycleManager`, MCP circuit breakers — see [`docs/monitoring/monitoring-guide.md`](docs/monitoring/monitoring-guide.md) |
 | 11a   | Persistent Memory        | IUserMemoryStore, UserMemoryTool, DreamService, McpMemoryTools, Property.Visibility                 |
 | —     | Conversation Windows     | Token-aware windowing, rolling summary, ConversationRecallTool                                      |
 | —     | Agentic Improvements 1–5 | Counterweights, MCP governance, capability registry, multimodal attachments, agent signing          |
@@ -172,7 +173,7 @@ Follow this order unless the user explicitly requests something different.
 | —     | Memory Architecture       | Commit flags, RAG threshold, context selection, auto-compaction, property consolidation (see `planning/memory-architecture-plan.md`) |
 | —     | Session Forking           | State snapshotting, conversation forking (see `planning/agentic-improvements-plan.md` §7)                                                 |
 | —     | Conversation Chaining     | Cross-session context carry-over (see `planning/conversation-window-management.md` Strategy 3)                                       |
-| 9     | DAG Pipeline              | Parallel tasks, circuit breakers, OpenTelemetry tracing                                                                                   |
+| 9     | DAG Pipeline              | Parallel task execution and the dependency graph. OpenTelemetry tracing and MCP circuit breakers already shipped — see Completed          |
 | —     | HITL — remaining          | EDDI-Manager approvals UI (Manager repo) and the reserved `inGroupTurns: INBOX` mode for member *tool-call* pauses. Core framework shipped; humans as group *members* shipped in 10c — see Completed. `VoteConfig.tiePolicy: HUMAN_DECIDES` is likewise still save-time rejected pending its own resume machinery |
 | —     | Guardrails                | Config-driven input/output guardrails in LlmTask (see `planning/guardrails-architecture.md`)                                         |
 | 11b   | Multi-Channel             | Teams adapter (Slack already ships via HITL approval channels; see `planning/multi-agent-ux-improvements.md`)                        |
@@ -801,7 +802,7 @@ Matcher:      "actions" : "ask_for_model"
 | `longTerm`     | Persisted to `usermemories` collection across conversations                                                                                   |
 | `secret`       | Auto-vaulted: plaintext stored in SecretsVault, raw input scrubbed from memory, vault reference (`${vault:...}`) stored as property value |
 
-> **Warning**: `scope: "secret"` requires the vault to be active (`EDDI_VAULT_MASTER_KEY` env var set). If vault is disabled (common in dev mode), `autoVaultSecret()` fails and falls back to storing plaintext — but logs an ERROR that may confuse users. For wizard-style agents that collect API keys and pass them to an endpoint (see §5.6), prefer `scope: "conversation"` and delegate vaulting to the receiving service.
+> **Warning**: `scope: "secret"` requires the vault to be active (`EDDI_VAULT_MASTER_KEY` env var set). If the vault is disabled — which is the shipped default — `autoVaultSecret()` **fails closed**: it scrubs the plaintext from the conversation step, logs an ERROR, and throws a `LifecycleException` naming `EDDI_VAULT_MASTER_KEY`. The whole turn fails; the plaintext is never persisted. (An earlier release persisted the plaintext instead; that behaviour was removed deliberately — see the comment in `PropertySetterTask.autoVaultSecret` and `docs/properties.md`.) For wizard-style agents that collect API keys and pass them to an endpoint (see §5.6), prefer `scope: "conversation"` and delegate vaulting to the receiving service — a dev instance without a master key cannot complete a secret-scoped turn at all.
 
 #### Capturing user input vs. setting fixed values
 
@@ -901,7 +902,20 @@ The file naming convention is `{id}.{type}.json` where `{id}` matches the last p
     {outputId}.descriptor.json
     {llmId}.langchain.json        → LLM configuration (file ext stays "langchain", URI uses "llm")
     {llmId}.descriptor.json
+    {dictionaryId}.regulardictionary.json → Regular dictionary (URI uses "dictionary")
+    {dictionaryId}.descriptor.json
+    {mcpId}.mcpcalls.json         → MCP tool calls
+    {mcpId}.descriptor.json
+    {ragId}.rag.json              → RAG retrieval configuration
+    {ragId}.descriptor.json
+snippets/
+  {snippetId}.snippet.json        → Prompt snippets (root, agent, or version level)
+schedules/
+  {scheduleId}.schedule.json      → Agent schedules
 ```
+
+> The authoritative list of file extensions is `AbstractBackupService`'s `*_EXT` constants —
+> twelve of them. Check against that file rather than against this block if the two ever disagree.
 
 > **Important**: File extensions use legacy names (`behavior`, `httpcalls`, `langchain`) while URIs use v6 names (`rules`, `apicalls`, `llm`). The import service maps between them via `AbstractBackupService` constants.
 
@@ -935,6 +949,8 @@ Always use v6 canonical URIs in new configs:
 | `eddi://ai.labs.httpcalls` | `eddi://ai.labs.apicalls/...` | Optional — API calls        |
 | `eddi://ai.labs.output`    | `eddi://ai.labs.output/...`   | Usually yes — user messages |
 | `eddi://ai.labs.llm`       | `eddi://ai.labs.llm/...`      | Optional — LLM interaction  |
+| `eddi://ai.labs.mcpcalls`  | `eddi://ai.labs.mcpcalls/...` | Optional — MCP tool calls   |
+| `eddi://ai.labs.templating`| — (no config URI)             | Yes when any output or system prompt contains `{…}` placeholders — must be last |
 
 ### 5.6 Reference Implementation
 

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ EDDI implements open standards — not proprietary APIs:
 - 🐳 **One-Command Install** — Interactive wizard sets up EDDI + database via Docker
 - ☸️ **Kubernetes / OpenShift** — Kustomize overlays, Helm charts, PDB, NetworkPolicy (no HPA: EDDI is single-writer per conversation, so both delivery paths pin one replica)
 - 📊 **Prometheus & Grafana** — 50+ Micrometer metrics at `/q/metrics` (tools, vault, memory, scheduling, conversations). Pre-built [Grafana dashboard](docs/monitoring/eddi-grafana-dashboard.json) included
-- 🔭 **OpenTelemetry Tracing** — Per-task distributed traces via OTLP (Jaeger, Tempo, Datadog). Every pipeline task emits spans with `task.id`, `task.type`, `conversation.id`, and `agent.id`
+- 🔭 **OpenTelemetry Tracing** — Per-task distributed traces via OTLP (Jaeger, Tempo, Datadog). Every pipeline task emits a span named `eddi.pipeline.task` carrying `eddi.task.id`, `eddi.task.type`, `eddi.task.index`, `eddi.conversation.id` and `eddi.agent.id`. The equivalent *metric* tags are un-prefixed (`task.id`, `task.type`)
 - 🩺 **Health Checks** — Liveness & readiness probes at `/q/health/live` and `/q/health/ready`
 - 🔄 **NATS JetStream** — Async event bus for distributed processing
 - 🛟 **Error Handling & Recovery** — Automatic retry with exponential backoff, MCP circuit breakers (3 failures / 60s cooldown), LLM response validation (`onEmpty` / `onTruncation` / `onRefusal`), streaming timeout retry, and admin endpoint to reset stuck conversations
@@ -575,7 +575,8 @@ target/site/jacoco/index.html
 | Property                                    | Default                     | Description                                    |
 | ------------------------------------------- | --------------------------- | ---------------------------------------------- |
 | `-Dquarkus.http.port=<port>`                | `7070`                      | Override the HTTP port                         |
-| `-Dquarkus.mongodb.connection-string=<uri>` | `mongodb://localhost:27017` | MongoDB connection                             |
+| `-Dmongodb.connectionString=<uri>`          | dev: `mongodb://localhost:27017/eddi`  | MongoDB connection, read by `PersistenceModule`. `quarkus.mongodb.connection-string` is a different key that only the health check reads |
+| `-Dmongodb.database=<name>`                 | `eddi`                      | MongoDB database name                          |
 | `-Dquarkus.profile=<profile>`               | `dev`                       | Active Quarkus profile (`dev`, `test`, `prod`) |
 | `-DskipTests`                               | `false`                     | Skip all tests                                 |
 | `-DskipITs`                                 | `true`                      | Skip integration tests only                    |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -64,6 +64,7 @@
 - [Secrets Vault](secrets-vault.md)
 - [Global Variables](global-variables.md)
 - [Audit Ledger](audit-ledger.md)
+- [Tenant Quotas](tenant-quotas.md)
 - [GDPR / CCPA Compliance](gdpr-compliance.md)
 - [HIPAA Compliance](hipaa-compliance.md)
 - [Business Associate Agreement (BAA) Template](templates/baa-template.md)
@@ -86,6 +87,7 @@
 - [Metrics & Monitoring](metrics.md)
 - [Monitoring & Tracing Guide](monitoring/monitoring-guide.md)
 - [Log Administration](log-administration.md)
+- [Coordinator & Dead Letters](coordinator-admin.md)
 
 ## Reference
 

--- a/docs/behavior-rules.md
+++ b/docs/behavior-rules.md
@@ -383,8 +383,12 @@ anything.
 
 | Config       | Type   | Description                                                                       |
 | ------------ | ------ | --------------------------------------------------------------------------------- |
-| `when`       | string | Required. Matched against the current deployment environment                       |
-| `tagMatches` | string | Optional. When set, the agent's tags (from context) must also contain this value   |
+| `when`       | string | Optional. Matched against the current deployment environment; skipped when absent or blank |
+| `tagMatches` | string | Optional. When set, the agent's tags (from context) must also contain this value           |
+
+Both are optional and both are checked when set, so a rule carrying only `tagMatches` matches on
+the tag alone in every environment. A rule with neither matches everywhere, which is rarely what
+anyone means — set at least one.
 
 The environment is read from the system property `eddi.deployment.env`, falling back to the
 environment variable `EDDI_DEPLOYMENT_ENV` and then to `development`. Prefer this over passing an

--- a/docs/behavior-rules.md
+++ b/docs/behavior-rules.md
@@ -80,6 +80,13 @@ Each `Behavior Rule` has a list of `conditions`, that, depending on the `conditi
 - [Dependency](behavior-rules.md#dependency)
 - [Action Matcher](behavior-rules.md#action-matcher)
 - [Dynamic Value Matcher](behavior-rules.md#dynamic-value-matcher)
+- [Size Matcher](behavior-rules.md#size-matcher)
+- [Deployment Context](behavior-rules.md#deployment-context)
+- [Capability Match](capability-match-guide.md) — type `capabilityMatch`, matches on the agent's declared capabilities
+- [Content Type Matcher](attachments-guide.md) — type `contentTypeMatcher`, matches on an attachment's media type
+
+All twelve registered condition types are listed above. The registry is the `ID` constant on each
+class under `modules/rules/impl/conditions`; check against that if this list ever looks short.
 
 ### General Structure
 
@@ -355,6 +362,34 @@ The example above matches whenever the API call stored between 1 and 10 result e
 | Any other value           | The length of its textual representation                               |
 
 If `min`, `max` and `equal` are all `-1`, the condition reports `NOT_EXECUTED` — it neither succeeds nor fails, and a wrapping `negation` propagates that state instead of inverting it.
+
+### Deployment Context
+
+This condition matches on the deployment environment the instance is running in, so one agent
+configuration can behave differently in production and in test without the client having to send
+anything.
+
+```json
+(...)
+{
+  "type": "deploymentContext",
+  "configs": {
+    "when": "production",
+    "tagMatches": "high-risk"
+  }
+}
+(...)
+```
+
+| Config       | Type   | Description                                                                       |
+| ------------ | ------ | --------------------------------------------------------------------------------- |
+| `when`       | string | Required. Matched against the current deployment environment                       |
+| `tagMatches` | string | Optional. When set, the agent's tags (from context) must also contain this value   |
+
+The environment is read from the system property `eddi.deployment.env`, falling back to the
+environment variable `EDDI_DEPLOYMENT_ENV` and then to `development`. Prefer this over passing an
+`env` context variable from the client and matching it with `contextmatcher`: a client that forgets
+the variable makes a production agent behave like a test one, silently.
 
 ## The Behavior Rule API Endpoints
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -97,8 +97,16 @@ Proven by mutation. Removing the `oneTimeAt` row, dropping the templating step, 
 extension and restoring the wrong MongoDB property each fail with the missing name in the message.
 The test also caught three errors in this very commit's edits before it was run deliberately.
 
-**Files:** `AGENTS.md`, `README.md`, seven pages under `docs/`, two new pages, five under
-`planning/`, and `src/test/java/ai/labs/eddi/docs/DocumentationAccuracyTest.java`.
+**Files:** `AGENTS.md`, `README.md`; under `docs/` — `SUMMARY.md`, `behavior-rules.md`,
+`configuration-reference.md`, `creating-your-first-agent/creating-your-first-agent.md`,
+`creating-your-first-agent/creating-your-first-agent-1.md`,
+`deployment-management-of-agents.md`, `docker.md`, `langchain.md`,
+`monitoring/monitoring-guide.md`, `output-templating.md`, `putting-it-all-together.md`,
+`rag.md`, `release-versioning.md`, `scheduling.md`, `user-memory.md`, plus the two new pages
+`coordinator-admin.md` and `tenant-quotas.md`; under `planning/` — `conversation-cancel-plan.md`,
+`hitl-tool-approval-plan.md`, `mcp-hitl-surface-plan.md`,
+`multimodal-attachments-completion-plan.md`, `observability-and-pipeline-plan.md`; and
+`src/test/java/ai/labs/eddi/docs/DocumentationAccuracyTest.java`.
 
 **Next:** slices 2-6 of the same backlog — config keys, API consistency, and 63 test-quality
 findings.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,62 @@ bottom of this file and are never archived.
 
 ---
 
+## 📘 docs: correct 23 false claims and pin them with a guard test (2026-09-07)
+
+**Repo:** EDDI (`docs/review-quickwins-docs`)
+
+The first slice of the code-review quick-win backlog (`planning/code-review-backlog/`). Twenty-three
+findings, all of them documentation that said something the code does not do. Markdown compiles to
+nothing, so none of them were visible to any check in the build and several had been wrong for more
+than one release.
+
+**The ones that cost a reader real time.** `AGENTS.md` and `configuration-reference.md` said a
+`scope: "secret"` property degrades to plaintext without a vault key; it fails the whole turn
+closed. The README named `quarkus.mongodb.connection-string` as the connection knob — a real
+Quarkus key that only the extension's health check reads, so pointing it at another host reports
+the new host as UP while every read and write still goes to the old one. Both first-agent tutorials
+named the workflow field `packageextensions`, which the strict write boundary rejects with a 400,
+and documented a Facebook channel connector that does not exist. The README documented span
+attributes without the `eddi.` prefix the code emits, so a trace filter on `task.id` matches nothing
+and reads as "tracing is not emitting".
+
+**The ones that hid a shipped feature.** `behavior-rules.md` presented eight of the twelve
+registered condition types as the complete list; `deploymentContext` was documented nowhere at all.
+`AGENTS.md`'s ZIP section listed seven of twelve backup file extensions, so the most common case —
+an agent with a regular dictionary — could not be built from the file that tells you how to build
+one, and its workflow step table omitted the templating step the same section calls mandatory.
+Six shipped LLM task fields were documented nowhere, including the rolling conversation summary;
+`scheduling.md` omitted `oneTimeAt` and `metadata`; `user-memory.md` omitted `dream.parameters`,
+without which every summarization step fails with a provider 401 while stale pruning keeps working.
+
+**Three admin surfaces gained their first documentation:** tenant quotas, coordinator dead letters
+and template preview. New pages `docs/tenant-quotas.md` and `docs/coordinator-admin.md`, a section
+in `docs/output-templating.md`, all linked from `SUMMARY.md`.
+
+**Five plans in `planning/` described shipped subsystems as unbuilt.** Two went further and
+instructed an agent to implement them task-by-task, with 107 unchecked boxes between them, against
+a spec whose class names all resolve to files that already exist. Those two now carry a status
+marker, the directive is gone, and the checkbox syntax is stripped rather than ticked — stripping
+does not assert that every sub-step shipped, which ticking would.
+
+**Decision — guard the claims, not the wording.** `DocumentationAccuracyTest` asserts that the docs
+mention what the code declares: every condition `ID`, every `*_EXT` backup constant, the schedule
+fields the validator enforces, the LLM task fields the model declares. A new condition type is then
+a failing test naming the missing type, not a reference table that quietly goes stale. Fixed
+expected strings would have needed editing on every rename and would have guarded nothing.
+
+Proven by mutation. Removing the `oneTimeAt` row, dropping the templating step, deleting a backup
+extension and restoring the wrong MongoDB property each fail with the missing name in the message.
+The test also caught three errors in this very commit's edits before it was run deliberately.
+
+**Files:** `AGENTS.md`, `README.md`, seven pages under `docs/`, two new pages, five under
+`planning/`, and `src/test/java/ai/labs/eddi/docs/DocumentationAccuracyTest.java`.
+
+**Next:** slices 2-6 of the same backlog — config keys, API consistency, and 63 test-quality
+findings.
+
+---
+
 ## 🏷️ fix(ci): a release tag could execute on the runner (2026-09-07)
 
 **Repo:** EDDI (`fix/review-quality-gates`)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -33,9 +33,9 @@ eddi.tools.websearch.google.api-key →  EDDI_TOOLS_WEBSEARCH_GOOGLE_API_KEY
 > **Getting this wrong fails silently.** An unrecognised environment variable is
 > not an error — the property simply keeps its default and the service starts
 > normally. `EDDI_VAULT_MASTERKEY` (dash deleted rather than replaced) leaves
-> `eddi.vault.master-key` empty, which means the vault is inactive and
-> `scope: "secret"` properties fall back to plaintext. Nothing in the startup log
-> mentions the variable you set.
+> `eddi.vault.master-key` empty, which means the vault is inactive, and a
+> `scope: "secret"` property setter then fails the whole turn. Nothing in the
+> startup log mentions the variable you set.
 >
 > To check what actually bound, read the value back from the Dev UI at `/q/dev`,
 > or compare against the spellings already used in `docker-compose.yml`,
@@ -162,7 +162,7 @@ Full guide: [secrets-vault.md](secrets-vault.md).
 
 | Property | Default | Description |
 |---|---|---|
-| `eddi.vault.master-key` | *(empty)* | KEK source. **Empty means the vault is inactive** and `scope: "secret"` properties fall back to plaintext with an ERROR log |
+| `eddi.vault.master-key` | *(empty)* | KEK source. **Empty means the vault is inactive.** A `scope: "secret"` property setter then scrubs the plaintext, logs an ERROR and **fails the turn** with a `LifecycleException` naming `EDDI_VAULT_MASTER_KEY` — it never persists the value. (`AgentSetupService`'s own `vaultApiKey` path is the exception and still degrades; see [secrets-vault.md](secrets-vault.md).) |
 | `eddi.vault.grant-enforcement` | `enforce` | `off`, `warn` or `enforce`. An unrecognised value fails startup rather than silently disabling the check |
 | `eddi.vault.cache-ttl-minutes` | `5` | Resolved-secret cache lifetime |
 | `eddi.vault.cache-max-size` | `1000` | Resolved-secret cache entries |

--- a/docs/coordinator-admin.md
+++ b/docs/coordinator-admin.md
@@ -1,0 +1,93 @@
+# Coordinator & Dead Letters
+
+The conversation coordinator serialises work per conversation. A turn that fails past its retries
+is **dead-lettered**: kept with its payload and error rather than dropped, so an operator can look
+at it and decide whether to replay or discard it.
+
+`eddi_nats_dead_letter_count_total` is the metric that tells you it happened — see
+[Metrics & Monitoring](metrics.md). This page is the API that lets you do something about it.
+
+All operations sit under `/administration/coordinator` and require the `eddi-admin` role.
+
+## Status
+
+```
+GET /administration/coordinator/status
+```
+
+```json
+{
+  "coordinatorType": "in-memory",
+  "connected": true,
+  "connectionStatus": "CONNECTED",
+  "activeConversations": 12,
+  "totalProcessed": 48213,
+  "totalDeadLettered": 3,
+  "queueDepths": { "default": 0 }
+}
+```
+
+`coordinatorType` is `in-memory` or `nats`, following `eddi.messaging.type`. For the in-memory
+coordinator `connected` is always true — there is nothing to connect to — so read it as meaningful
+only under NATS.
+
+## Listing dead letters
+
+```
+GET /administration/coordinator/dead-letters
+```
+
+```json
+[
+  {
+    "id": "dl-9f3c1a",
+    "conversationId": "68b1f0c2d4e5a60012ab34cd",
+    "error": "LifecycleException: Cannot store property 'api_token' with scope 'secret'...",
+    "timestamp": 1757251920000,
+    "payload": "{\"input\":\"my key is ...\"}"
+  }
+]
+```
+
+Retention is bounded by `eddi.coordinator.max-dead-letters` (default `1000`; `-1` unbounded, `0`
+retains none). The oldest entries are evicted first, so a flood of failures can push an older
+entry out before anyone looks at it.
+
+> The `payload` is the turn's input. It can contain whatever the user typed, including material
+> they would not expect an administrator to read. Treat this endpoint as carrying conversation
+> content, not just diagnostics.
+
+## Replaying one entry
+
+```
+POST /administration/coordinator/dead-letters/{entryId}/replay
+```
+
+Re-injects the entry into the processing pipeline. Answers `200` on success and `404` if the entry
+is gone — which it will be if retention evicted it in the meantime. Replaying re-runs the turn's
+side effects, so replay a failure whose cause you have actually fixed, not one you are still
+diagnosing.
+
+## Discarding
+
+```
+DELETE /administration/coordinator/dead-letters/{entryId}     → 204, or 404
+DELETE /administration/coordinator/dead-letters               → 200, count purged
+```
+
+Both are permanent. The bulk form returns the number of entries it removed.
+
+## Live tail
+
+```
+GET /administration/coordinator/stream        (text/event-stream)
+```
+
+Server-sent events for `task_submitted`, `task_completed`, `task_failed` and
+`task_dead_lettered`. Useful while reproducing a failure; it is a tail, not a backlog, so it shows
+only what happens after you connect.
+
+## See also
+
+- [Configuration Reference](configuration-reference.md) — `eddi.coordinator.*`
+- [Metrics & Monitoring](metrics.md) — the coordinator gauges and the dead-letter alert

--- a/docs/coordinator-admin.md
+++ b/docs/coordinator-admin.md
@@ -4,14 +4,16 @@ The conversation coordinator serialises work per conversation. A turn that fails
 is **dead-lettered**: kept with its payload and error rather than dropped, so an operator can look
 at it and decide whether to replay or discard it.
 
-`eddi_nats_dead_letter_count_total` is the metric that tells you it happened — see
-[Metrics & Monitoring](metrics.md). This page is the API that lets you do something about it.
+The meter `eddi_nats_dead_letter_count` tells you it happened. Micrometer's Prometheus
+exposition appends `_total` to a counter, so the series you query is
+`eddi_nats_dead_letter_count_total` — see [Metrics & Monitoring](metrics.md). This page is the
+API that lets you do something about it.
 
 All operations sit under `/administration/coordinator` and require the `eddi-admin` role.
 
 ## Status
 
-```
+```http
 GET /administration/coordinator/status
 ```
 
@@ -33,7 +35,7 @@ only under NATS.
 
 ## Listing dead letters
 
-```
+```http
 GET /administration/coordinator/dead-letters
 ```
 
@@ -59,7 +61,7 @@ entry out before anyone looks at it.
 
 ## Replaying one entry
 
-```
+```http
 POST /administration/coordinator/dead-letters/{entryId}/replay
 ```
 
@@ -70,7 +72,7 @@ diagnosing.
 
 ## Discarding
 
-```
+```http
 DELETE /administration/coordinator/dead-letters/{entryId}     → 204, or 404
 DELETE /administration/coordinator/dead-letters               → 200, count purged
 ```
@@ -79,7 +81,7 @@ Both are permanent. The bulk form returns the number of entries it removed.
 
 ## Live tail
 
-```
+```http
 GET /administration/coordinator/stream        (text/event-stream)
 ```
 

--- a/docs/creating-your-first-agent/creating-your-first-agent-1.md
+++ b/docs/creating-your-first-agent/creating-your-first-agent-1.md
@@ -420,10 +420,13 @@ Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **
 
 | Name                         | Description                                          | Required |
 | ---------------------------- | ---------------------------------------------------- | -------- |
-| packageextensions            | `Array` of `WorkflowExtension`                       |          |
-| WorkflowExtension.type       | possible values, see table below "`Extension Types`" |          |
-| WorkflowExtension.extensions | `Array` of `Object`                                  | False    |
-| WorkflowExtension.config     | `Config` object, but can be empty.                   | True     |
+| workflowSteps                | `Array` of `WorkflowStep`                            | True     |
+| WorkflowStep.type            | possible values, see table below "`Extension Types`" |          |
+| WorkflowStep.extensions      | `Array` of `Object`                                  | False    |
+| WorkflowStep.config          | `Config` object, but can be empty.                   | True     |
+
+`workflowExtensions` is still accepted as a v5 alias. No other spelling is: writes go through a
+strict parser that rejects an unknown top-level key with a `400`.
 
 Extension Types
 
@@ -531,8 +534,7 @@ Make a **`POST`** to **`/agentstore/agents`** with a JSON like this:
 {
 "packages": [
 "eddi://ai.labs.workflow/workflowstore/workflows/<UNIQUE_WORKFLOW_ID>?version=<WORKFLOW_VERSION>"
-],
-"channels": []
+]
 }
 ```
 
@@ -541,9 +543,10 @@ Make a **`POST`** to **`/agentstore/agents`** with a JSON like this:
 | Name           | Description                                                                                                                                           |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | packages       | `Array` of `String`, references to `Workflows`                                                                                                        |
-| channels       | `Array` of `Channel`,                                                                                                                                 |
-| Channel.type   | `String`, e.g. `"eddi://ai.labs.channel.facebook"`                                                                                                    |
-| Channel.config | `Config` Object. For "Facebook" this object has the params "`appSecret`" (`String`), "`verificationToken`" (`String`), "`pageAccessToken`" (`String`) |
+
+Channel delivery is configured separately — see [Slack Integration](../slack-integration.md).
+The embedded `channels` field on the agent is deprecated since 6.1.0 and is auto-migrated to
+standalone channel documents at startup. There is no Facebook connector.
 
 b. You should again get a return code of **`201`** with a `URI` in the `location` header referencing the newly created agent :
 

--- a/docs/creating-your-first-agent/creating-your-first-agent-1.md
+++ b/docs/creating-your-first-agent/creating-your-first-agent-1.md
@@ -422,7 +422,7 @@ Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **
 | ---------------------------- | ---------------------------------------------------- | -------- |
 | workflowSteps                | `Array` of `WorkflowStep`                            | True     |
 | WorkflowStep.type            | possible values, see table below "`Extension Types`" |          |
-| WorkflowStep.extensions      | `Array` of `Object`                                  | False    |
+| WorkflowStep.extensions      | `Object` (a map of extension name to value)          | False    |
 | WorkflowStep.config          | `Config` object, but can be empty.                   | True     |
 
 `workflowExtensions` is still accepted as a v5 alias. No other spelling is: writes go through a

--- a/docs/creating-your-first-agent/creating-your-first-agent.md
+++ b/docs/creating-your-first-agent/creating-your-first-agent.md
@@ -62,10 +62,13 @@ Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **
 
 | Name                         | Description                                          | Required |
 | ---------------------------- | ---------------------------------------------------- | -------- |
-| packageextensions            | `Array` of `WorkflowExtension`                       |          |
-| WorkflowExtension.type       | possible values, see table below "`Extension Types`" |          |
-| WorkflowExtension.extensions | `Array` of `Object`                                  | False    |
-| WorkflowExtension.config     | `Config` object, but can be empty.                   | True     |
+| workflowSteps                | `Array` of `WorkflowStep`                            | True     |
+| WorkflowStep.type            | possible values, see table below "`Extension Types`" |          |
+| WorkflowStep.extensions      | `Array` of `Object`                                  | False    |
+| WorkflowStep.config          | `Config` object, but can be empty.                   | True     |
+
+`workflowExtensions` is still accepted as a v5 alias. No other spelling is: writes go through a
+strict parser that rejects an unknown top-level key with a `400`.
 
 Extension Types in this examples
 

--- a/docs/creating-your-first-agent/creating-your-first-agent.md
+++ b/docs/creating-your-first-agent/creating-your-first-agent.md
@@ -64,7 +64,7 @@ Now we will align the just created `LifecycleTasks` in the `Workflow`. Make a **
 | ---------------------------- | ---------------------------------------------------- | -------- |
 | workflowSteps                | `Array` of `WorkflowStep`                            | True     |
 | WorkflowStep.type            | possible values, see table below "`Extension Types`" |          |
-| WorkflowStep.extensions      | `Array` of `Object`                                  | False    |
+| WorkflowStep.extensions      | `Object` (a map of extension name to value)          | False    |
 | WorkflowStep.config          | `Config` object, but can be empty.                   | True     |
 
 `workflowExtensions` is still accepted as a v5 alias. No other spelling is: writes go through a

--- a/docs/deployment-management-of-agents.md
+++ b/docs/deployment-management-of-agents.md
@@ -112,6 +112,8 @@ The undeployment of a specific agent is done through a **`POST`** to **`/adminis
 | {environment} | (`Path parameter`):`String` deployment environment: `production` (default) or `test`             |
 | {agentId}     | (`Path parameter`):`String` id of the agent that you wish to **undeploy**.               |
 | version       | (`Query parameter`, **required**):`Integer` version of the agent that you wish to **undeploy**. |
+| endAllActiveConversations | (`Query parameter`, optional, default `false`):`Boolean` end the agent's active conversations instead of refusing. Without it, undeploying an agent that has active conversations returns `409`. |
+| undeployThisAndAllPreviousAgentVersions | (`Query parameter`, optional, default `false`):`Boolean` also undeploy every earlier version, counting down to version 1. |
 
 ### Example :
 
@@ -128,6 +130,17 @@ _Response Body_
 _Response Code_
 
 `202`
+
+### Conflict: the agent has active conversations
+
+If the agent has at least one active conversation and `endAllActiveConversations` is `false`,
+the endpoint answers `409 Conflict` with a `text/plain` body naming the count. Nothing is
+undeployed. This is the normal case for a live agent, so a caller that treats any non-2xx as a
+hard failure will abort a rollback here.
+
+Retry with `endAllActiveConversations=true` to end those conversations and proceed:
+
+`http://localhost:7070/administration/production/undeploy/5aaf98e19f7dd421ac3c7de9?version=1&endAllActiveConversations=true`
 
 
 ## **Check the deployment status of an agent:**

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,18 +5,17 @@
 ### Without Authentication (default)
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 This starts EDDI on port `7070` and MongoDB. No login required.
 
 ### With Keycloak Authentication
 
-The EDDI-Manager repo provides a full-stack docker-compose with Keycloak:
+This repository ships a Keycloak overlay. Layer it on the base stack:
 
 ```bash
-# From the EDDI-Manager repo
-docker compose -f docker-compose.keycloak.yml up
+docker compose -f docker-compose.yml -f docker-compose.auth.yml up
 ```
 
 This starts:

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -559,6 +559,13 @@ Both stored shapes therefore keep working: a config that sets only `streamingTim
 | `toolCacheScopes`          | map      | Per-tool cache partition: `user`/`conversation`/`global` | (all `user`)   |
 | `defaultToolCacheScope`    | string   | Cache partition for tools without an override    | `user`                 |
 | `enableRateLimiting`       | boolean  | Limit tool/LLM usage rate                        | true                   |
+| `toolLoadingStrategy`      | string   | `EAGER` sends every tool spec on every request. `LAZY` sends only a `discover_tools` meta-tool, and injects the tools the model asks for from the next iteration on. Use `LAZY` when a large tool set is crowding the context window | `EAGER` |
+| `maxToolsInContext`        | int      | Maximum tool specifications returned per discovery call under `LAZY`. Ignored under `EAGER` | 20 |
+| `retry`                    | object   | Retry policy for LLM calls — see [Retry configuration](#retry-configuration) | (none) |
+| `responseValidation`       | object   | Validates the model's response and applies a remediation action. Policies: `onEmpty`, `onTruncation`, `onContentFilter`, `onRefusal`, `onStreamingTimeout` | (none) |
+| `maxRagContextChars`       | int      | Ceiling on the assembled RAG context, in characters. `-1` or `0` disables it and restores the older unbounded behaviour | 20000 |
+| `maxSystemPromptChars`     | int      | Hard ceiling on the whole assembled system prompt, applied after RAG context, counterweight, identity masking and response-format blocks are appended. `-1` leaves it untouched | -1 |
+| `conversationSummary`      | object   | Rolling conversation summary — see [Rolling Conversation Summary](#rolling-conversation-summary) | (none) |
 
 ### Behavioral Safety (Counterweight & Identity Masking)
 
@@ -657,6 +664,7 @@ When `enableBuiltInTools: true`, you can use these tools:
 | **PDF Reader**      | Extract text from PDF URLs (SSRF-protected)     | `pdfreader`      |
 | **Weather**         | Get weather information                         | `weather`        |
 | **Tool Response Paging** | Fetch the next page of a tool response that was truncated by `toolResponseLimits` | `fetch_page` / `fetch_tool_response_page` |
+| **Conversation Recall** | Drill back into turns the [rolling summary](#rolling-conversation-summary) has compressed. Only assembled when `conversationSummary.enabled` is true | `conversationRecall` |
 
 > Because a non-empty `builtInToolsWhitelist` enables **only** the tools it names, a whitelist that includes verbose tools should also include `fetch_page` — otherwise truncated tool responses cannot be paged through.
 
@@ -912,6 +920,68 @@ This agent:
 - **All other providers**: Uses an approximate tokenizer (characters ÷ 4)
 
 When `maxContextTokens` is -1 (default), the existing `conversationHistoryLimit` step-count behavior applies. **Full backward compatibility is guaranteed.**
+
+### Retry Configuration
+
+`retry` on an LLM task bounds how the engine re-attempts a failed model call. Only errors the
+engine classifies as retriable are retried — transport faults, rate limits and 5xx responses —
+never a malformed request or an authentication failure.
+
+```json
+{
+  "retry": {
+    "maxAttempts": 3,
+    "backoffDelayMs": 1000,
+    "backoffMultiplier": 2.0,
+    "maxBackoffDelayMs": 10000
+  }
+}
+```
+
+| Parameter            | Type   | Description                                          | Default |
+| -------------------- | ------ | ---------------------------------------------------- | ------- |
+| `maxAttempts`        | int    | Total attempts including the first                   | 3       |
+| `backoffDelayMs`     | long   | Delay before the second attempt                      | 1000    |
+| `backoffMultiplier`  | double | Multiplier applied to the delay after each failure   | 2.0     |
+| `maxBackoffDelayMs`  | long   | Ceiling on any single delay                          | 10000   |
+
+The engine clamps these so a config cannot pin a pipeline thread: at most 10 attempts, at most
+30 seconds for one backoff, and at most 60 seconds of backoff in total across the retry sequence.
+A clamped value is reported once in a WARN.
+
+### Rolling Conversation Summary
+
+The third windowing strategy compresses older turns into a running summary that is injected into
+the system message, and keeps only the most recent turns verbatim. Unlike token-aware windowing,
+nothing is dropped outright: the model still sees what happened, in condensed form, and can drill
+back into the full text through the `conversationRecall` built-in tool.
+
+```json
+{
+  "conversationSummary": {
+    "enabled": true,
+    "recentWindowSteps": 5,
+    "maxSummaryTokens": 800,
+    "excludePropertiesFromSummary": true,
+    "maxRecallTurns": 20
+  }
+}
+```
+
+| Parameter                      | Type    | Description                                                                                     | Default |
+| ------------------------------ | ------- | ----------------------------------------------------------------------------------------------- | ------- |
+| `enabled`                      | boolean | Master switch. Nothing is summarized while this is false                                         | false   |
+| `llmProvider`                  | string  | Provider for the summarization call. Inherits the parent task's provider when unset              | (inherit) |
+| `llmModel`                     | string  | Model for the summarization call. Inherits the parent task's model when unset                    | (inherit) |
+| `maxSummaryTokens`             | int     | Token ceiling on the generated summary                                                           | 800     |
+| `excludePropertiesFromSummary` | boolean | Tell the summarizer to skip facts already captured as persistent properties                      | true    |
+| `recentWindowSteps`            | int     | Conversation steps kept verbatim alongside the summary. Everything older is covered by it        | 5       |
+| `maxRecallTurns`               | int     | Maximum verbatim turns returned per `conversationRecall` invocation                              | 20      |
+
+> **Watch the whitelist.** A non-empty `builtInToolsWhitelist` enables only the tools it names, and
+> `conversationRecall` is one of them. Enabling the rolling summary on a task whose whitelist does
+> not include `conversationRecall` leaves the model unable to drill back into summarized turns — it
+> answers from the condensed view with no error and no log line.
 
 ### In-Turn Tool Context Budget
 

--- a/docs/monitoring/monitoring-guide.md
+++ b/docs/monitoring/monitoring-guide.md
@@ -111,12 +111,12 @@ EDDI adds manual spans in `LifecycleManager` for each pipeline task:
 
 ```text
 Trace: POST /agentstore/agents/{agentId}/conversations/{convId}
-  └── eddi.pipeline.task [task.id=ai.labs.behavior, task.type=behavior_rules]
-  └── eddi.pipeline.task [task.id=ai.labs.property, task.type=properties]
-  └── eddi.pipeline.task [task.id=ai.labs.llm, task.type=langchain]
+  └── eddi.pipeline.task [eddi.task.id=ai.labs.behavior, eddi.task.type=behavior_rules]
+  └── eddi.pipeline.task [eddi.task.id=ai.labs.property, eddi.task.type=properties]
+  └── eddi.pipeline.task [eddi.task.id=ai.labs.llm, eddi.task.type=langchain]
       └── HTTP POST https://api.openai.com/v1/chat/completions (auto)
       └── MongoDB find conversations (auto)
-  └── eddi.pipeline.task [task.id=ai.labs.output, task.type=output]
+  └── eddi.pipeline.task [eddi.task.id=ai.labs.output, eddi.task.type=output]
 ```
 
 **Span attributes:**

--- a/docs/output-templating.md
+++ b/docs/output-templating.md
@@ -189,7 +189,7 @@ If you are upgrading from EDDI v5, template syntax is automatically migrated:
 
 Rather than deploying an agent to find out what a template resolves to, resolve it directly:
 
-```
+```http
 POST /administration/preview/template
 ```
 

--- a/docs/output-templating.md
+++ b/docs/output-templating.md
@@ -185,6 +185,40 @@ If you are upgrading from EDDI v5, template syntax is automatically migrated:
 | `#json.method()` | `{json:method()}` |
 | `a + '/' + b` | `{a}/{b}` |
 
+## Previewing a template
+
+Rather than deploying an agent to find out what a template resolves to, resolve it directly:
+
+```
+POST /administration/preview/template
+```
+
+Requires the `eddi-admin` or `eddi-editor` role.
+
+```json
+{
+  "template": "Hello {properties.firstName}, your booking is {properties.bookingId}.",
+  "conversationId": "68b1f0c2d4e5a60012ab34cd"
+}
+```
+
+`conversationId` is optional. With it, the template resolves against that conversation's real
+memory; without it, against built-in sample data. Because supplying a conversation returns the
+flattened variable values as well as the resolved text, the role check is paired with a
+per-conversation ownership check — an editor cannot read someone else's conversation this way.
+
+```json
+{
+  "resolved": "Hello Ada, your booking is BK-12345.",
+  "availableVariables": ["properties.firstName", "properties.bookingId", "memory.current.input"],
+  "variableValues": { "properties.firstName": "Ada", "properties.bookingId": "BK-12345" },
+  "error": null
+}
+```
+
+A template that fails to render returns the failure in `error` rather than as an HTTP error, so a
+preview of a broken template still tells you which variables were available.
+
 ## _**Additional Information:**_
 
 [Quarkus Qute documentation.](https://quarkus.io/guides/qute-reference)

--- a/docs/putting-it-all-together.md
+++ b/docs/putting-it-all-together.md
@@ -486,7 +486,11 @@ curl -X POST "http://localhost:7070/agents/CONV_ID" \
   "conversationOutputs": [
     {
       "output": [
-        "Great! I found 5 available rooms in Paris. Here are your options:"
+        {
+          "type": "text",
+          "text": "Great! I found 5 available rooms in Paris. Here are your options:",
+          "delay": 0
+        }
       ],
       "quickReplies": [
         { "value": "Deluxe Suite", "expressions": "property(room_id(101))" },
@@ -528,7 +532,11 @@ curl -X POST "http://localhost:7070/agents/CONV_ID" \
   "conversationOutputs": [
     {
       "output": [
-        "🎉 Booking confirmed! Your booking ID is BK-12345. Total price: $450. We've sent a confirmation email. Have a great stay!"
+        {
+          "type": "text",
+          "text": "🎉 Booking confirmed! Your booking ID is BK-12345. Total price: $450. We've sent a confirmation email. Have a great stay!",
+          "delay": 0
+        }
       ]
     }
   ]

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -71,6 +71,11 @@ A `RagConfiguration` is a versioned resource at `/ragstore/rags/`. It defines:
 
 RAG is wired into LLM tasks via three fields on `LlmConfiguration.Task`:
 
+A fourth field bounds the result. `maxRagContextChars` (default `20000`) caps the assembled
+RAG context in characters, across every matched knowledge base and any `httpCallRag` response.
+Without it the prompt grows with the corpus until the provider rejects the request. Set `-1`
+or `0` to disable the cap.
+
 #### Option 1: Explicit Knowledge Base References
 
 ```json

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -69,9 +69,10 @@ A `RagConfiguration` is a versioned resource at `/ragstore/rags/`. It defines:
 
 ### LLM Task RAG Configuration
 
-RAG is wired into LLM tasks via three fields on `LlmConfiguration.Task`:
+RAG is wired into LLM tasks via four fields on `LlmConfiguration.Task`. Three of them choose what
+is retrieved:
 
-A fourth field bounds the result. `maxRagContextChars` (default `20000`) caps the assembled
+The fourth bounds the result. `maxRagContextChars` (default `20000`) caps the assembled
 RAG context in characters, across every matched knowledge base and any `httpCallRag` response.
 Without it the prompt grows with the corpus until the provider rejects the request. Set `-1`
 or `0` to disable the cap.

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -176,30 +176,50 @@ The entire pipeline lives in a single file: [`.github/workflows/ci.yml`](../.git
 ```text
 ┌──────────────────┐
 │  build-and-test  │  ← Always runs (push, PR, tag)
-│  mvnw verify     │     Tests + JaCoCo coverage
+│  mvnw clean test │     Unit tests only
 └────────┬─────────┘
          │
-    ┌────┴────┐
-    │         │
-    ▼         ▼
-┌────────┐  ┌──────────────────┐
-│ docker │  │ preflight-check  │  ← PRs only
-│ build  │  │ Red Hat dry-run  │
-│ + push │  └──────────────────┘
-└────┬───┘
-     │
-     ▼
-┌────────────┐
-│ smoke-test │  ← Starts image + MongoDB, checks /q/health/ready
-└────────────┘
+         ├──────────────┬─────────────┬────────────┐
+         ▼              ▼             ▼            ▼
+┌──────────────────┐ ┌────────────┐ ┌────────┐ ┌──────────┐
+│ integration-test │ │ trivy-scan │ │ codeql │ │ gitleaks │
+│ mvnw verify      │ └─────┬──────┘ └───┬────┘ └────┬─────┘
+│ -DskipITs=false  │       │            │           │
+│ ITs + the JaCoCo │       │            │           │
+│ 90/80 gate       │       │            │           │
+└────────┬─────────┘       │            │           │
+         └─────────────────┴────────────┴───────────┘
+                           │
+              ┌────────────┴────────────┐
+              ▼                         ▼
+         ┌────────┐          ┌──────────────────┐
+         │ docker │          │ preflight-check  │  ← PRs only
+         │ build  │          │ Red Hat dry-run  │
+         │ + push │          └──────────────────┘
+         └───┬────┘
+             ▼
+       ┌────────────┐
+       │ smoke-test │  ← Starts image + MongoDB, checks /q/health/ready
+       └────────────┘
 ```
+
+Nothing is published until every gate above `docker` has passed. Its `needs` list is
+`[detect-changes, build-and-test, integration-test, trivy-scan, codeql, gitleaks]`, so a failing
+CVE scan, a secret leak, a CodeQL finding or a coverage shortfall each block the push on their
+own. **`build-and-test` runs `mvnw clean test`, not `verify`** — `integration-test` is the only
+job that runs the JaCoCo 90/80 coverage gate.
 
 ### Job Details
 
 | Job | Runs on | Condition | Duration |
 |---|---|---|---|
 | **build-and-test** | Every push/PR/tag | When changed paths match the `code` filter (`src/**`, `pom.xml`, `.github/workflows/**`, `Dockerfile*`, `docker-compose*.yml`, `.dockerignore`, `k8s/**`, `helm/**`, `mvnw*`, `.mvn/**`); always on tags | ~3-5 min |
-| **docker** | Push to `main` or a tag matching `[0-9]*` | `[skip docker]` to skip (ignored on tags) | ~3-4 min |
+| **integration-test** | Same as build-and-test | Runs `mvnw verify -DskipITs=false`; the only job that enforces the JaCoCo 90/80 gate | ~10-15 min |
+| **codeql** | Every push/PR/tag on the `code` filter | SAST build + analysis; blocks `docker` | ~8-12 min |
+| **trivy-scan** | Same | Filesystem CVE scan, `exit-code 1`; blocks `docker` | ~2-3 min |
+| **gitleaks** | Same | Secret scanning; blocks `docker` | ~1 min |
+| **sbom** | Same | CycloneDX SBOM; does not block `docker` | ~2 min |
+| **docker** | Push to `main` or a tag matching `[0-9]*` | `[skip docker]` to skip (ignored on tags). Needs build-and-test, integration-test, trivy-scan, codeql and gitleaks | ~3-4 min |
 | **smoke-test** | After `docker` succeeds | Same as docker | ~1-2 min |
 | **preflight-check** | Pull requests only | Always on PRs | ~5-7 min |
 

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -219,7 +219,7 @@ job that runs the JaCoCo 90/80 coverage gate.
 | **trivy-scan** | Same | Filesystem CVE scan, `exit-code 1`; blocks `docker` | ~2-3 min |
 | **gitleaks** | Same | Secret scanning; blocks `docker` | ~1 min |
 | **sbom** | Same | CycloneDX SBOM; does not block `docker` | ~2 min |
-| **docker** | Push to `main` or a tag matching `[0-9]*` | `[skip docker]` to skip (ignored on tags). Needs build-and-test, integration-test, trivy-scan, codeql and gitleaks | ~3-4 min |
+| **docker** | Push to `main` or a tag matching `[0-9]*` | `[skip docker]` to skip (ignored on tags). Needs detect-changes, build-and-test, integration-test, trivy-scan, codeql and gitleaks | ~3-4 min |
 | **smoke-test** | After `docker` succeeds | Same as docker | ~1-2 min |
 | **preflight-check** | Pull requests only | Always on PRs | ~5-7 min |
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -41,6 +41,9 @@ A **Schedule** defines when and how often an agent fires:
 | `CRON` | Wall-clock aligned cron expression | `new` | `0 2 * * *` (daily at 2am) |
 | `HEARTBEAT` | Fixed-interval, drift-proof | `persistent` | Every 300 seconds |
 
+A `CRON` schedule carrying `oneTimeAt` instead of `cronExpression` fires **once** at that instant
+rather than recurring. Exactly one of the two is required.
+
 ### Conversation Strategies
 
 | Strategy | Behavior | Use When |
@@ -124,6 +127,8 @@ Heartbeats are **drift-proof** — the next fire is the time this fire was *due*
 | `environment` | string | `production` | Deployment environment |
 | `enabled` | boolean | `true` | Whether the schedule is active |
 | `maxCostPerFire` | double | `-1` (unlimited) | Dollar ceiling per fire |
+| `oneTimeAt` | string | — | ISO-8601 instant for a single fire. Mutually exclusive with `cronExpression`; exactly one of the two is required for a `CRON` trigger |
+| `metadata` | object | — | Free-form markers read by the fire executor. `{"dreamType": "dream_consolidation"}` dispatches the fire to the Dream service — see [Scheduling a Dream Cycle](user-memory.md#scheduling-a-dream-cycle) |
 
 ### Managing Schedules
 
@@ -214,6 +219,7 @@ Dream consolidation is configured in the agent configuration:
         "preserveAgentProvenance": false,
         "llmProvider": "anthropic",
         "llmModel": "claude-sonnet-4-6",
+        "parameters": { "apiKey": "${vault:anthropic-api-key}" },
         "maxCostPerRun": 0.50,
         "batchSize": 50,
         "maxUsersPerRun": 1000

--- a/docs/tenant-quotas.md
+++ b/docs/tenant-quotas.md
@@ -1,0 +1,110 @@
+# Tenant Quotas
+
+EDDI meters usage per tenant and can refuse work once a tenant passes its limits. The limits
+themselves are stored per tenant and are editable at runtime through the admin API below — you do
+not need a restart to raise one tenant's ceiling.
+
+The deployment-wide defaults that seed a new tenant live in
+[configuration-reference.md](configuration-reference.md) under `eddi.tenant.quota.*`. A tenant row
+is created from those defaults the first time the tenant is seen; editing the properties afterwards
+does not rewrite rows that already exist, and a mismatch between a stored row and the configured
+default is reported in a startup WARN.
+
+## What is metered
+
+| Limit | Meaning | Unlimited |
+|---|---|---|
+| `maxConversationsPerDay` | New conversations started in the current calendar day | `-1` |
+| `maxAgentsPerTenant` | Agents the tenant may own | `-1` |
+| `maxApiCallsPerMinute` | API calls in the current calendar minute | `-1` |
+| `maxMonthlyCostUsd` | Dollar spend in the current calendar month | `-1` |
+| `enabled` | Whether enforcement is active for this tenant at all | — |
+
+Windows are **calendar-aligned, not sliding**. The daily counter resets at the start of the day in
+the store's clock, the per-minute counter at the start of the minute, and the cost counter at the
+start of the month.
+
+> **`maxMonthlyCostUsd` is not enforced today.** The limit is stored and returned, and the gate
+> that would read it exists, but nothing records cost against it yet, so the counter stays at zero
+> and the gate never trips. Writing a non-negative value logs a WARN saying so. Treat it as a
+> declaration of intent, not a control.
+
+## Failing closed
+
+If the quota store cannot be read — the database is down, a query fails — the gate **denies** the
+request rather than letting it through. Both the MongoDB and the PostgreSQL store answer with the
+same message, `Quota accounting unavailable — denying request for safety`, surfaced as `503`, so a
+caller cannot tell which backend refused and cannot get a different answer by retrying against
+another node.
+
+## Admin API
+
+All five operations sit under `/administration/quotas` and require the `eddi-admin` role.
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/administration/quotas` | List every configured tenant quota |
+| `GET` | `/administration/quotas/{tenantId}` | Read one tenant's quota |
+| `PUT` | `/administration/quotas/{tenantId}` | Create or replace one tenant's quota |
+| `GET` | `/administration/quotas/{tenantId}/usage` | Read the tenant's current counters |
+| `POST` | `/administration/quotas/{tenantId}/usage/reset` | Zero the tenant's counters |
+
+### Quota shape
+
+```json
+{
+  "tenantId": "acme",
+  "maxConversationsPerDay": 5000,
+  "maxAgentsPerTenant": 50,
+  "maxApiCallsPerMinute": 600,
+  "maxMonthlyCostUsd": -1,
+  "enabled": true
+}
+```
+
+`-1` means unlimited for any of the four numeric limits. A `PUT` rejects a negative value other
+than `-1` with a `400`.
+
+### Raising one tenant's ceiling
+
+```bash
+curl -X PUT "http://localhost:7070/administration/quotas/acme" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "tenantId": "acme",
+    "maxConversationsPerDay": 20000,
+    "maxAgentsPerTenant": 50,
+    "maxApiCallsPerMinute": 600,
+    "maxMonthlyCostUsd": -1,
+    "enabled": true
+  }'
+```
+
+The write takes effect immediately: the service caches quotas but drops the tenant's entry on
+every write, so the next check reads the new row.
+
+### Usage shape
+
+```json
+{
+  "tenantId": "acme",
+  "conversationsToday": 143,
+  "apiCallsThisMinute": 7,
+  "monthlyCostUsd": 0.0,
+  "minuteWindowStart": "2026-09-07T14:32:00Z",
+  "dayStart": "2026-09-07T00:00:00Z",
+  "costMonth": "2026-09"
+}
+```
+
+Counters from an expired window read as zero rather than as their stale value, so a `conversationsToday`
+of `0` on a tenant that was busy yesterday is correct, not a lost write.
+
+Resetting is an operator escape hatch — it zeroes the stored counters for the current windows and
+does not change the limits.
+
+## See also
+
+- [Configuration Reference](configuration-reference.md) — the `eddi.tenant.quota.*` defaults
+- [Metrics & Monitoring](metrics.md) — the quota counters exposed at `/q/metrics`

--- a/docs/user-memory.md
+++ b/docs/user-memory.md
@@ -60,7 +60,8 @@ Enable advanced memory features (LLM tools, Dream consolidation, guardrails, rec
       "summarizeTargetEntries": 2,
       "summarizeGroupBy": "category",
       "preserveAgentProvenance": false,
-      "maxCostPerRun": 0.50
+      "maxCostPerRun": 0.50,
+      "parameters": { "apiKey": "${vault:anthropic-api-key}" }
     }
   }
 }
@@ -117,6 +118,9 @@ Attaching the memory tools is a three-way conjunction across the two configurati
 | `crossAgentMaintenance` | `boolean` | `false` | By default a dream cycle only touches memories the **firing agent** wrote (`sourceAgentId`). Set `true` to let it maintain the user's whole memory set across agents — otherwise agent A's retention setting would delete agent B's memories, and A's model endpoint would see B's private text. |
 | `llmProvider` | `String` | `"anthropic"` | LLM provider for dream operations |
 | `llmModel` | `String` | `"claude-sonnet-4-6"` | Model for dream operations |
+| `parameters` | `Map<String,String>` | `{}` | Model parameters for the consolidation LLM — `apiKey`, `baseUrl`, `temperature`, … — passed to the model registry exactly like an LLM task's `parameters` block, so `${vault:…}` and `${vars:…}` resolve. **Required when `summarizeInteractions` is `true`**: a background dream cycle has no parent LLM task to inherit credentials from, so without it every summarization step fails with a provider 401 while stale pruning keeps working. |
+| `schedule` | `String` | `"0 3 * * *"` | Cron expression the dream schedule should use |
+| `contradictionResolution` | `String` | `"keep_newest"` | Reserved. The current detector counts and logs contradictions without resolving them. |
 
 ## LLM Tools
 

--- a/planning/conversation-cancel-plan.md
+++ b/planning/conversation-cancel-plan.md
@@ -1,5 +1,8 @@
 # Conversation Cancellation & Lifecycle Control
 
+> **Status: IMPLEMENTED.** `DiscussionControlToken` / `ControlSignal` and
+> `POST /agents/{conversationId}/cancel` (`IRestAgentEngine`) shipped. Kept as the design record.
+>
 > **Scope**: Cancel/stop for group discussions and regular conversations.  
 > **HITL prerequisite**: This plan designs the detection mechanism (safe-point checking) to be reusable for HITL. However, HITL pause/resume requires significant additional work beyond what cancel provides — this is documented honestly in §6.
 
@@ -7,7 +10,8 @@
 
 ## 1. Problem Statement
 
-Currently, neither group discussions nor regular agent conversations can be stopped mid-execution.
+When this plan was written, neither group discussions nor regular agent conversations could be
+stopped mid-execution.
 
 - **Group discussions**: The `executeDiscussion()` loop runs all phases to completion. SSE client disconnect silently drops events but the backend keeps calling LLM agents — wasting tokens and compute.
 - **Regular conversations**: The `Conversation.say()` method submits work via `ConversationCoordinator.submitInOrder()` which runs the full lifecycle pipeline (parser → rules → LLM → output → property setter). There is no way to externally cancel an in-flight turn.

--- a/planning/hitl-tool-approval-plan.md
+++ b/planning/hitl-tool-approval-plan.md
@@ -1,6 +1,11 @@
 # Tool-Level HITL Approval Gating — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Status: IMPLEMENTED.** Shipped as `ToolApprovalsConfig`, `ToolApprovalRules`,
+> `ToolApprovalRequiredException`, `TaskToolApprovalsResolver`, `ChatTranscriptCodec` and
+> `pauseOrigin=TOOL_CALL`. Kept as the design record — user-facing documentation is
+> [`docs/hitl.md`](../docs/hitl.md).
+> **Do not execute the task list below.** The checkbox syntax has been
+> stripped so the steps read as the record of a design, not as an open work queue.
 
 **Goal:** Pause a conversation for human approval when the LLM invokes a *gated tool* (any source: built-in `@Tool`, MCP, A2A, httpcall, dynamic-agent, memory, recall), configured via allow/disallow pattern lists — co-existing with the behavior-rule `PAUSE_CONVERSATION` mechanism and reusing all its machinery (state model, `/resume`, timeout policies, audit, Slack, crash recovery). Also fixes the remaining HITL-critique findings (structured pauseDetails, per-call verdicts, approve-with-amendments, save-time lints).
 
@@ -121,7 +126,7 @@ The entire resume design depends on `ChatMessageSerializer.messagesToJson()` / `
 **Interfaces:**
 - Produces: `ChatTranscriptCodec.serialize(List<ChatMessage> messages, int maxBytes)` → `CodecResult(String json, boolean omitted)`; `ChatTranscriptCodec.deserialize(String json)` → `List<ChatMessage>` (throws `TranscriptCodecException` on failure — callers fall back).
 
-- [ ] **Step 1: Write the failing test**
+- **Step 1: Write the failing test**
 
 ```java
 /*
@@ -220,12 +225,12 @@ class ChatTranscriptCodecTest {
 
 Note: the size constant lives on `PendingToolCallBatch` (created in Task 4). For THIS task it is inlined as the `private static final int TRANSCRIPT_MAX_BYTES_DEFAULT` field shown above. Task 4 Step 4 deletes that field and adds `import static ai.labs.eddi.engine.memory.model.PendingToolCallBatch.TRANSCRIPT_MAX_BYTES_DEFAULT;`. There is no separate `…Limits` class — the constants live directly on `PendingToolCallBatch`.
 
-- [ ] **Step 2: Run the test to verify it fails**
+- **Step 2: Run the test to verify it fails**
 
 Run: `./mvnw test -Dtest=ChatTranscriptCodecTest -q`
 Expected: COMPILATION ERROR — `ChatTranscriptCodec` does not exist.
 
-- [ ] **Step 3: Implement `ChatTranscriptCodec`**
+- **Step 3: Implement `ChatTranscriptCodec`**
 
 ```java
 /*
@@ -298,12 +303,12 @@ public class ChatTranscriptCodec {
 }
 ```
 
-- [ ] **Step 4: Run the tests**
+- **Step 4: Run the tests**
 
 Run: `./mvnw test -Dtest=ChatTranscriptCodecTest -q`
 Expected: PASS (5 tests). **If `roundTrip_preservesToolExecutionRequests_idsNamesArgs` or the multimodal test fails with the real langchain4j 1.17.0 codec (e.g. a content type has no mixin), STOP — report exactly which message shape fails and wait for a design decision before continuing.** Do not silently work around it.
 
-- [ ] **Step 5: Also add a provider-shape smoke test for the resume message sequence**
+- **Step 5: Also add a provider-shape smoke test for the resume message sequence**
 
 Append to `ChatTranscriptCodecTest`:
 
@@ -328,7 +333,7 @@ Append to `ChatTranscriptCodecTest`:
 
 Run: `./mvnw test -Dtest=ChatTranscriptCodecTest -q` — Expected: PASS (6 tests).
 
-- [ ] **Step 6: Commit**
+- **Step 6: Commit**
 
 ```bash
 git add src/main/java/ai/labs/eddi/engine/hitl/tools/ChatTranscriptCodec.java src/test/java/ai/labs/eddi/engine/hitl/tools/ChatTranscriptCodecTest.java
@@ -394,7 +399,7 @@ public class ToolApprovalsConfig {
 }
 ```
 
-- [ ] **Step 1: Write the failing tests**
+- **Step 1: Write the failing tests**
 
 `ToolApprovalPatternsTest`:
 
@@ -515,9 +520,9 @@ class ToolApprovalGateTest {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — `./mvnw test -Dtest='ToolApprovalPatternsTest,ToolApprovalGateTest' -q` → COMPILATION ERROR.
+- **Step 2: Run to verify failure** — `./mvnw test -Dtest='ToolApprovalPatternsTest,ToolApprovalGateTest' -q` → COMPILATION ERROR.
 
-- [ ] **Step 3: Implement**
+- **Step 3: Implement**
 
 `ToolApprovalPatterns`:
 
@@ -680,9 +685,9 @@ Also create `ToolApprovalsConfig` exactly as specified in the Interfaces block a
 
 Performance note: `classify` compiles per call. Acceptable for v1 (a handful of patterns, tool batches ≤ ~10); if the executor wants, cache `List<CompiledPattern>` keyed by the config object identity inside `ToolApprovalGate` — NOT static state.
 
-- [ ] **Step 4: Run** — `./mvnw test -Dtest='ToolApprovalPatternsTest,ToolApprovalGateTest' -q` → PASS (10 tests).
+- **Step 4: Run** — `./mvnw test -Dtest='ToolApprovalPatternsTest,ToolApprovalGateTest' -q` → PASS (10 tests).
 
-- [ ] **Step 5: Commit**
+- **Step 5: Commit**
 
 ```bash
 git add src/main/java/ai/labs/eddi/engine/hitl/tools/ToolApprovalPatterns.java src/main/java/ai/labs/eddi/engine/hitl/tools/ToolApprovalGate.java src/main/java/ai/labs/eddi/configs/hitl/model/ToolApprovalsConfig.java src/test/java/ai/labs/eddi/engine/hitl/tools/ToolApprovalPatternsTest.java src/test/java/ai/labs/eddi/engine/hitl/tools/ToolApprovalGateTest.java
@@ -721,13 +726,13 @@ git commit -m "feat(hitl): tool approval pattern engine and batch gate classifie
 | `pauseReason`/`pendingMessage` > 500 chars | 400 (mirror the existing pauseReason length rule) |
 | `toolApprovals.timeoutPolicy` absent AND outer `hitlConfig.timeoutPolicy == AUTO_APPROVE` | **WARNING** (not 400): `"agent-level AUTO_APPROVE does not apply to tool approvals; tool pauses will WAIT_INDEFINITELY unless toolApprovals.timeoutPolicy is set explicitly"` |
 
-- [ ] **Step 1:** Read `HitlConfigValidation.java` and `HitlConfigValidationWiringTest.java` fully. Note the exception type, message prefixing style, and exactly where `AgentStore` invokes it.
-- [ ] **Step 2:** Write the failing test `HitlConfigValidationToolApprovalsTest` — one `@Test` per table row above, each building a `ToolApprovalsConfig`, calling `validateToolApprovals`, and asserting the thrown message contains the quoted phrase (use the real exception type discovered in Step 1). Plus one happy-path test: a full valid config passes.
-- [ ] **Step 3:** Run: `./mvnw test -Dtest=HitlConfigValidationToolApprovalsTest -q` → COMPILATION ERROR / failures.
-- [ ] **Step 4:** Implement: add the `toolApprovals` field + getter/setter to `AgentConfiguration.HitlConfig` (after `pauseReason`, keeping the null-safe-setter style of `timeoutPolicy`); add the same to `LlmConfiguration.Task`; implement `validateToolApprovals` in `HitlConfigValidation` per the table; call it from the existing agent-store validation path (where the outer hitlConfig is validated) and add the equivalent invocation to the LLM store create/update path found in Step 1's grep.
-- [ ] **Step 5:** Run: `./mvnw test -Dtest='HitlConfigValidationToolApprovalsTest,HitlConfigValidationTest,HitlConfigValidationWiringTest' -q` → PASS, including all pre-existing tests.
-- [ ] **Step 6:** ZIP import: confirm `RestImportService` funnels agent configs through the same store create/update path (it does for the outer hitlConfig per docs/hitl.md:83) — if the LLM configs imported via ZIP bypass the LlmStore validation seam, add the `validateToolApprovals` call to the import path too, with a test.
-- [ ] **Step 7: Commit**
+- **Step 1:** Read `HitlConfigValidation.java` and `HitlConfigValidationWiringTest.java` fully. Note the exception type, message prefixing style, and exactly where `AgentStore` invokes it.
+- **Step 2:** Write the failing test `HitlConfigValidationToolApprovalsTest` — one `@Test` per table row above, each building a `ToolApprovalsConfig`, calling `validateToolApprovals`, and asserting the thrown message contains the quoted phrase (use the real exception type discovered in Step 1). Plus one happy-path test: a full valid config passes.
+- **Step 3:** Run: `./mvnw test -Dtest=HitlConfigValidationToolApprovalsTest -q` → COMPILATION ERROR / failures.
+- **Step 4:** Implement: add the `toolApprovals` field + getter/setter to `AgentConfiguration.HitlConfig` (after `pauseReason`, keeping the null-safe-setter style of `timeoutPolicy`); add the same to `LlmConfiguration.Task`; implement `validateToolApprovals` in `HitlConfigValidation` per the table; call it from the existing agent-store validation path (where the outer hitlConfig is validated) and add the equivalent invocation to the LLM store create/update path found in Step 1's grep.
+- **Step 5:** Run: `./mvnw test -Dtest='HitlConfigValidationToolApprovalsTest,HitlConfigValidationTest,HitlConfigValidationWiringTest' -q` → PASS, including all pre-existing tests.
+- **Step 6:** ZIP import: confirm `RestImportService` funnels agent configs through the same store create/update path (it does for the outer hitlConfig per docs/hitl.md:83) — if the LLM configs imported via ZIP bypass the LlmStore validation seam, add the `validateToolApprovals` call to the import path too, with a test.
+- **Step 7: Commit**
 
 ```bash
 git add src/main/java/ai/labs/eddi/configs/agents/model/AgentConfiguration.java src/main/java/ai/labs/eddi/modules/llm/model/LlmConfiguration.java src/main/java/ai/labs/eddi/configs/hitl/HitlConfigValidation.java src/test/java/ai/labs/eddi/configs/hitl/HitlConfigValidationToolApprovalsTest.java
@@ -810,12 +815,12 @@ public enum PauseOrigin { RULE, TOOL_CALL }
 
 with a new 4-arg constructor `(String pausedWorkflowId, int pausedAbsoluteTaskIndex, String pauseReason, PauseOrigin origin)`; the existing 3-arg constructor delegates with `PauseOrigin.RULE` — zero call-site changes.
 
-- [ ] **Step 1: Write the failing test** — `PendingToolCallBatchSnapshotTest`: build a `ConversationMemorySnapshot`, set `hitlPauseType="TOOL_CALL"` and a fully-populated batch (2 calls, one `argsTruncated`), serialize with the same `ObjectMapper` configuration the Mongo store uses (find it: `grep -rn "ObjectMapper" src/main/java/ai/labs/eddi/engine/memory/ src/main/java/ai/labs/eddi/datastore/serialization/` and reuse `IJsonSerialization` if that is the snapshot path), deserialize, assert field-for-field equality. Second test: deserializing a snapshot JSON **without** the new fields yields `null` pauseType and `null` batch (backward compat). Third test: `new ConversationPauseException("wf", 3, "r")` has `getPauseOrigin() == RULE`.
-- [ ] **Step 2:** Run → COMPILATION ERROR.
-- [ ] **Step 3:** Implement all model changes. In the snapshot conversion code, copy `hitlPauseType` and `hitlPendingToolCalls` in BOTH directions everywhere the existing six bookmark fields are copied (there are at least two directions: memory→snapshot on store, snapshot→memory on load — `grep "setHitlPausedWorkflowId"` finds every site). Do NOT copy `hitlResumeDecision`.
-- [ ] **Step 4:** Update `ChatTranscriptCodecTest` from Task 1 to import `PendingToolCallBatch.TRANSCRIPT_MAX_BYTES_DEFAULT` and delete its inlined constant.
-- [ ] **Step 5:** Run: `./mvnw test -Dtest='PendingToolCallBatchSnapshotTest,ChatTranscriptCodecTest,ConversationStateHitlTest' -q` → PASS. The locally-runnable round-trip check is `PendingToolCallBatchSnapshotTest` (pure Jackson). **`MongoConversationMemoryStoreTest` / `PostgresConversationMemoryStoreTest` are `@Testcontainers` ITs (need Docker) — do NOT run them locally; they run in CI.** The new nullable fields must not break them — CI will confirm.
-- [ ] **Step 6: Commit** — `feat(hitl): pause-type discriminator and pending tool-call batch on conversation memory`
+- **Step 1: Write the failing test** — `PendingToolCallBatchSnapshotTest`: build a `ConversationMemorySnapshot`, set `hitlPauseType="TOOL_CALL"` and a fully-populated batch (2 calls, one `argsTruncated`), serialize with the same `ObjectMapper` configuration the Mongo store uses (find it: `grep -rn "ObjectMapper" src/main/java/ai/labs/eddi/engine/memory/ src/main/java/ai/labs/eddi/datastore/serialization/` and reuse `IJsonSerialization` if that is the snapshot path), deserialize, assert field-for-field equality. Second test: deserializing a snapshot JSON **without** the new fields yields `null` pauseType and `null` batch (backward compat). Third test: `new ConversationPauseException("wf", 3, "r")` has `getPauseOrigin() == RULE`.
+- **Step 2:** Run → COMPILATION ERROR.
+- **Step 3:** Implement all model changes. In the snapshot conversion code, copy `hitlPauseType` and `hitlPendingToolCalls` in BOTH directions everywhere the existing six bookmark fields are copied (there are at least two directions: memory→snapshot on store, snapshot→memory on load — `grep "setHitlPausedWorkflowId"` finds every site). Do NOT copy `hitlResumeDecision`.
+- **Step 4:** Update `ChatTranscriptCodecTest` from Task 1 to import `PendingToolCallBatch.TRANSCRIPT_MAX_BYTES_DEFAULT` and delete its inlined constant.
+- **Step 5:** Run: `./mvnw test -Dtest='PendingToolCallBatchSnapshotTest,ChatTranscriptCodecTest,ConversationStateHitlTest' -q` → PASS. The locally-runnable round-trip check is `PendingToolCallBatchSnapshotTest` (pure Jackson). **`MongoConversationMemoryStoreTest` / `PostgresConversationMemoryStoreTest` are `@Testcontainers` ITs (need Docker) — do NOT run them locally; they run in CI.** The new nullable fields must not break them — CI will confirm.
+- **Step 6: Commit** — `feat(hitl): pause-type discriminator and pending tool-call batch on conversation memory`
 
 ---
 
@@ -840,14 +845,14 @@ This is the heart of the feature's first half. After this task, a gated tool cal
 
 **Sub-steps:**
 
-- [ ] **Step 1: Effective config resolution.** In `LlmTask.executeTask`, resolve `ToolApprovalsConfig effectiveToolApprovals = task.getToolApprovals() != null ? task.getToolApprovals() : memory.getAgentToolApprovalsConfig()`. The agent-level config reaches memory via a **transient, non-snapshotted carrier** on `IConversationMemory`/`ConversationMemory` — `getAgentToolApprovalsConfig()`/`setAgentToolApprovalsConfig(ToolApprovalsConfig)` — added in this task, **exactly mirroring the proven `userMemoryConfig` precedent** (`ConversationMemory.java:45` transient field, :200 getter, :205 setter; set in `Conversation.init` :92 from `propertiesHandler`). ⚠️ **Do NOT claim `Conversation` has the `AgentConfiguration` — it does not** (its ctor takes only `executableWorkflows`, memory, `IPropertiesHandler`, renderer). Pick one carrier wiring:
+- **Step 1: Effective config resolution.** In `LlmTask.executeTask`, resolve `ToolApprovalsConfig effectiveToolApprovals = task.getToolApprovals() != null ? task.getToolApprovals() : memory.getAgentToolApprovalsConfig()`. The agent-level config reaches memory via a **transient, non-snapshotted carrier** on `IConversationMemory`/`ConversationMemory` — `getAgentToolApprovalsConfig()`/`setAgentToolApprovalsConfig(ToolApprovalsConfig)` — added in this task, **exactly mirroring the proven `userMemoryConfig` precedent** (`ConversationMemory.java:45` transient field, :200 getter, :205 setter; set in `Conversation.init` :92 from `propertiesHandler`). ⚠️ **Do NOT claim `Conversation` has the `AgentConfiguration` — it does not** (its ctor takes only `executableWorkflows`, memory, `IPropertiesHandler`, renderer). Pick one carrier wiring:
   - **(a) service-side (recommended, least surface):** in `ConversationService`, wherever the pinned agent config is already read for a turn (the same `readAgentConfigPinned()` that `populateHitlTimeoutBookmark` uses at :1542), call `memory.setAgentToolApprovalsConfig(agentCfg.getHitlConfig() != null ? agentCfg.getHitlConfig().getToolApprovals() : null)` at conversation start / say-time so it is present before `LlmTask` runs; OR
   - **(b) properties-handler route:** extend `IPropertiesHandler` with a `getToolApprovalsConfig()` accessor and populate it in `ConversationService.createPropertiesHandler` (4 call sites: :218, :427, :584, :1243), then set it in `Conversation.init` alongside `setUserMemoryConfig` — this is the exact shape the `userMemoryConfig` carrier already uses (`AgentStoreClientLibrary.java:55-56` copies `userMemoryConfig` off `AgentConfiguration`; do the same for `toolApprovals`).
 
   Feature flag: also check `eddi.hitl.tool.enabled` (`@ConfigProperty`, default `true`, injected into `LlmTask`) — when false, effective config is `null` (gate inert; rolling-upgrade control).
   Pass `effectiveToolApprovals` into `agentOrchestrator.executeIfToolsEnabled(...)` as a new parameter (both call sites: `LlmTask:415` cascade-disabled branch and `:433` standard branch; also thread through `CascadingModelExecutor.execute` → its internal `executeIfToolsEnabled` call).
-- [ ] **Step 2: Build `toolSources` during registration.** In `executeWithTools`, alongside every `toolExecutors.put(...)`: built-in loop (:236-242) → `"builtin"`; httpcall merge (:254-257) → `"http"`; mcpcall merge (:260-263) → `"mcp"`; A2A merge (:266-269) → `"a2a"`; and inside `collectEnabledTools`' registration of UserMemoryTool → `"memory"`, ConversationRecallTool → `"recall"`, dynamic tools (createSubAgent/converseWithAgent/findAgentsByCapability/teardownAgent) → `"dynamic"`. (If those latter registrations happen via the same `@Tool`-reflection loop, tag by tool-name membership instead: after the loop, overwrite sources for the known dynamic/memory/recall names. MCP-server tools configured on the task (`McpServerConfig`) also → `"mcp"`.) Missing entries are tolerated — the gate falls back to bare-name matching (fail-safe, tested in Task 2).
-- [ ] **Step 3: Gate hook.** In `executeWithTools`, immediately after `if (aiMessage.hasToolExecutionRequests()) {` (:350), insert the batch classification:
+- **Step 2: Build `toolSources` during registration.** In `executeWithTools`, alongside every `toolExecutors.put(...)`: built-in loop (:236-242) → `"builtin"`; httpcall merge (:254-257) → `"http"`; mcpcall merge (:260-263) → `"mcp"`; A2A merge (:266-269) → `"a2a"`; and inside `collectEnabledTools`' registration of UserMemoryTool → `"memory"`, ConversationRecallTool → `"recall"`, dynamic tools (createSubAgent/converseWithAgent/findAgentsByCapability/teardownAgent) → `"dynamic"`. (If those latter registrations happen via the same `@Tool`-reflection loop, tag by tool-name membership instead: after the loop, overwrite sources for the known dynamic/memory/recall names. MCP-server tools configured on the task (`McpServerConfig`) also → `"mcp"`.) Missing entries are tolerated — the gate falls back to bare-name matching (fail-safe, tested in Task 2).
+- **Step 3: Gate hook.** In `executeWithTools`, immediately after `if (aiMessage.hasToolExecutionRequests()) {` (:350), insert the batch classification:
 
 ```java
 if (aiMessage.hasToolExecutionRequests()) {
@@ -887,7 +892,7 @@ if (aiMessage.hasToolExecutionRequests()) {
 `buildPauseReason`: `cfg.getPauseReason()` with `{toolNames}` replaced by the comma-joined gated names, falling back to `"Tool call requires approval: " + names`. Redact + cap at 500 chars.
 `clearedCallIds`: a `Set<String>` parameter of `executeWithTools`, empty for live turns (Task 9 passes approved ids on resume).
 
-- [ ] **Step 4: Signal plumbing — the three swallow-traps.**
+- **Step 4: Signal plumbing — the three swallow-traps.**
   1. `AgentExecutionHelper.executeWithRetry` — at the very top of `catch (Exception e)` (line 53): `if (e instanceof ai.labs.eddi.engine.hitl.tools.ToolApprovalRequiredException tare) { throw tare; }` (unchecked → compiles without signature change).
   2. `CascadingModelExecutor` — same guard at the top of `catch (Exception e)` (line ~196). The `ExecutionException` unwrap at :253-259 already rethrows the cause, which then reaches :196.
   3. `LifecycleManager.executeTaskRange` — at the top of `catch (LifecycleException | RuntimeException e)` (line 342), BEFORE strict-write failure handling and error counters:
@@ -907,7 +912,7 @@ if (aiMessage.hasToolExecutionRequests()) {
 
 Also audit every other `catch (Exception` / `catch (RuntimeException` / `catch (Throwable` between the gate throw-site and `LifecycleManager` and add the same one-line guard where reachable: run `grep -n "catch (Exception\|catch (RuntimeException\|catch (Throwable" src/main/java/ai/labs/eddi/modules/llm/impl/AgentOrchestrator.java src/main/java/ai/labs/eddi/modules/llm/impl/LlmTask.java src/main/java/ai/labs/eddi/modules/llm/impl/CascadingModelExecutor.java src/main/java/ai/labs/eddi/modules/llm/impl/AgentExecutionHelper.java` and inspect each hit: guards are needed ONLY where the catch encloses the tool loop or a call chain that reaches it (e.g. NOT the RAG catches at LlmTask:251/264 — they run pre-loop). Document each decision in a code comment at the catch site you modify.
 
-- [ ] **Step 5: Pause commit.** `Conversation.pauseConversation` (:451-457) gains:
+- **Step 5: Pause commit.** `Conversation.pauseConversation` (:451-457) gains:
 
 ```java
 private void pauseConversation(ConversationPauseException e) {
@@ -938,9 +943,9 @@ private void pauseConversation(ConversationPauseException e) {
 
 (Mirror the exact `Data`/output pattern of the REJECTED path at :493-496.) The RULE branch above calls `clearToolPauseState()` (defined in Task 4) to defensively null any stray tool batch. **Do NOT change `clearHitlBookmark()`'s contract** — it keeps clearing only the six bookmark fields (Task 4 contract). Add the new `clearToolPauseState()` method to `Conversation` in this task.
 
-- [ ] **Step 6: Stale-batch hygiene.** At the start of each turn (find where `startNextStep`/say-path turn setup runs in `Conversation`), clear any leftover `hitlPendingToolCalls`/`hitlPauseType` when state is not AWAITING_HUMAN (defends against a crash that persisted a batch without the pause committing, and against future code paths that error after the gate trips). One line + WARN log when a stale batch is actually cleared.
-- [ ] **Step 7: pauseReason override scope.** In `ConversationService.populateHitlTimeoutBookmark` (:1534-1556): apply the agent-level `hitlConfig.pauseReason` override **only when** `snapshot.hitlPauseType` is null/`RULE` — a TOOL_CALL pause keeps its tool-specific reason (with tool names) built at gate time.
-- [ ] **Step 8: Tests.**
+- **Step 6: Stale-batch hygiene.** At the start of each turn (find where `startNextStep`/say-path turn setup runs in `Conversation`), clear any leftover `hitlPendingToolCalls`/`hitlPauseType` when state is not AWAITING_HUMAN (defends against a crash that persisted a batch without the pause committing, and against future code paths that error after the gate trips). One line + WARN log when a stale batch is actually cleared.
+- **Step 7: pauseReason override scope.** In `ConversationService.populateHitlTimeoutBookmark` (:1534-1556): apply the agent-level `hitlConfig.pauseReason` override **only when** `snapshot.hitlPauseType` is null/`RULE` — a TOOL_CALL pause keeps its tool-specific reason (with tool names) built at gate time.
+- **Step 8: Tests.**
   `AgentOrchestratorToolPauseTest` (Mockito; mock `ChatModel` returning an `AiMessage` with two tool requests, one matching `requireApproval`):
   - gated call never reaches its executor; ungated call in the same batch executes exactly once (verify mock executor invocations)
   - thrown `ToolApprovalRequiredException` carries a batch with: correct callIds/names/sources/gateReason, serialized transcript containing the AiMessage, `executedUngatedCallNames` listing the ungated call, correct `llmTaskId`
@@ -950,8 +955,8 @@ private void pauseConversation(ConversationPauseException e) {
   `LifecycleManagerToolPauseTest`:
   - a task throwing `ToolApprovalRequiredException` → `ConversationPauseException` with `PauseOrigin.TOOL_CALL` and absolute index `indexOffset + i`; error counter NOT incremented; strict-write rollback NOT invoked
   - `AgentExecutionHelper.executeWithRetry(() -> { throw new ToolApprovalRequiredException(...); }, task, "x")` rethrows the SAME instance, no retry sleep, no LifecycleException wrap
-- [ ] **Step 9:** Run: `./mvnw test -Dtest='AgentOrchestratorToolPauseTest,LifecycleManagerToolPauseTest,LifecycleManagerHitlTest,ConversationHitlTest' -q` → PASS including the pre-existing HITL suites.
-- [ ] **Step 10:** `./mvnw compile -q` then commit: `feat(hitl): tool-approval gate pauses the LLM loop via the conversation pause machinery`
+- **Step 9:** Run: `./mvnw test -Dtest='AgentOrchestratorToolPauseTest,LifecycleManagerToolPauseTest,LifecycleManagerHitlTest,ConversationHitlTest' -q` → PASS including the pre-existing HITL suites.
+- **Step 10:** `./mvnw compile -q` then commit: `feat(hitl): tool-approval gate pauses the LLM loop via the conversation pause machinery`
 
 ---
 
@@ -997,9 +1002,9 @@ public interface IHitlToolJournalStore {
 
 Mongo impl: collection `hitltoolexecutionjournal`; unique compound index `(conversationId, pauseEpoch, callId)`; TTL index on `executedAt` with `eddi.hitl.tool.journal-retention` (default 30 days); `tryClaim` = insert with `status=EXECUTING`, return false on duplicate-key (`MongoWriteException`/`DuplicateKeyException` — catch and return false, don't leak it); `markExecuted` = update set status/result/executedAt. **Result cap 32 KB.** Follow the existing store pattern exactly: **create the indexes in the `@Inject` constructor** (mirror `AgentTriggerStore.java:50` for the unique index, or `MongoScheduleStore.java:98-113` for named `IndexOptions` + TTL — **no store in this repo uses `@PostConstruct` for index creation**); use the same Mongo client injection idiom (`MongoDatabase`/`MongoCollection` via CDI, as those stores do).
 
-- [ ] **Step 1:** Write failing test (use the same test harness the existing Mongo store tests use — check `MongoConversationMemoryStoreTest` for whether it uses an embedded/fake Mongo or is mock-based; mirror it): claim → find returns EXECUTING; markExecuted → find returns EXECUTED with result; second `tryClaim` same key → false; same callId different pauseEpoch → true (independent claim).
-- [ ] **Step 2:** Run → fails. **Step 3:** Implement. **Step 4:** Run → PASS.
-- [ ] **Step 5:** Commit: `feat(hitl): write-ahead journal for approved tool executions`
+- **Step 1:** Write failing test (use the same test harness the existing Mongo store tests use — check `MongoConversationMemoryStoreTest` for whether it uses an embedded/fake Mongo or is mock-based; mirror it): claim → find returns EXECUTING; markExecuted → find returns EXECUTED with result; second `tryClaim` same key → false; same callId different pauseEpoch → true (independent claim).
+- **Step 2:** Run → fails. **Step 3:** Implement. **Step 4:** Run → PASS.
+- **Step 5:** Commit: `feat(hitl): write-ahead journal for approved tool executions`
 
 ---
 
@@ -1051,9 +1056,9 @@ public class ToolCallDecision {
 
 Semantics: calls not listed in `toolDecisions` inherit the top-level verdict. NOTE: the pre-CAS read needs the snapshot — `resumeConversation` already loads state pre-CAS (:1154-1157); load the snapshot's pauseType/batch for validation the same way the 409-state-hint body does (read the existing code first; reuse its snapshot access, do not add a second load if one exists).
 
-- [ ] **Step 1:** Failing test — one `@Test` per table row (Mockito on the store returning a snapshot with a TOOL_CALL batch of two pending calls), asserting 400-mapped exception type + message fragment AND that the CAS/state was never touched (verify no `compareAndSetState` interaction). Plus: valid mixed body passes validation.
-- [ ] **Step 2:** Run → fails. **Step 3:** Implement. **Step 4:** Run + `./mvnw test -Dtest='ConversationServiceResumeTest,ConversationServiceHitlTest' -q` → all PASS (existing bodies unaffected).
-- [ ] **Step 5:** Commit: `feat(hitl): per-tool-call verdicts and amended arguments on the resume decision`
+- **Step 1:** Failing test — one `@Test` per table row (Mockito on the store returning a snapshot with a TOOL_CALL batch of two pending calls), asserting 400-mapped exception type + message fragment AND that the CAS/state was never touched (verify no `compareAndSetState` interaction). Plus: valid mixed body passes validation.
+- **Step 2:** Run → fails. **Step 3:** Implement. **Step 4:** Run + `./mvnw test -Dtest='ConversationServiceResumeTest,ConversationServiceHitlTest' -q` → all PASS (existing bodies unaffected).
+- **Step 5:** Commit: `feat(hitl): per-tool-call verdicts and amended arguments on the resume decision`
 
 ---
 
@@ -1126,9 +1131,9 @@ public void execute(IConversationMemory memory, Object component) throws Lifecyc
 4. Store the result EXACTLY like the normal path stores it (raw response data `:484-485`, trace `:518-521`, output `:527-535`, `prePostUtils.runPostResponse` `:537` — postResponse DOES run: it reacts to the final response, which only now exists). Then `memory.clearToolPauseState()` (nulls batch + resume decision + pauseType).
 5. **Multi-task note:** tasks in `llmConfig.tasks()` before `batch.llmTaskIndex` already ran pre-pause (their step data is committed); tasks after it never ran. After `executeResume` returns the resumed task's result, iterate the remaining matching tasks (`index > batch.llmTaskIndex`) through the NORMAL `executeTask` path so the turn completes fully. Implement by restructuring the task loop: in resume mode, skip tasks with index < batch index, resume at ==, normal-execute >.
 
-- [ ] **Step 1:** Failing tests. `ConversationToolResumeTest` (Mockito on workflows/lifecycle manager): TOOL_CALL pause + APPROVED → `executeLifecycleFromIndex` called with the SAME index (not +1); RULE pause (null pauseType) → +1 unchanged (backward compat); TOOL_CALL + REJECTED → NO short-circuit, same-index re-entry, hitlDecision outputs still written; legacy snapshot without pauseType behaves as RULE. LlmTask side (`LlmTaskResumeModeTest`): resume mode skips RAG/preRequest (verify zero interactions on their mocks), consumes the batch via `resumeToolLoop` (mock orchestrator), stores result + runs postResponse, clears tool-pause state; index/id mismatch → config-drift degradation (public output stored, batch cleared, orchestrator never called); tasks after the resumed index run normally.
-- [ ] **Step 2:** Run → fails. **Step 3:** Implement. **Step 4:** Run new + `ConversationServiceResumeTest` + `ConversationHitlTest` + `RestAgentEngineHitlTest` → all PASS.
-- [ ] **Step 5:** Commit: `feat(hitl): same-index re-entry into LlmTask for tool-call pauses`
+- **Step 1:** Failing tests. `ConversationToolResumeTest` (Mockito on workflows/lifecycle manager): TOOL_CALL pause + APPROVED → `executeLifecycleFromIndex` called with the SAME index (not +1); RULE pause (null pauseType) → +1 unchanged (backward compat); TOOL_CALL + REJECTED → NO short-circuit, same-index re-entry, hitlDecision outputs still written; legacy snapshot without pauseType behaves as RULE. LlmTask side (`LlmTaskResumeModeTest`): resume mode skips RAG/preRequest (verify zero interactions on their mocks), consumes the batch via `resumeToolLoop` (mock orchestrator), stores result + runs postResponse, clears tool-pause state; index/id mismatch → config-drift degradation (public output stored, batch cleared, orchestrator never called); tasks after the resumed index run normally.
+- **Step 2:** Run → fails. **Step 3:** Implement. **Step 4:** Run new + `ConversationServiceResumeTest` + `ConversationHitlTest` + `RestAgentEngineHitlTest` → all PASS.
+- **Step 5:** Commit: `feat(hitl): same-index re-entry into LlmTask for tool-call pauses`
 
 ---
 
@@ -1180,7 +1185,7 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
 4. **Continue the loop.** Enter the same iteration loop as `executeWithTools` starting at `i = batch.getIterationIndex() + 1` up to the task's `maxToolIterations` (budget continuity — the pause does not launder fresh iterations), with `clearedCallIds` = the approved callIds, gate ACTIVE for new calls (a new gated batch throws `ToolApprovalRequiredException` again → re-pause; `pauseCountThisTurn` carries from `batch.getPauseCountThisTurn()`, `autoApproveCount` per Task 10). Merge `batch.getTraceSoFar()` + new trace entries into the returned `ExecutionResult`. Wrap the loop in `AgentExecutionHelper.executeWithRetry` exactly like the live path (the rethrow guard from Task 5 lets re-pauses escape).
 5. Return `new ExecutionResult(finalText, mergedTrace)`.
 
-- [ ] **Step 1:** Failing tests (mock ChatModel scripted per scenario; mock journal store; mock executors):
+- **Step 1:** Failing tests (mock ChatModel scripted per scenario; mock journal store; mock executors):
   - approve-all: both tools execute once, journal claim+markExecuted per call, results appended by callId, model called again, final text returned, trace merged
   - reject-all: NO executor invocation, rejection envelopes contain the note, model produces final text (verify the messages list passed to the final `chat()` contains the envelopes)
   - mixed + amendment: approved call executes with amended args; envelope has `argsAmendedByReviewer:true`; rejected call gets note
@@ -1189,8 +1194,8 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
   - transcript codec failure → fallback rebuild path: history builder invoked, reconstructed AiMessage carries the batch's callIds, gated approved call still executes
   - re-pause: model's next response contains a NEW gated call → `ToolApprovalRequiredException` with a fresh pauseEpoch and `pauseCountThisTurn = old + 1`
   - iteration budget: `batch.iterationIndex = maxToolIterations - 1` → after verdicts, loop makes at most one more model call
-- [ ] **Step 2:** Run → fails. **Step 3:** Implement (extraction refactor first, then resumeToolLoop; run `AgentOrchestratorToolPauseTest` after the extraction to prove the live path is unbroken). **Step 4:** All orchestrator tests PASS.
-- [ ] **Step 5:** Commit: `feat(hitl): journal-protected resume of gated tool calls with transcript replay`
+- **Step 2:** Run → fails. **Step 3:** Implement (extraction refactor first, then resumeToolLoop; run `AgentOrchestratorToolPauseTest` after the extraction to prove the live path is unbroken). **Step 4:** All orchestrator tests PASS.
+- **Step 5:** Commit: `feat(hitl): journal-protected resume of gated tool calls with transcript replay`
 
 ---
 
@@ -1213,9 +1218,9 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
    **Audit per guard:** every guard activation writes an audit-ledger entry, not just a metric — `hitl.tool.pause_cap` (from Task 5's cap branch — thread the audit collector so the DENIED path can audit), `hitl.tool.auto_approve_cap`, and `hitl.tool.no_progress`. Each entry records the guard name, the fingerprint (for no-progress), and `decidedBy`. This satisfies the "audit per guard" requirement literally.
 5. **Audit detail extension** in `auditHitlDecision` (:1390-1413): when TOOL_CALL, add `pauseType`, and a `toolDecisions` summary list `[{callId, verdict, amended:bool, toolName}]` + per-call SHA-256 `argsDigest` (never raw args in the ledger).
 
-- [ ] **Step 1:** Failing tests: inherited AUTO_APPROVE demoted to WAIT_INDEFINITELY (no schedule armed); explicit tool-level AUTO_APPROVE honored (schedule armed, timeout fires → resume path invoked with system:timeout); identical-fingerprint re-pause after system approval with default policy → new pause has WAIT_INDEFINITELY + audit entry; AUTO_REJECT no-progress → reject-all resume; human decision resets the counter; audit detail contains argsDigest not raw args.
-- [ ] **Step 2:** Run → fails. **Step 3:** Implement. **Step 4:** Run + full existing HITL service suites (`ConversationServiceHitlTest`, `ConversationServiceSayHitlTest`, `ConversationServiceResumeTest`) → PASS.
-- [ ] **Step 5:** Commit: `feat(hitl): tool-pause timeout policy scoping and no-progress guards`
+- **Step 1:** Failing tests: inherited AUTO_APPROVE demoted to WAIT_INDEFINITELY (no schedule armed); explicit tool-level AUTO_APPROVE honored (schedule armed, timeout fires → resume path invoked with system:timeout); identical-fingerprint re-pause after system approval with default policy → new pause has WAIT_INDEFINITELY + audit entry; AUTO_REJECT no-progress → reject-all resume; human decision resets the counter; audit detail contains argsDigest not raw args.
+- **Step 2:** Run → fails. **Step 3:** Implement. **Step 4:** Run + full existing HITL service suites (`ConversationServiceHitlTest`, `ConversationServiceSayHitlTest`, `ConversationServiceResumeTest`) → PASS.
+- **Step 5:** Commit: `feat(hitl): tool-pause timeout policy scoping and no-progress guards`
 
 ---
 
@@ -1235,9 +1240,9 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
 - `PendingApprovalSummary` gains `pauseType` (String) and `toolNames` (List<String> — names only, no args) so inbox lists can badge tool pauses. Populate in **`ConversationMemoryStore.collectPendingSummaries()` :242-246** (the 6-arg ctor + `setApprovalTimeout` site — add the two new fields there).
 - The `detail=full` authz behavior is untouched (approver-only-while-paused already implemented).
 
-- [ ] **Step 1:** Failing tests: TOOL_CALL snapshot → pauseDetails carries redacted args only (assert the raw `argumentsRaw` value does NOT appear anywhere in the response), executedUngatedCalls present; **an `EXECUTING` journal entry for a callId → that callId appears in `outcomeUnknown`** (mock `IHitlToolJournalStore.find` returning EXECUTING); no journal entries → `outcomeUnknown` empty; RULE snapshot → type RULE with actions list; legacy snapshot (null pauseType) → type RULE; pending-approvals entries carry pauseType + toolNames.
-- [ ] **Step 2-4:** Red → implement → green (+ `RestConversationStoreTest`, `RestAgentEngineHitlTest` still PASS).
-- [ ] **Step 5:** Commit: `feat(hitl): structured pauseDetails for tool and rule pauses`
+- **Step 1:** Failing tests: TOOL_CALL snapshot → pauseDetails carries redacted args only (assert the raw `argumentsRaw` value does NOT appear anywhere in the response), executedUngatedCalls present; **an `EXECUTING` journal entry for a callId → that callId appears in `outcomeUnknown`** (mock `IHitlToolJournalStore.find` returning EXECUTING); no journal entries → `outcomeUnknown` empty; RULE snapshot → type RULE with actions list; legacy snapshot (null pauseType) → type RULE; pending-approvals entries carry pauseType + toolNames.
+- **Step 2-4:** Red → implement → green (+ `RestConversationStoreTest`, `RestAgentEngineHitlTest` still PASS).
+- **Step 5:** Commit: `feat(hitl): structured pauseDetails for tool and rule pauses`
 
 ---
 
@@ -1253,7 +1258,7 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
 - The existing state+bookmark-driven notification flow (`notifyApprovers`, `loadHitlBookmark` retry) requires NO dispatch changes — verify with a test that a TOOL_CALL pause triggers the notification exactly like a RULE pause.
 - Continuation push: `HitlResumeCompletedEvent` observers already post the resumed output; the tool-resume path produces normal output (Task 8/9) → works unchanged; add one test asserting the resumed final text reaches the thread-post call.
 
-- [ ] Steps: failing test → implement → green (`SlackInteractivityHandlerTest` untouched and passing). Commit: `feat(hitl): tool-pause detail blocks in Slack approval messages`
+- Steps: failing test → implement → green (`SlackInteractivityHandlerTest` untouched and passing). Commit: `feat(hitl): tool-pause detail blocks in Slack approval messages`
 
 ---
 
@@ -1269,7 +1274,7 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
 2. **Group members:** when a member conversation tool-pauses during a group turn (the group's `executeAgentTurn` awaits the member future and observes the pause), the group auto-resolves it with `HitlDecision(REJECTED, decidedBy="system:group", note="tool approval is not available during group discussions in this version")` — routed through the NORMAL resume path (so the member's LLM receives rejection tool-results, Task 9, and produces a coherent tool-less answer that becomes its turn contribution when the resume completes synchronously; if the resume cannot complete within the member-turn budget, fall back to the existing member-pause handling: turn recorded SKIPPED + `member_pause_skipped` SSE + audited auto-cancel). Read the existing member-pause auto-cancel code first (`grep -rn "member_pause_skipped\|system:group" src/main/java`) and extend it minimally: the DIFFERENCE for tool pauses is the graceful system-rejection attempt before falling back to cancel. Metric: reuse `eddi_group_member_pause_skipped_count`.
 3. `inGroupTurns` config: v1 only supports `REJECT` (above). `INBOX` was already rejected at save time (Task 3).
 
-- [ ] Steps: failing tests → implement → green (all existing group HITL tests still pass: `GroupConversationServiceHitlTest`). Commit: `feat(hitl): tool-pause parity for delegated conversations and group-member policy`
+- Steps: failing tests → implement → green (all existing group HITL tests still pass: `GroupConversationServiceHitlTest`). Commit: `feat(hitl): tool-pause parity for delegated conversations and group-member policy`
 
 ---
 
@@ -1289,7 +1294,7 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
 
 **Also (review follow-up — real-codec round-trip):** the Task 4 unit test `PendingToolCallBatchSnapshotTest` only proves the POJOs are bean-shaped via a plain Jackson `ObjectMapper`. Add a **Testcontainers** round-trip in `MongoConversationMemoryStoreTest` (CI-only) that stores a `ConversationMemorySnapshot` with `hitlPauseType="TOOL_CALL"` and a fully-populated `PendingToolCallBatch` (incl. `traceSoFar` with a nested `Map<String,Object>` and two calls) via `store.storeConversationMemorySnapshot`, loads it back, and asserts every batch field survives — this exercises the real `JacksonCodec` (BSON-backed) path the unit test cannot. Mirror it for Postgres (JSONB) if that store's test harness exists.
 
-- [ ] Steps: tests → (minimal) fixes → green. Commit: `test(hitl): crash-recovery, retention and undeploy coverage for tool pauses`
+- Steps: tests → (minimal) fixes → green. Commit: `test(hitl): crash-recovery, retention and undeploy coverage for tool pauses`
 
 ---
 
@@ -1304,7 +1309,7 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
 1. **Near-miss lint (rules save):** for every action name in a saved ruleset, if it is a case-variant or Levenshtein-distance ≤ 2 of a reserved action (`PAUSE_CONVERSATION`, `STOP_CONVERSATION`, `CONVERSATION_START`, `CONVERSATION_END`) **and not exactly equal** → WARN log + warnings entry (non-fatal; a legitimate action may legally resemble the name). Reuse `ToolApprovalPatterns.levenshtein` (make it public or move to a shared util — executor's choice, keep it in one place).
 2. **Nothing-can-pause lint (deployment):** when a deployed agent has `hitlConfig` set (any field) AND no referenced ruleset emits `PAUSE_CONVERSATION` AND `hitlConfig.toolApprovals.requireApproval` is empty/absent → WARN log `"agent <id>: hitlConfig is configured but nothing in this agent can trigger a pause"` (+ deployment-descriptor warning if the deployment response supports warnings — inspect first, WARN-log-only is acceptable).
 
-- [ ] Steps: failing tests (exact-match not flagged; `PAUSE_CONVERSATON` flagged; `pause_conversation` flagged; unrelated names not flagged; deployment warn fires only in the configured-but-inert case) → implement → green. Commit: `feat(hitl): save-time lint for reserved-action near-misses and inert hitlConfig`
+- Steps: failing tests (exact-match not flagged; `PAUSE_CONVERSATON` flagged; `pause_conversation` flagged; unrelated names not flagged; deployment warn fires only in the configured-but-inert case) → implement → green. Commit: `feat(hitl): save-time lint for reserved-action near-misses and inert hitlConfig`
 
 ---
 
@@ -1316,7 +1321,7 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
 
 **Scenarios (as far as the harness allows):** gated call pauses (409 on say, approval-status shows pauseDetails) → approve via REST → turn completes with tool executed once → journal has EXECUTED entry; reject-all → graceful answer, no execution; toolDecisions validation 400s end-to-end.
 
-- [ ] Write ITs; run `./mvnw compile -q` and the full local unit suite `./mvnw test -q` (NOT the ITs — CI-only). Fix any regression. Commit: `test(hitl): tool-pause integration tests (CI)`
+- Write ITs; run `./mvnw compile -q` and the full local unit suite `./mvnw test -q` (NOT the ITs — CI-only). Fix any regression. Commit: `test(hitl): tool-pause integration tests (CI)`
 
 ---
 
@@ -1328,7 +1333,7 @@ The riskiest task. Everything here lives in `AgentOrchestrator` so it shares `ex
 - Modify: `docs/changelog.md` — full entry per repo conventions (date, branch `feat/hitl-framework`, files + reasoning, the 5 product decisions from the decision record, what's next).
 - Modify: `planning/hitl-framework-plan.md` — flip "Tool-level HITL: Deferred" to "Implemented — see planning/hitl-tool-approval-plan.md".
 
-- [ ] Write docs; commit together with nothing else: `docs(hitl): tool-level approval gating reference and upgrade notes`
+- Write docs; commit together with nothing else: `docs(hitl): tool-level approval gating reference and upgrade notes`
 
 ---
 

--- a/planning/mcp-hitl-surface-plan.md
+++ b/planning/mcp-hitl-surface-plan.md
@@ -1,6 +1,9 @@
 # MCP HITL Surface — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Status: IMPLEMENTED.** Shipped as `McpHitlTools` and the shared `HitlAccessGuard`.
+> Kept as the design record — user-facing documentation is [`docs/hitl.md`](../docs/hitl.md).
+> **Do not execute the task list below.** The checkbox syntax has been
+> stripped so the steps read as the record of a design, not as an open work queue.
 
 **Goal:** Expose EDDI's Human-in-the-Loop (HITL) approval operations over the MCP server so an external MCP client can list, read, resume/approve, and cancel human-approval gates for both regular (1:1) and group conversations — at full parity with the existing REST endpoints, without ever granting an LLM the authority to approve its own gate.
 
@@ -92,7 +95,7 @@ Gives every HITL tool a machine-readable error shape so a programmatic MCP clien
 **Interfaces:**
 - Produces: `static String McpToolUtils.errorJson(String message, String errorCode, Map<String,String> details)` — returns `{"error":"...","errorCode":"...","details":{...}}`, always valid JSON, never throws.
 
-- [ ] **Step 1: Write the failing test**
+- **Step 1: Write the failing test**
 
 Create `src/test/java/ai/labs/eddi/engine/mcp/McpToolUtilsErrorJsonTest.java`:
 
@@ -131,12 +134,12 @@ class McpToolUtilsErrorJsonTest {
 }
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- **Step 2: Run test to verify it fails**
 
 Run: `./mvnw test -Dtest=McpToolUtilsErrorJsonTest`
 Expected: FAIL (compilation error — `errorJson(String,String,Map)` not defined).
 
-- [ ] **Step 3: Add the overload**
+- **Step 3: Add the overload**
 
 In `McpToolUtils.java`, add (keep the existing single-arg `errorJson` untouched; add `import java.util.Map;`):
 
@@ -168,12 +171,12 @@ static String errorJson(String message, String errorCode, java.util.Map<String, 
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- **Step 4: Run test to verify it passes**
 
 Run: `./mvnw test -Dtest=McpToolUtilsErrorJsonTest`
 Expected: PASS (3 tests).
 
-- [ ] **Step 5: Commit**
+- **Step 5: Commit**
 
 ```bash
 git add src/main/java/ai/labs/eddi/engine/mcp/McpToolUtils.java src/test/java/ai/labs/eddi/engine/mcp/McpToolUtilsErrorJsonTest.java
@@ -197,11 +200,11 @@ Extract the HITL ownership composition and the owner-scoped pending-approvals de
   - `String requireConversationHitlAccess(String conversationId)` — returns owner userId (or `null` if the descriptor is absent and caller is admin/approver); throws `io.quarkus.security.ForbiddenException` on denial.
   - `List<PendingApprovalSummary> listScopedPendingApprovals(int limit) throws ResourceStoreException`.
 
-- [ ] **Step 1: Read the source being extracted**
+- **Step 1: Read the source being extracted**
 
 Read `RestAgentEngine.java:397–419` (`listPendingApprovals`) and `:438–466` (`validateConversationOwnership`) and note the exact injected field names/types for `ownershipValidator`, the descriptor store, `conversationService`, and `identity`. Reproduce those exact types in the guard.
 
-- [ ] **Step 2: Write the failing test**
+- **Step 2: Write the failing test**
 
 Create `src/test/java/ai/labs/eddi/engine/hitl/HitlAccessGuardTest.java`. Use the descriptor-store type you found in Step 1 (shown here as `IConversationDescriptorStore` — replace with the actual type). Mock all deps:
 
@@ -282,12 +285,12 @@ class HitlAccessGuardTest {
 
 Fill in the descriptor-store mock and the `requireConversationHitlAccess` arrange-block using the exact descriptor read (`descriptorStore.readDescriptor("conv-1", 0)` returning a descriptor with a `getUserId()`), mirroring `RestAgentEngine.java:440–442`.
 
-- [ ] **Step 3: Run test to verify it fails**
+- **Step 3: Run test to verify it fails**
 
 Run: `./mvnw test -Dtest=HitlAccessGuardTest`
 Expected: FAIL (compilation error — `HitlAccessGuard` does not exist).
 
-- [ ] **Step 4: Create the guard**
+- **Step 4: Create the guard**
 
 Create `src/main/java/ai/labs/eddi/engine/hitl/HitlAccessGuard.java`. Port `RestAgentEngine.listPendingApprovals` (`397–419`) into `listScopedPendingApprovals`, and the `hitlOperation=true` body of `validateConversationOwnership` (`438–466`) into `requireConversationHitlAccess`. Replace `IConversationDescriptorStore`/field names with the actual types from Step 1:
 
@@ -378,7 +381,7 @@ public class HitlAccessGuard {
 
 Match the actual descriptor store import/type and the `sanitize(...)`/logging idiom used in `RestAgentEngine` if you prefer.
 
-- [ ] **Step 5: Refactor `RestAgentEngine` to delegate**
+- **Step 5: Refactor `RestAgentEngine` to delegate**
 
 In `RestAgentEngine.java`: inject `HitlAccessGuard hitlAccessGuard` (add to the constructor). Change the top of `validateConversationOwnership` (`438`) so the HITL branch delegates:
 
@@ -405,7 +408,7 @@ public List<PendingApprovalSummary> listPendingApprovals(Integer limit) {
 }
 ```
 
-- [ ] **Step 6: Run guard test + REST regression**
+- **Step 6: Run guard test + REST regression**
 
 Run: `./mvnw test -Dtest=HitlAccessGuardTest`
 Expected: PASS.
@@ -414,7 +417,7 @@ Run the existing regular-surface HITL REST test unchanged (find its name: `grep 
 Run: `./mvnw test -Dtest=RestAgentEngineHitlTest`
 Expected: PASS (behavior unchanged after extraction). If this test is a `@QuarkusTest` that cannot boot locally, note it and rely on CI (Task 9) — do not weaken it.
 
-- [ ] **Step 7: Compile & commit**
+- **Step 7: Compile & commit**
 
 Run: `./mvnw compile`
 Expected: BUILD SUCCESS.
@@ -441,11 +444,11 @@ Symmetric to Task 2 for the group surface. This closes the owner-scope leak risk
   - `void requireGroupConversationHitlAccess(String groupId, String groupConversationId)` — throws `ForbiddenException` / `NotFoundException` as the REST method does.
   - `List<PendingApprovalSummary> listScopedGroupPendingApprovals(String groupId, int limit) throws ResourceStoreException` — `groupId=null` → cross-group inbox.
 
-- [ ] **Step 1: Read the group source**
+- **Step 1: Read the group source**
 
 Read `RestGroupConversation.java:~363–412` (`validateGroupConversationOwnership`) and `512–548` (group listing scoping). Note the group descriptor store field/type and how it derives the owner userId, and confirm the scoping mirrors the regular one (admin/approver → all; else own; anonymous → none).
 
-- [ ] **Step 2: Write the failing tests (extend `HitlAccessGuardTest`)**
+- **Step 2: Write the failing tests (extend `HitlAccessGuardTest`)**
 
 Add to `HitlAccessGuardTest`:
 
@@ -473,20 +476,20 @@ void listScopedGroupPendingApprovals_ownerFilteredToOwn() throws Exception {
 
 Add `groupConversationService = mock(IGroupConversationService.class)` to `setup()` and pass it to the (now widened) guard constructor.
 
-- [ ] **Step 3: Run to verify failure**
+- **Step 3: Run to verify failure**
 
 Run: `./mvnw test -Dtest=HitlAccessGuardTest`
 Expected: FAIL (compilation — group methods/constructor arg not present).
 
-- [ ] **Step 4: Add the group methods to the guard**
+- **Step 4: Add the group methods to the guard**
 
 Widen the `HitlAccessGuard` constructor to also inject `IGroupConversationService` and the group descriptor store. Add `requireGroupConversationHitlAccess` (port the `hitlOperation=true` branch of `validateGroupConversationOwnership`) and `listScopedGroupPendingApprovals` (port `RestGroupConversation.java:512–548`, calling `groupConversationService.listGroupPendingApprovals(groupId, limit)` then applying the same admin/approver-vs-own filter). Keep the regular methods from Task 2 unchanged.
 
-- [ ] **Step 5: Refactor `RestGroupConversation` to delegate**
+- **Step 5: Refactor `RestGroupConversation` to delegate**
 
 Inject `HitlAccessGuard`. Route the `hitlOperation=true` branch of `validateGroupConversationOwnership` to `hitlAccessGuard.requireGroupConversationHitlAccess(groupId, gcId)`, and route the group listing methods (`512–524`, `532–548`) through `hitlAccessGuard.listScopedGroupPendingApprovals(...)`. Leave any non-HITL group ownership path untouched.
 
-- [ ] **Step 6: Run guard test + group regression**
+- **Step 6: Run guard test + group regression**
 
 Run: `./mvnw test -Dtest=HitlAccessGuardTest`
 Expected: PASS.
@@ -495,7 +498,7 @@ Run the existing group HITL REST test unchanged (find it: `grep -rli "group" src
 Run: `./mvnw test -Dtest=RestGroupConversationHitlTest`
 Expected: PASS (or CI-only if `@QuarkusTest`; note and defer to Task 9).
 
-- [ ] **Step 7: Compile & commit**
+- **Step 7: Compile & commit**
 
 Run: `./mvnw compile`
 
@@ -511,7 +514,7 @@ git commit -m "refactor(hitl): extract group HITL ownership + scoped listing int
 **Files:**
 - Modify: `src/main/resources/application.properties`
 
-- [ ] **Step 1: Add the property**
+- **Step 1: Add the property**
 
 Append (near other `eddi.*` / MCP properties):
 
@@ -521,12 +524,12 @@ Append (near other `eddi.*` / MCP properties):
 eddi.mcp.hitl.mutations.enabled=true
 ```
 
-- [ ] **Step 2: Compile**
+- **Step 2: Compile**
 
 Run: `./mvnw compile`
 Expected: BUILD SUCCESS.
 
-- [ ] **Step 3: Commit**
+- **Step 3: Commit**
 
 ```bash
 git add src/main/resources/application.properties
@@ -552,7 +555,7 @@ Four tools: `list_pending_approvals`, `get_approval_status`, `resume_conversatio
   - `String cancelConversation(String conversationId)`
   - helper `String principalWithMcpPrefix()` → `"mcp:" + name` or `"mcp:anonymous"`.
 
-- [ ] **Step 1: Write the failing test**
+- **Step 1: Write the failing test**
 
 Create `src/test/java/ai/labs/eddi/engine/mcp/McpHitlToolsTest.java`:
 
@@ -680,12 +683,12 @@ class McpHitlToolsTest {
 
 If `HitlDecision` lacks `getDecidedBy()`, add it (trivial getter) in Task 5 Step 2 so the test can assert attribution.
 
-- [ ] **Step 2: Run to verify failure**
+- **Step 2: Run to verify failure**
 
 Run: `./mvnw test -Dtest=McpHitlToolsTest`
 Expected: FAIL (compilation — `McpHitlTools` not defined).
 
-- [ ] **Step 3: Implement `McpHitlTools` (regular tools)**
+- **Step 3: Implement `McpHitlTools` (regular tools)**
 
 Create `src/main/java/ai/labs/eddi/engine/mcp/McpHitlTools.java`. Model annotations/imports on `McpConversationTools` (confirm the exact `@Tool`/`@ToolArg`/`@Blocking` import packages there). Use inline `meterRegistry.counter(...).increment()` (no `@PostConstruct` needed):
 
@@ -920,12 +923,12 @@ public class McpHitlTools {
 
 Adapt `new HitlDecision(); setVerdict/setNote` to `HitlDecision`'s actual API, and the `snapshot.getHitl*` getters to their real names (read `ConversationMemorySnapshot` + `RestAgentEngine.getApprovalStatus:378–384`). Ensure `HitlDecision` exposes `getDecidedBy()`/`getVerdict()` for the test.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- **Step 4: Run tests to verify they pass**
 
 Run: `./mvnw test -Dtest=McpHitlToolsTest`
 Expected: PASS (all regular-tool tests).
 
-- [ ] **Step 5: Compile & commit**
+- **Step 5: Compile & commit**
 
 Run: `./mvnw compile`
 
@@ -950,7 +953,7 @@ Five tools: `list_group_pending_approvals`, `list_all_group_pending_approvals`, 
 - Consumes: `HitlAccessGuard.requireGroupConversationHitlAccess`, `HitlAccessGuard.listScopedGroupPendingApprovals`, `IGroupConversationService.resumeDiscussion/cancelDiscussion`, `GroupApprovalRequest`, `IJsonSerialization.deserialize` (confirm the method name).
 - Produces: `String listGroupPendingApprovals(String groupId, String limit)`, `String listAllGroupPendingApprovals(String limit)`, `String getGroupApprovalStatus(String groupId, String conversationId, String detail)`, `String approveGroupPhase(String groupId, String conversationId, String verdict, String note, String taskApprovalsJson)`, `String cancelGroupDiscussion(String groupId, String conversationId)`.
 
-- [ ] **Step 1: Write the failing tests (extend `McpHitlToolsTest`)**
+- **Step 1: Write the failing tests (extend `McpHitlToolsTest`)**
 
 ```java
 @Test
@@ -993,12 +996,12 @@ void cancelGroup_happyPath_delegates() throws Exception {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- **Step 2: Run to verify failure**
 
 Run: `./mvnw test -Dtest=McpHitlToolsTest`
 Expected: FAIL (group tool methods not defined).
 
-- [ ] **Step 3: Implement the group tools**
+- **Step 3: Implement the group tools**
 
 Add to `McpHitlTools`. `approve_group_phase` parses `taskApprovals` from a JSON-object string, mirrors the regular resume validation, delegates to `resumeDiscussion(conversationId, request, null)`, and serializes the returned `GroupConversation`:
 
@@ -1152,12 +1155,12 @@ public String cancelGroupDiscussion(
 
 Fill in the `get_group_approval_status` summary map from the exact getters in `RestGroupConversation.java:302–347`. Confirm `GroupApprovalRequest`'s constructor/setters and `IJsonSerialization.deserialize`'s signature.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- **Step 4: Run tests to verify they pass**
 
 Run: `./mvnw test -Dtest=McpHitlToolsTest`
 Expected: PASS (regular + group tests).
 
-- [ ] **Step 5: Compile & commit**
+- **Step 5: Compile & commit**
 
 Run: `./mvnw compile`
 
@@ -1176,18 +1179,18 @@ So an LLM MCP client that receives a paused signal knows which tool to call to c
 - Modify: the method that builds the `PAUSED_FOR_APPROVAL` JSON (`pausedForApprovalJson`, likely in `McpConversationTools.java` or `McpToolUtils.java` — locate with grep).
 - Test: the existing test covering that payload (e.g. `McpConversationToolsHitlTest`).
 
-- [ ] **Step 1: Locate the payload builder**
+- **Step 1: Locate the payload builder**
 
 Run: `grep -rn "PAUSED_FOR_APPROVAL\|pausedForApproval" src/main/java`
 Note the method and the JSON fields it emits (state, conversationId, agentId, reason).
 
-- [ ] **Step 2: Update the existing test to expect the hint**
+- **Step 2: Update the existing test to expect the hint**
 
 In the test that asserts the paused payload, add an assertion that the JSON now contains `"suggestNextTool":"resume_conversation"`. Run it to confirm it FAILS first:
 Run: `./mvnw test -Dtest=McpConversationToolsHitlTest`
 Expected: FAIL on the new assertion. (If this is a `@QuarkusTest` not runnable locally, add the assertion and defer verification to CI — Task 9.)
 
-- [ ] **Step 3: Add the field**
+- **Step 3: Add the field**
 
 `McpConversationTools` has **two** `pausedForApprovalJson` overloads (≈lines 602 and 629); both build a `Map`/`result` and `put("status", "PAUSED_FOR_APPROVAL")`. Add to **both**:
 
@@ -1197,12 +1200,12 @@ result.put("suggestNextTool", "resume_conversation");
 
 Neither overload currently emits `pauseType` (the tool-approval plan will add that separately) — so only add the `suggestNextTool` key; do not touch or assume any other field. `resume_conversation` is the correct next tool for both RULE and TOOL_CALL pauses (both resolve via the single-verdict resume).
 
-- [ ] **Step 4: Run the test**
+- **Step 4: Run the test**
 
 Run: `./mvnw test -Dtest=McpConversationToolsHitlTest`
 Expected: PASS (or CI-only).
 
-- [ ] **Step 5: Commit**
+- **Step 5: Commit**
 
 ```bash
 git add <the payload-builder file> <the test file>
@@ -1217,23 +1220,23 @@ git commit -m "feat(mcp): name resume_conversation in PAUSED_FOR_APPROVAL payloa
 - Modify: `docs/hitl.md`, `docs/mcp-server.md`, `docs/changelog.md`
 - Optional: `AGENTS.md` (add an "MCP Tool Class Checklist" note)
 
-- [ ] **Step 1: `docs/hitl.md` — add an "MCP Surface" section**
+- **Step 1: `docs/hitl.md` — add an "MCP Surface" section**
 
 Document the 9 tools (name + one-line description), that they mirror the REST endpoints, that mutating tools require the same owner/admin/approver authority and honor `eddi.mcp.hitl.mutations.enabled`, that MCP decisions are attributed `mcp:<principal>`, that there is no streaming variant (`approve_group_phase` blocks and returns the resumed discussion), and the structured error codes (`NOT_FOUND | WRONG_STATE | FORBIDDEN | DISABLED | BAD_REQUEST`). Note that the regular tools resolve **both** `RULE` and `TOOL_CALL` pauses (both are `AWAITING_HUMAN`, both resolved by a single verdict); `get_approval_status` reports `pauseType`, and for a `TOOL_CALL` pause the pending tool-call batch is visible via `detail=full`.
 
-- [ ] **Step 2: `docs/mcp-server.md` — add a "HITL Tools (9)" category**
+- **Step 2: `docs/mcp-server.md` — add a "HITL Tools (9)" category**
 
 List all 9 tools with descriptions matching `docs/hitl.md`, so they are discoverable in the tool catalog.
 
-- [ ] **Step 3: `docs/changelog.md` — add an entry**
+- **Step 3: `docs/changelog.md` — add an entry**
 
 Add a dated entry (repo: EDDI, branch: `feat/hitl-framework`) summarizing: new `McpHitlTools` (9 tools), the shared `HitlAccessGuard` extraction (regular + group), the `eddi.mcp.hitl.mutations.enabled` kill-switch, `mcp:`-prefixed decision attribution, and the `PAUSED_FOR_APPROVAL` `suggestNextTool` hint. Note design decisions: human authority preserved; delegate to services not REST; mirror REST auth + kill-switch; no streaming/agent-approver.
 
-- [ ] **Step 4: (Optional) `AGENTS.md` — MCP tool class checklist**
+- **Step 4: (Optional) `AGENTS.md` — MCP tool class checklist**
 
 Under §4.3, add a short note that an MCP tool class needs only `@ApplicationScoped` + constructor-injected deps + `@Tool`/`@ToolArg` methods returning JSON strings + `@Blocking` on I/O + Mockito unit tests — NOT the `ILifecycleTask` artifacts (Configuration POJO, Store, REST, ExtensionDescriptor). Reference `McpConversationTools`/`McpHitlTools` as examples.
 
-- [ ] **Step 5: Commit**
+- **Step 5: Commit**
 
 ```bash
 git add docs/hitl.md docs/mcp-server.md docs/changelog.md AGENTS.md
@@ -1248,22 +1251,22 @@ git commit -m "docs(mcp): document MCP HITL surface (tools, kill-switch, auth, e
 
 **Files:** none (verification only).
 
-- [ ] **Step 1: Full compile**
+- **Step 1: Full compile**
 
 Run: `./mvnw compile`
 Expected: BUILD SUCCESS.
 
-- [ ] **Step 2: Run the full locally-runnable test suite (Mockito unit tests)**
+- **Step 2: Run the full locally-runnable test suite (Mockito unit tests)**
 
 Run: `./mvnw test -Dtest='McpToolUtilsErrorJsonTest,HitlAccessGuardTest,McpHitlToolsTest'`
 Expected: PASS, 0 failures.
 
-- [ ] **Step 3: Run the broader HITL/MCP regression (whatever runs locally)**
+- **Step 3: Run the broader HITL/MCP regression (whatever runs locally)**
 
 Run: `./mvnw test -Dtest='*Hitl*,*McpHitl*'`
 Expected: PASS for all non-`@QuarkusTest` tests. Any `@QuarkusTest` / integration tests that cannot boot locally are expected to be verified in CI — record which were skipped locally; do not delete or weaken them.
 
-- [ ] **Step 4: Push and let CI run the full suite**
+- **Step 4: Push and let CI run the full suite**
 
 CI (`.github/workflows/ci.yml`) runs the complete suite including `@QuarkusTest` and integration tests. Push the branch and confirm CI is green before requesting review. (Get explicit approval before pushing.)
 
@@ -1272,7 +1275,7 @@ git status          # confirm only intended files are committed across Tasks 1-8
 git log --oneline -9
 ```
 
-- [ ] **Step 5: Final self-check against the design**
+- **Step 5: Final self-check against the design**
 
 Confirm: 9 tools present; all mutating tools honor the kill-switch; `decidedBy`/`cancelledBy` are `mcp:`-prefixed and never taken from args; group listings are owner-scoped via the guard; REST HITL regression tests unchanged and green in CI; docs + changelog landed on `feat/hitl-framework`.
 

--- a/planning/multimodal-attachments-completion-plan.md
+++ b/planning/multimodal-attachments-completion-plan.md
@@ -1,6 +1,17 @@
 # Multimodal Attachments — Completion Plan v3 (Unified Upload → LLM, 1:1 + Groups)
 
-> **Status:** Planning only. No code changes yet.
+> **Status: IMPLEMENTED.** Kept as the design record. User-facing documentation is
+> [`docs/attachments-guide.md`](../docs/attachments-guide.md).
+>
+> **What shipped vs. this plan.** Every root defect below is resolved. The two blob-store
+> abstractions were unified into `IAttachmentStore` (`IAttachmentStorage` no longer exists;
+> see the historical note in `IAttachmentStore`), so conversation deletion and GDPR erasure
+> cascade through the same store uploads write to. Conversation-scoped ownership with explicit
+> member grants is the shipped model. PDF, audio and text extraction ships as
+> `AttachmentTextExtractor`; the capability gate as `ModelCapabilityService`. Also shipped and
+> not in this plan by name: `ReadAttachmentTool`, `AttachmentForwarder`, `ContentTypeMatcher`
+> and `MaxInlineAttachmentSizeValidator`. Read the paragraphs below as the reasoning behind
+> those decisions, not as a description of current behaviour.
 > **v3 (second critical pass):** Major corrections vs v2 —
 > (1) **Unify the two parallel blob-store abstractions** (`IAttachmentStore` vs `IAttachmentStorage`) — today conversation-deletion/GDPR cascade through a *different* store than the one uploads write to;
 > (2) **Ownership reverted to conversation-scoped + explicit member grants** — v2's user-scoped model broke anonymous deployments and invited a context-injection privilege escalation;

--- a/planning/observability-and-pipeline-plan.md
+++ b/planning/observability-and-pipeline-plan.md
@@ -1,5 +1,10 @@
 # Observability & Pipeline Architecture Plan
 
+> **Status: ALL FOUR ITEMS SHIPPED.** Kept as the design record. OpenTelemetry tracing,
+> the LlmTask decomposition, the coordinator queue bound with its gauges, and the Grafana
+> dashboards are all in the tree — see [`docs/monitoring/monitoring-guide.md`](../docs/monitoring/monitoring-guide.md)
+> for what was delivered. Do not pick items from this file up as available work.
+>
 > **Context:** These are larger architectural improvements deferred from the v6.0.2 security sprint. They span the pipeline engine, coordinator, and observability infrastructure.
 
 ## Prerequisite Reading

--- a/planning/observability-and-pipeline-plan.md
+++ b/planning/observability-and-pipeline-plan.md
@@ -17,7 +17,7 @@
 
 ## 1. OpenTelemetry Tracing 🟡 MEDIUM
 
-**Why:** EDDI has Micrometer metrics but no distributed tracing. For production debugging, each conversation turn should produce a trace showing: request → parse → behavior rules → actions → task execution → response.
+**Why (historical):** at the time of writing, EDDI had Micrometer metrics but no distributed tracing. The goal was that each conversation turn should produce a trace showing: request → parse → behavior rules → actions → task execution → response. It now does — `LifecycleManager` emits an `eddi.pipeline.task` span per task.
 
 **What to do:**
 
@@ -117,7 +117,7 @@ LlmTask.execute()
 
 ## 3. ConversationCoordinator Hardening 🟢 LOW
 
-**Why:** `InMemoryConversationCoordinator` uses unbounded `ConcurrentHashMap<String, BlockingQueue>` keyed by conversationId. Active conversations are cleaned up, but abandoned conversations (client disconnects mid-turn) may leak entries.
+**Why (historical):** at the time of writing, `InMemoryConversationCoordinator` used an unbounded `ConcurrentHashMap<String, BlockingQueue>` keyed by conversationId. Active conversations were cleaned up, but abandoned ones (client disconnects mid-turn) could leak entries. It is now bounded by `eddi.coordinator.max-active-conversations` and gauged.
 
 **What to do:**
 
@@ -133,7 +133,7 @@ LlmTask.execute()
 
 ## 4. Metrics Dashboard 🟢 LOW
 
-**Why:** EDDI has 20+ Micrometer metrics but no dashboard to visualize them.
+**Why (historical):** at the time of writing, EDDI had 20+ Micrometer metrics and no dashboard. Three now ship under `docs/monitoring/`, and `MetricsDashboardCoverageTest` fails the build when a registered meter has no panel.
 
 **What to do:**
 

--- a/src/test/java/ai/labs/eddi/docs/DocumentationAccuracyTest.java
+++ b/src/test/java/ai/labs/eddi/docs/DocumentationAccuracyTest.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright EDDI contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.labs.eddi.docs;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins documentation claims to the code that makes them true.
+ * <p>
+ * {@link DocumentationLinksTest} keeps the links honest; this keeps the
+ * <em>content</em> honest. Every assertion below corresponds to a claim a
+ * repository review found to be false — a field reference that omitted a
+ * required field, a table that named a property the application never reads, a
+ * warning describing a fallback that was deliberately removed. Markdown
+ * compiles to nothing, so none of those were visible to any other check in the
+ * build, and several had been wrong for more than one release.
+ * <p>
+ * The assertions are deliberately shaped as "the doc must mention what the code
+ * declares" rather than as fixed expected strings. A new condition type, a new
+ * schedule field or a new backup extension is then a failing test with the
+ * missing name in the message, not a silent divergence discovered later by a
+ * reader who followed the reference and got a 400.
+ */
+@DisplayName("documentation accuracy")
+class DocumentationAccuracyTest {
+
+    private static Path repoRoot() {
+        Path root = Path.of("").toAbsolutePath();
+        assertTrue(Files.isRegularFile(root.resolve("pom.xml")),
+                "expected the working directory to be the project root, was " + root);
+        return root;
+    }
+
+    private static String read(String relativePath) {
+        Path p = repoRoot().resolve(relativePath);
+        assertTrue(Files.isRegularFile(p), relativePath + " is missing");
+        try {
+            return Files.readString(p, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** Directories with no documentation to check (or not ours to check). */
+    private static final Set<String> SKIPPED_DIRS = Set.of("target", ".git", "node_modules", ".claude", ".mvn");
+
+    private static List<Path> markdownFiles() {
+        Path root = repoRoot();
+        List<Path> found = new ArrayList<>();
+        try {
+            Files.walkFileTree(root, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (!dir.equals(root) && SKIPPED_DIRS.contains(dir.getFileName().toString())) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (attrs.isRegularFile()
+                            && file.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".md")) {
+                        found.add(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return found;
+    }
+
+    /**
+     * Every documentation page except the changelog and its archives, which record
+     * what was true at the time and must not be rewritten to match today's code.
+     */
+    private static List<Path> currentDocs() {
+        List<Path> docs = new ArrayList<>();
+        for (Path p : markdownFiles()) {
+            String rel = repoRoot().relativize(p).toString().replace('\\', '/');
+            if (rel.equals("docs/changelog.md") || rel.startsWith("docs/changelog/")) {
+                continue;
+            }
+            docs.add(p);
+        }
+        return docs;
+    }
+
+    private static String contentOf(Path p) {
+        try {
+            return Files.readString(p, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Collects the {@code ID = "..."} string constants declared in a source
+     * directory.
+     */
+    private static Set<String> declaredIds(String sourceDir) {
+        Pattern id = Pattern.compile("String\\s+ID\\s*=\\s*\"([^\"]+)\"");
+        Set<String> ids = new TreeSet<>();
+        Path dir = repoRoot().resolve(sourceDir);
+        assertTrue(Files.isDirectory(dir), sourceDir + " is missing");
+        try (var files = Files.list(dir)) {
+            files.filter(f -> f.getFileName().toString().endsWith(".java")).forEach(f -> {
+                Matcher m = id.matcher(contentOf(f));
+                while (m.find()) {
+                    ids.add(m.group(1));
+                }
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        assertFalse(ids.isEmpty(), "found no ID constants under " + sourceDir);
+        return ids;
+    }
+
+    // ---------------------------------------------------------------- secrets
+
+    /**
+     * {@code PropertySetterTask.autoVaultSecret} fails closed: with no master key
+     * it scrubs the plaintext and throws, aborting the turn. An earlier release did
+     * fall back to storing plaintext, and three pages still described that fallback
+     * — including AGENTS.md, which every contributor and AI session auto-loads, so
+     * the wrong mental model was re-seeded rather than read once.
+     */
+    @Test
+    @DisplayName("no page claims a secret-scoped property falls back to plaintext")
+    void secretScopeIsDocumentedAsFailingClosed() {
+        String task = read("src/main/java/ai/labs/eddi/modules/properties/impl/PropertySetterTask.java");
+        assertTrue(task.contains("Refusing to persist the value in plaintext"),
+                "autoVaultSecret no longer fails closed — this test's premise is gone, revisit the docs it guards");
+
+        List<String> offenders = new ArrayList<>();
+        for (Path p : currentDocs()) {
+            String text = contentOf(p).toLowerCase(Locale.ROOT);
+            if (!text.contains("scope: \"secret\"") && !text.contains("scope=\"secret\"")) {
+                continue;
+            }
+            if (text.contains("fall back to plaintext") || text.contains("falls back to plaintext")
+                    || text.contains("fall back to storing plaintext")) {
+                offenders.add(repoRoot().relativize(p).toString());
+            }
+        }
+        assertTrue(offenders.isEmpty(),
+                "these pages still describe the removed plaintext fallback for scope: \"secret\": " + offenders);
+    }
+
+    // ------------------------------------------------------------- conditions
+
+    /**
+     * behavior-rules.md presents its list as exhaustive ("List of available
+     * conditions"), and it was missing four of the twelve registered types. One of
+     * them, {@code deploymentContext}, was documented nowhere at all, so a designer
+     * needing an environment check hand-rolled one from a client-supplied context
+     * variable instead.
+     */
+    @Test
+    @DisplayName("behavior-rules.md names every registered condition type")
+    void everyConditionTypeIsDocumented() {
+        String doc = read("docs/behavior-rules.md");
+        Set<String> missing = new TreeSet<>();
+        for (String id : declaredIds("src/main/java/ai/labs/eddi/modules/rules/impl/conditions")) {
+            if (!doc.contains(id)) {
+                missing.add(id);
+            }
+        }
+        assertTrue(missing.isEmpty(), "behavior-rules.md does not mention these condition types: " + missing);
+    }
+
+    // ----------------------------------------------------------------- backup
+
+    /**
+     * AGENTS.md §5.5 is the stated reference for hand-building an import ZIP. It
+     * listed seven of the twelve file extensions the importer handles, so the most
+     * common case — an agent with a regular dictionary — could not be built from
+     * the file that tells you how to build one.
+     */
+    @Test
+    @DisplayName("AGENTS.md's ZIP section names every backup file extension")
+    void everyBackupExtensionIsDocumented() {
+        String agents = read("AGENTS.md");
+        String backup = read("src/main/java/ai/labs/eddi/backup/impl/AbstractBackupService.java");
+        Matcher m = Pattern.compile("String\\s+\\w+_EXT\\s*=\\s*\"([^\"]+)\"").matcher(backup);
+        Set<String> missing = new TreeSet<>();
+        int found = 0;
+        while (m.find()) {
+            found++;
+            String ext = m.group(1);
+            if (!agents.contains("." + ext + ".json")) {
+                missing.add(ext);
+            }
+        }
+        assertTrue(found >= 12, "expected at least 12 *_EXT constants, found " + found);
+        assertTrue(missing.isEmpty(), "AGENTS.md's ZIP structure omits these file extensions: " + missing);
+    }
+
+    /**
+     * The same section tells the reader a templating step is mandatory whenever
+     * output contains {@code {properties.x}}, and then gave a step-type table that
+     * did not contain it — so the mandatory step was undiscoverable from the file
+     * that mandates it. Omitting it deploys READY and emits the literal
+     * {@code {properties.agentName}} to end users.
+     */
+    @Test
+    @DisplayName("AGENTS.md's workflow step table names the templating and mcpcalls steps")
+    void workflowStepTableIsComplete() {
+        String agents = read("AGENTS.md");
+        int table = agents.indexOf("#### Workflow step types");
+        assertTrue(table > 0, "AGENTS.md no longer has a 'Workflow step types' section");
+        String section = agents.substring(table, Math.min(agents.length(), table + 2000));
+        for (String step : List.of("ai.labs.parser", "ai.labs.behavior", "ai.labs.property",
+                "ai.labs.httpcalls", "ai.labs.output", "ai.labs.llm",
+                "ai.labs.mcpcalls", "ai.labs.templating")) {
+            assertTrue(section.contains(step), "the workflow step table omits " + step);
+        }
+    }
+
+    // --------------------------------------------------------------- schedules
+
+    /**
+     * scheduling.md's Schedule Fields table omitted {@code oneTimeAt} — a validated
+     * one-time trigger mode mentioned on no page at all — and {@code metadata}, the
+     * field a Dream schedule needs to be dispatched.
+     */
+    @Test
+    @DisplayName("scheduling.md documents oneTimeAt and metadata")
+    void scheduleFieldsTableCoversTheValidatedFields() {
+        String doc = read("docs/scheduling.md");
+        String model = read("src/main/java/ai/labs/eddi/engine/schedule/model/ScheduleConfiguration.java");
+        // Anchor on the reference table, not on the page. A field named in passing in
+        // the prose is not discoverable by someone reading the field reference, which
+        // is exactly how oneTimeAt stayed undocumented while being validated.
+        int table = doc.indexOf("### Schedule Fields");
+        assertTrue(table > 0, "scheduling.md no longer has a 'Schedule Fields' section");
+        int end = doc.indexOf("\n### ", table + 1);
+        String fields = end > 0 ? doc.substring(table, end) : doc.substring(table);
+        for (String field : List.of("oneTimeAt", "metadata")) {
+            assertTrue(model.contains(field), "ScheduleConfiguration no longer declares " + field);
+            assertTrue(fields.contains("`" + field + "`"),
+                    "the Schedule Fields table in scheduling.md has no row for " + field);
+        }
+    }
+
+    /**
+     * A background dream cycle has no parent LLM task to inherit credentials from,
+     * so {@code dream.parameters} is required for {@code summarizeInteractions}.
+     * The field appeared in no reference table, and its absence fails every
+     * summarization step with a provider 401 while stale pruning keeps working — so
+     * the failure looks intermittent rather than like a missing credential.
+     */
+    @Test
+    @DisplayName("the Dream reference tables document the parameters field")
+    void dreamParametersAreDocumented() {
+        String agentConfig = read("src/main/java/ai/labs/eddi/configs/agents/model/AgentConfiguration.java");
+        assertTrue(agentConfig.contains("private Map<String, String> parameters"),
+                "DreamConfig no longer declares parameters");
+        assertTrue(read("docs/user-memory.md").contains("`parameters`"),
+                "user-memory.md's Dream table does not document the parameters field");
+        assertTrue(read("docs/scheduling.md").contains("\"parameters\""),
+                "scheduling.md's Dream example does not set parameters");
+    }
+
+    // -------------------------------------------------------------- llm fields
+
+    /**
+     * Six shipped fields on the LLM task appeared in no page under {@code docs/}.
+     * The costly one is {@code conversationSummary}: a non-empty
+     * {@code builtInToolsWhitelist} enables only the tools it names, so a rolling
+     * summary configured without {@code conversationRecall} in the whitelist leaves
+     * the model answering from a truncated view with no error.
+     */
+    @Test
+    @DisplayName("langchain.md documents every shipped LLM task field the review found missing")
+    void llmTaskFieldsAreDocumented() {
+        String doc = read("docs/langchain.md");
+        String model = read("src/main/java/ai/labs/eddi/modules/llm/model/LlmConfiguration.java");
+        for (String field : List.of("toolLoadingStrategy", "maxToolsInContext", "conversationSummary",
+                "maxSystemPromptChars", "responseValidation")) {
+            assertTrue(model.contains(field), "LlmConfiguration no longer declares " + field);
+            assertTrue(doc.contains("`" + field + "`"), "langchain.md does not document " + field);
+        }
+        assertTrue(doc.contains("`conversationRecall`"),
+                "langchain.md's built-in tool table does not list conversationRecall");
+        assertTrue(read("docs/rag.md").contains("`maxRagContextChars`"),
+                "rag.md does not document maxRagContextChars");
+    }
+
+    // ------------------------------------------------------------- properties
+
+    /**
+     * The README's system-property table named
+     * {@code quarkus.mongodb.connection-string}. That key is real — the Quarkus
+     * extension's health check reads it — but the application does not, so pointing
+     * it at another host reported the new host as UP while every read and write
+     * still went to the old one.
+     */
+    @Test
+    @DisplayName("no page presents quarkus.mongodb.connection-string as the connection knob")
+    void mongoConnectionPropertyIsTheOneTheCodeReads() {
+        String module = read("src/main/java/ai/labs/eddi/datastore/bootstrap/PersistenceModule.java");
+        assertTrue(module.contains("mongodb.connectionString"),
+                "PersistenceModule no longer reads mongodb.connectionString");
+
+        List<String> offenders = new ArrayList<>();
+        for (Path p : currentDocs()) {
+            if (contentOf(p).contains("quarkus.mongodb.connection-string=")) {
+                offenders.add(repoRoot().relativize(p).toString());
+            }
+        }
+        assertTrue(offenders.isEmpty(),
+                "these pages set quarkus.mongodb.connection-string, which the application never reads: " + offenders);
+    }
+
+    // ------------------------------------------------------------------ traces
+
+    /**
+     * The pipeline emits span attributes under an {@code eddi.} prefix; the
+     * un-prefixed names are the Micrometer <em>metric</em> tags, a different
+     * surface. A TraceQL filter on {@code task.id} matches zero spans with no
+     * error, which reads as "tracing is not emitting" rather than as a typo.
+     */
+    @Test
+    @DisplayName("documented span attributes carry the eddi. prefix the code emits")
+    void spanAttributesAreDocumentedWithTheirPrefix() {
+        String manager = read("src/main/java/ai/labs/eddi/engine/lifecycle/internal/LifecycleManager.java");
+        assertTrue(manager.contains("\"eddi.task.id\""), "LifecycleManager no longer sets eddi.task.id");
+
+        Pattern unprefixed = Pattern.compile("eddi\\.pipeline\\.task\\s*\\[\\s*task\\.");
+        List<String> offenders = new ArrayList<>();
+        for (Path p : currentDocs()) {
+            if (unprefixed.matcher(contentOf(p)).find()) {
+                offenders.add(repoRoot().relativize(p).toString());
+            }
+        }
+        assertTrue(offenders.isEmpty(),
+                "these pages show eddi.pipeline.task with un-prefixed attribute names: " + offenders);
+    }
+
+    // ------------------------------------------------------------- tutorials
+
+    /**
+     * Both first-agent tutorials named the workflow field
+     * {@code packageextensions}. Configuration writes go through a strict parser
+     * that rejects an unknown top-level key, so a reader working from the reference
+     * table — the only way to discover field names for a client library — got a 400
+     * with nothing in the table to correct it from.
+     */
+    @Test
+    @DisplayName("no page names a workflow field the strict parser rejects")
+    void tutorialsNameTheRealWorkflowField() {
+        String model = read("src/main/java/ai/labs/eddi/configs/workflows/model/WorkflowConfiguration.java");
+        assertTrue(model.contains("workflowSteps"), "WorkflowConfiguration no longer declares workflowSteps");
+        assertFalse(model.contains("packageextensions"), "packageextensions is a real field now — delete this test");
+
+        List<String> offenders = new ArrayList<>();
+        for (Path p : currentDocs()) {
+            if (contentOf(p).contains("packageextensions")) {
+                offenders.add(repoRoot().relativize(p).toString());
+            }
+        }
+        assertTrue(offenders.isEmpty(), "these pages still name the non-existent field packageextensions: " + offenders);
+    }
+
+    /**
+     * A tutorial documented a Facebook channel connector with three config keys.
+     * None exists. The POST succeeds because the deprecated {@code channels} field
+     * still deserialises, nothing is wired, and no log line points at the cause.
+     */
+    @Test
+    @DisplayName("no page documents a Facebook channel connector")
+    void noFacebookConnectorIsDocumented() {
+        List<String> offenders = new ArrayList<>();
+        for (Path p : currentDocs()) {
+            String text = contentOf(p).toLowerCase(Locale.ROOT);
+            if (text.contains("ai.labs.channel.facebook") || text.contains("pageaccesstoken")) {
+                offenders.add(repoRoot().relativize(p).toString());
+            }
+        }
+        assertTrue(offenders.isEmpty(), "these pages document a Facebook channel that does not exist: " + offenders);
+    }
+
+    /**
+     * Compose v2 ships as the {@code docker compose} subcommand; the standalone
+     * {@code docker-compose} binary is end-of-life and is not used here. It was
+     * still the first command on the Docker page, which fails with "command not
+     * found" on a current Docker Desktop or Engine.
+     */
+    @Test
+    @DisplayName("no page invokes the end-of-life docker-compose binary")
+    void composeInvocationsUseV2() {
+        Pattern v1 = Pattern.compile("(?m)^\\s*(?:#\\s*)?docker-compose\\s+(up|down|build|run|logs|ps|pull|-f)\\b");
+        List<String> offenders = new ArrayList<>();
+        for (Path p : currentDocs()) {
+            if (v1.matcher(contentOf(p)).find()) {
+                offenders.add(repoRoot().relativize(p).toString());
+            }
+        }
+        assertTrue(offenders.isEmpty(), "these pages invoke the end-of-life docker-compose binary: " + offenders);
+    }
+
+    // --------------------------------------------------------------- planning
+
+    /**
+     * {@code planning/} is where an engineer or an agent looks for available work.
+     * Five files there described shipped subsystems as unbuilt, and two of them
+     * went further and instructed an agent to implement them task-by-task. An agent
+     * pointed at either began at "Step 1: Write the failing test" against a spec
+     * whose class names all resolve to files that already exist.
+     */
+    @Test
+    @DisplayName("shipped plans are marked and carry no execute-this directive")
+    void shippedPlansAreMarkedAsImplemented() {
+        List<String> shipped = List.of(
+                "planning/multimodal-attachments-completion-plan.md",
+                "planning/conversation-cancel-plan.md",
+                "planning/observability-and-pipeline-plan.md",
+                "planning/hitl-tool-approval-plan.md",
+                "planning/mcp-hitl-surface-plan.md");
+        for (String rel : shipped) {
+            String text = read(rel);
+            String head = text.substring(0, Math.min(text.length(), 1200));
+            assertTrue(head.contains("Status:"),
+                    rel + " has no status marker in its opening block, so it reads as available work");
+            assertFalse(text.contains("implement this plan task-by-task"),
+                    rel + " still instructs an agent to implement a shipped subsystem");
+        }
+    }
+
+    /**
+     * The unchecked-checkbox format is what makes a plan read as in-progress, and
+     * it is the signal a triage pass acts on. The two HITL plans held 107 of them
+     * for a subsystem AGENTS.md lists as complete.
+     */
+    @Test
+    @DisplayName("no shipped plan carries an unchecked task list")
+    void shippedPlansCarryNoOpenCheckboxes() {
+        for (String rel : List.of("planning/hitl-tool-approval-plan.md", "planning/mcp-hitl-surface-plan.md")) {
+            assertFalse(read(rel).contains("- [ ] "),
+                    rel + " still carries unchecked task boxes for work that shipped");
+        }
+    }
+}

--- a/src/test/java/ai/labs/eddi/docs/DocumentationAccuracyTest.java
+++ b/src/test/java/ai/labs/eddi/docs/DocumentationAccuracyTest.java
@@ -124,6 +124,24 @@ class DocumentationAccuracyTest {
     }
 
     /**
+     * The text of one Markdown section: from the heading that starts with
+     * {@code headingPrefix} up to the next heading at the same level.
+     * <p>
+     * Scoping matters more than it looks. Searching a whole file lets an unrelated
+     * paragraph — an example, a changelog line, a prose mention — satisfy an
+     * assertion after the reference table it is really about has lost the field.
+     * The test would then pass while the reader following the table still cannot
+     * find what they need, which is the exact failure mode this class exists to
+     * catch.
+     */
+    private static String section(String markdown, String headingPrefix, String nextHeadingPrefix) {
+        int start = markdown.indexOf(headingPrefix);
+        assertTrue(start >= 0, "expected a section starting with \"" + headingPrefix + "\"; the document has been restructured");
+        int end = markdown.indexOf(nextHeadingPrefix, start + headingPrefix.length());
+        return end > 0 ? markdown.substring(start, end) : markdown.substring(start);
+    }
+
+    /**
      * Collects the {@code ID = "..."} string constants declared in a source
      * directory.
      */
@@ -210,7 +228,9 @@ class DocumentationAccuracyTest {
     @Test
     @DisplayName("AGENTS.md's ZIP section names every backup file extension")
     void everyBackupExtensionIsDocumented() {
-        String agents = read("AGENTS.md");
+        // §5.5 only: the URI table further down names some of the same types, and would
+        // otherwise satisfy this check for an extension the ZIP block no longer lists.
+        String agents = section(read("AGENTS.md"), "### 5.5 ZIP Structure for Agent Import", "### 5.6 ");
         String backup = read("src/main/java/ai/labs/eddi/backup/impl/AbstractBackupService.java");
         Matcher m = Pattern.compile("String\\s+\\w+_EXT\\s*=\\s*\"([^\"]+)\"").matcher(backup);
         Set<String> missing = new TreeSet<>();
@@ -286,8 +306,11 @@ class DocumentationAccuracyTest {
         String agentConfig = read("src/main/java/ai/labs/eddi/configs/agents/model/AgentConfiguration.java");
         assertTrue(agentConfig.contains("private Map<String, String> parameters"),
                 "DreamConfig no longer declares parameters");
-        assertTrue(read("docs/user-memory.md").contains("`parameters`"),
-                "user-memory.md's Dream table does not document the parameters field");
+        // The reference table only. The example config above it also sets parameters,
+        // and a reader working from the table — the normal way to discover a field —
+        // would not see it there.
+        String dreamTable = section(read("docs/user-memory.md"), "### Dream Configuration", "\\n## ");
+        assertTrue(dreamTable.contains("`parameters`"), "the Dream Configuration table in user-memory.md has no row for parameters");
         assertTrue(read("docs/scheduling.md").contains("\"parameters\""),
                 "scheduling.md's Dream example does not set parameters");
     }
@@ -451,8 +474,11 @@ class DocumentationAccuracyTest {
         for (String rel : shipped) {
             String text = read(rel);
             String head = text.substring(0, Math.min(text.length(), 1200));
-            assertTrue(head.contains("Status:"),
-                    rel + " has no status marker in its opening block, so it reads as available work");
+            // "Status:" alone also accepts "Status: Planned", which is effectively what
+            // these files said before. What has to hold is that a reader scanning
+            // planning/ for available work can tell at a glance that this one is done.
+            assertTrue(head.contains("Status: IMPLEMENTED") || head.contains("Status: ALL FOUR ITEMS SHIPPED"),
+                    rel + " does not declare a shipped status in its opening block, so it still reads as available work");
             assertFalse(text.contains("implement this plan task-by-task"),
                     rel + " still instructs an agent to implement a shipped subsystem");
         }


### PR DESCRIPTION
Twenty-three findings, all of them documentation that said something the code does not do. Markdown compiles to nothing, so none were visible to any check in the build and several had been wrong for more than one release.

## Claims that cost a reader real time

- `AGENTS.md` and `configuration-reference.md` said a `scope: "secret"` property degrades to plaintext without a vault key. It fails the whole turn closed, scrubbing the plaintext first.
- The README named `quarkus.mongodb.connection-string` as the connection knob. That is a real Quarkus key, but only the extension's health check reads it, so pointing it at another host reports the new host UP while every read and write still goes to the old one.
- Both first-agent tutorials named the workflow field `packageextensions`, which the strict write boundary rejects with a 400, and documented a Facebook channel connector that does not exist.
- Span attributes were documented without the `eddi.` prefix the code emits, so a trace filter on `task.id` matches nothing and reads as "tracing is not emitting".

## Claims that hid a shipped feature

- `behavior-rules.md` presented 8 of the 12 registered condition types as the complete list. `deploymentContext` was documented nowhere; it now has a section.
- `AGENTS.md`'s ZIP section listed 7 of 12 backup file extensions, so an agent with a regular dictionary could not be built from the file that tells you how to build one. Its workflow step table also omitted the templating step the same section calls mandatory.
- Six shipped LLM task fields were undocumented, including the rolling conversation summary and its `conversationRecall` tool.
- `scheduling.md` omitted `oneTimeAt` and `metadata`; `user-memory.md` omitted `dream.parameters`, without which every summarization step fails with a provider 401 while stale pruning keeps working.

## New pages

Tenant quotas, coordinator dead letters and template preview had no documentation at all. Two new pages plus a section in `output-templating.md`, linked from `SUMMARY.md`.

## Stale plans

Five files under `planning/` described shipped subsystems as unbuilt. Two went further and instructed an agent to implement them task by task, 107 unchecked boxes between them, against a spec whose class names all resolve to files that already exist. Those now carry a status marker, the directive is gone, and the checkbox syntax is stripped rather than ticked. Stripping does not assert that every sub-step shipped, which ticking would.

## The guard

`DocumentationAccuracyTest` pins the claims to the code rather than to fixed strings: the docs must mention what the code declares, so every condition `ID`, every `*_EXT` backup constant, the schedule fields the validator enforces, the LLM task fields the model declares. A new condition type is then a failing test naming it, not a reference table that quietly goes stale.

Proven by mutation. Removing the `oneTimeAt` row, dropping the templating step, deleting a backup extension and restoring the wrong MongoDB property each fail with the missing name in the message. It also caught three errors in this PR's own edits before it was run deliberately.

Docs-only change plus one new test class; no production code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guides for tenant quotas, coordinator administration, template previews, LangChain options, scheduling, and user-memory configuration.
  - Updated workflow, deployment, Docker, monitoring, tracing, MongoDB, RAG, and output-format documentation.
  - Documented additional workflow steps, behavior-rule conditions, ZIP import formats, and API requirements.
  - Clarified that secret-scoped properties fail closed when vault protection is unavailable.
  - Updated planning records to reflect shipped capabilities and added documentation accuracy checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->