### PR TITLE
docs(configs): add class Javadoc to config store interfaces

### DIFF
--- a/src/main/java/ai/labs/eddi/configs/agents/IAgentStore.java
+++ b/src/main/java/ai/labs/eddi/configs/agents/IAgentStore.java
@@ -11,7 +11,11 @@ import ai.labs.eddi.configs.descriptors.model.DocumentDescriptor;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Versioned store for agent configurations, the resources that tie workflows,
+ * channels and capabilities together into a deployable agent. The runtime
+ * orchestrators and the REST layer read agents through this interface; the
+ * lookup below lists which agents reference a given workflow so callers can
+ * warn about destructive changes before they happen.
  */
 public interface IAgentStore extends IResourceStore<AgentConfiguration> {
     List<DocumentDescriptor> getAgentDescriptorsContainingWorkflow(String workflowId, Integer workflowVersion, boolean includePreviousVersions)

--- a/src/main/java/ai/labs/eddi/configs/apicalls/IApiCallsStore.java
+++ b/src/main/java/ai/labs/eddi/configs/apicalls/IApiCallsStore.java
@@ -10,7 +10,10 @@ import ai.labs.eddi.datastore.IResourceStore;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Persistence for API call configurations, the named sets of external HTTP
+ * calls an agent can invoke during a conversation. Besides the usual CRUD,
+ * readActions() exposes the call keys of a version so the REST editor can offer
+ * them wherever an action name is expected.
  */
 public interface IApiCallsStore extends IResourceStore<ApiCallsConfiguration> {
     List<String> readActions(String id, Integer version, String filter, Integer limit)

--- a/src/main/java/ai/labs/eddi/configs/dictionary/IDictionaryStore.java
+++ b/src/main/java/ai/labs/eddi/configs/dictionary/IDictionaryStore.java
@@ -10,7 +10,10 @@ import ai.labs.eddi.datastore.IResourceStore;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Store for dictionary configurations, the word, regex and phrase lists an
+ * agent's parser and rules expand while matching input. readExpressions()
+ * returns the expressions of a given version and is what the expression listing
+ * endpoints call to fill their results.
  */
 public interface IDictionaryStore extends IResourceStore<DictionaryConfiguration> {
     DictionaryConfiguration read(String id, Integer version, String filter, String order, Integer index, Integer limit)

--- a/src/main/java/ai/labs/eddi/configs/llm/ILlmStore.java
+++ b/src/main/java/ai/labs/eddi/configs/llm/ILlmStore.java
@@ -8,7 +8,10 @@ import ai.labs.eddi.datastore.IResourceStore;
 import ai.labs.eddi.modules.llm.model.LlmConfiguration;
 
 /**
- * @author ginccc
+ * Store for LLM configurations, i.e. the provider and model settings behind an
+ * agent's language tasks. Versioned like every other configuration resource and
+ * mostly read through the generic configuration client when an agent is
+ * deployed or edited.
  */
 public interface ILlmStore extends IResourceStore<LlmConfiguration> {
 }

--- a/src/main/java/ai/labs/eddi/configs/mcpcalls/IMcpCallsStore.java
+++ b/src/main/java/ai/labs/eddi/configs/mcpcalls/IMcpCallsStore.java
@@ -10,7 +10,10 @@ import ai.labs.eddi.datastore.IResourceStore;
 import java.util.List;
 
 /**
- * Store interface for MCP Calls configurations.
+ * Store interface for MCP Calls configurations. Each configuration describes a
+ * connection to an external MCP server (URL, transport, credentials and the
+ * tool allow/deny lists); readActions() lists the actions defined across the
+ * entries of a configuration version for the editor endpoints.
  */
 public interface IMcpCallsStore extends IResourceStore<McpCallsConfiguration> {
 

--- a/src/main/java/ai/labs/eddi/configs/output/IOutputStore.java
+++ b/src/main/java/ai/labs/eddi/configs/output/IOutputStore.java
@@ -10,7 +10,10 @@ import ai.labs.eddi.datastore.IResourceStore;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Store for output configurations, the versioned sets that tell an agent how to
+ * phrase and deliver a reply. The runtime resolves the output set for a turn
+ * through this store, while readActions() and the paged read back the endpoints
+ * that list and preview output keys.
  */
 public interface IOutputStore extends IResourceStore<OutputConfigurationSet> {
     OutputConfigurationSet read(String id, Integer version, String filter, String order, Integer index, Integer limit)

--- a/src/main/java/ai/labs/eddi/configs/parser/IParserStore.java
+++ b/src/main/java/ai/labs/eddi/configs/parser/IParserStore.java
@@ -8,7 +8,10 @@ import ai.labs.eddi.configs.parser.model.ParserConfiguration;
 import ai.labs.eddi.datastore.IResourceStore;
 
 /**
- * @author ginccc
+ * Store for parser configurations. Deliberately declares no extra methods:
+ * keeping a dedicated interface lets the generic configuration machinery
+ * resolve the parser store by type, the same way it does for the other
+ * configuration kinds.
  */
 public interface IParserStore extends IResourceStore<ParserConfiguration> {
     // class for reflection purposes

--- a/src/main/java/ai/labs/eddi/configs/rules/IRuleSetStore.java
+++ b/src/main/java/ai/labs/eddi/configs/rules/IRuleSetStore.java
@@ -10,7 +10,10 @@ import ai.labs.eddi.datastore.IResourceStore;
 import java.util.List;
 
 /**
- * @author ginccc
+ * Persistence for behaviour rule sets, the rules that decide how an agent
+ * reacts to what a user said. Consumed by the deployment machinery and the REST
+ * resource; readActions() lists the actions a rule set version can trigger,
+ * which the editor uses for completion.
  */
 public interface IRuleSetStore extends IResourceStore<RuleSetConfiguration> {
     List<String> readActions(String id, Integer version, String filter, Integer limit)


### PR DESCRIPTION
Adds class-level Javadoc to the config store interfaces in `configs/` that
still only had an `@author` tag (or, for IMcpCallsStore, a one-line comment).
I kept it short per interface: what the store persists, who reads it, and what
the extra lookup methods are for, following the style used for the datastore
interfaces. No behaviour changes, `./mvnw compile` passes locally.

Closes #544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified documentation for agent, API call, dictionary, LLM, MCP call, output, parser, and rule-set configuration storage.
  - Documented configuration contents, versioning, runtime responsibilities, and editor-related lookup behavior.
  - No functional or user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->